### PR TITLE
GRAILS-3577 - adds honoring the pluginexcludes for resources

### DIFF
--- a/grails-core/src/test/groovy/org/codehaus/groovy/grails/plugins/publishing/PluginDescriptorGeneratorSpec.groovy
+++ b/grails-core/src/test/groovy/org/codehaus/groovy/grails/plugins/publishing/PluginDescriptorGeneratorSpec.groovy
@@ -27,6 +27,46 @@ class PluginDescriptorGeneratorSpec extends Specification {
             xml.resources.resource[1].text() == 'bar.BarController'
     }
 
+    def "Test plugin excludes causes no problems when no resources"() {
+        given:
+            def generator = new PluginDescriptorGenerator(new BuildSettings(),"foo", [])
+        when:
+            def sw = new StringWriter()
+            generator.generatePluginXml([version:1.0, dependsOn:[core:1.0], author:"Bob", pluginExcludes: ["**/test/**"]], sw)
+            def xml = new XmlSlurper().parseText(sw.toString())
+        then:
+            xml.@name == 'foo'
+            xml.@version == '1.0'
+            xml.author.text() == 'Bob'
+            xml.runtimePluginRequirements.plugin[0].@name == 'core'
+            xml.runtimePluginRequirements.plugin[0].@version == '1.0'
+            xml.resources.resource.size() == 0
+    }
+
+    def "Test plugin/excludes is honoured for resources"() {
+        given:
+            def generator = new PluginDescriptorGenerator(new BuildSettings(),"foo", [
+                new FileSystemResource(new File("grails-app/controllers/FooController.groovy")),
+                new FileSystemResource(new File("grails-app/controllers/test/BarController.groovy")),
+                new FileSystemResource(new File("grails-app/services/test/MyService.groovy")),
+                new FileSystemResource(new File("grails-app/services/MyService2.groovy"))
+            ])
+        when:
+            def sw = new StringWriter()
+            generator.generatePluginXml([version:1.0, dependsOn:[core:1.0], author:"Bob", pluginExcludes: ["**/test/**"]], sw)
+            def xml = new XmlSlurper().parseText(sw.toString())
+        then:
+            xml.@name == 'foo'
+            xml.@version == '1.0'
+            xml.author.text() == 'Bob'
+            xml.runtimePluginRequirements.plugin[0].@name == 'core'
+            xml.runtimePluginRequirements.plugin[0].@version == '1.0'
+            xml.resources.resource.size() == 2
+            xml.resources.resource[0].text() == 'FooController'
+            xml.resources.resource[1].text() == 'MyService2'
+
+    }
+
     void "Test that dependencies and repositories are correctly populated from BuildSettings"() {
         given:"A plugin descriptor generator with a BuildSettings instance that defines repositories and dependencies"
             PluginDescriptorGenerator generator = systemUnderTest()


### PR DESCRIPTION
This is designed to fix this ticket: http://jira.grails.org/browse/GRAILS-3577 and affects binary plugins so they don't get errors when loading.

My only concern about this commit is that the resources that are being added are those that belong to the plugin, and not those that come in from references plugins.
