### PR TITLE
Resource mapping addition for HEAD requests

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingEvaluator.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingEvaluator.java
@@ -40,7 +40,8 @@ public interface UrlMappingEvaluator {
         "GET", "show",
         "POST", "save",
         "PUT", "update",
-        "DELETE", "delete");
+        "DELETE", "delete",
+        "HEAD", "head");
 
     /**
      * Evaluates URL mapping from the give Spring Resource


### PR DESCRIPTION
Should there be a default mapping for HEAD requests for resource mappings?

http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods

If so, should Grails automatically respond to this request by issuing a corresponding GET request and only sending back the headers?  I could work on that next if this pull request is accepted.  Please let me know.
