### PR TITLE
Adjusted BuildConfig.groovy template to stop rest-client-builder from le...

### DIFF
--- a/grails-resources/src/grails/plugin/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/plugin/grails-app/conf/BuildConfig.groovy
@@ -28,7 +28,8 @@ grails.project.dependency.resolution = {
 
     plugins {
         build(":tomcat:$grailsVersion",
-              ":release:2.0.3") {
+              ":release:2.0.3",
+              ":rest-client-builder:1.0.2") {
             export = false
         }
     }


### PR DESCRIPTION
...aking into the grails apps
- added rest-client-builder (dependency of the release-plugin) explicitly  to plugin-dependencies to be able to mark it with "export = false"

---

Question:
Maybe it is desired to specify the versions of release-plugin and rest-client-builder with latest.integration or latest.release to make the BuilldConfig.grooy template more future-proof.
