### PR TITLE
GRAILS-8279

### DIFF
--- a/grails-spring/src/main/groovy/org/codehaus/groovy/grails/commons/spring/BeanConfiguration.java
+++ b/grails-spring/src/main/groovy/org/codehaus/groovy/grails/commons/spring/BeanConfiguration.java
@@ -138,4 +138,11 @@ public interface BeanConfiguration {
     void setParent(Object name);
 
     void setBeanDefinition(BeanDefinition definition);
+    
+    /** Add a qualifier to the bean definition. */
+    public void addQualifier(String name);
+
+    /** A qualifier, using a custom annotation, to the bean definition. */
+    public void addQualifier(Class qualifierClass, String name);
+    
 }

--- a/grails-spring/src/main/groovy/org/codehaus/groovy/grails/commons/spring/DefaultBeanConfiguration.java
+++ b/grails-spring/src/main/groovy/org/codehaus/groovy/grails/commons/spring/DefaultBeanConfiguration.java
@@ -25,11 +25,13 @@ import java.util.List;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 import org.springframework.beans.PropertyValue;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConstructorArgumentValues;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.AutowireCandidateQualifier;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.util.Assert;
 
@@ -304,5 +306,13 @@ public class DefaultBeanConfiguration extends GroovyObjectSupport implements Bea
         }
         getBeanDefinition().setParentName(parentName);
         setAbstract(false);
+    }
+    
+    public void addQualifier(String name) { 
+        addQualifier(Qualifier.class, name);
+    }
+
+    public void addQualifier(Class qualifierClass, String name) {
+        getBeanDefinition().addQualifier(new AutowireCandidateQualifier(qualifierClass, name));
     }
 }


### PR DESCRIPTION
GRAILS-8279: Added 'addQualifier' methods to the DefaultBeanConfiguration to make qualifiers a 'first-level citizen' of the Spring DSL

See http://jira.grails.org/browse/GRAILS-8279

(No unit tests included as there do not appear to be any for the BeanConfiguration classes at this time)
