### PR TITLE
Jquery update maven

### DIFF
--- a/grails-resources/src/grails/templates/maven/app.pom
+++ b/grails-resources/src/grails/templates/maven/app.pom
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.grails.plugins</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.7.1</version>
+            <version>1.7.2</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
I also added the pom.xml file as a required change for future default plugin version updates on the version management wiki page: https://github.com/grails/grails-core/wiki/Version-Management
