### PR TITLE
Patch for GRAILS-6695

### DIFF
--- a/src/java/org/codehaus/groovy/grails/cli/ScriptNameResolver.groovy
+++ b/src/java/org/codehaus/groovy/grails/cli/ScriptNameResolver.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.grails.cli
+
+/**
+ * @author Andres Almiray
+ * @author Dierk Koenig
+ */
+class ScriptNameResolver {
+    /**
+     * Matches a camelCase scriptName to a potential scriptFileName in canonical form.<p>
+     * The following scriptNames match FooBar: FB, FoB, FBa
+     */
+    static boolean resolvesTo(String scriptName, String scriptFileName) {
+        def scriptFileNameTokens = scriptFileName.findAll(/[A-Z][a-z]+/)
+        def scriptNameTokens = scriptName.findAll(/[A-Z][a-z]*/)
+        
+        if(scriptFileNameTokens.size() != scriptNameTokens.size()) return false
+        for(int i = 0; i < scriptNameTokens.size(); i++) {
+            String str = scriptNameTokens[i]
+            if(!scriptFileNameTokens[i].startsWith(str)) return false
+        }
+        true    
+    }
+}

--- a/src/test/org/codehaus/groovy/grails/cli/ScriptNameResolverTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/cli/ScriptNameResolverTests.groovy
@@ -1,0 +1,18 @@
+package org.codehaus.groovy.grails.cli
+
+class ScriptNameResolverTests extends GroovyTestCase {
+    void testFoo(){
+        assert ScriptNameResolver.resolvesTo('F', 'Foo')
+        assert ScriptNameResolver.resolvesTo('FB', 'FooBar')
+        assert ScriptNameResolver.resolvesTo('FoB', 'FooBar')
+        assert ScriptNameResolver.resolvesTo('FBa', 'FooBar')
+        assert ScriptNameResolver.resolvesTo('FoBa', 'FooBar')
+        assert ScriptNameResolver.resolvesTo('FooBar', 'FooBar')
+        assert !ScriptNameResolver.resolvesTo('FB', 'FooBarZoo')
+        assert !ScriptNameResolver.resolvesTo('FBaz', 'FooBar')
+        assert !ScriptNameResolver.resolvesTo('FBr', 'FooBar')
+        assert !ScriptNameResolver.resolvesTo('F', 'FooBar')
+        assert !ScriptNameResolver.resolvesTo('Fo', 'FooBar')
+        assert !ScriptNameResolver.resolvesTo('Foo', 'FooBar')
+    }
+}


### PR DESCRIPTION
This patch enables command target expansion like the one found in Gradle/Griffon.
# Changes to be committed:
# new file:   src/java/org/codehaus/groovy/grails/cli/ScriptNameResolver.groovy
# new file:   src/test/org/codehaus/groovy/grails/cli/ScriptNameResolverTests.groovy
# modified:   src/java/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
