### PR TITLE
add uaa classpath to eclipse classpath

### DIFF
--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -55,3 +55,10 @@ jar.appendix = 'bootstrap'
 jar {
     from compileUaaGroovy.outputs.files
 }
+
+
+eclipse {
+	classpath {
+		plusConfigurations += configurations.uaa
+	}
+}


### PR DESCRIPTION
Fix missing uaa dependency on eclipse import.
