### PR TITLE
fallback for findDatastore

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
@@ -175,7 +175,12 @@ public class ClosureEventTriggeringInterceptor extends SaveOrUpdateEventListener
                 }
             }
         }
-        return datastores.get(sessionFactory);
+
+        Datastore datastore = datastores.get(sessionFactory);
+        if ((datastore == null) && (datastores.size()==1)) {
+            datastore = datastores.values().iterator().next();
+        }
+        return datastore;
     }
 
 


### PR DESCRIPTION
When using e.g. the grails-hibernate-hijacker plugin, the sessionFactory gets
proxied to get notified when a new hibernate session get created.
Due to some weirdnesses in Hibernate the new session holds a reference to the
unproxied original sessionfactory. This causes findDatastore to return null.
A workaround for cases where only one datasource is available is to return the
one and only datasource.
