### PR TITLE
GRAILS-8900: excluding action and controller from generated action tag and corresponding test-case change

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/JavascriptTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/JavascriptTagLib.groovy
@@ -254,6 +254,8 @@ class JavascriptTagLib implements ApplicationContextAware {
         // These options should not be included as attributes of the anchor element.
         attrs.remove('method')
         attrs.remove('url')
+        attrs.remove('action')
+        attrs.remove('controller')
 
         // handle elementId like link
         def elementId = attrs.remove('elementId')

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/JavascriptTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/JavascriptTagLibTests.groovy
@@ -44,7 +44,7 @@ class TestUrlMappings {
         def template = '''<g:javascript library="test" /><p><g:remoteLink controller="bar" action="list" /></p><g:render template="part" model="['foo1':foo2]" />'''
 
         String newLine = EOL
-        assertOutputContains('<script src="/js/test.js" type="text/javascript"></script>\r\n<p><a href="/bar/list" onclick="<remote>return false;" controller="bar" action="list"></a></p><a href="/foo/list" onclick="<remote>return false;" controller="foo" action="list"></a>', template)
+        assertOutputContains('<script src="/js/test.js" type="text/javascript"></script>\r\n<p><a href="/bar/list" onclick="<remote>return false;"></a></p><a href="/foo/list" onclick="<remote>return false;"></a>', template)
     }
 
     void testJavascriptIncludeWithPluginAttribute() {


### PR DESCRIPTION
My previous commit for GRAILS-8900 caused a test-case to fail. Since that commit was reverted, this pull request has the fix and the test-case combined in one commit. 

The test-case fix removes the controller="bar" action="list" from the expected generated anchor tag which obviously is the point of the fix for GRAILS-8900.

All tests in JavascriptTagLibTests.groovy pass now. Thanks, Bobby
