### PR TITLE
Fix to find i18n internationalization files for inline plugins.

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/context/support/PluginAwareResourceBundleMessageSource.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/context/support/PluginAwareResourceBundleMessageSource.java
@@ -18,12 +18,17 @@ import grails.util.BuildSettings;
 import grails.util.BuildSettingsHolder;
 import grails.util.Environment;
 import grails.util.Metadata;
+import grails.util.PluginBuildSettings;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.plugins.BinaryGrailsPlugin;
 import org.codehaus.groovy.grails.plugins.GrailsPlugin;
+import org.codehaus.groovy.grails.plugins.GrailsPluginInfo;
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
+import org.codehaus.groovy.grails.plugins.GrailsPluginUtils;
 import org.codehaus.groovy.grails.plugins.PluginManagerAware;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
 import org.codehaus.groovy.grails.support.DevelopmentResourceLoader;
@@ -33,6 +38,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
+import java.io.File;
+import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,6 +52,8 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class PluginAwareResourceBundleMessageSource extends ReloadableResourceBundleMessageSource implements GrailsApplicationAware, PluginManagerAware, InitializingBean{
 
+	private static final Log LOG = LogFactory.getLog(PluginAwareResourceBundleMessageSource.class);
+
     private static final String WEB_INF_PLUGINS_PATH = "/WEB-INF/plugins/";
     protected GrailsApplication application;
     protected GrailsPluginManager pluginManager;
@@ -53,6 +62,7 @@ public class PluginAwareResourceBundleMessageSource extends ReloadableResourceBu
     private PathMatchingResourcePatternResolver resourceResolver;
     private Map<Locale, PropertiesHolder> cachedMergedPluginProperties = new ConcurrentHashMap<Locale, PropertiesHolder>();
     private int pluginCacheMillis = -1;
+	private final PluginBuildSettings pluginBuildSettings = GrailsPluginUtils.getPluginBuildSettings();
 
     public List<String> getPluginBaseNames() {
         return pluginBaseNames;
@@ -72,29 +82,97 @@ public class PluginAwareResourceBundleMessageSource extends ReloadableResourceBu
 
     public void afterPropertiesSet() throws Exception {
         if (pluginManager != null && localResourceLoader != null) {
+
             GrailsPlugin[] plugins = pluginManager.getAllPlugins();
             for (GrailsPlugin plugin : plugins) {
                 Resource[] pluginBundles;
-
-                final String pluginName = plugin.getFileSystemName();
-                pluginBundles = getPluginBundles(pluginName);
+                pluginBundles = getPluginBundles(plugin);
                 for (Resource pluginBundle : pluginBundles) {
-                    String baseName = FilenameUtils.getBaseName(pluginBundle.getFilename());
-                    baseName = StringUtils.substringBefore(baseName,"_");
-                    pluginBaseNames.add(WEB_INF_PLUGINS_PATH.substring(1) + pluginName + "/grails-app/i18n/" + baseName);
+					String basePath = null;
+					final String baseName = StringUtils.substringBefore(FilenameUtils.getBaseName(pluginBundle.getFilename()), "_");
+
+					// If the plugin is an inline plugin, use the abosolute path to the plugin's i18n files.
+					// Otherwise, use the relative path to the plugin from the application's perspective.
+					if(isInlinePlugin(plugin)) {
+						basePath = getInlinePluginPath(plugin);
+					} else {
+                    	basePath = WEB_INF_PLUGINS_PATH.substring(1) + plugin.getFileSystemName();
+					}
+					
+					pluginBaseNames.add(basePath + "/grails-app/i18n/" + baseName);
                 }
             }
         }
     }
 
-    protected Resource[] getPluginBundles(String pluginName) {
+	/**
+	 * Returns the i18n message bundles for the provided plugin or an empty
+	 * array if the plugin does not contain any .properties files in its
+	 * grails-app/i18n folder.
+	 * @param grailsPlugin The grails plugin that may or may not contain i18n internationalization files.
+	 * @returns An array of {@code Resource} objects representing the internationalization files or
+	 *    an empty array if no files are found.
+	 */
+    protected Resource[] getPluginBundles(GrailsPlugin grailsPlugin) {
         try {
-            return resourceResolver.getResources(WEB_INF_PLUGINS_PATH + pluginName + "/grails-app/i18n/*.properties");
+			String basePath = null;
+			
+			// If the plugin is inline, use the absolute path to the internationalization files
+			// in order to convert to resources.  Otherwise, use the relative WEB-INF path.
+			if(isInlinePlugin(grailsPlugin)) {
+				basePath = getInlinePluginPath(grailsPlugin);
+			} else {
+				basePath = WEB_INF_PLUGINS_PATH + grailsPlugin.getFileSystemName();
+			}
+			
+            return resourceResolver.getResources(basePath + "/grails-app/i18n/*.properties");
         }
         catch (Exception e) {
+			LOG.debug("Could not resolve any resources for plugin " + grailsPlugin.getFileSystemName(), e);
             return new Resource[0];
         }
     }
+
+    /**
+     * Tests whether or not the Grails plugin is currently being run "inline".
+     * @param grailsPlugin The Grails plugin to test.
+     * @returns {@code true} if the plugin is being used "inline" or {@code false} if the
+     *   plugin is not being used "inline".
+	 */
+	protected boolean isInlinePlugin(GrailsPlugin grailsPlugin) {
+		return (getInlinePluginPath(grailsPlugin) != null);
+	}
+
+    /**
+     * Returns the absolute path to the provided Grails plugin if it is being used "inline" or {@code null}
+     * if the plugin is <b>not</b> being used "inline".
+     * @param grailsPlugin The Grails plugin.
+     * @returns The absolute path to the "inline" plugin or {@code null} if the plugin is not being used "inline".
+     */
+	protected String getInlinePluginPath(GrailsPlugin grailsPlugin) {
+		String path = null;
+		try {
+			final GrailsPluginInfo pluginInfo = pluginBuildSettings.getPluginInfoForName(grailsPlugin.getFileSystemShortName());
+			if(pluginInfo != null) {
+				String pluginDirPath = pluginInfo.getPluginDir().getFile().getPath();
+				if(pluginDirPath != null) {
+					// Remove the "/." added to the end of the plugin path by the PluginInfo class.  This is necessary
+					// so that the path matches the key used in the BuildSettings class for the stored inline plugins map.
+					if(pluginDirPath.endsWith("/.")) {
+						pluginDirPath = pluginDirPath.substring(0, pluginDirPath.length() - 2);
+					}
+					
+					// If the path to the plugin represents an inline plugin, use that path (minus the trailing "/.")
+					if(BuildSettingsHolder.getSettings().isInlinePluginLocation(new File(pluginDirPath))) {
+						path = pluginDirPath;
+					}
+				}
+			}
+		} catch(final IOException e) {
+			LOG.debug("Unable to retrieve plugin directory for plugin " + grailsPlugin.getFileSystemShortName() + ".", e);
+		}
+		return path;
+	}
 
     @Override
     protected String resolveCodeWithoutArguments(String code, Locale locale) {

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/support/DevelopmentResourceLoader.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/support/DevelopmentResourceLoader.java
@@ -19,9 +19,12 @@ import grails.util.BuildSettingsHolder;
 import grails.util.Metadata;
 import grails.util.PluginBuildSettings;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.io.support.GrailsResourceUtils;
 import org.springframework.core.io.DefaultResourceLoader;
@@ -36,10 +39,13 @@ import org.springframework.core.io.Resource;
  */
 public class DevelopmentResourceLoader extends DefaultResourceLoader {
 
+	private static final Log LOG = LogFactory.getLog(DevelopmentResourceLoader.class);
+
     private String baseLocation = ".";
     private GrailsApplication application;
     private static final String PLUGINS_PREFIX = "plugins/";
     private static final String SLASH = "/";
+	private static final String GRAILS_APP_DIR_PATTERN = "/grails-app/.*";
 
     public DevelopmentResourceLoader(GrailsApplication application) {
         this.application = application;
@@ -73,38 +79,47 @@ public class DevelopmentResourceLoader extends DefaultResourceLoader {
 
         if (!location.startsWith(SLASH)) location = SLASH + location;
 
-        if (!location.startsWith(GrailsResourceUtils.WEB_INF)) {
-            return GrailsResourceUtils.WEB_APP_DIR+location;
-        }
+		// If the location (minus the "grails-app/.*" ending so that it matches the key value used in BuildSettings for
+		// the inline plugin map) matches an "inline" plugin, use the location as-is
+		// for the resource location.  Otherwise, perform the logic to "normalize" the resource location based on
+		// its relativity to the application (i.e. is it from a non-inline plugin, etc).
+		if(BuildSettingsHolder.getSettings().isInlinePluginLocation(new File(location.replaceAll(GRAILS_APP_DIR_PATTERN, "")))) {
+			return "file:" + location;
+		} else {
+	        if (!location.startsWith(GrailsResourceUtils.WEB_INF)) {
+	            return GrailsResourceUtils.WEB_APP_DIR+location;
+	        }
 
-        final String noWebInf = location.substring(GrailsResourceUtils.WEB_INF.length() + 1);
-        final String defaultPath = "file:" + baseLocation + SLASH + noWebInf;
-        if (!noWebInf.startsWith(PLUGINS_PREFIX)) {
-            return defaultPath;
-        }
+	        final String noWebInf = location.substring(GrailsResourceUtils.WEB_INF.length() + 1);
+	        final String defaultPath = "file:" + baseLocation + SLASH + noWebInf;
+	        if (!noWebInf.startsWith(PLUGINS_PREFIX)) {
+	            return defaultPath;
+	        }
 
-        if (application != null) {
+	        if (application != null) {
 
-            BuildSettings settings = BuildSettingsHolder.getSettings();
-            PluginBuildSettings pluginBuildSettings = org.codehaus.groovy.grails.plugins.GrailsPluginUtils.getPluginBuildSettings();
-            String pluginPath = StringUtils.substringAfter(noWebInf, SLASH);
-            String pluginName = StringUtils.substringBefore(pluginPath, SLASH);
-            String remainingPath = StringUtils.substringAfter(pluginPath, SLASH);
-            Resource r = pluginBuildSettings.getPluginDirForName(pluginName);
-            if (r != null) {
-                try {
-                    return "file:" + r.getFile().getAbsolutePath() + SLASH + remainingPath;
-                }
-                catch (IOException e) {
-                    return defaultPath;
-                }
-            }
+	            BuildSettings settings = BuildSettingsHolder.getSettings();
+	            PluginBuildSettings pluginBuildSettings = org.codehaus.groovy.grails.plugins.GrailsPluginUtils.getPluginBuildSettings();
+	            String pluginPath = StringUtils.substringAfter(noWebInf, SLASH);
+	            String pluginName = StringUtils.substringBefore(pluginPath, SLASH);
+	            String remainingPath = StringUtils.substringAfter(pluginPath, SLASH);
+	            Resource r = pluginBuildSettings.getPluginDirForName(pluginName);
+	            if (r != null) {
+	                try {
+	                    return "file:" + r.getFile().getAbsolutePath() + SLASH + remainingPath;
+	                }
+	                catch (IOException e) {
+						LOG.debug("Unable to locate plugin resource -- returning default path " + defaultPath + ".", e);
+	                    return defaultPath;
+	                }
+	            }
 
-            if (settings != null) {
-                return "file:" + settings.getProjectPluginsDir().getAbsolutePath() + SLASH + pluginName + SLASH + remainingPath;
-            }
-        }
+	            if (settings != null) {
+	                return "file:" + settings.getProjectPluginsDir().getAbsolutePath() + SLASH + pluginName + SLASH + remainingPath;
+	            }
+	        }
 
-        return defaultPath;
+	        return defaultPath;
+		}
     }
 }

--- a/grails-plugin-i18n/src/main/groovy/org/codehaus/groovy/grails/plugins/i18n/I18nGrailsPlugin.groovy
+++ b/grails-plugin-i18n/src/main/groovy/org/codehaus/groovy/grails/plugins/i18n/I18nGrailsPlugin.groovy
@@ -15,6 +15,8 @@
  */
 package org.codehaus.groovy.grails.plugins.i18n
 
+import java.io.File
+
 import grails.util.BuildSettingsHolder
 import grails.util.Environment
 import grails.util.GrailsUtil
@@ -23,13 +25,14 @@ import org.apache.commons.lang.StringUtils
 import org.apache.commons.logging.LogFactory
 
 import org.codehaus.groovy.grails.context.support.PluginAwareResourceBundleMessageSource
-import org.codehaus.groovy.grails.web.context.GrailsConfigUtils;
+import org.codehaus.groovy.grails.web.context.GrailsConfigUtils
 import org.codehaus.groovy.grails.web.i18n.ParamsAwareLocaleChangeInterceptor
 import org.codehaus.groovy.grails.web.pages.GroovyPagesTemplateEngine
 
 import org.springframework.core.io.ContextResource
 import org.springframework.core.io.Resource;
 import org.springframework.context.support.ReloadableResourceBundleMessageSource
+import org.springframework.util.ResourceUtils
 import org.springframework.web.servlet.i18n.SessionLocaleResolver
 import org.codehaus.groovy.grails.cli.logging.GrailsConsoleAntBuilder
 
@@ -61,14 +64,22 @@ class I18nGrailsPlugin {
 
         if (messageResources) {
             for (resource in messageResources) {
-                // Extract the file path of the file's parent directory
-                // that comes after "grails-app/i18n".
+				// Check to see if the resource's parent directory (minus the "/grails-app/i18n" portion) is an "inline" plugin location
+				def isInlineResource = BuildSettingsHolder.settings.isInlinePluginLocation(new File(resource.file.getParent().minus("/grails-app/i18n")))
                 String path
-                if (resource instanceof ContextResource) {
-                    path = StringUtils.substringAfter(resource.pathWithinContext, baseDir)
-                }
-                else {
-                    path = StringUtils.substringAfter(resource.path, baseDir)
+
+				// If the resource is from an inline plugin, use the absolute path of the resource.  Otherwise,
+				// generate the path to the resource based on its relativity to the application.
+				if(isInlineResource) {
+					path = resource.file.path
+				} else {
+                    // Extract the file path of the file's parent directory
+                    // that comes after "grails-app/i18n".
+                    if (resource instanceof ContextResource) {
+                        path = StringUtils.substringAfter(resource.pathWithinContext, baseDir)
+                    } else {
+                        path = StringUtils.substringAfter(resource.path, baseDir)
+                    }
                 }
 
                 // look for an underscore in the file name (not the full path)
@@ -76,7 +87,7 @@ class I18nGrailsPlugin {
                 int firstUnderscore = fileName.indexOf('_')
 
                 if (firstUnderscore > 0) {
-                    // grab everyting up to but not including
+                    // grab everything up to but not including
                     // the first underscore in the file name
                     int numberOfCharsToRemove = fileName.length() - firstUnderscore
                     int lastCharacterToRetain = -1 * (numberOfCharsToRemove + 1)
@@ -87,7 +98,8 @@ class I18nGrailsPlugin {
                     // message source cannot have entries with an extension.
                     path -= ".properties"
                 }
-                baseNames << "WEB-INF/" + baseDir + path
+
+                baseNames << (isInlineResource ? path : "WEB-INF/${baseDir}${path}")
             }
         }
 


### PR DESCRIPTION
Modified to check whether or not a plugin is inline and subsequently use the absolute path to its i18n folder instead of using a relative path from the Grails work directory (for installed plugins).  This is a necessary fix following the pull request that handled the deletion of an inline plugin by removing the installed version of the same plugin.
