### PR TITLE
GRAILS-8677 Text over icon for buttons of type <input> in IE6 and IE7

### DIFF
--- a/grails-resources/src/war/css/main.css
+++ b/grails-resources/src/war/css/main.css
@@ -567,6 +567,11 @@ th:hover, tr:hover {
 	text-indent: 25px;
 }
 
+.ie6 .buttons input.delete, .ie6 .buttons input.edit, .ie6 .buttons input.save,
+.ie7 .buttons input.delete, .ie7 .buttons input.edit, .ie7 .buttons input.save {
+	padding-left: 36px;
+}
+
 .buttons .delete {
 	background-image: url(../images/skin/database_delete.png);
 }


### PR DESCRIPTION
Fix by adding a padding for IE6 and IE7.
A different solution would be to add text-transform: capitalize; (http://stackoverflow.com/questions/2888298/text-indent-is-not-working-in-ie7)
That solution would of course have the side effect that the text would be capitalized. Default button texts are already capitalize by default, but some users might want lowercase buttons, so adding a padding is probably a better solution.
