### PR TITLE
GRAILS-6864 - g:select produces unexpected results when keys and valueMessagePrefix attributes are specified, but I18n message key doesn't exist

### DIFF
--- a/src/java/org/codehaus/groovy/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/src/java/org/codehaus/groovy/grails/plugins/web/taglib/FormTagLib.groovy
@@ -663,6 +663,10 @@ class FormTagLib {
                     if (message != null) {
                         writer << message.encodeAsHTML()
                     }
+                    else if (keyValue && keys) {
+                        def s = el.toString()
+                        if (s) writer << s.encodeAsHTML()
+                    }                    
                     else if (keyValue) {
                         writer << keyValue.encodeAsHTML()
                     }


### PR DESCRIPTION
More info at http://jira.codehaus.org/browse/GRAILS-6864
