### PR TITLE
Added suggested Alias for grails.Criteria

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormEnhancer.groovy
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormEnhancer.groovy
@@ -52,6 +52,7 @@ import org.springframework.orm.hibernate3.SessionHolder
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.hibernate.Criteria
+import org.grails.datastore.mapping.query.api.Criteria as GrailsCriteria
 
 /**
  * Extended GORM Enhancer that fills out the remaining GORM for Hibernate methods
@@ -259,7 +260,7 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
     }
 
     @Override
-    org.grails.datastore.mapping.query.api.Criteria createCriteria() {
+    GrailsCriteria createCriteria() {
         def builder = new HibernateCriteriaBuilder(persistentClass, sessionFactory)
         builder.grailsApplication = grailsApplication
         builder


### PR DESCRIPTION
In [this commit](https://github.com/grails/grails-core/commit/de2f6a809d1bcbc20510da8472cf8e75d92e3644), i suggested to @graemerocher to alias one of the Criteria classes instead of using a fully qualified import.
I went ahead and made the change.

Validated via `gradlew test` in grails-hibernate.
