### PR TITLE
Add default param to make it more obvious that mavenLocal can be called ...

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/config/RepositoriesConfigurer.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/config/RepositoriesConfigurer.groovy
@@ -221,7 +221,7 @@ class RepositoriesConfigurer extends AbstractDependencyManagementConfigurer {
     }
 
     @CompileStatic
-    void mavenLocal(String repoPath) {
+    void mavenLocal(String repoPath = null) {
         if (isResolverNotAlreadyDefined('mavenLocal')) {
             dependencyManager.repositoryData << ['type':'mavenLocal']
             FileSystemResolver localMavenResolver = new FileSystemResolver()


### PR DESCRIPTION
...without params. Actually, this is the main use case.

Ref http://stackoverflow.com/questions/11227267/intellij-mavenlocal-warning-in-grails-buildconfig/11227645#11227645
