### PR TITLE
Support grails.doc configuration as nested Closures in Config.groovy

### DIFF
--- a/scripts/_GrailsDocs.groovy
+++ b/scripts/_GrailsDocs.groovy
@@ -265,7 +265,7 @@ ${m.arguments?.collect { '* @'+GrailsNameUtils.getPropertyName(it)+'@\n' }}
         publisher.license = ""
         publisher.copyright = ""
         publisher.footer = ""
-        publisher.engineProperties = config?.grails?.doc
+        publisher.engineProperties = config?.grails?.doc?.flatten()
         // if this is a plugin obtain additional metadata from the plugin
         readPluginMetadataForDocs(publisher)
         readDocProperties(publisher)


### PR DESCRIPTION
This commit enhances the support for rendering external links in a project's Reference Guide.

Currently, this configuration is supported in `Config.groovy`:

```
grails.doc.api.javax.servlet = "http://docs.oracle.com/javaee/6/api"
grails.doc.api.java.lang = "http://docs.oracle.com/javase/6/docs/api"
grails.doc.api.java.util = "http://docs.oracle.com/javase/6/docs/api"
grails.doc.api.groovy = "http://groovy.codehaus.org/gapi"
```

but this is not:

```
grails {
    doc {
        api {
            javax.servlet = "http://docs.oracle.com/javaee/6/api"
            java.lang = "http://docs.oracle.com/javase/6/docs/api"
            java.util = "http://docs.oracle.com/javase/6/docs/api"
            groovy = "http://groovy.codehaus.org/gapi"
        }
    }
}
```

This commit provides support for the latter configuration style.
