### PR TITLE
Test case and fix for GRAILS-7872

### DIFF
--- a/grails-hibernate/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
+++ b/grails-hibernate/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
@@ -1117,9 +1117,13 @@ public class HibernateCriteriaBuilder extends GroovyObjectSupport {
                     criteria.setProjection(Projections.rowCount());
                     int totalCount = ((Number)criteria.uniqueResult()).intValue();
 
-                    // Drop the projection, add settings for the pagination parameters,
+                    // Restore the previous projection, add settings for the pagination parameters,
                     // and then execute the query.
-                    criteria.setProjection(null);
+                    if (projectionList != null && projectionList.getLength() > 0) {
+                        criteria.setProjection(projectionList);
+                    } else {
+                        criteria.setProjection(null);
+                    }
                     for (Order orderEntry : orderEntries) {
                         criteria.addOrder(orderEntry);
                     }

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateCriteriaBuilderTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateCriteriaBuilderTests.groovy
@@ -1479,6 +1479,29 @@ class HibernateCriteriaBuilderTests extends AbstractGrailsHibernateTests {
                 "}", "Test1",CriteriaBuilderTestClass.name)
         assertEquals 1 , results.size()
     }
+    
+    void testPaginationParamsWithProjection() {
+        GrailsDomainClass domainClass = grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE,
+            CriteriaBuilderTestClass.name)
+
+        assertNotNull(domainClass)
+
+        GroovyObject obj = domainClass.newInstance()
+        obj.setProperty("firstName", "homer")
+        obj.setProperty("lastName", "simpson")
+        obj.setProperty("age", 45)
+
+        obj.invokeMethod("save", null)
+        
+        List results = parse(".list([:]) { " +
+                    "projections { " +
+                        "property('firstName')" +
+                    "}" +
+                "}", "Test1",CriteriaBuilderTestClass.name)
+        
+        assertEquals 1 , results.size()
+        assertTrue 'Result list should contain Strings', results[0] instanceof String
+    }
 
     private Object parse(String groovy,String testClassName, String criteriaClassName, boolean uniqueResult) {
 


### PR DESCRIPTION
HibernateCriteriaBuilder ignores projections when the list method is called with pagination arguments.

For getting the value of the totalCount field of PagedResultList, the Hibernate criteria's projection is set to Projections.rowCount(), after this, the criteria's projection is dropped with criteria.setProjection(null), causing the user's projection to be ignored.
This fix restores the previous projection, if it exists.
