### PR TITLE
GRAILS-8444, GRAILS-8486

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -823,11 +823,19 @@ public final class GrailsDomainBinder {
 
     private static void bindColumnConfigToColumn(Column column, ColumnConfig columnConfig) {
         if (columnConfig != null) {
-            column.setLength(columnConfig.getLength());
-            column.setPrecision(columnConfig.getPrecision());
-            column.setSqlType(columnConfig.getSqlType());
+            if(columnConfig.getLength() != -1) {
+                column.setLength(columnConfig.getLength());
+            }
+            if(columnConfig.getPrecision() != -1) {
+                column.setPrecision(columnConfig.getPrecision());
+            }
+            if(columnConfig.getScale() != -1) {
+                column.setScale(columnConfig.getScale());
+            }
+            if(columnConfig.getSqlType() != null && !columnConfig.getSqlType().isEmpty()) {
+                column.setSqlType(columnConfig.getSqlType());
+            }
             column.setUnique(columnConfig.getUnique());
-            column.setScale(columnConfig.getScale());
         }
     }
 

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
@@ -947,6 +947,8 @@ class Alert {
         assertNotNull(enumColumn)
         assertEquals(5, enumColumn.length)
         assertEquals('char', enumColumn.sqlType)
+        assertEquals(Column.DEFAULT_PRECISION, enumColumn.precision)
+        assertEquals(Column.DEFAULT_SCALE, enumColumn.scale)
     }
 
     private org.hibernate.mapping.Collection findCollection(DefaultGrailsDomainConfiguration config, String role) {


### PR DESCRIPTION
A previous fix is applying a ColumnConfig to the hibernate Column in GrailsDomainBinder. The ColumnConfig is created for a domain property if it is specified in the mapping block of the Domain Class. If not all the values are specified (i.e. scale, length, precision), then the default values (which are invalid) are being applied to the column. This includes -1 for length, precision, and scale. 

Instead the bindColumnConfigToColumn(Column, ColumnConfig) method should only apply those values from the ColumnConfig that are specified and valid to the Column.
