### PR TITLE
minor: changing prepared (commented) dependency for the mysql-connector ...

### DIFF
--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -33,7 +33,7 @@ grails.project.dependency.resolution = {
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
 
-        // runtime 'mysql:mysql-connector-java:5.1.16'
+        // runtime 'mysql:mysql-connector-java:5.1.18'
     }
 
     plugins {


### PR DESCRIPTION
...to the latest available version

There is a prepared dependency for mysql in BuildConfig.groovy. The version defined there is from april. It could define a newer version.

Cheers,
Kosta
