### PR TITLE
Fix for GRAILS-6818: Allow tests to be run in a consistent order

### DIFF
--- a/scripts/_GrailsTest.groovy
+++ b/scripts/_GrailsTest.groovy
@@ -134,10 +134,10 @@ target(allTests: "Runs the project's tests.") {
                     def rawTypeString = rawType.toString()
                     if (phaseName == 'integration') {
                         def mode = new GrailsTestMode(autowire: true, wrapInTransaction: true, wrapInRequestEnvironment: true)
-                        new JUnit4GrailsTestType(rawTypeString, rawTypeString, mode)
+                        new JUnit4GrailsTestType(rawTypeString, rawTypeString, buildConfig.grails.testing.sortFiles, mode)
                     }
                     else {
-                        new JUnit4GrailsTestType(rawTypeString, rawTypeString)
+                        new JUnit4GrailsTestType(rawTypeString, rawTypeString, buildConfig.grails.testing.sortFiles)
                     }
                 }
                 else {

--- a/src/java/org/codehaus/groovy/grails/test/junit4/JUnit4GrailsTestType.groovy
+++ b/src/java/org/codehaus/groovy/grails/test/junit4/JUnit4GrailsTestType.groovy
@@ -42,12 +42,12 @@ class JUnit4GrailsTestType extends GrailsTestTypeSupport {
     protected suite
     protected mode
 
-    JUnit4GrailsTestType(String name, String sourceDirectory) {
-        this(name, sourceDirectory, null)
+    JUnit4GrailsTestType(String name, String sourceDirectory, sortFiles) {
+        this(name, sourceDirectory, sortFiles, null)
     }
 
-    JUnit4GrailsTestType(String name, String sourceDirectory, GrailsTestMode mode) {
-        super(name, sourceDirectory)
+    JUnit4GrailsTestType(String name, String sourceDirectory, sortFiles, GrailsTestMode mode) {
+        super(name, sourceDirectory, sortFiles)
         this.mode = mode
     }
 

--- a/src/java/org/codehaus/groovy/grails/test/support/GrailsTestTypeSupport.groovy
+++ b/src/java/org/codehaus/groovy/grails/test/support/GrailsTestTypeSupport.groovy
@@ -41,6 +41,12 @@ abstract class GrailsTestTypeSupport implements GrailsTestType {
     final String relativeSourcePath
 
     /**
+     * Whether to sort the files that make up this test type; boolean,
+     * or a closure to indicate how they should be sorted
+     */
+    final sortFiles
+
+    /**
      * The test target patterns that should be used to filter the tests to run
      */
     final GrailsTestTargetPattern[] testTargetPatterns
@@ -61,13 +67,14 @@ abstract class GrailsTestTypeSupport implements GrailsTestType {
     /**
      * Sets the name and relativeSourcePath
      */    
-    GrailsTestTypeSupport(String name, String relativeSourcePath) {
+    GrailsTestTypeSupport(String name, String relativeSourcePath, sortFiles) {
         [name: name, relativeSourcePath: relativeSourcePath].each {
             if (!it.value) throw new IllegalArgumentException("$it.key cannot be empty or null")
         }
         
         this.name = name
         this.relativeSourcePath = relativeSourcePath
+        this.sortFiles = sortFiles
     }
 
     /**
@@ -188,6 +195,11 @@ abstract class GrailsTestTypeSupport implements GrailsTestType {
             }
         }
         
+        if (sortFiles instanceof Closure) {
+	    sourceFiles.sort(sortFiles)
+        } else if (sortFiles) {
+	    sourceFiles.sort()
+        }
         sourceFiles.unique()
     }
     


### PR DESCRIPTION
This patch allows tests to be run in a specific order.  Sorting is enabled by adding the following to `BuildConfig.groovy`:

```
grails.testing.sortFiles = true
```

For finer control, a closure can be provided:

```
grails.testing.sortFiles = { a, b -> a <=> b }
```
