### PR TITLE
Allow the action to be specified for g.paginate when using URL mappings

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
@@ -365,6 +365,9 @@ class RenderTagLib implements RequestConstants {
         def linkTagAttrs = [:]
         if (attrs.containsKey('mapping')) {
             linkTagAttrs.mapping = attrs.mapping
+            if (attrs.containsKey('action')) {
+                linkTagAttrs.action = action
+            }
         } else {
             linkTagAttrs.action = action
             if (attrs.controller) {


### PR DESCRIPTION
If using a URL mapping that requires an action, such as "/page/$id/$action", then the action can never be set
when using the pagination taglib, as it skips checking the action when the url mapping is specified.

For more info see http://jira.grails.org/browse/GRAILS-9304
