### PR TITLE
add domain classes to the grails application context when in unit test

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsApplication.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsApplication.java
@@ -21,18 +21,6 @@ import grails.util.Metadata;
 import groovy.lang.GroovyClassLoader;
 import groovy.lang.GroovyObjectSupport;
 import groovy.util.ConfigObject;
-
-import java.io.IOException;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -45,6 +33,17 @@ import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Default implementation of the GrailsApplication interface that manages application loading,

--- a/grails-plugin-testing/src/main/groovy/grails/test/MvcUnitTestCase.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/MvcUnitTestCase.groovy
@@ -14,22 +14,19 @@
  */
 package grails.test
 
-import grails.util.GrailsNameUtils
-
+import grails.util.Holders
 import org.codehaus.groovy.grails.commons.ApplicationAttributes
 import org.codehaus.groovy.grails.plugins.testing.GrailsMockHttpServletRequest
 import org.codehaus.groovy.grails.plugins.testing.GrailsMockHttpServletResponse
 import org.codehaus.groovy.grails.support.MockApplicationContext
 import org.codehaus.groovy.grails.web.pages.DefaultGroovyPagesUriService
 import org.codehaus.groovy.grails.web.pages.GroovyPagesUriService
+import org.codehaus.groovy.grails.web.pages.TagLibraryLookup
 import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
 import org.codehaus.groovy.grails.web.servlet.mvc.GrailsWebRequest
-
 import org.springframework.mock.web.MockHttpSession
-import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.WebApplicationContext
-import org.codehaus.groovy.grails.web.pages.TagLibraryLookup
-import org.codehaus.groovy.grails.commons.DefaultGrailsApplication
+import org.springframework.web.context.request.RequestContextHolder
 
 /**
  * Common test case support class for controllers, tag libraries, and
@@ -117,11 +114,12 @@ class MvcUnitTestCase extends GrailsUnitTestCase {
 
     protected def bindMockWebRequest(GrailsMockHttpServletRequest mockRequest, GrailsMockHttpServletResponse mockResponse) {
         MockApplicationContext ctx = new MockApplicationContext()
-        def application = new DefaultGrailsApplication([testClass] as Class[], getClass().classLoader)
-        application.initialise()
+        grailsApplication = getGrailsApplication([testClass] as Class[])
+        grailsApplication.initialise()
         ctx.registerMockBean(testClass.name, testClass.newInstance())
-        def lookup = new TagLibraryLookup(applicationContext: ctx, grailsApplication: application)
+        def lookup = new TagLibraryLookup(applicationContext: ctx, grailsApplication: grailsApplication)
         lookup.afterPropertiesSet()
+        ctx.registerMockBean(Holders.APPLICATION_BEAN_NAME, grailsApplication)
         ctx.registerMockBean("gspTagLibraryLookup", lookup)
         ctx.registerMockBean(GroovyPagesUriService.BEAN_ID, new DefaultGroovyPagesUriService())
         mockRequest.servletContext.setAttribute(ApplicationAttributes.APPLICATION_CONTEXT, ctx)


### PR DESCRIPTION
Domain classes are not being resolved as such inside the grails application context during unit tests which causes the DomainClassMarshaller to not support the object. Therefore, the object falls back on the GroovyBranMarshaller, which will fail to render the object.
