### PR TITLE
Modified forward dynamic method to use UrlConverter for controller/action parameters

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/ControllersGrailsPlugin.groovy
@@ -90,6 +90,7 @@ class ControllersGrailsPlugin {
 
         instanceControllersApi(ControllersApi, pluginManager) {
             linkGenerator = ref("grailsLinkGenerator")
+            urlConverter = ref("grailsUrlConverter")
         }
 
         for (controller in application.controllerClasses) {

--- a/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/ControllersApi.java
+++ b/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/ControllersApi.java
@@ -18,6 +18,7 @@ package org.codehaus.groovy.grails.plugins.web.api;
 import grails.util.CollectionUtils;
 import grails.util.Environment;
 import grails.util.GrailsNameUtils;
+import grails.web.UrlConverter;
 import groovy.lang.Closure;
 
 import java.util.Collection;
@@ -97,6 +98,10 @@ public class ControllersApi extends CommonWebApi {
 
     public void setLinkGenerator(LinkGenerator linkGenerator) {
         getRedirectMethod().setLinkGenerator(linkGenerator);
+    }
+
+    public void setUrlConverter(UrlConverter urlConverter) {
+        getForwardMethod().setUrlConverter(urlConverter);
     }
 
     /**

--- a/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethod.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethod.groovy
@@ -17,38 +17,70 @@ package org.codehaus.groovy.grails.web.metaclass
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
+import grails.web.UrlConverter
+
 import org.apache.commons.beanutils.BeanUtils
 import org.codehaus.groovy.grails.web.mapping.ForwardUrlMappingInfo
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
 import org.codehaus.groovy.grails.web.util.WebUtils
+import org.springframework.context.ApplicationContext
 
 /**
  * Implements performing a forward.
  *
  * @author Graeme Rocher
+ * @author Jonathan Pearlin
  * @since 1.1
  */
 class ForwardMethod {
 
     public static final String CALLED = "org.codehaus.groovy.grails.FORWARD_CALLED"
 
+    UrlConverter urlConverter
+
     String forward(HttpServletRequest request, HttpServletResponse response, Map params) {
         def urlInfo = new ForwardUrlMappingInfo()
 
         GrailsWebRequest webRequest = GrailsWebRequest.lookup(request)
-
-        if (params.controller) {
-            webRequest?.controllerName = params.controller
+        Map cleansedParams = [:]
+		
+        /*
+         * Make sure that any controller/action parameter is passed through the URL converter
+         * to ensure that it will match the URL mappings based on the configured URL converter
+         * scheme (camel case, hyphenated, etc).
+         */
+        cleansedParams = params?.collectEntries([:]) { key, value ->
+            (key == 'controller' || key == 'action') ? [(key) : (convert(webRequest, value))] : [(key) : value]
         }
-        else {
-            urlInfo.controllerName = webRequest?.controllerName
-        }
 
-        BeanUtils.populate(urlInfo, params)
+        // If the cleansed map contains a controller/action parameter, use it.  Otherwise, cleanse the value from the web request and use that.
+        urlInfo.controllerName = (cleansedParams.controller) ? cleansedParams.controller : webRequest?.controllerName
+        urlInfo.actionName = (cleansedParams.action) ? cleansedParams.action : webRequest?.actionName
+        BeanUtils.populate(urlInfo, cleansedParams)
 
-        def model = params.model instanceof Map ? params.model : Collections.EMPTY_MAP
+        def model = cleansedParams.model instanceof Map ? cleansedParams.model : Collections.EMPTY_MAP
         String uri = WebUtils.forwardRequestForUrlMappingInfo(request, response, urlInfo, model, true)
         request.setAttribute(CALLED, true)
         return uri
+    }
+
+    void setUrlConverter(UrlConverter urlConverter) {
+        this.urlConverter = urlConverter
+    }
+
+    private UrlConverter getUrlConverter(GrailsWebRequest webRequest) {
+        if (!urlConverter) {
+            ApplicationContext applicationContext = webRequest?.getApplicationContext()
+            if (applicationContext) {
+                urlConverter = applicationContext.getBean("grailsUrlConverter", UrlConverter)
+            }
+        }
+
+        urlConverter
+    }
+
+    private String convert(GrailsWebRequest webRequest, String value) {
+        UrlConverter urlConverter = getUrlConverter(webRequest)
+        (urlConverter) ? urlConverter.toUrlElement(value) : value
     }
 }

--- a/grails-plugin-controllers/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethodSpec.groovy
+++ b/grails-plugin-controllers/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethodSpec.groovy
@@ -1,0 +1,89 @@
+package org.codehaus.groovy.grails.web.metaclass
+
+import javax.servlet.RequestDispatcher
+import javax.servlet.ServletContext
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+import grails.web.UrlConverter
+
+import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
+import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
+import org.springframework.context.ApplicationContext
+
+import spock.lang.Specification
+
+class ForwardMethodSpec extends Specification {
+
+	ForwardMethod forwardMethod
+	ApplicationContext appContext
+	ServletContext servletContext
+	HttpServletRequest request
+	HttpServletResponse response
+	RequestDispatcher dispatcher
+	GrailsWebRequest webRequest
+	UrlConverter urlConverter
+	
+	def setup() {
+		forwardMethod = new ForwardMethod()
+		
+		appContext = Mock(ApplicationContext)
+		servletContext = Mock(ServletContext)
+		request = Mock(HttpServletRequest)
+		response = Mock(HttpServletResponse)
+		dispatcher = Mock(RequestDispatcher)
+		urlConverter = Mock(UrlConverter)
+
+		webRequest = new GrailsWebRequest(request, response, servletContext, appContext)
+			
+		dispatcher.forward(_,_) >> { }
+		request.getAttribute(GrailsApplicationAttributes.ACTION_NAME_ATTRIBUTE) >> { 'fooBar' }		
+		request.getAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE) >> { 'foo' }
+		request.getAttribute(GrailsApplicationAttributes.WEB_REQUEST) >> { webRequest }
+		request.getRequestDispatcher(_) >> { dispatcher }
+	}
+	
+	def 'Test forward request with controller and action params and url converter'() {
+		setup:
+			Map params = [controller : 'foo', action : 'fooBar', model : [param1 : 1, param2 : 2]]
+			urlConverter.toUrlElement(_) >> { it[0]?.toLowerCase() }
+			forwardMethod.urlConverter = urlConverter
+		when:
+			def forwardUri = forwardMethod.forward(request, response, params)
+		then:
+			forwardUri == '/grails/foo/foobar.dispatch'		
+	}
+	
+	def 'Test forward request with controller and action params and url converter in app context'() {
+		setup:
+			Map params = [controller : 'foo', action : 'fooBar', model : [param1 : 1, param2 : 2]]
+			urlConverter.toUrlElement(_) >> { it[0]?.toLowerCase() }
+			appContext.getBean("grailsUrlConverter", UrlConverter) >> { urlConverter }	
+		when:
+			def forwardUri = forwardMethod.forward(request, response, params)
+		then:
+			forwardUri == '/grails/foo/foobar.dispatch'
+	}
+	
+	def 'Test forward request with controller and action params without an url converter'() {
+		setup:
+			Map params = [controller : 'foo', action : 'fooBar', model : [param1 : 1, param2 : 2]]
+			appContext.getBean("grailsUrlConverter", UrlConverter) >> { null }
+			forwardMethod.urlConverter = null
+		when:
+			def forwardUri = forwardMethod.forward(request, response, params)
+		then:
+			forwardUri == '/grails/foo/fooBar.dispatch'
+	}	
+	
+	def 'Test forward request without controller and action params'() {
+		setup:
+			Map params = [url:'/foo/fooBar', model : [param1 : 1, param2 : 2]]
+			urlConverter.toUrlElement(_) >> { it[0]?.toLowerCase() }
+			forwardMethod.urlConverter = urlConverter
+		when:
+			def forwardUri = forwardMethod.forward(request, response, params)
+		then:
+			forwardUri == '/grails/foo/fooBar.dispatch'	
+	}
+}


### PR DESCRIPTION
This fix solves a 404 error when using the hyphenated URL converter in conjunction with a forward request.  The redirect method already uses the converter transitively through the LinkGenerator (which the forward
method does NOT use).  This patch brings the forward method in line with the logic applied by redirect and fixes the 404 issue when the forward URI is matched against the URL mappings.  An unit test was created to ensure proper functionality going forward.  I also built and ran all of the tests to ensure that they still pass.
