### PR TITLE
GRAILS-7336 & GRAILS-7154 adding readOnly, fetchSize, timeout, and flushMode options to grails dynamic finders/criteria/executeQuery methods

### DIFF
--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtilTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsHibernateUtilTests.groovy
@@ -1,0 +1,59 @@
+package org.codehaus.groovy.grails.orm.hibernate.cfg
+
+import org.hibernate.Criteria
+import static org.codehaus.groovy.grails.orm.hibernate.cfg.GrailsHibernateUtil.*
+import org.hibernate.FlushMode
+
+class GrailsHibernateUtilTests extends GroovyTestCase {
+    @Override protected void setUp() {
+        super.setUp()
+    }
+
+    @Override protected void tearDown() {
+        super.tearDown()
+    }
+
+    void testPopulateArgumentsForCriteria_fetchSize() {
+        assertMockedCriteriaCalledFor("setFetchSize", ARGUMENT_FETCH_SIZE, 10)
+    }
+
+    void testPopulateArgumentsForCriteria_timeout() {
+        assertMockedCriteriaCalledFor("setTimeout", ARGUMENT_TIMEOUT, 60)
+    }
+
+    void testPopulateArgumentsForCriteria_readOnly() {
+        assertMockedCriteriaCalledFor("setReadOnly", ARGUMENT_READ_ONLY, true)
+    }
+
+    // works for criteria methods with primitive arguments
+    protected assertMockedCriteriaCalledFor(String methodName, String keyName, value) {
+        Boolean methodCalled = false
+
+        Criteria criteria = [
+                (methodName): { passedValue ->
+                    assertEquals value, passedValue
+                    methodCalled = true
+                    return
+                }
+        ] as Criteria
+
+        GrailsHibernateUtil.populateArgumentsForCriteria(null, null, criteria, [(keyName): value])
+        assertTrue methodCalled
+    }
+
+    void testPopulateArgumentsForCriteria_flushMode() {
+        Boolean methodCalled = false
+        FlushMode value = FlushMode.MANUAL
+
+        Criteria criteria = [
+                setFlushMode: { FlushMode passedValue ->
+                    assertEquals value, passedValue
+                    methodCalled = true
+                    return
+                }
+        ] as Criteria
+
+        GrailsHibernateUtil.populateArgumentsForCriteria(null, null, criteria, [flushMode: value])
+        assertTrue methodCalled
+    }
+}


### PR DESCRIPTION
"readOnly", "fetchSize", "timeout", and "flushMode" work just like the existing pagination/cache parameters on all of the dynamic finders (findBy, findAllBy, list, etc) as well as executeQuery.  

All of these methods are already on the Hibernate 3.6 Criteria and Query objects, this patch simply passes those values through to hibernate.

If accepted, I'll also update the grails-docs repo with notes around the 4 new parameters that have been added to the map.
