### PR TITLE
adding slf4j-simple to generated .iml files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,16 @@ subprojects { project ->
         options.debug = true
     }
 
+    ideaModule {
+        // pathVariables GRADLE_USER_HOME: file('/home/myuser/.gradle') // that does not work
+        whenConfigured { module ->
+            // adding slf4j-simple with scope TEST to .iml
+            module.dependencies << new org.gradle.plugins.ide.idea.model.ModuleLibrary(
+                [new org.gradle.plugins.ide.idea.model.Path("jar://\$GRADLE_USER_HOME/cache/org.slf4j/slf4j-simple/jars/slf4j-simple-${slf4jVersion}.jar!/")], [], [], [], "TEST"
+            )
+        }
+    }
+
     repositories {
         mavenRepo(urls: "http://repo.grails.org/grails/core") {
             if (project.hasProperty('snapshotTimeout')) {


### PR DESCRIPTION
As discussed on grails-dev, this pull request amends slf4j-simple with scope "TEST" to the IntelliJ module definition files (*.iml). This allows unit/spock tests being run directly from inside the IDE and no longer causes 

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for
further details.
```
