### PR TITLE
GRAILS-7772: fix withFormat when Accept header contains non-matching form

### DIFF
--- a/grails-plugin-mimetypes/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/MimeTypesApiSupport.groovy
+++ b/grails-plugin-mimetypes/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/MimeTypesApiSupport.groovy
@@ -59,6 +59,13 @@ class MimeTypesApiSupport {
                             result = getResponseForFormat(formats[mime.extension], mime.extension, formatProvider)
                             break
                         }
+                        else {
+                            if (mime.extension == 'all') {
+                                def firstKey = formats.firstKey()
+                                result = getResponseForFormat(formats[firstKey], firstKey, formatProvider)
+                                break
+                            }
+                        }
                     }
                 }
             }

--- a/grails-plugin-mimetypes/src/test/groovy/org/codehaus/groovy/grails/plugins/web/api/RequestAndResponseMimeTypesApiSpec.groovy
+++ b/grails-plugin-mimetypes/src/test/groovy/org/codehaus/groovy/grails/plugins/web/api/RequestAndResponseMimeTypesApiSpec.groovy
@@ -95,6 +95,29 @@ class RequestAndResponseMimeTypesApiSpec extends Specification{
 
     }
 
+    void "Test withFormat method when Accept header contains the all (*/*) and non-matching formats"() {
+        setup: "The request Acept header is 'application/xml, text/csv, */*' and withFormat is used"
+            final webRequest = GrailsWebUtil.bindMockWebRequest()
+            def request = webRequest.currentRequest
+            def response = webRequest.currentResponse
+            request.addHeader('Accept', acceptHeader)
+            def responseResult = response.withFormat {
+                json { 'got json' }
+                text { 'got text' }
+                html { 'got html' }
+            }
+
+        expect:
+        formatResponse == responseResult
+
+        where:
+        formatResponse  | acceptHeader
+        null            | 'application/xml, text/csv'
+        'got html'      | 'application/xml, text/html, */*'
+        'got json'      | 'application/xml, */*, text/html'
+        'got json'      | 'application/xml, text/csv, */*'
+
+    }
 
     private RequestMimeTypesApi getRequestMimeTypesApi() {
         final application = new DefaultGrailsApplication()


### PR DESCRIPTION
This should fix Accept headers that contain one or more non-matching media type formats and that also has the all format (i.e., Accept: application/xml, _/_).

This is the least invasive change I could come up with.  I've also pushed an alternate change to my GRAILS-7772-ALT branch that refactors the method a bit more.

https://github.com/jwagenleitner/grails-core/commit/68548e63ea97ca3b0704745faafae751d5528f02
