### PR TITLE
Add Doc* events for refdocs

### DIFF
--- a/scripts/_GrailsDocs.groovy
+++ b/scripts/_GrailsDocs.groovy
@@ -199,7 +199,10 @@ target(javadoc:"Produces javadoc documentation") {
 target(refdocs:"Generates Grails style reference documentation") {
     depends(parseArguments, createConfig,loadPlugins, setupDoc)
 
-    if (docsDisabled()) return
+    if (docsDisabled()) {
+        event("DocSkip", ["refdocs"])
+        return
+    }
 
     def srcDocs = new File("${basedir}/src/docs")
 
@@ -239,6 +242,8 @@ ${m.arguments?.collect { '* @'+GrailsNameUtils.getPropertyName(it)+'@\n' }}
     }
 
     if (srcDocs.exists()) {
+        event("DocStart", ["refdocs"])
+        
         File refDocsDir = grailsSettings.docsOutputDir
         def publisher = new DocPublisher(srcDocs, refDocsDir, grailsConsole)
         publisher.ant = ant
@@ -270,7 +275,7 @@ ${m.arguments?.collect { '* @'+GrailsNameUtils.getPropertyName(it)+'@\n' }}
             }
             exit 1
         }
-
+        event("DocEnd", ["refdocs"])
     }
 }
 


### PR DESCRIPTION
We have a need to be able to tie into the guide generation during grails doc, but the events don't exist.  I've added them in here, it's a pretty trivial change.
