### PR TITLE
Fix for issue GRAILS-8216

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ValidationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ValidationTagLib.groovy
@@ -158,7 +158,7 @@ class ValidationTagLib {
     /**
      * Checks if the request has errors either for a field or global errors.
      *
-     * @attr bean REQUIRED The bean to check for errors
+     * @attr bean The bean to check for errors
      * @attr field The field of the bean or model reference to check
      * @attr model The model reference to check for errors
      */
@@ -223,7 +223,7 @@ class ValidationTagLib {
      *
      * @emptyTag
      *
-     * @attr bean REQUIRED The bean to check for errors
+     * @attr bean The bean to check for errors
      * @attr field The field of the bean or model reference to check
      * @attr model The model reference to check for errors
      */


### PR DESCRIPTION
The bug reporter and I found this issue. It's a distraction in my IDE; Eclipse / STS is giving me validation errors in my GSPs because the Javadoc lists the "bean" attribute as REQUIRED.

This commit removes that requirement for hasErrors() and renderErrors(), both of which do not require the bean attribute to be set, per the "Description" section of the web documentation for both calls. I verified that the underlying implementation supports this.

http://www.grails.org/doc/2.0.0.RC2/ref/Tags/hasErrors.html
http://www.grails.org/doc/2.0.0.RC2/ref/Tags/renderErrors.html

(Note: I had a previous pull request that I've since closed in order to use a more appropriate email address for the commit)
