### PR TITLE
syncing assemble.groovy with BuildConfig.groovy

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -90,7 +90,7 @@ task pluginsFromSvn {
     plugins = [
         hibernate: grailsVersion,
         tomcat: grailsVersion,
-        resources: "1.1.4",
+        resources: "1.1.5",
         webxml: "1.4.1",
         jquery: "1.7.1"
     ]


### PR DESCRIPTION
updated build script to package the same version (1.1.5) of resources plugin that is used in BuildConfig.groovy
