### PR TITLE
Exclude .txt files from plugin lib/ when setting commonClasspath

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectCompiler.groovy
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectCompiler.groovy
@@ -374,7 +374,7 @@ class GrailsProjectCompiler {
 
             def pluginLibDirs = pluginSettings.pluginLibDirectories.findAll { it.exists() }
             for (pluginLib in pluginLibDirs) {
-                fileset(dir: pluginLib.file.absolutePath)
+                fileset(dir: pluginLib.file.absolutePath, excludes:'**/*.txt')
             }
         }
 


### PR DESCRIPTION
Edited grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectCompiler.groovy via GitHub

See http://grails.1312388.n4.nabble.com/Re-Code-Coverage-running-tests-leads-to-huge-stacktrace-tp3418003p3491065.html
