### PR TITLE
Updated jQuery to 1.7.1

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -63,7 +63,7 @@ task pluginsFromSvn {
         hibernate: grailsVersion,
         tomcat: grailsVersion,
         resources: "1.1.1",
-        jquery: "1.7"
+        jquery: "1.7.1"
     ]
     
     dir = file("$buildDir/pluginsFromSvn")

--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -37,7 +37,7 @@ grails.project.dependency.resolution = {
 
     plugins {
         compile ":hibernate:$grailsVersion"
-        compile ":jquery:1.7"
+        compile ":jquery:1.7.1"
         compile ":resources:1.1.1"
 
         build ":tomcat:$grailsVersion"


### PR DESCRIPTION
jQuery 1.7.1 was just released today.  I sent a pull request on gpc/grails-jquery to upgrade to 1.7.1 and once that pull request is committed and a new version of the plugin is released, this pull request can be committed to update Grails to use the new version. Thanks, Bobby
