### PR TITLE
update to jQuery 1.8.0

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -94,7 +94,7 @@ task pluginsFromRepo {
         tomcat: grailsVersion,
         resources: "1.1.6",
         webxml: "1.4.1",
-        jquery: "1.7.2",
+        jquery: "1.8.0",
         'database-migration': "1.1",
         cache: "1.0.0"
     ]

--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -39,7 +39,7 @@ grails.project.dependency.resolution = {
 
     plugins {
         runtime ":hibernate:$grailsVersion"
-        runtime ":jquery:1.7.2"
+        runtime ":jquery:1.8.0"
         runtime ":resources:1.1.6"
 
         // Uncomment these (or add new ones) to enable additional resources capabilities

--- a/grails-resources/src/grails/templates/maven/app.pom
+++ b/grails-resources/src/grails/templates/maven/app.pom
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.grails.plugins</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.7.2</version>
+            <version>1.8.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
depends on 

https://github.com/gpc/grails-jquery/pull/13

and the release of the plugin in version 1.8.0
