### PR TITLE
1.3.x - a trivial fix correcting some typos in version # change to 1.3.7

### DIFF
--- a/bin/startGrails.bat
+++ b/bin/startGrails.bat
@@ -127,7 +127,7 @@ set TOOLS_JAR=%JAVA_HOME%\lib\tools.jar
 if "%JAVA_OPTS%" == "" set JAVA_OPTS=-Xmx512m -XX:MaxPermSize=96m
 set JAVA_OPTS=%JAVA_OPTS% -Dprogram.name="%PROGNAME%"
 set JAVA_OPTS=%JAVA_OPTS% -Dgrails.home="%GRAILS_HOME%"
-set JAVA_OPTS=%JAVA_OPTS% -Dgrails.version="1.3.7
+set JAVA_OPTS=%JAVA_OPTS% -Dgrails.version="1.3.7"
 set JAVA_OPTS=%JAVA_OPTS% -Dbase.dir="."
 set JAVA_OPTS=%JAVA_OPTS% -Dtools.jar="%TOOLS_JAR%"
 set JAVA_OPTS=%JAVA_OPTS% -Dgroovy.starter.conf="%STARTER_CONF%"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 apply plugin: 'groovy'
 
-version = '1.3.7
+version = '1.3.7'
 
 sourceCompatibility = "1.5"
 targetCompatibility = "1.5"


### PR DESCRIPTION
Hi,

I just fetched grails code this morning for the first time and was trying to locally build it and noticed that the very last commit made some typo mistakes in upgrading the version # to 1.3.7

I thought it was a good chance to become familiar with the github cycle of submitting a pull request for the Grails project.

rgds,
Roshan
