### PR TITLE
Configurable Reloading Behavior

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcher.java
@@ -209,11 +209,21 @@ public class GrailsProjectWatcher extends DirectoryWatcher {
         }
     }
 
-    private boolean fileIsReloadable(File file) {
+    protected boolean fileIsReloadable(File file) {
         String classname = GrailsResourceUtils.getClassName(file.getAbsolutePath());
-        boolean fileIsExcluded = (reloadExcludes != null) ? !reloadExcludes.contains(classname) : false;
+        boolean fileIsExcluded = (reloadExcludes != null) ? reloadExcludes.contains(classname) : false;
         boolean fileIsIncluded = (reloadIncludes != null) ? reloadIncludes.contains(classname) : true;
-        return (fileIsExcluded || fileIsIncluded);
+
+        // These are expanded for readability
+        if (fileIsExcluded == true) {
+            return false;
+        } else if (fileIsIncluded == true) {
+            return true;
+        } else if (fileIsExcluded == false && fileIsIncluded == false && reloadIncludes.size() > 0) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     private void reloadPlugin(File file) {

--- a/grails-core/src/test/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcherSpec.groovy
+++ b/grails-core/src/test/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcherSpec.groovy
@@ -1,0 +1,158 @@
+package org.codehaus.groovy.grails.compiler
+
+import spock.lang.Specification
+import org.junit.runner.RunWith
+import org.spockframework.runtime.Sputnik
+import grails.util.PluginBuildSettings
+import grails.util.BuildSettings
+import org.codehaus.groovy.grails.commons.GrailsClassUtils
+import org.codehaus.groovy.grails.io.support.GrailsResourceUtils
+
+@RunWith(Sputnik)
+class GrailsProjectWatcherSpec extends Specification {
+    static excludedConfig, includedConfig, includedAndExcludedConfig, slurper
+    static GrailsProjectWatcher projectWatcher
+    void setupSpec() {
+        slurper = new ConfigSlurper()
+        excludedConfig = slurper.parse("""
+            grails.reload.excludes = ['com.domain.package.Class']
+        """)
+        includedConfig = slurper.parse("""
+            grails.reload.includes = ['com.domain.package.Class']
+        """)
+        includedAndExcludedConfig = slurper.parse("""
+            grails.reload.excludes = ['com.domain.package.NonReloadableClass']
+            grails.reload.includes = ['com.domain.package.ReloadableClass']
+        """)
+
+        def compiler = new GrailsProjectCompiler(new PluginBuildSettings(new BuildSettings()))
+        compiler.compilerExtensions = [".java", ".groovy"]
+        projectWatcher = new GrailsProjectWatcher(compiler, null)
+
+    }
+    def "test that excluded reload classes make it to the project watcher"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def excludes = excludedConfig?.grails?.reload?.excludes
+        projectWatcher.reloadExcludes = (excludes instanceof List) ? excludes : []
+
+        expect:
+        1 == GrailsProjectWatcher.reloadExcludes.size()
+    }
+    def "test that included reload classes make it to the project watcher"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def includes = includedConfig?.grails?.reload?.includes
+        projectWatcher.reloadIncludes = (includes instanceof List) ? includes : []
+
+        expect:
+        1 == GrailsProjectWatcher.reloadIncludes.size()
+    }
+    def "test that included and excluded reload classes can be configured"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def excludes = excludedConfig?.grails?.reload?.excludes
+        projectWatcher.reloadExcludes = (excludes instanceof List) ? excludes : []
+        def includes = includedConfig?.grails?.reload?.includes
+        projectWatcher.reloadIncludes = (includes instanceof List) ? includes : []
+
+        expect:
+        1 == GrailsProjectWatcher.reloadExcludes.size()
+        1 == GrailsProjectWatcher.reloadIncludes.size()
+    }
+    def "test that excluded classes will not be reloaded"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def file = new MockFile(System.properties["java.io.tmpdir"])
+        def excludes = excludedConfig?.grails?.reload?.excludes
+        projectWatcher.reloadExcludes = (excludes instanceof List) ? excludes : []
+
+        when:
+        def isReloadable = projectWatcher.fileIsReloadable(file)
+
+        then:
+        false == isReloadable
+
+    }
+    def "test that included classes will be reloaded"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def file = new MockFile(System.properties["java.io.tmpdir"])
+        def includes = includedConfig?.grails?.reload?.includes
+        projectWatcher.reloadIncludes = (includes instanceof List) ? includes : []
+
+        when:
+        def isReloadable = projectWatcher.fileIsReloadable(file)
+
+        then:
+        true == isReloadable
+
+    }
+    def "test that non-configured classes will be reloaded when includes are not configured"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def file = new MockFile(System.properties["java.io.tmpdir"])
+        file.absPath = "reloading-test/src/java/com/domain/package/NonConfiguredClassTest.java"
+
+        when:
+        def isReloadable = projectWatcher.fileIsReloadable(file)
+
+        then:
+        true == isReloadable
+
+    }
+    def "test that non-configured classes will NOT be reloaded when includes are configured"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def file = new MockFile(System.properties["java.io.tmpdir"])
+        file.absPath = "reloading-test/src/java/com/domain/package/NonConfiguredClassTest.java"
+        def includes = includedConfig?.grails?.reload?.includes
+        projectWatcher.reloadIncludes = (includes instanceof List) ? includes : []
+
+        when:
+        def isReloadable = projectWatcher.fileIsReloadable(file)
+
+        then:
+        false == isReloadable
+    }
+    def "test that configured excluded classes will NOT be reloaded and that configured included classes WILL be reloaded"() {
+        given:
+        GrailsProjectWatcher.reloadExcludes = []
+        GrailsProjectWatcher.reloadIncludes = []
+        def reloadable = new MockFile(System.properties["java.io.tmpdir"])
+        reloadable.absPath = "reloading-test/src/java/com/domain/package/ReloadableClass.java"
+
+        def nonReloadable = new MockFile(System.properties["java.io.tmpdir"])
+        nonReloadable.absPath = "reloading-test/src/java/com/domain/package/NonReloadableClass.java"
+
+        def includes = includedAndExcludedConfig?.grails?.reload?.includes
+        def excludes = includedAndExcludedConfig?.grails?.reload?.excludes
+        projectWatcher.reloadIncludes = (includes instanceof List) ? includes : []
+        projectWatcher.reloadExcludes = (excludes instanceof List) ? excludes : []
+
+        when:
+        def reloadableIsReloadable = projectWatcher.fileIsReloadable(reloadable)
+        def nonReloadableIsReloadable = projectWatcher.fileIsReloadable(nonReloadable)
+
+        then:
+        true == reloadableIsReloadable
+        false == nonReloadableIsReloadable
+    }
+}
+
+class MockFile extends File {
+    String absPath = "reloading-test/src/java/com/domain/package/Class.java"
+    public MockFile(String fileName) {
+        super(fileName)
+    }
+    public String getAbsolutePath() {
+        return absPath
+    }
+}

--- a/scripts/RunApp.groovy
+++ b/scripts/RunApp.groovy
@@ -35,6 +35,8 @@ target('default': "Runs a Grails application") {
         runApp()
     }
 
+    startPluginScanner()
+
     if (!(grailsServer instanceof ForkedGrailsProcess)) {
         watchContext()
     }

--- a/scripts/_GrailsRun.groovy
+++ b/scripts/_GrailsRun.groovy
@@ -41,14 +41,15 @@ usingSecureServer = false
 
 grailsServer = null
 grailsContext = null
+autoRecompile = System.getProperty("disable.auto.recompile") ? !(System.getProperty("disable.auto.recompile").toBoolean()) : true
 
 // How often should recompilation occur while the application is running (in seconds)?
 // Defaults to 3s.
 recompileFrequency = System.getProperty("recompile.frequency")
 recompileFrequency = recompileFrequency ? recompileFrequency.toInteger() : 3
 
-// Should the reloading agent be enabled?
-isReloading = Boolean.getBoolean("grails.reload.enabled")
+// Should the reloading agent be enabled? By default, yes...
+isReloading = Boolean.getBoolean("grails.reload.enabled") ?: true
 
 shouldPackageTemplates = true
 
@@ -94,8 +95,11 @@ target(startPluginScanner: "Starts the plugin manager's scanner that detects cha
     }
 
     if (isReloading) {
-        projectWatcher = new GrailsProjectWatcher(projectCompiler, pluginManager)
-        projectWatcher.start()
+        new GrailsProjectWatcher(projectCompiler, pluginManager).with {
+            reloadExcludes = (config?.grails?.reload?.excludes instanceof List) ? config?.grails?.reload?.excludes : []
+            reloadIncludes = (config?.grails?.reload?.includes instanceof List) ? config?.grails?.reload?.includes : []
+            start()
+        }
     }
 }
 


### PR DESCRIPTION
This commit allows for reloading behavior to be configured from grails-app/conf/Config.groovy. By configuring the directives <code>grails.reload.excludes</code> and <code>grails.reload.includes</code> with a list of class names (Strings) that are to be excluded from reloading behavior or included in reloading behavior accordingly. If the <code>grails.reload.includes</code> list is configured, <i>only</i> the configured classes will be candidates for reloading. The default behavior will be to reload all source classes. The scope of the configuration is limited to project source files -- plugins will not be affected by this behavior. Spock tests are provided to validate project source file reloading behavior. This commit is derived from the JIRA conversation <a href="http://jira.grails.org/browse/GRAILS-8629" target="_blank">here</a>.

This commit also starts the pluginScanner (which activates the GrailsProjectWatcher) from the new RunApp invocation, and provides a default value of true to the <code>grails.reload.enabled</code> system variable when the RunApp script is executed.
