### PR TITLE
Minimal changes to allow STS 'long running process' to execute commands ...

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
+++ b/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
@@ -241,16 +241,19 @@ public class GrailsConsole {
     public static synchronized GrailsConsole getInstance() {
         if (instance == null) {
             try {
-                instance = createInstance();
+            	setInstance(createInstance());
             } catch (IOException e) {
                 throw new RuntimeException("Cannot create grails console: " + e.getMessage(), e);
             }
         }
-
+        return instance;
+    }
+    
+    public static void setInstance(GrailsConsole newConsole) {
+    	instance = newConsole;
         if (!(System.out instanceof GrailsConsolePrintStream)) {
             System.setOut(new GrailsConsolePrintStream(instance.out));
         }
-        return instance;
     }
 
     public static GrailsConsole createInstance() throws IOException {

--- a/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsEclipseConsole.java
+++ b/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsEclipseConsole.java
@@ -45,8 +45,14 @@ public class GrailsEclipseConsole extends GrailsConsole {
 
     private Boolean eclipseSupportsAnsi = null; //lazy initialized because implicitly used from super constructor.
 
-    protected GrailsEclipseConsole() throws IOException {
-        super();
+    /**
+     * Create a GrailsConsole that has some customizations to work better with STS. Note that
+     * this console implicitly captures and redirects System.out, System.err and System.in in the
+     * super class. So extreme care must be taken to ensure these streams are setup correctly
+     * before creating an instance.
+     */
+    public GrailsEclipseConsole() throws IOException {
+    	super();
     }
 
     @Override


### PR DESCRIPTION
...and redirect to a new GrailsConsole for each command.

These are a 'minimal' set of changes that will allow STS to provide a 'long running' grails process to execute Grails commands from within STS. This considerably speeds up command execution from STS compared to the current execution mechanims which starts a new process for each command.

I know it is tight... but I hope that these changes can still make it into Grails 2.2.0 release.
