### PR TITLE
Updated Log Messages for GSP Attribute Parsing Errors

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
@@ -313,14 +313,14 @@ public class GrailsCoreDependencies {
                         ModuleRevisionId[] ehcacheDependencies = {
                             ModuleRevisionId.newInstance("net.sf.ehcache", "ehcache-core", "2.4.6")
                         };
-                        registerDependencies(dependencyManager, runtimeDependenciesMethod, ehcacheDependencies, "jms", "commons-logging", "servlet-api");
+                        registerDependencies(dependencyManager, runtimeDependenciesMethod, ehcacheDependencies, "javax.jms:jms", "commons-logging", "javax.servlet:servlet-api", "org.slf4j:slf4j-api");
 
                         ModuleRevisionId[] loggingDependencies = {
                             ModuleRevisionId.newInstance("log4j", "log4j", "1.2.16"),
                             ModuleRevisionId.newInstance("org.slf4j", "jcl-over-slf4j", slf4jVersion),
                             ModuleRevisionId.newInstance("org.slf4j", "jul-to-slf4j", slf4jVersion)
                         };
-                        registerDependencies(dependencyManager, runtimeDependenciesMethod, loggingDependencies, "mail", "jms", "jmxtools", "jmxri");
+                        registerDependencies(dependencyManager, runtimeDependenciesMethod, loggingDependencies, "javax.mail:mail", "javax.jms:jms", "com.sun.jdmk:jmxtools", "com.sun.jmx:jmxri");
 
                         return null;
                     }

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPageParser.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPageParser.java
@@ -1136,7 +1136,7 @@ public class GroovyPageParser implements Tokens {
             // parse name (before '=' character)
             int equalsignPos = attrTokens.indexOf('=', startPos);
             if (equalsignPos == -1) {
-                throw new GrailsTagException("Expecting '=' after attribute name", pageName, getCurrentOutputLineNumber());
+                throw new GrailsTagException("Expecting '=' after attribute name (" + attrTokens + ").", pageName, getCurrentOutputLineNumber());
             }
             String name = attrTokens.substring(startPos, equalsignPos).trim();
 
@@ -1147,14 +1147,14 @@ public class GroovyPageParser implements Tokens {
                 ch = attrTokens.charAt(startPos++);
             }
             if (!(ch=='\'' || ch=='"')) {
-                throw new GrailsTagException("Attribute value must be quoted.", pageName, getCurrentOutputLineNumber());
+                throw new GrailsTagException("Attribute value must be quoted (" + attrTokens + ").", pageName, getCurrentOutputLineNumber());
             }
             char quoteChar = ch;
 
             GroovyPageExpressionParser expressionParser = new GroovyPageExpressionParser(attrTokens, startPos, quoteChar, (char)0, false);
             int endQuotepos = expressionParser.parse();
             if (endQuotepos==-1) {
-                throw new GrailsTagException("Attribute value quote wasn't closed.", pageName, getCurrentOutputLineNumber());
+                throw new GrailsTagException("Attribute value quote wasn't closed (" + attrTokens + ").", pageName, getCurrentOutputLineNumber());
             }
 
             String val=attrTokens.substring(startPos, endQuotepos);


### PR DESCRIPTION
- Updated the error messages when failing to parse a GSP attribute to include the attribute itself to aid with debugging.
- Cleaned up dependency exclusions to be Maven-friendly (i.e. include the groupId values where different from the artifactId).  This is important if we wish to use my Grails dependency POM generator project to aid in the creation of the grails-dependency POM file for the Maven archetype.

Note that this pull request replaces my previous one, which was on the incorrect branch (2.0.x instead of master).
