### PR TITLE
GRAILS-9051: Log4jConfig#propertyMissing now throws an exception instead...

### DIFF
--- a/grails-plugin-log4j/src/main/groovy/org/codehaus/groovy/grails/plugins/log4j/Log4jConfig.groovy
+++ b/grails-plugin-log4j/src/main/groovy/org/codehaus/groovy/grails/plugins/log4j/Log4jConfig.groovy
@@ -87,6 +87,8 @@ class Log4jConfig {
         }
 
         LogLog.error "Property missing when configuring log4j: $name"
+        
+        throw new MissingPropertyException("Property missing when configuring log4j: $name")
     }
 
     def methodMissing(String name, args) {

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/logging/Log4jDslTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/logging/Log4jDslTests.groovy
@@ -331,6 +331,40 @@ class Log4jDslTests extends GroovyTestCase {
         assert fa.layout instanceof SimpleLayout
         assert fa.name == 'fileSimple'
     }
+    
+    void testPropertyMissing() {
+        shouldFail(MissingPropertyException) {
+            log4jConfig.nonExistentProp    
+        }
+    }
+
+    void testPropertyMissingResortsToOwner() {
+		
+		ConfigObject config = new ConfigSlurper().parse("""
+		
+		    configured.loggingRoot = 'configured/and/fake'
+		    
+		    log4j = {
+        		def loggingRoot = configured.loggingRoot
+                appenders {            
+                    rollingFile name: 'quartz', file: "\${loggingRoot}/quartz.log"
+                }
+                
+                debug quartz: 'org.quartz', additivity: false
+            }
+		""")
+		
+		Log4jConfig myLog4jConfig = new Log4jConfig(config)
+
+		myLog4jConfig.configure(config.log4j) 
+        
+        Logger logger = Logger.getLogger('org.quartz')
+
+        Appender appender = logger.getAppender('quartz')
+        assert appender
+        assert "quartz" == appender.name
+        assert "configured/and/fake/quartz.log" == appender.file
+    }   
 
     private void setEnv(String name) {
         System.setProperty Environment.KEY, name


### PR DESCRIPTION
Since this commit:
https://github.com/grails/grails-core/commit/1a9487186f52994aba723ebffcdcd0cd7ff65221

We've seen errors with our log4j Configuration.

Also submitted a JIRA
http://jira.grails.org/browse/GRAILS-9051
