### PR TITLE
assemble.gradle change for default plugins upgrade

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -95,8 +95,8 @@ task pluginsFromRepo {
         resources: "1.1.6",
         webxml: "1.4.1",
         jquery: "1.8.0",
-        'database-migration': "1.1",
-        cache: "1.0.0"
+        'database-migration': "1.2",
+        cache: "1.0.1"
     ]
 
     ext.dir = file("$buildDir/pluginsFromRepo")


### PR DESCRIPTION
This commit 87cfc1ae2695780fa282fb29f8ae22271a216873 for default plugins upgrade should have included a change to assemble.gradle too.
