### PR TITLE
GRAILS-8439 fix default background for IE7 and IE8

### DIFF
--- a/grails-resources/src/war/css/main.css
+++ b/grails-resources/src/war/css/main.css
@@ -11,7 +11,7 @@ html {
 	background-image: -moz-linear-gradient(center top, #aaa, #ddd);
 	background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0, #aaa), color-stop(1, #ddd));
 	background-image: linear-gradient(top, #aaa, #ddd);
-	filter: progid:DXImageTransform.Microsoft.gradient(startColorStr = '#aaa', EndColorStr = '#ddd');
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorStr = '#aaaaaa', EndColorStr = '#dddddd');
 	background-repeat: no-repeat;
 	height: 100%;
 	/* change the box model to exclude the padding from the calculation of 100% height (IE8+) */


### PR DESCRIPTION
By a mistake, the default background of a Grails application is blue in IE. This fix makes the background gray as in all other browsers.
Jira: http://jira.grails.org/browse/GRAILS-8439
