### PR TITLE
GRAILS-7986 Fix for windows docs errors

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
@@ -90,7 +90,7 @@ class YamlTocStrategy {
             //    intro/whatsNew/changelog/$basename.gdoc
             //
             for (i in 1..pathElements.size()) {
-                filePath = "${pathElements[-1..-i].join('/')}/${basename}.gdoc"
+                filePath = "${pathElements[-1..-i].join(File.separator)}${File.separator}${basename}.gdoc"
                 if (resourceChecker.exists(filePath)) {
                     return filePath
                 }


### PR DESCRIPTION
Changed TOC generation in docs to use Path.separator instead of '/'
