### PR TITLE
GRAILS-7309 fix 

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/MockUtils.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/MockUtils.groovy
@@ -830,6 +830,8 @@ class MockUtils {
                 // now set back-reference
                 if (!(arg instanceof Map)) {
                     def otherHasMany = GrailsClassUtils.getStaticPropertyValue(instanceClass, 'hasMany')
+                    // if there are hasMany definition, try to find back-reference among fields defined there
+                    boolean fieldFound = false
                     if (otherHasMany) {
                         // many-to-many
                         otherHasMany.each { String otherCollectionName, Class otherCollectionType ->
@@ -838,10 +840,12 @@ class MockUtils {
                                     arg."$otherCollectionName" = GrailsClassUtils.createConcreteCollection(otherCollectionType)
                                 }
                                 arg."$otherCollectionName" << obj
+                                fieldFound = true
                             }
                         }
-                    }
-                    else {
+                    } 
+                    // if back-reference is not found, try among 1-many fields 
+                    if (!fieldFound) {                    
                         // 1-many
                         for (PropertyDescriptor pd in Introspector.getBeanInfo(instanceClass).propertyDescriptors) {
                             if (clazz.isAssignableFrom(pd.propertyType)) {

--- a/grails-test-suite-uber/src/test/groovy/grails/test/MockUtilsAndHasManyTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/MockUtilsAndHasManyTests.groovy
@@ -1,8 +1,12 @@
 package grails.test
 
 import grails.persistence.Entity
+import grails.test.mixin.Mock;
+import grails.test.mixin.domain.DomainClassUnitTestMixin;
 
 import org.codehaus.groovy.grails.commons.ApplicationHolder
+import org.junit.Test;
+import static org.junit.Assert.*
 
 /**
  * @author Graeme Rocher
@@ -40,6 +44,45 @@ class MagazineTests extends GrailsUnitTestCase {
 
         assertEquals 1, magazine1.articles.size()
     }
+    
+    // check against GRAILS-7309
+    void testAddToOneManyAssociation_GRAILS_7309() {
+        // given
+        mockDomain(Magazine)
+        mockDomain(Article)
+        mockDomain(Paragraph)
+        def magazine = new Magazine()
+        assertNotNull magazine.save()
+        
+        // when
+        def article = new Article()
+        magazine.addToArticles(article)
+        
+        // then
+        assertNotNull article.magazine
+        assertEquals magazine, article.magazine
+    }
+}
+
+// test mockDomain using mixin
+@Mock([Magazine,Article,Paragraph])
+class MockDomainMixinTests {
+    
+    // check against GRAILS-7309
+    @Test
+    void testAddToOneManyAssociation_GRAILS_7309() {
+        // given
+        def magazine = new Magazine()
+        assertNotNull magazine.save()
+        
+        // when
+        def article = new Article()
+        magazine.addToArticles(article)
+        
+        // then
+        assertNotNull article.magazine
+        assertEquals magazine, article.magazine
+    }
 }
 
 @Entity
@@ -49,5 +92,11 @@ class Magazine {
 
 @Entity
 class Article {
+    static hasMany = [paragraphs: Paragraph]
     static belongsTo = [magazine: Magazine]
+}
+
+@Entity
+class Paragraph {
+    static belongsTo = [article: Article]
 }


### PR DESCRIPTION
Bug: MockUtils.addDynamicInstanceMethods() generates addTo\* methods that look only at fields listed in hasMany property when searching for a proper place to put back-reference. If such a field is not found, the rest of fields are not considered for placing the back-reference. Hence, the domain classes crafted as in the example posted in GRAILS-7309 are not properly mocked.

The patch fixes MockUtils class and provide two additional tests: one based on the old GrailsUnitTestCase and another using the new mixin approach.
