### PR TITLE
Validation step produces errors with field names containing indexes for domain object with nested collections of domain objects

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
@@ -162,7 +162,6 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
         if (collection instanceof Collection) {
             Integer index = 0;
             for (Object associatedObject : ((Collection)collection)) {
-                System.out.println("toOne with index " + index);
                 cascadeValidationToOne(errors, bean,associatedObject, persistentProperty, propertyName, index);
                 index++;
             }
@@ -255,19 +254,19 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
             errors.setNestedPath(nestedPath);
         }
     }
-    
+
     private String buildNestedPath(String nestedPath, String componentName, Object indexOrKey) {
       if (indexOrKey == null) {
         // Component is neither part of a Collection nor Map.
         return nestedPath + componentName;
       }
-      
+
       if (indexOrKey instanceof Integer) {
         // Component is part of a Collection. Collection access string
         // e.g. path.object[1] will be appended to the nested path.
         return nestedPath + componentName + "[" + indexOrKey + "]";
       }
-      
+
       // Component is part of a Map. Nested path should have a key surrounded
       // with apostrophes at the end.
       return nestedPath + componentName + "['" + indexOrKey + "']";

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
@@ -201,6 +201,7 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
      * @param associatedObject The associated object's current value
      * @param persistentProperty The GrailsDomainClassProperty instance
      * @param propertyName The name of the property
+     * @param index Index of the object in the collection, otherwise -1
      */
     @SuppressWarnings("rawtypes")
     protected void cascadeValidationToOne(Errors errors, BeanWrapper bean, Object associatedObject,

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationToMapTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationToMapTests.groovy
@@ -42,6 +42,6 @@ class Door {
         assert vehicle.errors
         assertEquals 1, vehicle.errors.allErrors.size()
 
-        assert vehicle.errors.getFieldError("doors.make")
+        assert vehicle.errors.getFieldError("doors[Front].make")
     }
 }

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationWithInheritance2Tests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationWithInheritance2Tests.groovy
@@ -68,7 +68,7 @@ class ArticleRevision extends ContentRevision {
 
         assertNull "should have failed cascading validation", article.save(flush:true)
 
-        assertNotNull "title should not have been allowed to be blank", article.errors.getFieldError("revisions.title")
-        assertNotNull "body should not have been allowed to be blank", article.errors.getFieldError("revisions.body")
+        assertNotNull "title should not have been allowed to be blank", article.errors.getFieldError("revisions[0].title")
+        assertNotNull "body should not have been allowed to be blank", article.errors.getFieldError("revisions[0].body")
     }
 }

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/validation/AssociationsValidationErrorsTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/validation/AssociationsValidationErrorsTests.groovy
@@ -1,0 +1,191 @@
+package org.codehaus.groovy.grails.validation
+
+import org.codehaus.groovy.grails.orm.hibernate.AbstractGrailsHibernateTests
+
+/**
+ * @author Adrian Stachowiak
+ * @since 1.0
+ */
+class AssociationsValidationErrorsTests extends AbstractGrailsHibernateTests {
+
+  protected void onSetUp() {
+    gcl.parseClass('''
+class BaseTest {
+    Long id
+    Long version
+
+    String name
+    
+    List listTests = new ArrayList()
+    Map mapTests
+    Set setTests
+
+    static hasMany = [listTests:ListTest, mapTests:MapTest, setTests:SetTest]
+
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class ListTest {
+    Long id
+    Long version
+    
+    String name
+    
+    List list2Tests = new ArrayList()
+    
+    static belongsTo = BaseTest
+ 
+    static hasMany = [list2Tests:List2Test]
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class List2Test {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = ListTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class MapTest {
+    Long id
+    Long version
+    
+    String name
+    
+    Map map2Tests
+    
+    static belongsTo = BaseTest
+    
+    static hasMany = [map2Tests:Map2Test]
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class Map2Test {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = MapTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class SetTest {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = BaseTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+''')
+  }
+
+  void testListValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def listTest0 = ga.getDomainClass('ListTest').newInstance()
+    listTest0.name = 'LIST TEST'
+
+    def listTest1 = ga.getDomainClass('ListTest').newInstance()
+
+    baseTest.addToListTests(listTest0)
+    baseTest.addToListTests(listTest1)
+    baseTest.validate()
+
+    assertNotNull("Error not found for field listTests[1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('listTests[1].name'))
+  }
+
+  void test2ndLevelListValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def listTest = ga.getDomainClass('ListTest').newInstance()
+    listTest.name = 'LIST TEST'
+
+    def list2Test0 = ga.getDomainClass('List2Test').newInstance()
+    list2Test0.name = 'LIST2 TEST'
+
+    def list2Test1 = ga.getDomainClass('List2Test').newInstance()
+
+    listTest.addToList2Tests(list2Test0)
+    listTest.addToList2Tests(list2Test1)
+    baseTest.addToListTests(listTest)
+    baseTest.validate()
+
+    assertNotNull("Error not found for field listTests[0].list2Tests[1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('listTests[0].list2Tests[1].name'))
+  }
+
+  void testMapValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def mapTest0 = ga.getDomainClass('MapTest').newInstance()
+    mapTest0.name = 'MAP TEST'
+
+    def mapTest1 = ga.getDomainClass('MapTest').newInstance()
+
+    baseTest.mapTests = [MKEY0:mapTest0, MKEY1:mapTest1]
+    baseTest.validate()
+
+    assertNotNull("Error not found for field mapTests[MKEY1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('mapTests[MKEY1].name'))
+  }
+
+  void test2ndLevelMapValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def mapTest = ga.getDomainClass('MapTest').newInstance()
+    mapTest.name = 'MAP TEST'
+
+    def map2Test0 = ga.getDomainClass('Map2Test').newInstance()
+    map2Test0.name = 'MAP2 TEST'
+
+    def map2Test1 = ga.getDomainClass('Map2Test').newInstance()
+
+    mapTest.map2Tests = [M2KEY0:map2Test0, M2KEY1:map2Test1]
+    baseTest.mapTests = [MKEY:mapTest]
+    baseTest.validate()
+
+    assertNotNull("Error not found for field mapTests[MKEY].map2Tests[M2KEY1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('mapTests[MKEY].map2Tests[M2KEY1].name'))
+  }
+
+  void testSetValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def setTest0 = ga.getDomainClass('SetTest').newInstance()
+    setTest0.name = 'SET TEST'
+
+    def setTest1 = ga.getDomainClass('SetTest').newInstance()
+
+    baseTest.setTests = [setTest1, setTest0]
+    baseTest.validate()
+
+    int index = baseTest.setTests.findIndexOf { it == setTest1 }
+
+    assertNotNull("Error not found for field setTests[${index}].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError("setTests[${index}].name"))
+  }
+}


### PR DESCRIPTION
Implementation of GRAILS-7678. Domain class validation produces errors with proper filed names that is field names containing index in the collection. This allows to easily implement error field highlighting without using any workaround mentions in the jira issue. E.g. instead of author.books.title this will produce author.books[0].title. This means that when there are 2 fields for 2 different object in the collection that are not valid there will be 2 errors produces instead of 1 in the current 1.3 and 1.4 implementation.

A sample application to test is in git@github.com:halfdozenshots/GrailsBlogSamples.git repository in the com.halfdozenshots.errorsinassociations.AuthorController

This implementation touches only collections and leaves maps untouched. For maps to be implemented in the same way GrailsDomainClassValidator would have to change even more and the iterations through the map would have to be on keys from map instead of values as in current solution. That would have an impact on performance.
