### PR TITLE
LayoutWriterStack utility class for creating layout tags + tests

### DIFF
--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/LayoutWriterStackTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/LayoutWriterStackTests.groovy
@@ -1,0 +1,67 @@
+package org.codehaus.groovy.grails.web.taglib
+
+import grails.artefact.Artefact
+import grails.test.mixin.TestFor
+import org.junit.Test
+
+@TestFor(TwoColumnTagLib)
+class LayoutWriterStackTests {
+    def template = """
+    <g:twoColumn>
+        <g:left>leftContent</g:left>
+        <g:right>rightContent</g:right>
+        bodyContent
+    </g:twoColumn>"""
+
+    @Test void testLayoutTag() {
+        String result = applyTemplate(template)
+        assertEqualsIgnoreWhiteSpace("""
+        <div class='twoColumn'>
+            left: <div class='left'>leftContent</div>,
+            right: <div class='right'>rightContent</div>,
+            body: bodyContent
+        </div>""",
+                result)
+    }
+
+    @Test void testNestedLayoutTags() {
+        def nested = template.replaceAll("leftContent", template)
+        String result = applyTemplate(nested)
+
+        assertEqualsIgnoreWhiteSpace("""
+        <div class='twoColumn'>
+            left: <div class='left'>
+                <div class='twoColumn'>
+                    left: <div class='left'>leftContent</div>,
+                    right: <div class='right'>rightContent</div>,
+                    body: bodyContent
+                </div>
+            </div>,
+            right: <div class='right'>rightContent</div>,
+            body: bodyContent</div>""",
+                result)
+    }
+
+    void assertEqualsIgnoreWhiteSpace(String s1, String s2) {
+        assert s1.replaceAll(/\s/, '') == s2.replaceAll(/\s/, '')
+    }
+}
+
+
+@Artefact("TagLib")
+class TwoColumnTagLib {
+
+    Closure twoColumn = {attrs, body ->
+        def parts = LayoutWriterStack.writeParts(body)
+        out << "<div class='twoColumn'>left: " << parts.left << ", right: " << parts.right << ", body: " << parts.body << "</div>"
+    }
+    Closure left = {attrs, body ->
+        def w = LayoutWriterStack.currentWriter('left')
+        w << "<div class='left'>" << body() << "</div>"
+    }
+
+    Closure right = {attrs, body ->
+        def w = LayoutWriterStack.currentWriter('right')
+        w << "<div class='right'>" << body() << "</div>"
+    }
+}

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/taglib/LayoutWriterStack.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/taglib/LayoutWriterStack.java
@@ -1,0 +1,103 @@
+package org.codehaus.groovy.grails.web.taglib;
+
+import groovy.lang.Closure;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * Class that can be used by "layout" tags, i.e. tags that use the different parts in their body to assemble a bigger part.
+ * Example a threeColumn tag that expects a left, center and right part in its body and places them in a table:
+ * <pre>
+ *  {@code
+ *  <g.threeColumn>
+ *      <g.left>left contents</g.left>
+ *      <g.center>middle contents</g.center>
+ *      <g.right>right contents</g.right>
+ *  </g.threeColumn>
+ *  }
+ *  </pre>
+ *
+ *  @author Ivo Houbrechts
+ */
+public class LayoutWriterStack {
+    private static final String ATTRIBUTE_NAME_WRITER_STACK = "be.ixor.grails.gsptaglib.WRITER_STACK";
+    private Stack<Map<String, Object>> stack = new Stack<Map<String, Object>>();
+
+    /**
+     * Returns a {@link Writer} where a layout part can write its contents to.
+     * This method should only be called by tags that are part of a surrounding layout tag.
+     * Example:
+     * <pre>
+     *  {@code
+     *  def left = &#123; attrs, body ->
+     *      LayoutWriterStack.currentWriter('left') << "<div class='left'>" << body() <<"</div>"
+     *  &#125;
+     *  }
+     *  </pre>
+     *
+     * @param name Name of the layout part
+     * @return writer
+     */
+    public static Writer currentWriter(String name) {
+        Map<String, Object> writers = currentStack().stack.peek();
+        if (writers != null) {
+            Writer result = (Writer) writers.get(name);
+            if (result == null) {
+                result = new StringWriter();
+                writers.put(name, result);
+            }
+            return result;
+        }
+        return null;
+    }
+
+    /**
+     * Executes the body closure of a tag and returns a Map with namned results that hold the content of the parts within the body.
+     * This method should only be called by tags that are part of a surrounding layout tag.
+     * Example:
+     * <pre>
+     *  {@code
+     *  def parts = LayoutWriterStack.writeParts(body)
+     *  out << "left part:" << parts.left << "; right part:" << parts.right << ";remainder of body:" << parts.body
+     *  }
+     *  </pre>
+     *
+     * @param body the body closure of the calling "layout" tag
+     * @return a Map that contains the results of all the parts in the body and the body itself
+     */
+    public static Map<String, Object> writeParts(Closure body) {
+        LayoutWriterStack stack = LayoutWriterStack.currentStack();
+        stack.push();
+        Map<String, Object> result = new HashMap<String, Object>();
+        result.put("body", body.call());
+        result.putAll(stack.pop());
+        return result;
+    }
+
+    private static LayoutWriterStack currentStack() {
+        RequestAttributes attributes = RequestContextHolder.currentRequestAttributes();
+        if (attributes != null) {
+            LayoutWriterStack stack = (LayoutWriterStack) attributes.getAttribute(ATTRIBUTE_NAME_WRITER_STACK, RequestAttributes.SCOPE_REQUEST);
+            if (stack == null) {
+                stack = new LayoutWriterStack();
+                attributes.setAttribute(ATTRIBUTE_NAME_WRITER_STACK, stack, RequestAttributes.SCOPE_REQUEST);
+            }
+            return stack;
+        }
+        return null;
+    }
+
+    private void push() {
+        stack.push(new HashMap<String, Object>());
+    }
+
+    private Map<String, Object> pop() {
+        return stack.pop();
+    }
+}


### PR DESCRIPTION
This makes it possible to define layout tags with 'sub' tags :
<g:box>
    <g:header><h1>The header</h1>/g:header
    <g:left>complex content.../g:left
    <g:right>other content.../g:right
/g:box

see http://grails.org/plugin/gsp-taglib
