### PR TITLE
removed anonymous ThreadLocal subclasses (part of GRAILS-5823)

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractSavePersistentMethod.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractSavePersistentMethod.java
@@ -69,14 +69,11 @@ public abstract class AbstractSavePersistentMethod extends AbstractDynamicPersis
      * the value. Note that this only works because the session is
      * flushed when a domain instance is saved without validation.
      */
-    private static ThreadLocal<Set<Integer>> disableAutoValidationFor = new ThreadLocal<Set<Integer>>() {
-        @Override
-        protected Set<Integer> initialValue() {
-            return new HashSet<Integer>();
-        }
-    };
+    private static ThreadLocal<Set<Integer>> disableAutoValidationFor = new ThreadLocal<Set<Integer>>();
 
     static {
+        disableAutoValidationFor.set(new HashSet<Integer>());
+
         ShutdownOperations.addOperation(new Runnable() {
             public void run() {
                 disableAutoValidationFor.remove();

--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/support/HibernatePersistenceContextInterceptor.java
@@ -36,9 +36,15 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class HibernatePersistenceContextInterceptor implements PersistenceContextInterceptor {
 
     private static final Log LOG = LogFactory.getLog(HibernatePersistenceContextInterceptor.class);
+    private static ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>();
+    private static ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>();
+
     private SessionFactory sessionFactory;
 
     static {
+        participate.set(Boolean.FALSE);
+        nestingCount.set(Integer.valueOf(0));
+
         ShutdownOperations.addOperation(new Runnable() {
             public void run() {
                 participate.remove();
@@ -46,20 +52,6 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
             }
         });
     }
-
-    private static ThreadLocal<Boolean> participate = new ThreadLocal<Boolean>() {
-        @Override
-        protected Boolean initialValue() {
-            return Boolean.FALSE;
-        }
-    };
-
-    private static ThreadLocal<Integer> nestingCount = new ThreadLocal<Integer>() {
-        @Override
-        protected Integer initialValue() {
-            return Integer.valueOf(0);
-        }
-    };
 
     /* (non-Javadoc)
      * @see org.codehaus.groovy.grails.support.PersistenceContextInterceptor#destroy()


### PR DESCRIPTION
this patch removes the anonymous ThreadLocal subclass declarations in AbstractSavePersistentMethod and HibernatePersistenceContextInterceptor as discussed in http://jira.grails.org/browse/GRAILS-5823

Eclipse MAT shows that these anonymous ThreadLocal subclasses reference the WebappClassLoader class loader instance and keep hanging on application redeployment. As far as I understood the tomcat doc, the private static variables should be nullified in >= 7.0.6, but as far as our setup is concerned, this was not the case with our Grails 2.0.1 app running on 7.0.26.
