### PR TITLE
Added Idea project files to the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 /conf
 /dsl-support
 *.ipr
+*.iml
+*.iws
 idea
 /lib
 /doc


### PR DESCRIPTION
When you get the sources from git and simply issue the gradlew install followed by gradlew idea you'll end up with just the project file that's already in .gitignore. However when the grails-core project is opened in Idea two additional files are added: grails-core.iml and grails-core.iws.

For the sake of completeness I've added *.iml and *.iws to .gitignore so that the working copy stays clean after opening grails-core in Idea.
