### PR TITLE
1.3.x GRAILS-6929/6931 Nested properties default sort / Unique contraints with Identity Mapping

### DIFF
--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,4 @@
-#Tue Sep 22 15:33:10 EEST 2009
+#Fri Nov 26 13:19:55 CET 2010
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.5
@@ -10,3 +10,4 @@ org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.source=1.5
+org.eclipse.jdt.core.formatter.tabulation.char=space

--- a/src/java/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClass.java
+++ b/src/java/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClass.java
@@ -774,4 +774,8 @@ public class DefaultGrailsDomainClass extends AbstractGrailsClass implements Gra
     public void setMappingStrategy(String strategy) {
         mappingStrategy = strategy;
     }
+    
+    public void setIdentifier(GrailsDomainClassProperty identifier) {
+        this.identifier = identifier;
+    }
 }

--- a/src/java/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassProperty.java
+++ b/src/java/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassProperty.java
@@ -686,5 +686,10 @@ public class DefaultGrailsDomainClassProperty implements GrailsDomainClassProper
         public void setMappingStrategy(String strategy) {
             // do nothing
         }
+        
+        public void setIdentifier(GrailsDomainClassProperty identifier) {
+            // do nothing
+        }
+
     }
 }

--- a/src/java/org/codehaus/groovy/grails/commons/GrailsDomainClass.java
+++ b/src/java/org/codehaus/groovy/grails/commons/GrailsDomainClass.java
@@ -206,4 +206,10 @@ public interface GrailsDomainClass extends GrailsClass {
      * @param strategy The mapping strategy
      */
     void setMappingStrategy(String strategy);
+
+    /**
+     * Set the identifier property.
+     * @param identifier The new identifier property 
+     */
+    public void setIdentifier(GrailsDomainClassProperty identifier);
 }

--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateDomainClass.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateDomainClass.java
@@ -285,4 +285,8 @@ public class GrailsHibernateDomainClass extends AbstractGrailsClass implements E
     public Map getAssociationMap() {
         return Collections.emptyMap();
     }
+    
+    public void setIdentifier(GrailsDomainClassProperty identifier) {
+        this.identifier = (GrailsHibernateDomainClassProperty) identifier;
+    }
 }

--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1458,6 +1458,7 @@ public final class GrailsDomainBinder {
                         throw new MappingException("Mapping specifies an identifier property name that doesn't exist ["+propertyName+"]");
                     }
                     if (!namedIdentityProp.equals(identifierProp)) {
+                        domainClass.setIdentifier(namedIdentityProp);
                         identifierProp = namedIdentityProp;
                     }
                 }

--- a/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
+++ b/src/java/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtil.java
@@ -216,12 +216,7 @@ public class GrailsHibernateUtil {
         else {
             Mapping m = GrailsDomainBinder.getMapping(targetClass);
             if (m != null && !StringUtils.isBlank(m.getSort())) {
-                if (ORDER_DESC.equalsIgnoreCase(m.getOrder())) {
-                    c.addOrder(Order.desc(m.getSort()));
-                }
-                else {
-                    c.addOrder(Order.asc(m.getSort()));
-                }
+                addOrderPossiblyNested(c, targetClass, m.getSort(), m.getOrder(), true);
             }
         }
     }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/IdentityNameMappingTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/IdentityNameMappingTests.groovy
@@ -30,4 +30,10 @@ class IdentityNameMapping {
 
         assertNotNull "Persistent instance with named and assigned identifier should have been saved", testClass.get("John")
     }
+    
+    void testMetaData() {
+        def domainClass = ga.getDomainClass("IdentityNameMapping")
+        assertEquals "Persistent instance with named identifier should have correct id metadata", "test", domainClass.identifier.name
+    }
+        
 }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/SortWithNestedPropertiesTests.groovy
@@ -22,6 +22,9 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
                         eq('publisher', 'Manning')
                     }
                 }
+                static mapping = {
+                    sort 'author.name'
+                }
             }
             
             @Entity
@@ -93,5 +96,9 @@ class SortWithNestedPropertiesTests extends AbstractGrailsHibernateTests {
     
     void testSortByEmbeddedProperty() {
         assertEquals( ['a','A','B','b','c','C'], bookClass.list(sort:'address.street').address.street)
+    }
+
+    void testDefaultSort() {
+        assertEquals( ['a','A','B','b','c','C'], bookClass.list().address.street)
     }
 }

--- a/src/test/org/codehaus/groovy/grails/orm/hibernate/validation/UniqueConstraintTests.groovy
+++ b/src/test/org/codehaus/groovy/grails/orm/hibernate/validation/UniqueConstraintTests.groovy
@@ -260,6 +260,18 @@ class UniqueConstraintTests extends AbstractGrailsHibernateTests {
         link.validate()
         assertTrue link.hasErrors()
     }
+    
+    void testFailingUniqueConstraintWithNamedIdentityMapping() {
+        def userClass = ga.getDomainClass("IdentityMappedUser").clazz
+
+        def user1 = userClass.newInstance()
+        user1.name = "Erling"
+        user1.save(true)
+        
+        user1 = userClass.get(user1.namedId)
+        user1.validate() 
+        assertFalse "unique constraint should not fail when using identity name mapping (GRAILS-6931)", user1.hasErrors()
+    } 
 
 
     void onSetUp() {
@@ -291,6 +303,19 @@ class LinkedUser {
 
     static constraints = {
         user2(unique:'user1')
+    }
+}
+
+@Entity
+class IdentityMappedUser {
+    long namedId
+    String name
+
+    static mapping = {
+        id name:'namedId'
+    }
+    static constraints = {
+        name(unique:true)
     }
 }
 '''


### PR DESCRIPTION
GRAILS-6929 is applied in master, thought it belonged in 1.3.x too.
GRAILS-6931 have separate pull request in master. 
More details:
http://jira.codehaus.org/browse/GRAILS-6931
http://jira.codehaus.org/browse/GRAILS-6929
