### PR TITLE
fix for GRAILS-7576, now with test

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/ConfigurableLocalSessionFactoryBean.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/ConfigurableLocalSessionFactoryBean.java
@@ -22,7 +22,6 @@ import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.GrailsDomainClassProperty;
 import org.codehaus.groovy.grails.orm.hibernate.cfg.DefaultGrailsDomainConfiguration;
 import org.codehaus.groovy.grails.orm.hibernate.cfg.GrailsDomainConfiguration;
-import org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener;
 import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
 import org.hibernate.SessionFactory;

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateEventListenerTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateEventListenerTests.groovy
@@ -4,6 +4,8 @@ import org.hibernate.event.PostDeleteEvent
 import org.hibernate.event.PostDeleteEventListener
 import org.hibernate.event.PostInsertEvent
 import org.hibernate.event.PostInsertEventListener
+import org.hibernate.event.SaveOrUpdateEvent
+import org.hibernate.event.SaveOrUpdateEventListener
 import org.codehaus.groovy.grails.plugins.DefaultGrailsPlugin
 
 /**
@@ -28,6 +30,7 @@ class HibernateEventListenerTests extends AbstractGrailsHibernateTests {
         def eventListeners = appCtx.sessionFactory.eventListeners
         assertTrue eventListeners.postInsertEventListeners.any { it instanceof TestAuditListener }
         assertTrue eventListeners.postDeleteEventListeners.any { it instanceof TestAuditListener }
+        assertTrue eventListeners.saveOrUpdateEventListeners.any { it instanceof TestAuditListener }
         assertFalse eventListeners.postUpdateEventListeners.any { it instanceof TestAuditListener }
     }
 }
@@ -38,12 +41,14 @@ class EventListenerGrailsPlugin {
         testAuditListener(TestAuditListener)
         hibernateEventListeners(HibernateEventListeners) {
             listenerMap = ['post-insert': testAuditListener,
-                           'post-delete': testAuditListener]
+                           'post-delete': testAuditListener,
+                           'save-update': testAuditListener]
         }
     }
 }
 
-class TestAuditListener implements PostInsertEventListener, PostDeleteEventListener {
+class TestAuditListener implements PostInsertEventListener, PostDeleteEventListener, SaveOrUpdateEventListener {
     void onPostInsert(PostInsertEvent event) {}
     void onPostDelete(PostDeleteEvent event) {}
+    void onSaveOrUpdate(SaveOrUpdateEvent event) {}
 }


### PR DESCRIPTION
Sounds unlikely, but just removing the import of org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener will fix this problem.

The import of org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener was making addNewListenerToConfiguration be called with that class, when it should be called with org.hibernate.event.SaveOrUpdateEventListener.

The java.lang.ArrayStoreException was happening because an instance of org.hibernate.event.SaveOrUpdateEventListener was being added to an array of org.codehaus.groovy.grails.orm.hibernate.events.SaveOrUpdateEventListener.
