### PR TITLE
Grails 6249

### DIFF
--- a/src/java/org/codehaus/groovy/grails/validation/routines/DomainValidator.java
+++ b/src/java/org/codehaus/groovy/grails/validation/routines/DomainValidator.java
@@ -63,7 +63,7 @@ public class DomainValidator implements Serializable {
 
     private static final long serialVersionUID = -7709130257134339371L;
     // Regular expression strings for hostnames (derived from RFC2396 and RFC 1123)
-    private static final String DOMAIN_LABEL_REGEX = "\\p{Alnum}(?:[\\p{Alnum}-]*\\p{Alnum})*";
+    private static final String DOMAIN_LABEL_REGEX = "\\p{Alnum}(?>[\\p{Alnum}-]*\\p{Alnum})*";
     private static final String TOP_LABEL_REGEX = "\\p{Alpha}{2,}";
     private static final String DOMAIN_NAME_REGEX =
         "^(?:" + DOMAIN_LABEL_REGEX + "\\.)+" + "(" + TOP_LABEL_REGEX + ")$";


### PR DESCRIPTION
A short fix for GRAILS-6249.  Updates the regex in the grails validator to a better one used in the apache commons validator from which it was cloned.  Corresponds to http://svn.apache.org/viewvc?view=revision&revision=600231.
