### PR TITLE
added inject tag to ApplictionTagLib

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -121,6 +121,38 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
     }
 
     /**
+     * Injects a dependency into a variable in the pageContext or the specified scope.
+     *
+     * @attr beanName the bean name; either beanName or beanType must be specified
+     * @attr beanType type the bean must match; can be an interface or superclass; either beanName or beanType must be specified
+     * @attr var the variable name; mandatory if beanType is specified, otherwise defaults to beanName
+     * @attr scope the scope name; defaults to pageScope
+     */
+    Closure inject = { attrs, body ->
+        def bean
+        def var = attrs.var
+        if (attrs.beanName) {
+            bean = applicationContext.getBean(attrs.beanName)
+            if (!var) {
+                var = attrs.beanName
+            }
+        } else if (attrs.beanType) {
+            bean = applicationContext.getBean(attrs.beanType)
+            if (!var) {
+                throw new IllegalArgumentException("[var] attribute must be specified to for <g:inject> when the [beanType] attribute is also specified!")
+            }
+        } else {
+            throw new IllegalArgumentException("either the [beanName] or [beanType] attribute must be specified to for <g:inject>!")
+        }
+
+        def scope = attrs.scope ? ApplicationTagLib.SCOPES[attrs.scope] : 'pageScope'
+        if (!scope) throw new IllegalArgumentException("Invalid [scope] attribute for tag <g:inject>!")
+
+        this."$scope"."$var" = bean
+        null
+    }
+
+    /**
      * Creates a link to a resource, generally used as a method rather than a tag.<br/>
      *
      * eg. &lt;link type="text/css" href="${createLinkTo(dir:'css',file:'main.css')}" /&gt;

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -184,6 +184,25 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals('foo', template, [c:[a:[b:'foo']]])
     }
 
+    void testInjectTagByName() {
+        def template = '<g:inject beanName="grailsApplication"/>${grailsApplication.initialised}'
+        assertOutputEquals('true', template)
+
+        template = '<g:inject beanName="grailsApplication" var="myVar"/>${myVar.initialised}'
+        assertOutputEquals('true', template)
+
+        template = '<g:inject beanName="grailsApplication" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
+        assertOutputEquals('true', template)
+    }
+
+    void testInjectTagByType() {
+        def template = '<%@ page import="org.codehaus.groovy.grails.commons.*" %><g:inject beanType="${GrailsApplication}" var="myVar"/>${myVar.initialised}'
+        assertOutputEquals('true', template)
+
+        template = '<%@ page import="org.codehaus.groovy.grails.commons.*" %><g:inject beanType="${GrailsApplication}" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
+        assertOutputEquals('true', template)
+    }
+
     void testIteration() {
         def template = '''<g:set var="counter" value="${1}" />
 <g:each in="${[10,11,12]}" var="myVal"><g:set var="counter" value="${myVal+counter}" />${counter}</g:each>'''


### PR DESCRIPTION
The inject tag injects a spring bean into the page context similar to the g:set tag
The tag was created for the gsp taglib plugin, but it is generally useable in gsp's
