### PR TITLE
improve watchedResources / merge inject tag with set tag

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/DefaultGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/DefaultGrailsPlugin.java
@@ -387,13 +387,11 @@ public class DefaultGrailsPlugin extends AbstractGrailsPlugin implements ParentA
     private String getResourcePatternForBaseLocation(String baseLocation, String resourcePath) {
         String location = baseLocation;
         if (!location.endsWith(File.separator)) location = location + File.separator;
-        if (resourcePath.startsWith(".")) {
-            resourcePath = resourcePath.substring(1);
-        }
+        if (resourcePath.startsWith("./")) {
+            return "file:" + location + resourcePath.substring(2);        }
         else if (resourcePath.startsWith("file:./")) {
-            resourcePath = resourcePath.substring(7);
+            return "file:" + location + resourcePath.substring(7);
         }
-        resourcePath = "file:" + location + resourcePath;
         return resourcePath;
     }
 

--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -99,9 +99,11 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
 
     /**
      * Sets a variable in the pageContext or the specified scope.
+     * The value can be specified directly or can be a bean retrieved from the applicationContext.
      *
      * @attr var REQUIRED the variable name
      * @attr value the variable value; if not specified uses the rendered body
+     * @attr bean the name or the type of a bean in the applicationContext; the type can be an interface or superclass
      * @attr scope the scope name; defaults to pageScope
      */
     Closure set = { attrs, body ->
@@ -111,44 +113,16 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         def scope = attrs.scope ? SCOPES[attrs.scope] : 'pageScope'
         if (!scope) throw new IllegalArgumentException("Invalid [scope] attribute for tag <g:set>!")
 
-        def value = attrs.value
-        def containsValue = attrs.containsKey('value')
-
-        if (!containsValue && body) value = body()
-
-        this."$scope"."$var" = value
-        null
-    }
-
-    /**
-     * Injects a dependency into a variable in the pageContext or the specified scope.
-     *
-     * @attr beanName the bean name; either beanName or beanType must be specified
-     * @attr beanType type the bean must match; can be an interface or superclass; either beanName or beanType must be specified
-     * @attr var the variable name; mandatory if beanType is specified, otherwise defaults to beanName
-     * @attr scope the scope name; defaults to pageScope
-     */
-    Closure inject = { attrs, body ->
-        def bean
-        def var = attrs.var
-        if (attrs.beanName) {
-            bean = applicationContext.getBean(attrs.beanName)
-            if (!var) {
-                var = attrs.beanName
-            }
-        } else if (attrs.beanType) {
-            bean = applicationContext.getBean(attrs.beanType)
-            if (!var) {
-                throw new IllegalArgumentException("[var] attribute must be specified to for <g:inject> when the [beanType] attribute is also specified!")
-            }
+        def value
+        if (attrs.bean) {
+            value = applicationContext.getBean(attrs.bean)
         } else {
-            throw new IllegalArgumentException("either the [beanName] or [beanType] attribute must be specified to for <g:inject>!")
+            value = attrs.value
+            def containsValue = attrs.containsKey('value')
+            if (!containsValue && body) value = body()
         }
 
-        def scope = attrs.scope ? ApplicationTagLib.SCOPES[attrs.scope] : 'pageScope'
-        if (!scope) throw new IllegalArgumentException("Invalid [scope] attribute for tag <g:inject>!")
-
-        this."$scope"."$var" = bean
+        this."$scope"."$var" = value
         null
     }
 

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/DefaultGrailsPluginTests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/DefaultGrailsPluginTests.java
@@ -39,11 +39,15 @@ public class DefaultGrailsPluginTests extends AbstractGrailsMockTests {
     protected void onSetUp() {
         versioned = gcl.parseClass("class MyGrailsPlugin {\n" +
                         "def version = 1.1;" +
+                        "def watchedResources = [\"file:./grails-app/taglib/**/*TagLib.groovy\", \"./grails-app/controller/**/*.groovy\", \"file:/absolutePath/**/*.gsp\" ]\n" +
                         "def doWithSpring = {" +
                         "classEditor(org.springframework.beans.propertyeditors.ClassEditor,application.classLoader)" +
                         "}\n" +
                         "def doWithApplicationContext = { ctx ->" +
                         "assert ctx != null" +
+                        "}\n" +
+                        "def onChange = { event ->" +
+                        "assert event != null" +
                         "}" +
                         "}");
         notVersion = gcl.parseClass("class AnotherGrailsPlugin {\n" +
@@ -147,5 +151,12 @@ public class DefaultGrailsPluginTests extends AbstractGrailsMockTests {
 
         assertEquals(1, observingPlugin.getObservedPluginNames().length);
         assertEquals("another", observingPlugin.getObservedPluginNames()[0]);
+    }
+
+    public void testWatchedResources(){
+        GrailsPlugin versionPlugin = new DefaultGrailsPlugin(versioned, ga);
+        assertEquals(versionPlugin.getWatchedResourcePatterns().get(0).getDirectory().getPath(), "./grails-app/taglib");
+        assertEquals(versionPlugin.getWatchedResourcePatterns().get(1).getDirectory().getPath(), "./grails-app/controller");
+        assertEquals(versionPlugin.getWatchedResourcePatterns().get(2).getDirectory().getPath(), "/absolutePath");
     }
 }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -188,24 +188,18 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         def template = '<g:set var="var1" value="1"/>${var1}<g:set var="var1" value="2"/> ${var1}<g:set var="var2" value="3" scope="request"/> ${var2}<g:set var="var2" value="4" scope="request"/> ${var2}'
         assertOutputEquals('1 2 3 4', template)
     }
-    
 
-    void testInjectTagByName() {
-        def template = '<g:inject beanName="grailsApplication"/>${grailsApplication.initialised}'
+
+    void testSetTagWithBeanName() {
+        def template = '<g:set bean="grailsApplication" var="myVar"/>${myVar.initialised}'
         assertOutputEquals('true', template)
 
-        template = '<g:inject beanName="grailsApplication" var="myVar"/>${myVar.initialised}'
-        assertOutputEquals('true', template)
-
-        template = '<g:inject beanName="grailsApplication" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
+        template = '<g:set bean="grailsApplication" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
         assertOutputEquals('true', template)
     }
 
-    void testInjectTagByType() {
-        def template = '<%@ page import="org.codehaus.groovy.grails.commons.*" %><g:inject beanType="${GrailsApplication}" var="myVar"/>${myVar.initialised}'
-        assertOutputEquals('true', template)
-
-        template = '<%@ page import="org.codehaus.groovy.grails.commons.*" %><g:inject beanType="${GrailsApplication}" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
+    void testSetTagWithBeanType() {
+        def template = '<%@ page import="org.codehaus.groovy.grails.commons.*" %><g:set bean="${GrailsApplication}" var="myRequestVar" scope="request"/>${request.myRequestVar.initialised}'
         assertOutputEquals('true', template)
     }
 


### PR DESCRIPTION
1)
Absolute paths in watchedResorces don't work.
This change makes it possible to use paths like "file:${buildSettings.projectTargetDir}/*_/_.groovy"
I added a test to verify that paths starting with "file:/." and "." are not affected.

2)
a few months ago I added the g.inject tag to the ApplicationTagLib, but as Graeme pointed out in http://grails.1312388.n4.nabble.com/gsp-taglib-pull-request-tp4512023p4512578.html it should be part of the g.set tag.
The inject tag slipped in silently, so it's best to remove it now before it's getting used.
