### PR TITLE
GRAILS-7196: Paginate TabLib change for restful urls

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
@@ -347,7 +347,7 @@ class RenderTagLib implements RequestConstants {
         def locale = RCU.getLocale(request)
 
         def total = attrs.int('total') ?: 0
-        def action = (attrs.action ? attrs.action : (params.action ? params.action : "list"))
+        def action = (attrs.action ?: (params.action ?: ""))
         def offset = params.int('offset') ?: 0
         def max = params.int('max')
         def maxsteps = (attrs.int('maxsteps') ?: 10)


### PR DESCRIPTION
Fix needed to make restful URLs work with paginate tag (http://jira.grails.org/browse/GRAILS-7196).  Also switched to the elvis-operator.
