### PR TITLE
GRAILS-7678: Domain validation produces errors with indexes in the names 

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
@@ -138,7 +138,7 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
 
         if (persistentProperty.isManyToOne() || persistentProperty.isOneToOne() || persistentProperty.isEmbedded()) {
             Object associatedObject = bean.getPropertyValue(propertyName);
-            cascadeValidationToOne(errors, bean,associatedObject, persistentProperty, propertyName);
+            cascadeValidationToOne(errors, bean,associatedObject, persistentProperty, propertyName, null);
         }
         else if (persistentProperty.isOneToMany()) {
             cascadeValidationToMany(errors, bean, persistentProperty, propertyName);
@@ -160,13 +160,16 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
 
         Object collection = bean.getPropertyValue(propertyName);
         if (collection instanceof Collection) {
+            Integer index = 0;
             for (Object associatedObject : ((Collection)collection)) {
-                cascadeValidationToOne(errors, bean,associatedObject, persistentProperty, propertyName);
+                cascadeValidationToOne(errors, bean,associatedObject, persistentProperty, propertyName, index++);
             }
         }
         else if (collection instanceof Map) {
-            for (Object associatedObject : ((Map)collection).values()) {
-                cascadeValidationToOne(errors, bean, associatedObject, persistentProperty, propertyName);
+            for (Object entryObject : ((Map) collection).entrySet()) {
+                @SuppressWarnings("unchecked")
+                Map.Entry<String, Object> entry = (Map.Entry<String, Object>) entryObject;
+                cascadeValidationToOne(errors, bean, entry.getValue(), persistentProperty, propertyName, entry.getKey());
             }
         }
     }
@@ -202,7 +205,7 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
      */
     @SuppressWarnings("rawtypes")
     protected void cascadeValidationToOne(Errors errors, BeanWrapper bean, Object associatedObject,
-            GrailsDomainClassProperty persistentProperty, String propertyName) {
+            GrailsDomainClassProperty persistentProperty, String propertyName, Object indexOrKey) {
 
         if (associatedObject == null) {
             return;
@@ -224,7 +227,7 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
         GrailsDomainClassProperty[] associatedPersistentProperties = associatedDomainClass.getPersistentProperties();
         String nestedPath = errors.getNestedPath();
         try {
-            errors.setNestedPath(nestedPath+propertyName);
+            errors.setNestedPath(buildNestedPath(nestedPath, propertyName, indexOrKey));
 
             for (GrailsDomainClassProperty associatedPersistentProperty : associatedPersistentProperties) {
                 if (associatedPersistentProperty.equals(otherSide)) continue;
@@ -248,6 +251,23 @@ public class GrailsDomainClassValidator implements Validator, CascadingValidator
         finally {
             errors.setNestedPath(nestedPath);
         }
+    }
+
+    private String buildNestedPath(String nestedPath, String componentName, Object indexOrKey) {
+        if (indexOrKey == null) {
+            // Component is neither part of a Collection nor Map.
+            return nestedPath + componentName;
+        }
+
+        if (indexOrKey instanceof Integer) {
+          // Component is part of a Collection. Collection access string
+          // e.g. path.object[1] will be appended to the nested path.
+            return nestedPath + componentName + "[" + indexOrKey + "]";
+        }
+
+        // Component is part of a Map. Nested path should have a key surrounded
+        // with apostrophes at the end.
+        return nestedPath + componentName + "['" + indexOrKey + "']";
     }
 
     private GrailsDomainClass getAssociatedDomainClass(Object associatedObject, GrailsDomainClassProperty persistentProperty) {

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationToMapTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationToMapTests.groovy
@@ -42,6 +42,6 @@ class Door {
         assert vehicle.errors
         assertEquals 1, vehicle.errors.allErrors.size()
 
-        assert vehicle.errors.getFieldError("doors.make")
+        assert vehicle.errors.getFieldError("doors[Front].make")
     }
 }

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationWithInheritance2Tests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/validation/CascadingValidationWithInheritance2Tests.groovy
@@ -68,7 +68,7 @@ class ArticleRevision extends ContentRevision {
 
         assertNull "should have failed cascading validation", article.save(flush:true)
 
-        assertNotNull "title should not have been allowed to be blank", article.errors.getFieldError("revisions.title")
-        assertNotNull "body should not have been allowed to be blank", article.errors.getFieldError("revisions.body")
+        assertNotNull "title should not have been allowed to be blank", article.errors.getFieldError("revisions[0].title")
+        assertNotNull "body should not have been allowed to be blank", article.errors.getFieldError("revisions[0].body")
     }
 }

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/validation/AssociationsValidationErrorsTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/validation/AssociationsValidationErrorsTests.groovy
@@ -1,0 +1,192 @@
+package org.codehaus.groovy.grails.validation
+
+import org.codehaus.groovy.grails.orm.hibernate.AbstractGrailsHibernateTests
+
+/**
+ * @author Adrian Stachowiak
+ * @since 1.0
+ */
+class AssociationsValidationErrorsTests extends AbstractGrailsHibernateTests {
+
+  protected void onSetUp() {
+    gcl.parseClass('''
+class BaseTest {
+    Long id
+    Long version
+
+    String name
+    
+    List listTests = new ArrayList()
+    Map mapTests
+    Set setTests
+
+    static hasMany = [listTests:ListTest, mapTests:MapTest, setTests:SetTest]
+
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class ListTest {
+    Long id
+    Long version
+    
+    String name
+    
+    List list2Tests = new ArrayList()
+    
+    static belongsTo = BaseTest
+ 
+    static hasMany = [list2Tests:List2Test]
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class List2Test {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = ListTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class MapTest {
+    Long id
+    Long version
+    
+    String name
+    
+    Map map2Tests
+    
+    static belongsTo = BaseTest
+    
+    static hasMany = [map2Tests:Map2Test]
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class Map2Test {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = MapTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+
+class SetTest {
+    Long id
+    Long version
+    
+    String name
+    
+    static belongsTo = BaseTest
+    
+    static constraints = {
+        name nullable:false, blank:false
+    }
+}
+''')
+  }
+
+  void testListValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def listTest0 = ga.getDomainClass('ListTest').newInstance()
+    listTest0.name = 'LIST TEST'
+
+    def listTest1 = ga.getDomainClass('ListTest').newInstance()
+
+    baseTest.addToListTests(listTest0)
+    baseTest.addToListTests(listTest1)
+    baseTest.validate()
+
+    assertNotNull("Error not found for field listTests[1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('listTests[1].name'))
+  }
+
+  void test2ndLevelListValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def listTest = ga.getDomainClass('ListTest').newInstance()
+    listTest.name = 'LIST TEST'
+
+    def list2Test0 = ga.getDomainClass('List2Test').newInstance()
+    list2Test0.name = 'LIST2 TEST'
+
+    def list2Test1 = ga.getDomainClass('List2Test').newInstance()
+
+    listTest.addToList2Tests(list2Test0)
+    listTest.addToList2Tests(list2Test1)
+    baseTest.addToListTests(listTest)
+    baseTest.validate()
+
+    assertNotNull("Error not found for field listTests[0].list2Tests[1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('listTests[0].list2Tests[1].name'))
+  }
+
+  void testMapValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def mapTest0 = ga.getDomainClass('MapTest').newInstance()
+    mapTest0.name = 'MAP TEST'
+
+    def mapTest1 = ga.getDomainClass('MapTest').newInstance()
+
+    def key = 'key with spaces and non-standard chars $!@3уш'
+    baseTest.mapTests = [MKEY0:mapTest0, "${key}":mapTest1]
+    baseTest.validate()
+
+    assertNotNull("Error not found for field mapTests[${key}].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError("mapTests[${key}].name"))
+  }
+
+  void test2ndLevelMapValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def mapTest = ga.getDomainClass('MapTest').newInstance()
+    mapTest.name = 'MAP TEST'
+
+    def map2Test0 = ga.getDomainClass('Map2Test').newInstance()
+    map2Test0.name = 'MAP2 TEST'
+
+    def map2Test1 = ga.getDomainClass('Map2Test').newInstance()
+
+    mapTest.map2Tests = [M2KEY0:map2Test0, M2KEY1:map2Test1]
+    baseTest.mapTests = [MKEY:mapTest]
+    baseTest.validate()
+
+    assertNotNull("Error not found for field mapTests[MKEY].map2Tests[M2KEY1].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError('mapTests[MKEY].map2Tests[M2KEY1].name'))
+  }
+
+  void testSetValidation() {
+    def baseTest = ga.getDomainClass('BaseTest').newInstance()
+    baseTest.name = 'Base Name'
+
+    def setTest0 = ga.getDomainClass('SetTest').newInstance()
+    setTest0.name = 'SET TEST'
+
+    def setTest1 = ga.getDomainClass('SetTest').newInstance()
+
+    baseTest.setTests = [setTest1, setTest0]
+    baseTest.validate()
+
+    int index = baseTest.setTests.findIndexOf { it == setTest1 }
+
+    assertNotNull("Error not found for field setTests[${index}].name, errors were: ${baseTest.errors}", baseTest.errors.getFieldError("setTests[${index}].name"))
+  }
+}


### PR DESCRIPTION
Implementation of GRAILS-7678. Domain class validation produces errors with proper filed names that is field names containing index in the collection. This allows to easily implement error field highlighting without using any workaround mentions in the jira issue. E.g. instead of author.books.title this will produce author.books[0].title. This means that when there are 2 fields for 2 different object in the collection that are not valid there will be 2 errors produces instead of 1 in the current 1.3 and 1.4 (2.0) implementation.

A sample application to test is in git@github.com:halfdozenshots/GrailsBlogSamples.git repository in the com.halfdozenshots.errorsinassociations.AuthorController

This implementation works for Lists, Sets and Maps. For Lists and Sets it ads [int] with the index of object in the collection and for maps it adds [string] with the key in the map. Although Sets are usually not sorted and order of objects is not important I have included them because of the possibility of having a sorted set.

Alongside with the implementation new set of tests is provided and updates for tests that were failing because of this update.
