### PR TITLE
Integrate with Sublime Text 2

### DIFF
--- a/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
+++ b/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
@@ -13,3 +13,4 @@ stacktrace.log
 /out/
 /web-app/plugins
 /web-app/WEB-INF/classes
+*.sublime-workspace

--- a/grails-resources/src/grails/templates/ide-support/sublime-text-2/project.sublime-project.txt
+++ b/grails-resources/src/grails/templates/ide-support/sublime-text-2/project.sublime-project.txt
@@ -1,0 +1,21 @@
+{
+    "folders":
+    [
+        { "path":"grails-app/conf",             "name":"Configuration"        },
+        { "path":"grails-app/controllers",      "name":"Controllers"          },
+        { "path":"grails-app/domain",           "name":"Domain Objects"       },
+        { "path":"grails-app/i18n",             "name":"Internationalization" },
+        { "path":"grails-app/services",         "name":"Services"             },
+        { "path":"grails-app/taglib",           "name":"Tag Libraries"        },
+        { "path":"grails-app/utils",            "name":"Utils"                },
+        { "path":"grails-app/views",            "name":"Views"                },
+        { "path":"scripts",                     "name":"Scripts"              },
+        { "path":"src/groovy",                  "name":"Groovy Source"        },
+        { "path":"src/java",                    "name":"Java Source"          },
+        { "path":"test/integration",            "name":"Integeration Tests"   },
+        { "path":"test/unit",                   "name":"Unit Tests"           },
+        { "path":"web-app",                     "name":"Web App"              }
+    ],
+    "settings": { },
+    "build_systems": [ ]
+}

--- a/scripts/IntegrateWith.groovy
+++ b/scripts/IntegrateWith.groovy
@@ -27,7 +27,7 @@ import grails.util.GrailsNameUtils
 includeTargets << grailsScript("_GrailsInit")
 
 USAGE = """
-    integrate-with [--ant] [--eclipse] [--intellij] [--git] [--textmate] [--hg]
+    integrate-with [--ant] [--eclipse] [--intellij] [--git] [--textmate] [--hg] [--sublimetext2]
 
 where
     --ant = Generates an Ant build.xml with accompanying Ivy files.
@@ -36,6 +36,7 @@ where
     --git = Generates a '.gitignore' file.
     --textmate = Generates a TextMate project file.
     --hg = Generates a Mercurial '.hgignore' file.
+    --sublimetext2 = Generates a Sublime Text 2 project file.
 """
 
 integrationFiles = new File("${projectWorkDir}/integration-files")
@@ -128,6 +129,18 @@ target(integrateHg:"Integrates Mercurial with Grails") {
 
     replaceTokens([".hgignore"])
     grailsConsole.updateStatus "Created Mercurial '.hgignore' file."
+}
+
+target(integrateSublimetext2:"Integrates Sublime Text 2 with Grails") {
+    depends unpackSupportFiles
+    ant.copy(todir:basedir) {
+        fileset(dir:"${integrationFiles}/sublime-text-2")
+    }
+
+    ant.move(file: "${basedir}/project.sublime-project.txt", tofile: "${basedir}/${grailsAppName}.sublime-project", overwrite: true)
+
+    replaceTokens(["*.sublime-project"])
+    grailsConsole.updateStatus "Created Sublime Text 2 project file."
 }
 
 target(unpackSupportFiles:"Unpacks the support files") {


### PR DESCRIPTION
Add support for

```
grails integrate-with --sublimetext2
```

This creates a barebones [Sublime Text 2](http://www.sublimetext.com/2) project file named `${basedir}/${grailsAppName}.sublime-project`

Also, I added `*.sublime-workspace` to the bottom of the default .gitignore file (as it is recommended [in the instructions](http://www.sublimetext.com/docs/2/projects.html) for ST2)
