### PR TITLE
GRAILS-6483 MvcUnitTestCase#reset() might throw "IllegalStateException: Unable to reset response if already committed"

### DIFF
--- a/src/java/grails/test/MvcUnitTestCase.groovy
+++ b/src/java/grails/test/MvcUnitTestCase.groovy
@@ -86,8 +86,8 @@ class MvcUnitTestCase extends GrailsUnitTestCase {
     protected void reset() {
         mockRequest?.clearAttributes()
         mockRequest?.removeAllParameters()
-        mockResponse?.reset()
         mockResponse?.committed = false
+        mockResponse?.reset()
         mockSession?.clearAttributes()
         mockSession?.setNew(true)
 

--- a/src/test/grails/test/ControllerUnitTestCaseTests.groovy
+++ b/src/test/grails/test/ControllerUnitTestCaseTests.groovy
@@ -35,6 +35,20 @@ class ControllerUnitTestCaseTests extends GroovyTestCase {
         testCase.testModelAndView()
         testCase.tearDown()
     }
+
+    void testResetWithResponseNotCommitted() {
+        def testCase = new UnitTestControllerTestCase()
+        testCase.setUp()
+        testCase.testResetWithResponseNotCommitted()
+        testCase.tearDown()
+    }
+
+    void testResetWithResponseCommitted() {
+        def testCase = new UnitTestControllerTestCase()
+        testCase.setUp()
+        testCase.testResetWithResponseCommitted()
+        testCase.tearDown()
+    }
 }
 
 class UnitTestControllerTestCase extends ControllerUnitTestCase {
@@ -71,6 +85,20 @@ class UnitTestControllerTestCase extends ControllerUnitTestCase {
         assertTrue cmd.validate()
         assertFalse cmd.errors.hasErrors()
     }
+
+    void testResetWithResponseNotCommitted() {
+        controller.testSetModelAndView()
+        reset()
+        controller.testSetModelAndView()
+    }
+
+    void testResetWithResponseCommitted() {
+        controller.testWriteIntoResponse()
+        assert controller.response.contentAsString == "test"
+        reset()
+        controller.testWriteIntoResponse()
+        assert controller.response.contentAsString == "test"
+    }
 }
 
 class OtherTestCase extends ControllerUnitTestCase {
@@ -90,6 +118,10 @@ class UnitTestController {
 
     def testSetModelAndView() {
         modelAndView = new ModelAndView()
+    }
+
+    def testWriteIntoResponse() {
+        response << "test"
     }
 }
 


### PR DESCRIPTION
I created an issue on JIRA containing a patch in July but it has not been updated since.
So, I'm trying to integrate it with a pull request :).

Backporting this fix to the 1.3.x branch should go smoothly.

For more details on the issue:
https://jira.codehaus.org/browse/GRAILS-6483
