### PR TITLE
GRAILS-9110 TestFor(UrlMappings) matches closure parameters using toString

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
@@ -234,7 +234,7 @@ class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
                 paramAssertions.resolveStrategy = Closure.DELEGATE_ONLY
                 paramAssertions.call()
                 params.each {name, value ->
-                    assertEquals("Url mapping '$name' parameter assertion for '$url' failed", value.toString(), mapping.params[name])
+                    assertEquals("Url mapping '$name' parameter assertion for '$url' failed", value, mapping.params[name])
                 }
             }
             return true

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
@@ -137,6 +137,24 @@ class UrlMappingsTestMixinTests {
             }
         }
     }
+	
+	@Test
+	voide testGrails9110() {
+		mockController(UserController)
+		mockUrlMappings(GRAILS9110UrlMappings)
+		shouldfail(ComparisonFailure) {
+			assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
+				param1 = "true"
+			}
+		}
+		assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
+			boolParam = true
+			strParam = "string"
+			numParam = 123
+			objParam = [test:true]
+			dateParam = new Date(1)
+		}
+	}
 }
 
 class AnotherUrlMappings {
@@ -179,4 +197,15 @@ class GRAILS5222UrlMappings {
             action = "publicProfile"
         }
     }
+}
+
+class GRAILS9110UrlMappings {
+	static mappings = {
+		"/user"(controller:"user", action:"publicProfile") {
+			boolParam = true
+			strParam = "string"
+			numParam = 123
+			dateParam = new Date(1)
+		}
+	}
 }

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
@@ -137,24 +137,24 @@ class UrlMappingsTestMixinTests {
             }
         }
     }
-	
-	@Test
-	voide testGrails9110() {
-		mockController(UserController)
-		mockUrlMappings(GRAILS9110UrlMappings)
-		shouldfail(ComparisonFailure) {
-			assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
-				param1 = "true"
-			}
-		}
-		assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
-			boolParam = true
-			strParam = "string"
-			numParam = 123
-			objParam = [test:true]
-			dateParam = new Date(1)
-		}
-	}
+    
+    @Test
+    void testGrails9110() {
+        mockController(UserController)
+        mockUrlMappings(GRAILS9110UrlMappings)
+        shouldFail(ComparisonFailure) {
+            assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
+                param1 = "true"
+            }
+        }
+        assertForwardUrlMapping("/user", controller:"user", action:"publicProfile") {
+            boolParam = true
+            strParam = "string"
+            numParam = 123
+            objParam = [test:true]
+            dateParam = new Date(1)
+        }
+    }
 }
 
 class AnotherUrlMappings {
@@ -200,12 +200,13 @@ class GRAILS5222UrlMappings {
 }
 
 class GRAILS9110UrlMappings {
-	static mappings = {
-		"/user"(controller:"user", action:"publicProfile") {
-			boolParam = true
-			strParam = "string"
-			numParam = 123
-			dateParam = new Date(1)
-		}
-	}
+    static mappings = {
+        "/user"(controller:"user", action:"publicProfile") {
+            boolParam = true
+            strParam = "string"
+            numParam = 123
+            objParam = [test:true]
+            dateParam = new Date(1)
+        }
+    }
 }


### PR DESCRIPTION
I removed the toString code on the UrlMappingsTestMixin class.  This should fix the problem.
