### PR TITLE
Fix for GRAILS-9035. 'grails -help' and 'grails -help foo' now shows a d...

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
@@ -184,7 +184,11 @@ public class GrailsScriptRunner {
         }
 
         if (commandLine.hasOption(CommandLine.HELP_ARGUMENT)) {
-            console.log(parser.getHelpMessage());
+            if (commandLine.getCommandName() != null) {
+                console.log("The '-help' option is deprecated; use 'grails help [target]'");
+            } else {
+                console.log("The '-help' option is deprecated; use 'grails help'");
+            }
             System.exit(0);
         }
 
@@ -247,7 +251,6 @@ public class GrailsScriptRunner {
         parser.addOption(CommandLine.STACKTRACE_ARGUMENT, "Enable stack traces in output");
         parser.addOption(CommandLine.AGENT_ARGUMENT, "Enable the reloading agent");
         parser.addOption(CommandLine.NON_INTERACTIVE_ARGUMENT, "Whether to allow the command line to request input");
-        parser.addOption(CommandLine.HELP_ARGUMENT, "Command line help");
         parser.addOption(CommandLine.VERSION_ARGUMENT, "Current Grails version");
         parser.addOption(CommandLine.NOANSI_ARGUMENT, "Disables ANSI output");
         return parser;

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParser.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParser.java
@@ -142,9 +142,9 @@ public class CommandLineParser {
         }
     }
 
-    public String getHelpMessage() {
+    public String getOptionsHelpMessage() {
         String ls = System.getProperty("line.separator");
-        usageMessage = "usage: grails [options] [command]";
+        usageMessage = "Available options:";
         StringBuilder sb = new StringBuilder(usageMessage);
         sb.append(ls);
         for (Option option : declaredOptions.values()) {

--- a/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParserSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParserSpec.groovy
@@ -151,7 +151,7 @@ class CommandLineParserSpec extends Specification {
 
         then:
             String ls = System.getProperty("line.separator");
-            parser.helpMessage == "usage: grails [options] [command]${ls} -interactive-mode        Enabled interactive mode${ls} -version                 Shows the vesrion${ls}"
+            parser.optionsHelpMessage == "Available options:${ls} -interactive-mode        Enabled interactive mode${ls} -version                 Shows the vesrion${ls}"
     }
 
     // STRING tests

--- a/scripts/Help_.groovy
+++ b/scripts/Help_.groovy
@@ -24,6 +24,7 @@
 
 import grails.util.GrailsNameUtils
 import grails.util.Environment
+import org.codehaus.groovy.grails.cli.GrailsScriptRunner
 
 includeTargets << grailsScript("_GrailsInit")
 
@@ -76,12 +77,15 @@ target ('default' : "Prints out the help for each script") {
     else {
         println """
 Usage (optionals marked with *):
-grails [environment]* [target] [arguments]*
+grails [environment]* [options]* [target] [arguments]*
 
 Examples:
 grails dev run-app
 grails create-app books
 
+"""
+        println GrailsScriptRunner.commandLineParser.optionsHelpMessage
+        println """
 Available Targets (type grails help 'target-name' for more info):"""
 
         scripts.unique { it.name }. sort{ it.name }.each { file ->


### PR DESCRIPTION
...eprecation message with instructions to use 'grails help' or 'grails help foo'.

'grails help' now shows the list of options as 'grails -help' previously did, in addition to the list of targets.

Ref: http://grails.1312388.n4.nabble.com/Fix-for-GRAILS-9035-tt4578388.html
