### PR TITLE
fix Invalid maximum heap size error on Windows

### DIFF
--- a/grails-resources/src/grails/home/bash/startGrails.bat
+++ b/grails-resources/src/grails/home/bash/startGrails.bat
@@ -59,7 +59,7 @@ if "%GRAILS_HOME%" == "" set GRAILS_HOME=%DIRNAME%..
 
 set AGENT_STRING=-javaagent:%GRAILS_HOME:\=/%/lib/com.springsource.springloaded/springloaded-core/jars/springloaded-core-@spring.loaded.version@.jar -noverify -Dspringloaded=profile=grails
 set DISABLE_RELOADING=
-if "%GRAILS_OPTS%" == "" set GRAILS_OPTS=-server "-Xmx768M -Xms768M -XX:PermSize=256m -XX:MaxPermSize=256m -Dfile.encoding=UTF-8
+if "%GRAILS_OPTS%" == "" set GRAILS_OPTS=-server -Xmx768M -Xms768M -XX:PermSize=256m -XX:MaxPermSize=256m -Dfile.encoding=UTF-8
 
 @rem Get command-line arguments, handling Windows variants
 if "%@eval[2+2]" == "4" goto 4NT_args


### PR DESCRIPTION
The quote introduced in commit 0adc2c01 is causing the following when running any `grails` command on Windows.

``` bat
c:\Projects\grails-core>grails -version
Invalid maximum heap size: -Xmx768m -Xms768m -XX:PermSize=256m 
-XX:MaxPermSize=256m -Dfile.encoding=UTF-8   -Dprogram.name="
Could not create the Java virtual machine.
c:\Projects\grails-core>
```
