### PR TITLE
GRAILS-7597 fix

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -1889,6 +1889,7 @@ public final class GrailsDomainBinder {
         PropertyConfig propertyConfig = getPropertyConfig(property);
         if (propertyConfig != null && !propertyConfig.getColumns().isEmpty()) {
             bindIndex(columnName, column, propertyConfig.getColumns().get(0), t);
+            bindColumnConfigToColumn(column, propertyConfig.getColumns().get(0));
         }
     }
 

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
@@ -900,6 +900,30 @@ class TestManySide {
         assertSame getTableMapping('bagger', config), c.table
     }
 
+    
+    void testEnumProperty() {
+        DefaultGrailsDomainConfiguration config = getDomainConfig('''
+enum AlertType {
+    INFO, WARN, ERROR
+}
+class Alert {
+    Long id
+    Long version
+    String message
+    AlertType alertType
+    static mapping = {
+        alertType sqlType: 'char', length: 5
+    }
+}''')
+        Table tableMapping = getTableMapping("alert", config)
+        assertNotNull("Cannot find table mapping", tableMapping)
+        Column enumColumn = tableMapping.getColumn(new Column("alert_type"))
+        // we are mainly interested in length, but also check sqlType.
+        assertNotNull(enumColumn)
+        assertEquals(5, enumColumn.length)
+        assertEquals('char', enumColumn.sqlType)
+    }
+
     private org.hibernate.mapping.Collection findCollection(DefaultGrailsDomainConfiguration config, String role) {
         config.collectionMappings.find { it.role == role }
     }


### PR DESCRIPTION
Very simple patch to enable using sqlType mapping for ENUM fields.
There are some side-effects possible (for example, if you override with non-string sqlType: 'integer' it won't work).

Basically, allows overriding ENUM mapping with the following:
```static mapping = {
    enumField sqlType: 'varchar', length: 7
}

```
(It doesn't use property constraints, the only way to adjust column length is via column mapping).
```
