### PR TITLE
Cannot open test-report/dep-report in Grails 2.1.0.

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
@@ -211,7 +211,7 @@ class InteractiveMode {
                 arg = unescape(arg)
 
                 // Is this arg one of the fixed options for 'open'?
-                String fixedOption = openOptions.find { option, value ->
+                def fixedOption = openOptions.find { option, value ->
                     // No match if a file matching the name of the
                     // option exists.
                     arg == option && !new File(option).exists()


### PR DESCRIPTION
> grails> open test-report 
> | Error Could not open file test-report: No such property: path for class: [C
