### PR TITLE
Integrate with  git improvement

### DIFF
--- a/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
+++ b/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
@@ -13,3 +13,4 @@ stacktrace.log
 /out/
 /web-app/plugins
 /web-app/WEB-INF/classes
+link_to_grails_plugins


### PR DESCRIPTION
Makes "integrate-with --git" more usable for STS users
    -> ignoring Linked Folder ".link_to_grails_plugins"
