### PR TITLE
update datastorVersion to 1.0.0.RELEASE to match change in commit 2ec81cf

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
@@ -180,7 +180,7 @@ public class GrailsCoreDependencies {
                         };
                         registerDependencies(dependencyManager, compileTimeDependenciesMethod, commonsExcludingLoggingAndXmlApis, "commons-logging", "xml-apis", "commons-digester");
 
-                        String datastoreMappingVersion = "1.0.0.BUILD-SNAPSHOT";
+                        String datastoreMappingVersion = "1.0.0.RELEASE";
                         ModuleRevisionId[] compileDependencies = {
                             ModuleRevisionId.newInstance("aopalliance", "aopalliance", "1.0"),
                             ModuleRevisionId.newInstance("com.googlecode.concurrentlinkedhashmap", "concurrentlinkedhashmap-lru", "1.2_jdk5"),


### PR DESCRIPTION
Commit 2ec81cf076018e32dd8750a5c340ae99b52016ca broke the `grails create-app` command when running from master.

```
johnwa@johnwa-P-7811FX:~/projects/grails-issues$ grails create-app myt
| Configuring classpath
:: problems summary ::
:::: WARNINGS
                module not found: org.grails#grails-datastore-gorm;1.0.0.BUILD-SNAPSHOT
        ==== grailsPlugins: tried
          -- artifact org.grails#grails-datastore-gorm;1.0.0.BUILD-SNAPSHOT!grails-datastore-gorm.jar:
```
