### PR TITLE
1.3.x GRAILS-3911 - Criteria.list() sort nested properties

### DIFF
--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
@@ -29,10 +29,12 @@ import java.util.Set;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.groovy.grails.commons.ApplicationHolder;
 import org.codehaus.groovy.grails.commons.ArtefactHandler;
 import org.codehaus.groovy.grails.commons.ConfigurationHolder;
 import org.codehaus.groovy.grails.commons.DomainClassArtefactHandler;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
+import org.codehaus.groovy.grails.commons.GrailsClass;
 import org.codehaus.groovy.grails.commons.GrailsClassUtils;
 import org.codehaus.groovy.grails.commons.GrailsDomainClass;
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty;
@@ -197,7 +199,7 @@ public class GrailsHibernateUtil {
             if (caseArg instanceof Boolean) {
                 ignoreCase = (Boolean) caseArg;
             }
-            addOrder(c, sort, order, ignoreCase);
+            addOrderPossiblyNested(c, targetClass, sort, order, ignoreCase);
         }
         else {
             Mapping m = GrailsDomainBinder.getMapping(targetClass);
@@ -211,24 +213,52 @@ public class GrailsHibernateUtil {
             }
         }
     }
-    
-    /*
+
+    /**
      * Add order to criteria, creating necessary subCriteria if nested sort property (ie. sort:'nested.property').
      */
+    private static void addOrderPossiblyNested(Criteria c, Class<?> targetClass, String sort, String order, boolean ignoreCase) {
+        int firstDotPos = sort.indexOf(".");
+        if (firstDotPos == -1) {
+            addOrder(c, sort, order, ignoreCase);
+        } else { // nested property
+            String sortHead = sort.substring(0,firstDotPos);
+            String sortTail = sort.substring(firstDotPos+1);
+            GrailsDomainClassProperty property = getGrailsDomainClassProperty(targetClass, sortHead);
+            if (property.isEmbedded()) {
+                // embedded objects cannot reference entities (at time of writing), so no more recursion needed  
+                addOrder(c, sort, order, ignoreCase);
+            } else {
+                Criteria subCriteria = c.createCriteria(sortHead);
+                Class<?> propertyTargetClass = property.getReferencedDomainClass().getClazz(); 
+                addOrderPossiblyNested(subCriteria, propertyTargetClass, sortTail, order, ignoreCase); // Recurse on nested sort
+            }
+        }
+    }
+
+    /**
+     * Add order directly to criteria.
+     */
     private static void addOrder(Criteria c, String sort, String order, boolean ignoreCase) {
-    	int firstDotPos = sort.indexOf(".");
-    	if (firstDotPos == -1) {
-            if (ORDER_DESC.equals(order)) {
-                c.addOrder( ignoreCase ? Order.desc(sort).ignoreCase() : Order.desc(sort));
-            }
-            else {
-                c.addOrder( ignoreCase ? Order.asc(sort).ignoreCase() : Order.asc(sort) );
-            }
-    	} else {
-    		Criteria subCriteria = c.createCriteria(sort.substring(0,firstDotPos));
-    		String remainingSort = sort.substring(firstDotPos+1);
-    		addOrder(subCriteria, remainingSort, order, ignoreCase); // Recurse on nested sort
-    	}
+        if (ORDER_DESC.equals(order)) {
+            c.addOrder( ignoreCase ? Order.desc(sort).ignoreCase() : Order.desc(sort));
+        }
+        else {
+            c.addOrder( ignoreCase ? Order.asc(sort).ignoreCase() : Order.asc(sort) );
+        }
+    }
+
+    /**
+     * Get hold of the GrailsDomainClassProperty represented by the targetClass' propertyName, 
+     * assuming targetClass corresponds to a GrailsDomainClass.
+     */
+    private static GrailsDomainClassProperty getGrailsDomainClassProperty(Class<?> targetClass, String propertyName) {
+        GrailsClass grailsClass = ApplicationHolder.getApplication().getArtefact(DomainClassArtefactHandler.TYPE, targetClass.getName());
+        if (!(grailsClass instanceof GrailsDomainClass)) {
+            throw new IllegalArgumentException("Unexpected: class is not a domain class:"+targetClass.getName());
+        }
+        GrailsDomainClass domainClass = (GrailsDomainClass) grailsClass;
+        return domainClass.getPropertyByName(propertyName);
     }
     
     /**

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -1,0 +1,78 @@
+package org.codehaus.groovy.grails.orm.hibernate
+
+/**
+ * Test for GRAILS-3911
+ */
+class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
+    
+    def bookClass
+
+    protected void onSetUp() {
+        gcl.parseClass '''
+            class BookX {
+                Long id
+                Long version
+                String title
+                AuthorX author
+                String publisher = 'Manning'
+                static namedQueries = {
+                    manningBooks {
+                        eq('publisher', 'Manning')
+                    }
+                }
+            }
+            
+            class AuthorX {
+                Long id
+                Long version
+                String name
+                PersonX person
+            }
+            
+            class PersonX {
+                Long id
+                Long version
+                String name
+            }
+            '''
+    }
+
+    protected void setUp() {
+        super.setUp()
+        
+        def personClass = ga.getDomainClass('PersonX').clazz
+        def authorClass = ga.getDomainClass('AuthorX').clazz
+        bookClass = ga.getDomainClass('BookX').clazz
+        ['C','A','b','a','c','B'].eachWithIndex { name, i ->
+            def person = personClass.newInstance(id:i, version:1, name:name).save(flush:true)
+            def author = authorClass.newInstance(id:i, version:1, name:name, person:person).save(flush:true)
+            bookClass.newInstance(id:i, version:1, title:'foo', author:author).save(flush:true)
+        }
+    }
+    
+    void testListPersistentMethod() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.list(sort:'author.name').author.name )
+        assertEquals( ['A','B','C','a','b','c'], bookClass.list(sort:'author.name', ignoreCase:false).author.name )
+    }
+
+    void testHibernateNamedQueriesBuilder() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.manningBooks().list(sort:'author.name').author.name )
+    }
+
+    void testFindAllPersistentMethod() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.findAll([sort:'author.name']).author.name )
+    }
+
+    void testFindAllByPersistentMethod() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.findAllByPublisher('Manning', [sort:'author.name']).author.name )
+    }
+
+    void testFindByPersistentMethod() {
+        assertEquals( 'a', bookClass.findByPublisher('Manning', [sort:'author.name']).author.name )
+    }
+    
+    void testDeepSort() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.list(sort:'author.person.name').author.person.name )
+    }
+
+}


### PR DESCRIPTION
Including GRAILS-6928 - Sorting by embedded properties (sort:'embedded.property') broke after fix for GRAILS-3911.

Note: To be applied in 1.3.x only. For 1.4, GRAILS-3911 is applied already, and GRAILS-6928 is on pull request.
