### PR TITLE
fixing improper use of the elvis operator when evaluating potential "false" value

### DIFF
--- a/scripts/_GrailsRun.groovy
+++ b/scripts/_GrailsRun.groovy
@@ -49,7 +49,8 @@ recompileFrequency = System.getProperty("recompile.frequency")
 recompileFrequency = recompileFrequency ? recompileFrequency.toInteger() : 3
 
 // Should the reloading agent be enabled? By default, yes...
-isReloading = Boolean.getBoolean("grails.reload.enabled") ?: true
+isReloading = Boolean.getBoolean("grails.reload.enabled")
+isReloading = isReloading != null ? isReloading : true
 
 shouldPackageTemplates = true
 


### PR DESCRIPTION
Boolean.getBoolean("property") ?: true will always evaluate to true with Groovy truth.
