### PR TITLE
Fix for GRAILS-7448

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/grails/test/GrailsMockTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/GrailsMockTests.groovy
@@ -265,6 +265,26 @@ class GrailsMockTests extends GroovyTestCase {
 
         assertEquals "brussels-5", testClass.testInterfaceCollaborator()
     }
+
+    /**
+     * GRAILS-7448
+     * Tests that passing a mocked object to a mocked method works.
+     */
+    void testMockToMock() {
+        def mockControl1 = new GrailsMock(GrailsMockCollaborator)
+        mockControl1.demand.collabMethod(1) {GrailsMockCollaborator2 x ->}
+
+        def mockControl2 = new GrailsMock(GrailsMockCollaborator2)
+        mockControl2.demand.theMethod(1) {-> 'mocked' }
+
+        def testClass = new GrailsMockTestClass()
+        testClass.collaborator = mockControl1.createMock()
+
+        testClass.testMockPassedToMock(mockControl2.createMock())
+
+        mockControl1.verify()
+        mockControl2.verify()
+    }
 }
 
 class GrailsMockTestClass {
@@ -312,6 +332,11 @@ class GrailsMockTestClass {
          collaborator.multiMethod("Test string"),
          collaborator.multiMethod("Test string", [arg1: 1, arg2: 2])]
     }
+
+    void testMockPassedToMock(GrailsMockCollaborator2 collaborator2) {
+        collaborator2.theMethod()
+        collaborator.collabMethod(collaborator2)
+    }
 }
 
 class GrailsMockCollaborator {
@@ -324,6 +349,10 @@ class GrailsMockCollaborator {
     String multiMethod(String str, Map map) { "static" }
 
     String someMethod(String str1, Object[] args, String str2) { 'static' }
+}
+
+class GrailsMockCollaborator2 {
+    String theMethod() { 'static' }
 }
 
 interface GrailsMockInterface {

--- a/grails-test/src/main/groovy/grails/test/GrailsMock.groovy
+++ b/grails-test/src/main/groovy/grails/test/GrailsMock.groovy
@@ -101,8 +101,8 @@ class GrailsMock {
                 // Find an expando method with the same signature as the one being invoked.
                 def paramTypes = []
                 args.each {
-                    if (it) {
-                        paramTypes << it.getClass()
+                    if (it != null) {
+                        paramTypes << it.class
                     }
                     else {
                         paramTypes << null


### PR DESCRIPTION
Fix and regression test for GRAILS-7448 Passing a mock to a method mocked using GrailsMock invokes undemanded methods. http://jira.grails.org/browse/GRAILS-7448
