### PR TITLE
Additional test for MetaClassCleanupSpec

### DIFF
--- a/grails-plugin-testing/src/test/groovy/grails/test/mixin/MetaClassCleanupSpec.groovy
+++ b/grails-plugin-testing/src/test/groovy/grails/test/mixin/MetaClassCleanupSpec.groovy
@@ -13,9 +13,11 @@ class MetaClassCleanupSpec extends Specification {
     def "Test that meta classes are restored to prior state after test run"() {
         when:"A meta class is modified in the test"
             Author.metaClass.testMe = {-> "test"}
+            Author.metaClass.testToo = {-> "second"}
             def a = new Author()
-        then:"The method is available"
+        then:"The methods are available"
             a.testMe() == "test"
+            a.testToo() == "second"
     }
 
     @AfterClass
@@ -24,6 +26,12 @@ class MetaClassCleanupSpec extends Specification {
 
         try {
             a.testMe()
+            Assert.fail("Should have cleaned up meta class changes")
+        } catch (MissingMethodException) {
+        }
+        
+        try {
+            a.testToo()
             Assert.fail("Should have cleaned up meta class changes")
         } catch (MissingMethodException) {
         }


### PR DESCRIPTION
Originally a blocker for us in the 2.0.0.RC1 release. Just wanted to add
a test so it doesn't regress.
