### PR TITLE
fixed eclipse .classpath for grails-plugin-gsp

### DIFF
--- a/grails-plugin-gsp/build.gradle
+++ b/grails-plugin-gsp/build.gradle
@@ -36,7 +36,7 @@ eclipse {
        file {        
            whenMerged { classpath ->       
                 // remove invalid build/resources/ast entry
-                classpath.entries.removeAll { entry -> entry?.kind == 'lib' && entry?.path?.endsWith('build/resources/ast') }
+                classpath.entries.removeAll { entry -> entry?.kind == 'lib' && entry?.path ==~ ".+/build/\\w+/ast\$" }
            }
        }
     }


### PR DESCRIPTION
grails-plugin-gsp/build/classes/ast should be excluded from the classpath as well
