### PR TITLE
GRAILS-8608 - provided a transaction manager to the GormEnhancer when mocking a domain class

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/domain/DomainClassUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/domain/DomainClassUnitTestMixin.groovy
@@ -37,6 +37,8 @@ import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.datastore.mapping.core.Session
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.simple.SimpleMapDatastore
+import org.grails.datastore.mapping.transactions.DatastoreTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.validation.Validator
 import org.codehaus.groovy.grails.validation.ConstraintEvalUtils
 import org.codehaus.groovy.grails.validation.ConstrainedProperty
@@ -72,6 +74,7 @@ import org.junit.AfterClass
 class DomainClassUnitTestMixin extends GrailsUnitTestMixin {
 
     static SimpleMapDatastore simpleDatastore
+    static PlatformTransactionManager transactionManager
 
     protected Session currentSession
 
@@ -82,6 +85,7 @@ class DomainClassUnitTestMixin extends GrailsUnitTestMixin {
         }
 
         simpleDatastore = new SimpleMapDatastore(applicationContext)
+        transactionManager = new DatastoreTransactionManager(datastore: simpleDatastore)
         applicationContext.addApplicationListener new DomainEventListener(simpleDatastore)
         applicationContext.addApplicationListener new AutoTimestampEventListener(simpleDatastore)
         ConstrainedProperty.registerNewConstraint("unique", new UniqueConstraintFactory(simpleDatastore))
@@ -144,7 +148,7 @@ class DomainClassUnitTestMixin extends GrailsUnitTestMixin {
         def validator = applicationContext.getBean(validationBeanName, Validator.class)
         simpleDatastore.mappingContext.addEntityValidator(entity, validator)
 
-        def enhancer = new GormEnhancer(simpleDatastore)
+        def enhancer = new GormEnhancer(simpleDatastore, transactionManager)
         if (domainClassToMock.getAnnotation(Enhanced) != null) {
             enhancer.enhance(entity, true)
         }

--- a/grails-test-suite-persistence/src/test/groovy/grails/test/mixin/domain/DomainClassUnitTestMixinTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/grails/test/mixin/domain/DomainClassUnitTestMixinTests.groovy
@@ -20,6 +20,18 @@ class DomainClassUnitTestMixinTests {
         assert publication.ghostWriter == null
         assert writer.is(publication.writer)
     }
+    
+    @Test
+    void testWithTransaction() {
+        mockDomain Writer
+        def bodyInvoked = false
+        
+        Writer.withTransaction {
+            bodyInvoked = true
+        }
+
+        assert bodyInvoked
+    }    
 }
 
 @Entity

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/InheritedUniqueConstraintTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/InheritedUniqueConstraintTests.groovy
@@ -8,7 +8,7 @@ class InheritedUniqueConstraintTests extends AbstractGrailsHibernateTests {
 
     protected void onSetUp() {
         gcl.parseClass '''
-class Parent {
+class InheritedUniqueConstraintTestsParent {
 
     Long id
     Long version
@@ -19,26 +19,26 @@ class Parent {
     }
 }
 
-class Child extends Parent {}
+class InheritedUniqueConstraintTestsChild extends InheritedUniqueConstraintTestsParent {}
 '''
     }
 
     void testInheritedUniqueConstraint() {
-        def Parent = ga.getDomainClass("Parent").clazz
-        def Child = ga.getDomainClass("Child").clazz
+        def InheritedUniqueConstraintTestsParent = ga.getDomainClass("InheritedUniqueConstraintTestsParent").clazz
+        def InheritedUniqueConstraintTestsChild = ga.getDomainClass("InheritedUniqueConstraintTestsChild").clazz
 
-        def child1 = Child.newInstance(username:'mos')
+        def child1 = InheritedUniqueConstraintTestsChild.newInstance(username:'mos')
         assertNotNull "should have saved unqiue child",child1.save(flush:true)
 
-        def child2 = Child.newInstance(username:'mos')
+        def child2 = InheritedUniqueConstraintTestsChild.newInstance(username:'mos')
         assertNull "should not have saved non-unqiue child",child2.save(flush:true)
 
         //// now with parent
 
-        def parent1 = Parent.newInstance(username:'graeme')
+        def parent1 = InheritedUniqueConstraintTestsParent.newInstance(username:'graeme')
         assertNotNull "should have saved unqiue parent",parent1.save(flush:true)
 
-        def child = Child.newInstance(username:'graeme')
+        def child = InheritedUniqueConstraintTestsChild.newInstance(username:'graeme')
         assertNull "should not have saved non-unqiue child",child.save(flush:true)
     }
 }


### PR DESCRIPTION
I also fixed a failing test, InheritedUniqueConstraintTests.testInheritedUniqueConstraint by prefixing the class names, to prevent conflicts. The test worked when only running the test, but failed when running the complete test suite.
