### PR TITLE
Fix regression (GRAILS-8773) with GrailsMock when parameters are classes that implement metaClass.getProperty()

### DIFF
--- a/grails-test/src/main/groovy/grails/test/GrailsMock.groovy
+++ b/grails-test/src/main/groovy/grails/test/GrailsMock.groovy
@@ -102,7 +102,12 @@ class GrailsMock {
                 def paramTypes = []
                 args.each {
                     if (it != null) {
-                        paramTypes << it.class
+                        if( it.class instanceof Class ) {
+                            paramTypes << it.class
+                        }
+                        else {
+                            paramTypes << it.getClass()
+                        }
                     }
                     else {
                         paramTypes << null


### PR DESCRIPTION
Fix regression ([GRAILS-8773](http://jira.grails.org/browse/GRAILS-8773)) with GrailsMock when parameters are classes that implement metaClass.getProperty()
