### PR TITLE
changed to enable to use command line arguments supplied for the script....

### DIFF
--- a/scripts/RunScript.groovy
+++ b/scripts/RunScript.groovy
@@ -34,11 +34,11 @@ target(runScript: 'Main implementation that executes the specified script(s) aft
     def persistenceInterceptor = appCtx.containsBean('persistenceInterceptor') ? appCtx.persistenceInterceptor : null
     persistenceInterceptor?.init()
     try {
-        for (scriptFile in argsMap.params) {
-            event('StatusUpdate', ["Running script $scriptFile ..."])
-            executeScript scriptFile, classLoader
-            event('StatusUpdate', ["Script $scriptFile complete!"])
-        }
+        String scriptFile = argsMap.params[0]
+        String[] args = argsMap.params.tail()
+        event('StatusUpdate', ["Running script $scriptFile ..."])
+        executeScript scriptFile, args, classLoader
+        event('StatusUpdate', ["Script $scriptFile complete!"])
     } finally {
         persistenceInterceptor?.flush()
         persistenceInterceptor?.destroy()
@@ -46,7 +46,7 @@ target(runScript: 'Main implementation that executes the specified script(s) aft
 }
 
 
-def executeScript(scriptFile, classLoader) {
+def executeScript(scriptFile, args, classLoader) {
     File script = new File(scriptFile)
     if (!script.exists()) {
         event('StatusError', ["Designated script doesn't exist: $scriptFile"])
@@ -54,7 +54,7 @@ def executeScript(scriptFile, classLoader) {
     }
 
     def shell = new GroovyShell(classLoader, new Binding(ctx: appCtx, grailsApplication: grailsApp))
-    shell.evaluate script.text
+    shell.run(script, args)
 }
 
 setDefaultTarget main


### PR DESCRIPTION
... And to make include the script name in error message, change GroovyShell.evaluate(String) to GroovyShell.run(File).

Use of shell variable 'args' in groovy scripts are very common and useful. But in current implementation, scripts called from 'run-script' can't use args at all so fixed it.

As a side effect, in this version can't spcify multiple scripts at one command invocation of run-script.
It might be better to create another new script(for example 'run-batch') to use 'args' arguments from script.
I have no good idea anymore so send in this form as a one proposal.

Best regards,
