### PR TITLE
GRAILS-7884 - Remove warn 'org.mortbay.log' from the default log4j config

### DIFF
--- a/grails-resources/src/grails/grails-app/conf/Config.groovy
+++ b/grails-resources/src/grails/grails-app/conf/Config.groovy
@@ -87,6 +87,4 @@ log4j = {
            'org.springframework',
            'org.hibernate',
            'net.sf.ehcache.hibernate'
-
-    warn   'org.mortbay.log'
 }


### PR DESCRIPTION
GRAILS-7884 - Remove warn 'org.mortbay.log' from the default log4j configuration as Grails 1.2+ no longer ships with Jetty as the default container
