### PR TITLE
Translation for Norwegian Bokmål (nb). While "Sant" and "Falskt" are dir...

### DIFF
--- a/grails-resources/src/grails/grails-app/i18n/messages_nb.properties
+++ b/grails-resources/src/grails/grails-app/i18n/messages_nb.properties
@@ -17,8 +17,8 @@ default.not.unique.message=Feltet [{0}] i klassen [{1}] med verdien [{2}] mÃ¥ vÃ
 
 default.paginate.prev=Forrige
 default.paginate.next=Neste
-default.boolean.true=Sant
-default.boolean.false=Falskt
+default.boolean.true=Ja
+default.boolean.false=Nei
 default.date.format=dd.MM.yyyy HH:mm:ss z
 default.number.format=0
 


### PR DESCRIPTION
...ect translation of 'true' and 'false', they're never used in the context these properties are used.
