### PR TITLE
Minor Typo 'URl' in a comment that should have been 'URI' for the mapURI(

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
@@ -68,7 +68,7 @@ class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
     }
 
     /**
-     * Maps a URl and returns the appropriate controller instance
+     * Maps a URI and returns the appropriate controller instance
      *
      * @param uri The URI to map
      * @return The controller instance


### PR DESCRIPTION
Minor Typo 'URl' in a comment that should have been 'URI' for the mapURI(String uri) method.  Some fonts don't differentiate capital 'i' and lowercase 'L' very well.
