### PR TITLE
GRAILS-4685 - XML converter should base64 encode byte arrays

### DIFF
--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
@@ -120,6 +120,7 @@ public class ConvertersConfigurationInitializer implements ApplicationContextAwa
         LOG.debug("Initializing default XML Converters Configuration...");
 
         List<ObjectMarshaller<XML>> marshallers = new ArrayList<ObjectMarshaller<XML>>();
+        marshallers.add(new org.codehaus.groovy.grails.web.converters.marshaller.xml.Base64ByteArrayMarshaller());
         marshallers.add(new org.codehaus.groovy.grails.web.converters.marshaller.xml.ArrayMarshaller());
         marshallers.add(new org.codehaus.groovy.grails.web.converters.marshaller.xml.CollectionMarshaller());
         marshallers.add(new org.codehaus.groovy.grails.web.converters.marshaller.xml.MapMarshaller());

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/converters/XMLConverterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/converters/XMLConverterTests.groovy
@@ -24,7 +24,7 @@ class XMLConverterTests extends AbstractGrailsControllerTests {
 
     @Override
     protected Collection<Class> getDomainClasses() {
-        [XmlConverterTestBook, XmlConverterTestPublisher]
+        [XmlConverterTestBook, XmlConverterTestPublisher, XmlConverterTestBookData]
     }
 
     void testXMLConverter() {
@@ -34,6 +34,15 @@ class XMLConverterTests extends AbstractGrailsControllerTests {
         // @todo this test is fragile and depends on runtime environment because
         // of hash key ordering variations
         assertEquals '''<?xml version="1.0" encoding="UTF-8"?><xmlConverterTestBook><author>Stephen King</author><publisher /><title>The Stand</title></xmlConverterTestBook>''', response.contentAsString
+    }
+
+    void testXMLConverterWithByteArray() {
+        def c = new RestController()
+        c.testByteArray()
+
+        assertEquals '''<?xml version="1.0" encoding="UTF-8"?><xmlConverterTestBookData><data encoding="BASE-64">''' +
+                'It was the best of times, it was the worst...'.getBytes('UTF-8').encodeBase64() +
+                '''</data></xmlConverterTestBookData>''', response.contentAsString
     }
 
     void testConvertErrors() {
@@ -107,6 +116,11 @@ class RestController {
         render b as XML
     }
 
+    def testByteArray = {
+        def b = new XmlConverterTestBookData(data: 'It was the best of times, it was the worst...'.getBytes('UTF-8'))
+        render b as XML
+    }
+
     def testProxy = { render params.b as XML }
 
     def testProxyAssociations = { render params.b as XML }
@@ -135,4 +149,9 @@ class XmlConverterTestPublisher {
     Long version
     String name
 }
-
+@grails.persistence.Entity
+class XmlConverterTestBookData {
+    Long id
+    Long version
+    byte[] data
+}


### PR DESCRIPTION
This would be a breaking change, though my guess is the change introduced in 1.1 as noted in the jira issue was not intended.
