### PR TITLE
Prevent url encoding for controller and action

### DIFF
--- a/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlCreator.java
+++ b/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlCreator.java
@@ -87,13 +87,13 @@ public class DefaultUrlCreator implements UrlCreator {
             }
             else {
                 if (controllerName != null) {
-                    appendUrlToken(actualUriBuf, controllerName, encoding);
+                    appendUrlToken(actualUriBuf, controllerName, encoding, false);
                 }
                 else {
-                    appendUrlToken(actualUriBuf, requestStateLookupStrategy.getControllerName(), encoding);
+                    appendUrlToken(actualUriBuf, requestStateLookupStrategy.getControllerName(), encoding, false);
                 }
             }
-            appendUrlToken(actualUriBuf, actionName, encoding);
+            appendUrlToken(actualUriBuf, actionName, encoding, false);
         }
         if (id != null) {
             appendUrlToken(actualUriBuf, id, encoding);
@@ -240,9 +240,18 @@ public class DefaultUrlCreator implements UrlCreator {
     }
 
     /*
-     * Appends a URL token to the buffer
+     * Appends a URL token to the buffer. Always url encodes the token before append.
      */
-    private void appendUrlToken(FastStringWriter actualUriBuf, Object token, String charset) {
+    protected void appendUrlToken(FastStringWriter actualUriBuf, Object token, String charset) {
+        appendUrlToken(actualUriBuf, token, charset, true);
+    }
+
+    /*
+     * Appends a URL token to the buffer
+     *
+     * @param urlEncode If true, url encodes the token before append
+     */
+    protected void appendUrlToken(FastStringWriter actualUriBuf, Object token, String charset, boolean urlEncode) {
         actualUriBuf.append(SLASH).append(urlEncode(token, charset));
     }
 }

--- a/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlCreator.java
+++ b/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlCreator.java
@@ -249,9 +249,9 @@ public class DefaultUrlCreator implements UrlCreator {
     /*
      * Appends a URL token to the buffer
      *
-     * @param urlEncode If true, url encodes the token before append
+     * @param needsUrlEncode If true, url encodes the token before append
      */
-    protected void appendUrlToken(FastStringWriter actualUriBuf, Object token, String charset, boolean urlEncode) {
-        actualUriBuf.append(SLASH).append(urlEncode(token, charset));
+    protected void appendUrlToken(FastStringWriter actualUriBuf, Object token, String charset, boolean needsUrlEncode) {
+        actualUriBuf.append(SLASH).append(needsUrlEncode ? urlEncode(token, charset) : token);
     }
 }


### PR DESCRIPTION
Currently, the controller name and action name are url-encoded when creating an HTML link.

But I want to be able to configure my controller to have a featureUri with a slash in it - e.g. "admin/myController". This should be possible using the UrlMappings framework, but currently fails because the slash is encoded to "%2F" by the LinkGenerator. So the URI becomes "admin%2FmyController".

This patch prevents URL-encoding the controller name and action, when creating a URL.
