### PR TITLE
Minor Paginate Tag Improvements

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
@@ -310,6 +310,10 @@ class RenderTagLib implements RequestConstants {
      * @attr params A map containing request parameters
      * @attr prev The text to display for the previous link (defaults to "Previous" as defined by default.paginate.prev property in I18n messages.properties)
      * @attr next The text to display for the next link (defaults to "Next" as defined by default.paginate.next property in I18n messages.properties)
+     * @attr omitPrev Whether to not show the previous link (if set to true, the previous link will not be shown)
+     * @attr omitNext Whether to not show the next link (if set to true, the next link will not be shown)
+     * @attr omitFirst Whether to not show the first link (if set to true, the first link will not be shown)
+     * @attr omitLast Whether to not show the last link (if set to true, the last link will not be shown)
      * @attr max The number of records displayed per page (defaults to 10). Used ONLY if params.max is empty
      * @attr maxsteps The number of steps displayed for pagination (defaults to 10). Used ONLY if params.maxsteps is empty
      * @attr offset Used only if params.offset is empty
@@ -358,8 +362,8 @@ class RenderTagLib implements RequestConstants {
         int firststep = 1
         int laststep = Math.round(Math.ceil(total / max))
 
-        // display previous link when not on firststep
-        if (currentstep > firststep) {
+        // display previous link when not on firststep unless omitPrev is true
+        if (currentstep > firststep && !attrs.omitPrev) {
             linkTagAttrs.class = 'prevLink'
             linkParams.offset = offset - max
             writer << link(linkTagAttrs.clone()) {
@@ -388,10 +392,13 @@ class RenderTagLib implements RequestConstants {
             }
 
             // display firststep link when beginstep is not firststep
-            if (beginstep > firststep) {
+            if (beginstep > firststep && !attrs.omitFirst) {
                 linkParams.offset = 0
-                writer << link(linkTagAttrs.clone()) {firststep.toString()}
-                writer << '<span class="step">..</span>'
+                writer << link(linkTagAttrs.clone()) {firststep.toString()}	
+            }
+            //show a gap if beginstep isn't immediately after firststep, and if were not omitting first or rev 
+            if (beginstep > firststep+1 && (!attrs.omitFirst || !attrs.omitPrev) ) {
+                writer << '<span class="step gap">..</span>'
             }
 
             // display paginate steps
@@ -405,16 +412,19 @@ class RenderTagLib implements RequestConstants {
                 }
             }
 
+            //show a gap if beginstep isn't immediately before firststep, and if were not omitting first or rev 
+            if (endstep+1 < laststep && (!attrs.omitLast || !attrs.omitNext)) {
+                writer << '<span class="step gap">..</span>'
+            }
             // display laststep link when endstep is not laststep
-            if (endstep < laststep) {
-                writer << '<span class="step">..</span>'
+            if (endstep < laststep && !attrs.omitLast) {
                 linkParams.offset = (laststep - 1) * max
                 writer << link(linkTagAttrs.clone()) { laststep.toString() }
             }
         }
 
-        // display next link when not on laststep
-        if (currentstep < laststep) {
+        // display next link when not on laststep unless omitNext is true
+        if (currentstep < laststep && !attrs.omitNext) {
             linkTagAttrs.class = 'nextLink'
             linkParams.offset = offset + max
             writer << link(linkTagAttrs.clone()) {


### PR DESCRIPTION
Allow a user to turn off prev, first, last, and next tags.
Only show ".." if there is a gap between tags
