### PR TITLE
GRAILS-6928/6929 - More nested property sort support: embedded properties and default sort

### DIFF
--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
@@ -29,10 +29,12 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.groovy.grails.commons.ApplicationHolder;
 import org.codehaus.groovy.grails.commons.ArtefactHandler;
 import org.codehaus.groovy.grails.commons.ConfigurationHolder;
 import org.codehaus.groovy.grails.commons.DomainClassArtefactHandler;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
+import org.codehaus.groovy.grails.commons.GrailsClass;
 import org.codehaus.groovy.grails.commons.GrailsClassUtils;
 import org.codehaus.groovy.grails.commons.GrailsDomainClass;
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty;
@@ -197,7 +199,7 @@ public class GrailsHibernateUtil {
             if (caseArg instanceof Boolean) {
                 ignoreCase = (Boolean) caseArg;
             }
-            addOrder(c, sort, order, ignoreCase);
+            addOrderPossiblyNested(c, targetClass, sort, order, ignoreCase);
         }
         else {
             Mapping m = GrailsDomainBinder.getMapping(targetClass);
@@ -212,23 +214,51 @@ public class GrailsHibernateUtil {
         }
     }
     
-    /*
+    /**
      * Add order to criteria, creating necessary subCriteria if nested sort property (ie. sort:'nested.property').
      */
+    private static void addOrderPossiblyNested(Criteria c, Class<?> targetClass, String sort, String order, boolean ignoreCase) {
+        int firstDotPos = sort.indexOf(".");
+        if (firstDotPos == -1) {
+            addOrder(c, sort, order, ignoreCase);
+        } else { // nested property
+            String sortHead = sort.substring(0,firstDotPos);
+            String sortTail = sort.substring(firstDotPos+1);
+            GrailsDomainClassProperty property = getGrailsDomainClassProperty(targetClass, sortHead);
+            if (property.isEmbedded()) {
+                // embedded objects cannot reference entities (at time of writing), so no more recursion needed  
+                addOrder(c, sort, order, ignoreCase);
+            } else {
+                Criteria subCriteria = c.createCriteria(sortHead);
+                Class<?> propertyTargetClass = property.getReferencedDomainClass().getClazz(); 
+                addOrderPossiblyNested(subCriteria, propertyTargetClass, sortTail, order, ignoreCase); // Recurse on nested sort
+            }
+        }
+    }
+
+    /**
+     * Add order directly to criteria.
+     */
     private static void addOrder(Criteria c, String sort, String order, boolean ignoreCase) {
-    	int firstDotPos = sort.indexOf(".");
-    	if (firstDotPos == -1) {
-            if (ORDER_DESC.equals(order)) {
-                c.addOrder( ignoreCase ? Order.desc(sort).ignoreCase() : Order.desc(sort));
-            }
-            else {
-                c.addOrder( ignoreCase ? Order.asc(sort).ignoreCase() : Order.asc(sort) );
-            }
-    	} else {
-    		Criteria subCriteria = c.createCriteria(sort.substring(0,firstDotPos));
-    		String remainingSort = sort.substring(firstDotPos+1);
-    		addOrder(subCriteria, remainingSort, order, ignoreCase); // Recurse on nested sort
-    	}
+        if (ORDER_DESC.equals(order)) {
+            c.addOrder( ignoreCase ? Order.desc(sort).ignoreCase() : Order.desc(sort));
+        }
+        else {
+            c.addOrder( ignoreCase ? Order.asc(sort).ignoreCase() : Order.asc(sort) );
+        }
+    }
+    
+    /**
+     * Get hold of the GrailsDomainClassProperty represented by the targetClass' propertyName, 
+     * assuming targetClass corresponds to a GrailsDomainClass.
+     */
+    private static GrailsDomainClassProperty getGrailsDomainClassProperty(Class<?> targetClass, String propertyName) {
+        GrailsClass grailsClass = ApplicationHolder.getApplication().getArtefact(DomainClassArtefactHandler.TYPE, targetClass.getName());
+        if (!(grailsClass instanceof GrailsDomainClass)) {
+            throw new IllegalArgumentException("Unexpected: class is not a domain class:"+targetClass.getName());
+        }
+        GrailsDomainClass domainClass = (GrailsDomainClass) grailsClass;
+        return domainClass.getPropertyByName(propertyName);
     }
     
     /**

--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
@@ -204,12 +204,7 @@ public class GrailsHibernateUtil {
         else {
             Mapping m = GrailsDomainBinder.getMapping(targetClass);
             if (m != null && !StringUtils.isBlank(m.getSort())) {
-                if (ORDER_DESC.equalsIgnoreCase(m.getOrder())) {
-                    c.addOrder(Order.desc(m.getSort()));
-                }
-                else {
-                    c.addOrder(Order.asc(m.getSort()));
-                }
+                addOrderPossiblyNested(c, targetClass, m.getSort(), m.getOrder(), true);
             }
         }
     }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -21,6 +21,9 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
                     manningBooks {
                         eq('publisher', 'Manning')
                     }
+                    static mapping = {
+                        sort 'author.name'
+                    }
                 }
             }
             
@@ -93,5 +96,9 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
     
     void testSortByEmbeddedProperty() {
         assertEquals( ['A','a','b','B','C','c'], bookClass.list(sort:'address.street').address.street)
+    }
+
+    void testDefaultSort() {
+        assertEquals( ['A','a','b','B','C','c'], bookClass.list().address.street)
     }
 }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -4,53 +4,52 @@ package org.codehaus.groovy.grails.orm.hibernate
  * Test for GRAILS-3911
  */
 class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
-	
-	def bookClass
+    
+    def bookClass
 
     protected void onSetUp() {
         gcl.parseClass '''
-class Book {
-    Long id
-    Long version
-    String title
-    Author author
-    String publisher = 'Manning'
-    static namedQueries = {
-        manningBooks {
-            eq('publisher', 'Manning')
-        }
-    }
-    
-}
-
-class Author {
-    Long id
-    Long version
-    String name
-    Person person
-}
-
-class Person {
-    Long id
-    Long version
-    String name
-}
-'''
+            class Book {
+                Long id
+                Long version
+                String title
+                Author author
+                String publisher = 'Manning'
+                static namedQueries = {
+                    manningBooks {
+                        eq('publisher', 'Manning')
+                    }
+                }
+            }
+            
+            class Author {
+                Long id
+                Long version
+                String name
+                Person person
+            }
+            
+            class Person {
+                Long id
+                Long version
+                String name
+            }
+        '''
     }
 
     protected void setUp() {
-		super.setUp()
-		
-		def personClass = ga.getDomainClass('Person').clazz
-		def authorClass = ga.getDomainClass('Author').clazz
-		bookClass = ga.getDomainClass('Book').clazz
-		['C','A','b','a','c','B'].eachWithIndex { name, i ->
-			def person = personClass.newInstance(id:i, version:1, name:name).save(flush:true)
-			def author = authorClass.newInstance(id:i, version:1, name:name, person:person).save(flush:true)
-			bookClass.newInstance(id:i, version:1, title:'foo', author:author).save(flush:true)
-		}
-	}
-	
+        super.setUp()
+        
+        def personClass = ga.getDomainClass('Person').clazz
+        def authorClass = ga.getDomainClass('Author').clazz
+        bookClass = ga.getDomainClass('Book').clazz
+        ['C','A','b','a','c','B'].eachWithIndex { name, i ->
+            def person = personClass.newInstance(id:i, version:1, name:name).save(flush:true)
+            def author = authorClass.newInstance(id:i, version:1, name:name, person:person).save(flush:true)
+            bookClass.newInstance(id:i, version:1, title:'foo', author:author).save(flush:true)
+        }
+    }
+    
     void testListPersistentMethod() {
         assertEquals( ['A','a','b','B','C','c'], bookClass.list(sort:'author.name').author.name )
         assertEquals( ['A','B','C','a','b','c'], bookClass.list(sort:'author.name', ignoreCase:false).author.name )
@@ -71,9 +70,9 @@ class Person {
     void testFindByPersistentMethod() {
         assertEquals( 'A', bookClass.findByPublisher('Manning', [sort:'author.name']).author.name )
     }
-	
-	void testDeepSort() {
+    
+    void testDeepSort() {
         assertEquals( ['A','a','b','B','C','c'], bookClass.list(sort:'author.person.name').author.person.name )
-	}
+    }
 
 }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -21,9 +21,9 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
                     manningBooks {
                         eq('publisher', 'Manning')
                     }
-                    static mapping = {
-                        sort 'author.name'
-                    }
+                }
+                static mapping = {
+                    sort 'author.name'
                 }
             }
             

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -75,4 +75,12 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
         assertEquals( ['A','a','b','B','C','c'], bookClass.list(sort:'author.person.name').author.person.name )
     }
 
+    void testPreserveOtherParameters() {
+        assertEquals( ['b','B','C'], bookClass.list(max:3, offset:2, sort:'author.name').author.name )
+        assertEquals( ['C','a','b'], bookClass.list(max:3, offset:2, sort:'author.name', ignoreCase:false).author.name )
+        assertEquals( ['b','B','C'], bookClass.manningBooks().list(max:3, offset:2, sort:'author.name').author.name )
+        assertEquals( ['b','B','C'], bookClass.findAll([max:3, offset:2, sort:'author.name']).author.name )
+        assertEquals( ['b','B','C'], bookClass.findAllByPublisher('Manning', [max:3, offset:2, sort:'author.name']).author.name )
+        assertEquals( ['b','B','C'], bookClass.list(max:3, offset:2, sort:'author.person.name').author.person.name )
+    }
 }


### PR DESCRIPTION
GRAILS-6928 - Sorting by embedded properties (sort:'embedded.property') broke after fix for GRAILS-3911 
GRAILS-6929 - Add support for using nested properties in default sorting (ie. mapping {sort 'nested.property')}

These issues complements the nested property support described in further details in GRAILS-3911.
