### PR TITLE
GrailsInteractiveCompletor - use Resource.getFileName vs. Resource.getFile.getName 

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/GrailsInteractiveCompletor.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/GrailsInteractiveCompletor.groovy
@@ -80,7 +80,7 @@ class GrailsInteractiveCompletor extends SimpleCompletor {
     }
 
     static String[] getScriptNames(scriptResources) {
-        final scriptNames = scriptResources.collect { GrailsNameUtils.getScriptName(it.file.name) }
+        final scriptNames = scriptResources.collect { GrailsNameUtils.getScriptName(it.filename) }
         scriptNames.remove('create-app')
         scriptNames << "open"
         scriptNames as String[]


### PR DESCRIPTION
GrailsInteractiveCompletor - use Resource.getFileName vs. Resource.getFile.getName

Error starting grails cli with binary plugin that has scripts.
