### PR TITLE
Fix for GRAILS-9042

### DIFF
--- a/scripts/_GrailsTest.groovy
+++ b/scripts/_GrailsTest.groovy
@@ -290,6 +290,7 @@ runTests = { GrailsTestType type, File compiledClassesDir ->
             def result = type.run(testEventPublisher)
             def end = new Date()
 
+            testCount = result.passCount + result.failCount
             grailsConsole.addStatus "Completed $testCount $type.name test${testCount > 1 ? 's' : ''}, ${result.failCount} failed in ${end.time - start.time}ms"
             grailsConsole.lastMessage = ""
 


### PR DESCRIPTION
I've created a plugin for Fitnesse, and Fitnesse can only give the number of executed tests after the tests have been run. In order to work around this, I supply 1 test to run in the doPrepare() method, to trigger the test run. However, this number is also used in the reporting, which is, in my case, incorrect.
