### PR TITLE
Hitting [ENTER] on the CLI with no text entered reruns the last successful script

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
@@ -81,7 +81,7 @@ class InteractiveMode {
     static boolean isActive() {
         getCurrent() != null && getCurrent().interactiveModeActive
     }
-
+    def lastScriptName = null
     void run() {
         current = this
         System.setProperty("grails.disable.exit", "true") // you can't exit completely in interactive mode from a script
@@ -97,6 +97,9 @@ class InteractiveMode {
         addStatus("Enter a script name to run. Use TAB for completion: ")
         while (interactiveModeActive) {
             def scriptName = showPrompt()
+            if(!scriptName.trim() && lastScriptName){
+                scriptName = lastScriptName
+            }
             try {
                 def trimmed = scriptName.trim()
                 if (trimmed) {
@@ -168,6 +171,7 @@ class InteractiveMode {
                             console.stacktrace = commandLine.hasOption(CommandLine.STACKTRACE_ARGUMENT)
                             console.verbose = commandLine.hasOption(CommandLine.VERBOSE_ARGUMENT)
                             scriptRunner.executeScriptWithCaching(commandLine)
+                            lastScriptName = scriptName
                         } catch (ParseException e) {
                             error "Invalid command: ${e.message}"
                         }

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
@@ -97,11 +97,12 @@ class InteractiveMode {
         addStatus("Enter a script name to run. Use TAB for completion: ")
         while (interactiveModeActive) {
             def scriptName = showPrompt()
-            if(!scriptName.trim() && lastScriptName){
-                scriptName = lastScriptName
-            }
             try {
                 def trimmed = scriptName.trim()
+                if(!trimmed && lastScriptName){
+                    trimmed = lastScriptName
+                    scriptName = lastScriptName
+                }
                 if (trimmed) {
                     if(trimmed.startsWith("create-app")) {
                         error "You cannot create an application in interactive mode."
@@ -171,7 +172,7 @@ class InteractiveMode {
                             console.stacktrace = commandLine.hasOption(CommandLine.STACKTRACE_ARGUMENT)
                             console.verbose = commandLine.hasOption(CommandLine.VERBOSE_ARGUMENT)
                             scriptRunner.executeScriptWithCaching(commandLine)
-                            lastScriptName = scriptName
+                            lastScriptName = scriptName.trim()
                         } catch (ParseException e) {
                             error "Invalid command: ${e.message}"
                         }


### PR DESCRIPTION
Hitting [ENTER] on the CLI with no text entered reruns the last successful script

The above is the  previous behaviour on grails 1.3.7.

 It saves keystrokes especially when the last script run is something like: test-app -unit
