### PR TITLE
Add source property information to determine cause of MappingException

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -656,7 +656,10 @@ public final class GrailsDomainBinder {
                         typeName = type.getName();
                     }
                 }
-                if (typeName == null) throw new MappingException("Type ["+typeName+"] is not a basic type or a domain class and cannot be mapped. Either specify a type within the [mapping] block or use a basic type (String, Integer etc.)");
+                if (typeName == null) {
+                    String domainName = property.getDomainClass().getName();
+                    throw new MappingException("Missing type or column for column["+columnName+"] on domain["+domainName+"] referencing["+className+"]");
+                }
 
                 bindSimpleValue(typeName, element,true, columnName, mappings);
                 if (hasJoinColumnMapping) {


### PR DESCRIPTION
The original exception is ALWAYS:

  Type [null] is not a basic type or a domain class and cannot be
  mapped. Either specify a type within the [mapping] block or use a
  basic type (String, Integer etc.)

The replacement exception specifies the column name, domain class and
attempted reference of the property.

I was not sure about referencing the domain class without an additional null check.  I'm also not sure on what the intention of the error was, so I may be missing key cases, but at least with this error you can track down which domain class relationship may be causing it.
