### PR TITLE
GRAILS-5312 fixed always compile spring/resources.groovy on Windows

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/Grailsc.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/Grailsc.java
@@ -48,7 +48,7 @@ public class Grailsc extends Groovyc {
            File df = null;
            if (f.endsWith(".groovy")) {
                df = new File(destPath, f.substring(0, f.length()-7) + ".class");
-               int i = f.lastIndexOf('/');
+               int i = f.lastIndexOf(File.separator);
                if (!df.exists() && i > -1) {
                    // check root package
                    File tmp = new File(destPath, f.substring(i, f.length()-7) + ".class");


### PR DESCRIPTION
Took me 4 hours of my life to track down this bug.
Please integrate it in grails 2.1.x and 2.2.x.

see http://jira.grails.org/browse/GRAILS-5312
