### PR TITLE
fix for GRAILS-7576

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/ConfigurableLocalSessionFactoryBean.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/ConfigurableLocalSessionFactoryBean.java
@@ -22,7 +22,6 @@ import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty;
 import org.codehaus.groovy.grails.orm.hibernate.cfg.DefaultGrailsDomainConfiguration;
 import org.codehaus.groovy.grails.orm.hibernate.cfg.GrailsDomainConfiguration;
-import org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener;
 import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;


### PR DESCRIPTION
fix for GRAILS-7576: java.lang.ArrayStoreException when adding new hibernate listeners

org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener was being used instead of org.hibernate.event.SaveOrUpdateEventListener
