### PR TITLE
GRAILS-6870 - In scaffolding, non existing optional Date properties should be rendered as blanks instead as "now" date

### DIFF
--- a/src/grails/templates/scaffolding/renderEditor.template
+++ b/src/grails/templates/scaffolding/renderEditor.template
@@ -162,6 +162,9 @@
             if (property.manyToOne || property.oneToOne) {
                 return "noSelection=\"['null': '']\""
             }
+            else if (property.type == Date.class || property.type == java.sql.Date.class || property.type == java.sql.Time.class || property.type == Calendar.class) {
+                return "default=\"none\" noSelection=\"['': '']\""
+            }
             else {
                 return "noSelection=\"['': '']\""
             }


### PR DESCRIPTION
More info at http://jira.codehaus.org/browse/GRAILS-6870
