### PR TITLE
Fix git integratewith (last commit was incomplete)

### DIFF
--- a/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
+++ b/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
@@ -13,4 +13,5 @@ stacktrace.log
 /out/
 /web-app/plugins
 /web-app/WEB-INF/classes
-link_to_grails_plugins
+.link_to_grails_plugins
+target-eclipse


### PR DESCRIPTION
- missed '.' on '.link_to_grails_plugins'
- missed adding 'target-eclipse'

(committed incomplete index last time :( sorry - even thou it is minor)

please cherry pick into 2.1.0 / master (or if desired I can do that and create pull requests)
