### PR TITLE
Updated jQuery plugin to 1.8.3

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -94,7 +94,7 @@ task pluginsFromRepo {
         tomcat: grailsVersion,
         resources: "1.1.6",
         webxml: "1.4.1",
-        jquery: "1.8.2",
+        jquery: "1.8.3",
         'database-migration': "1.2",
         cache: "1.0.1"
     ]

--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -45,7 +45,7 @@ grails.project.dependency.resolution = {
 
     plugins {
         runtime ":hibernate:$grailsVersion"
-        runtime ":jquery:1.8.2"
+        runtime ":jquery:1.8.3"
         runtime ":resources:1.1.6"
 
         // Uncomment these (or add new ones) to enable additional resources capabilities

--- a/grails-resources/src/grails/templates/maven/app.pom
+++ b/grails-resources/src/grails/templates/maven/app.pom
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.grails.plugins</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.8.2</version>
+            <version>1.8.3</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Dependent on https://github.com/gpc/grails-jquery/pull/19 and a new version of the jQuery plugin being released.
