### PR TITLE
GRAILS-7231 Internal documentation engine produces broken links in index.html and grails doc -pdf does not work anymore

### DIFF
--- a/scripts/_GrailsDocs.groovy
+++ b/scripts/_GrailsDocs.groovy
@@ -271,12 +271,12 @@ target(createIndex: "Produces an index.html page in the root directory") {
 """
 
 		if (createdManual) {
-			writer.write '\t\t<a href="manual/index.html">Manual (Frames)</a><br />\n'
-			writer.write '\t\t<a href="manual/guide/single.html">Manual (Single)</a><br />\n'
+			writer.write '\t\t<a href="guide/index.html">Manual (Frames)</a><br />\n'
+			writer.write '\t\t<a href="guide/single.html">Manual (Single)</a><br />\n'
 		}
 
 		if (createdPdf) {
-			writer.write '\t\t<a href="manual/guide/single.pdf">Manual (PDF)</a><br />\n'
+			writer.write '\t\t<a href="guide/single.pdf">Manual (PDF)</a><br />\n'
 		}
 
 		writer.write """\

--- a/src/java/grails/doc/PdfBuilder.groovy
+++ b/src/java/grails/doc/PdfBuilder.groovy
@@ -32,9 +32,9 @@ class PdfBuilder {
     /**
      * Builds a PDF file from the manual's single.html file.<p>
      * The following directories are assumed to exist:<ul>
-     * <li> $basedir/manual/guide/single.html</li>
-     * <li> $basedir/manual/css/</li>
-     * <li> $basedir/manual/img/</li>
+     * <li> $basedir/guide/single.html</li>
+     * <li> $basedir/guide/css/</li>
+     * <li> $basedir/guide/img/</li>
      * <li> $home/src/$tool/docs/style</li>
      * </ul>
      *
@@ -49,12 +49,12 @@ class PdfBuilder {
         String home = options.home
         String tool = options.tool ?: 'grails'
  
-        File htmlFile = new File("${baseDir}/manual/guide/single.html")
-        File outputFile = new File("${baseDir}/manual/guide/single.pdf")
+        File htmlFile = new File("${baseDir}/guide/single.html")
+        File outputFile = new File("${baseDir}/guide/single.pdf")
         File homeFile = new File(home).canonicalFile
         String urlBase = "file://${homeFile.absolutePath}/src/${tool}/docs/style"
 
-        String xml = createXml(htmlFile, "${baseDir}/manual")
+        String xml = createXml(htmlFile, "${baseDir}")
         createPdf xml, outputFile, urlBase
     }
 


### PR DESCRIPTION
Fix for GRAILS-7231 by modifying links in `index.html` and allow `grails doc -pdf` to work properly again.

For more details on the issue:
https://jira.codehaus.org/browse/GRAILS-7231
