### PR TITLE
Grails 7475

### DIFF
--- a/src/java/org/codehaus/groovy/grails/scaffolding/view/ScaffoldingViewResolver.java
+++ b/src/java/org/codehaus/groovy/grails/scaffolding/view/ScaffoldingViewResolver.java
@@ -81,7 +81,7 @@ public class ScaffoldingViewResolver extends GrailsViewResolver implements Appli
                 if (v == null) {
                     String viewCode = null;
                     try {
-                        viewCode = generateViewSource(webRequest, domainClass);
+                        viewCode = generateViewSource(viewFileName, domainClass);
                     }
                     catch (Exception e) {
                         GrailsUtil.deepSanitize(e);
@@ -107,9 +107,9 @@ public class ScaffoldingViewResolver extends GrailsViewResolver implements Appli
         return view;
     }
 
-    protected String generateViewSource(GrailsWebRequest webRequest, GrailsDomainClass domainClass) {
+    protected String generateViewSource(String viewName, GrailsDomainClass domainClass) {
         StringWriter sw = new StringWriter();
-        templateGenerator.generateView(domainClass,webRequest.getActionName(),sw);
+        templateGenerator.generateView(domainClass, viewName, sw);
         return sw.toString();
     }
 


### PR DESCRIPTION
Fixes [GRAILS-7475](http://jira.grails.org/browse/GRAILS-7475): ScaffoldingViewResolver tosses out supplied view name in favour of using action name

Signed-off-by: Graham Bakay graham@bitmap.net
