### PR TITLE
Fix the path to the groovy library in the grails-macro file

### DIFF
--- a/grails-resources/src/grails/grails-macros.xml
+++ b/grails-resources/src/grails/grails-macros.xml
@@ -68,7 +68,7 @@
 
         <classpath>
           <pathelement location="@{cwd}"/>
-          <pathelement location="${grails.home}/lib/org.codehaus.groovy/groovy-all/@groovy.version@/jar/groovy-all-@groovy.version@.jar"/>
+          <pathelement location="${grails.home}/lib/org.codehaus.groovy/groovy-all/jars/groovy-all-@groovy.version@.jar"/>
           <pathelement location="${grails.home}/dist/grails-bootstrap-@grails.version@.jar"/>
           <extend-classpath/>
         </classpath>


### PR DESCRIPTION
For Ant files, the file grails-macros.xml has a dependency on the "groovy-all" library that is in the "lib" dir.
It looks like the structure of the "lib" directory has changed and the version is no more part of the path.
