### PR TITLE
"integrate-with --git" improvement for GGTS (git users)

### DIFF
--- a/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
+++ b/grails-resources/src/grails/templates/ide-support/git/grailsProject.gitignore
@@ -13,3 +13,5 @@ stacktrace.log
 /out/
 /web-app/plugins
 /web-app/WEB-INF/classes
+/.link_to_grails_plugins/
+/target-eclipse/


### PR DESCRIPTION
Makes "integrate-with --git" more usable for GGTS/STS users
    -> ignoring linked folder ".link_to_grails_plugins"
    -> ignoring folder target-eclipse
