### PR TITLE
GRAILS-7158 ConfigurationHolder.flatConfig is not reset during unit tests

### DIFF
--- a/src/java/org/codehaus/groovy/grails/commons/ConfigurationHolder.java
+++ b/src/java/org/codehaus/groovy/grails/commons/ConfigurationHolder.java
@@ -40,6 +40,8 @@ public class ConfigurationHolder {
         // reset flat config
         if (newConfig != null) {
             flatConfig = newConfig.flatten();
+        } else {
+            flatConfig = null;
         }
     }
 

--- a/src/test/grails/test/GrailsUnitTestCaseTests.groovy
+++ b/src/test/grails/test/GrailsUnitTestCaseTests.groovy
@@ -32,13 +32,24 @@ class GrailsUnitTestCaseTests extends GroovyTestCase {
 
     void testMockConfig() {
         def testCase = new TestUnitTestCase()
+        def d = new GrailsUnitTestClass()
+
+        // Empty at first
+        testCase.setUp()
+        d.testEmptyConfig()
+        testCase.tearDown()
+
+        // Not empty
         testCase.setUp()
         testCase.mockConfig '''
             foo.bar = "good"
         '''
+        d.testConfig()
+        testCase.tearDown()
 
-        new GrailsUnitTestClass().testConfig()
-
+        // Then empty again
+        testCase.setUp()
+        d.testEmptyConfig()
         testCase.tearDown()
     }
 
@@ -337,6 +348,12 @@ class GrailsUnitTestClass {
 
     void testConfig() {
         assert ConfigurationHolder.config.foo.bar == "good"
+        assert ConfigurationHolder.flatConfig["foo.bar"] == "good"
+    }
+
+    void testEmptyConfig() {
+        assert ConfigurationHolder.config == null
+        assert ConfigurationHolder.flatConfig.size() == 0
     }
 
     static constraints = {


### PR DESCRIPTION
Fix for GRAILS-7158 by resetting flagConfig when `ConfigurationHolder.setConfig(...)` is called with `null` in `GrailsUnitTestCase#tearDown()`

For more details on the issue:
https://jira.codehaus.org/browse/GRAILS-7158
