### PR TITLE
GRAILS-6800 transitive dependency of plugin is not evicted by direct project dependency

### DIFF
--- a/scripts/_GrailsWar.groovy
+++ b/scripts/_GrailsWar.groovy
@@ -209,25 +209,13 @@ target (war: "The implementation target") {
         if (includeJars) {
             if (pluginInfos) {
                 def libDir = "${stagingDir}/WEB-INF/lib"
+                // Copy embedded libs (dependencies declared inside dependencies.groovy are already provided)
                 ant.copy(todir:libDir, flatten:true, failonerror:false, preservelastmodified:true) {
                     for (GrailsPluginInfo info in pluginInfos) {
                         fileset(dir: info.pluginDir.file.path) {
                             include(name:"lib/*.jar")
                         }
                     }
-                }
-
-                for(GrailsPluginInfo info in pluginInfos) {
-                    IvyDependencyManager freshManager = new IvyDependencyManager(info.name, info.version)
-                    freshManager.parseDependencies {}
-                    freshManager.chainResolver = grailsSettings.dependencyManager.chainResolver
-                    grailsSettings.pluginDependencyHandler(freshManager).call(info.pluginDir.file.canonicalFile)
-                    for(File file in freshManager.resolveDependencies("runtime").allArtifactsReports.localFile) {
-                        if(file) {
-                            ant.copy(file:file, todir:libDir)
-                        }
-                    }
-                    
                 }
             }
         }

--- a/src/java/grails/util/BuildSettings.groovy
+++ b/src/java/grails/util/BuildSettings.groovy
@@ -309,7 +309,7 @@ class BuildSettings extends AbstractBuildSettings {
 		Message.info "Resolving [compile] dependencies..."
         def jarFiles = dependencyManager
                             .resolveDependencies(IvyDependencyManager.COMPILE_CONFIGURATION)
-                            .allArtifactsReports
+                            .getArtifactsReports(null, false)
                             .localFile + applicationJars
         Message.debug("Resolved jars for [compile]: ${{->jarFiles.join('\n')}}")
 		resolveCache['compile'] = jarFiles
@@ -341,7 +341,7 @@ class BuildSettings extends AbstractBuildSettings {
 		Message.info "Resolving [test] dependencies..."
         def jarFiles = dependencyManager
                             .resolveDependencies(IvyDependencyManager.TEST_CONFIGURATION)
-                            .allArtifactsReports
+                            .getArtifactsReports(null, false)
                             .localFile + applicationJars
         Message.debug("Resolved jars for [test]: ${{->jarFiles.join('\n')}}")
 		resolveCache['test'] = jarFiles
@@ -373,7 +373,7 @@ class BuildSettings extends AbstractBuildSettings {
 		Message.info "Resolving [runtime] dependencies..."
         def jarFiles = dependencyManager
                    .resolveDependencies(IvyDependencyManager.RUNTIME_CONFIGURATION)
-                   .allArtifactsReports
+                   .getArtifactsReports(null, false)
                    .localFile + applicationJars
         Message.debug("Resolved jars for [runtime]: ${{->jarFiles.join('\n')}}")
 		resolveCache['runtime'] = jarFiles
@@ -408,7 +408,7 @@ class BuildSettings extends AbstractBuildSettings {
 		Message.info "Resolving [provided] dependencies..."
         def jarFiles = dependencyManager
                        .resolveDependencies(IvyDependencyManager.PROVIDED_CONFIGURATION)
-                       .allArtifactsReports
+                       .getArtifactsReports(null, false)
                        .localFile
 
         Message.debug("Resolved jars for [provided]: ${{->jarFiles.join('\n')}}")
@@ -447,7 +447,7 @@ class BuildSettings extends AbstractBuildSettings {
 		Message.info "Resolving [build] dependencies..."
         def jarFiles = dependencyManager
                            .resolveDependencies(IvyDependencyManager.BUILD_CONFIGURATION)
-                           .allArtifactsReports
+                           .getArtifactsReports(null, false)
                            .localFile + applicationJars
 
         Message.debug("Resolved jars for [build]: ${{->jarFiles.join('\n')}}")

--- a/src/java/org/codehaus/groovy/grails/resolve/PluginInstallEngine.groovy
+++ b/src/java/org/codehaus/groovy/grails/resolve/PluginInstallEngine.groovy
@@ -120,7 +120,7 @@ class PluginInstallEngine {
                 errorHandler "Failed to resolve plugins."
             }
             else {
-                for (ArtifactDownloadReport ar in report.allArtifactsReports) {
+                for (ArtifactDownloadReport ar in report.getArtifactsReports(null, false)) {
                     def arName = ar.artifact.moduleRevisionId.name
                     if (plugins.any { it.name == arName }) {
                         installPlugin ar.localFile
@@ -363,7 +363,7 @@ You cannot upgrade a plugin that is configured via BuildConfig.groovy, remove th
                     errorHandler("Failed to install plugin [${pluginName}]. Plugin has missing JAR dependencies.")
                 }
                 else {
-                    addJarsToRootLoader resolveReport.allArtifactsReports.localFile
+                    addJarsToRootLoader resolveReport.getArtifactsReports(null, false).localFile
                 }
             }
         }
@@ -540,7 +540,7 @@ You cannot upgrade a plugin that is configured via BuildConfig.groovy, remove th
     private void resolveDependenciesAgain() {
         for (type in ['compile', 'build', 'test', 'runtime']) {
             def existing = settings."${type}Dependencies"
-            def all = settings.dependencyManager.resolveDependencies(IvyDependencyManager."${type.toUpperCase()}_CONFIGURATION").allArtifactsReports.localFile
+            def all = settings.dependencyManager.resolveDependencies(IvyDependencyManager."${type.toUpperCase()}_CONFIGURATION").getArtifactsReports(null, false).localFile
             def toAdd = all - existing
             if (toAdd) {
                 existing.addAll(toAdd)

--- a/src/java/org/codehaus/groovy/grails/resolve/PluginResolveEngine.groovy
+++ b/src/java/org/codehaus/groovy/grails/resolve/PluginResolveEngine.groovy
@@ -95,7 +95,7 @@ final class PluginResolveEngine {
             return null
         }
 
-        def reports = report.allArtifactsReports
+        def reports = report.getArtifactsReports(null, false)
         def artifactReport = reports.find { it.artifact.attributes.organisation == resolveArgs.group && it.artifact.name == resolveArgs.name && (pluginVersion == null || it.artifact.moduleRevisionId.revision == pluginVersion) }
         if(artifactReport == null) {
             artifactReport = reports.find { it.artifact.name == pluginName && (pluginVersion == null || it.artifact.moduleRevisionId.revision == pluginVersion) }
@@ -132,8 +132,8 @@ final class PluginResolveEngine {
             }
         }
         def report = dependencyManager.resolvePluginDependencies('runtime', [download:false])
-        if (!report.hasError() && report.allArtifactsReports) {
-            ArtifactOrigin origin = report.allArtifactsReports.origin.first()
+        if (!report.hasError() && report.getArtifactsReports(null, false)) {
+            ArtifactOrigin origin = report.getArtifactsReports(null, false).origin.first()
             def location = origin.location
             def parent = location[0..location.lastIndexOf('/')-1]
             for (DependencyResolver dr in dependencyManager.chainResolver.resolvers) {
@@ -172,11 +172,11 @@ final class PluginResolveEngine {
 
             report = dependencyManager.resolvePluginDependencies()
 
-            if (report.hasError() || !report.allArtifactsReports) {
+            if (report.hasError() || !report.getArtifactsReports(null, false)) {
                 return null
             }
 
-            return new XmlSlurper().parse(report.allArtifactsReports.localFile.first())
+            return new XmlSlurper().parse(report.getArtifactsReports(null, false).localFile.first())
         }
     }
 }


### PR DESCRIPTION
Fix for GRAILS-6800 by:
- using the proper Ivy method to prevent retrieval of evicted artefacts
- remove redundant dependencies resolving for plugins in grails war

I tested this fix against 1.3.x:
- backport without conflicts
- no more evicted artifacts found in WEB-INF/lib (like the report in grails dependency-report)

For more details on the issue:
https://jira.codehaus.org/browse/GRAILS-6800
