### PR TITLE
GRAILS-8658 Add ability to override css for project documentation pdf.

### DIFF
--- a/grails-docs/src/main/template/css/custom-pdf.css
+++ b/grails-docs/src/main/template/css/custom-pdf.css
@@ -1,0 +1,3 @@
+/*
+   Dummy stylesheet allowing for some customisation of pdf output without having to copy and modify the other stylesheets.
+*/

--- a/grails-docs/src/main/template/css/pdf.css
+++ b/grails-docs/src/main/template/css/pdf.css
@@ -1,3 +1,5 @@
+@import "custom-pdf.css";
+
 /* page layout and page numbering */
 @page {
    size: a4;


### PR DESCRIPTION
With this change, users can create a file custom-pdf.css to override css for pdf output, in the same way they already could override css for html output with custom.css.
To enable this, user need to add a property to Config.groovy to specify where these css files are located:
grails.doc.css = "somefolder" as File

Using the same approach as custom.css (@import from main.css) for consistency. Would be better though to modify the HTML templates to include both stylesheets rather than using @import. Main reason for this is that custom.css and custom-pdf.css should be loaded last, to let users custom css win without having to use !import.
With current solution users need to add custom css like this to override already existing rules:

.body {
    font-size: 20pt!important;
}

instead of

.body {
    font-size: 20pt;
}
