### PR TITLE
make javdoc read/write utf-8 & add meta tag with utf-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,6 +137,12 @@ subprojects { project ->
         options.debug = true
     }
 
+    configure([javadoc]) {
+        options.encoding "UTF-8"
+        options.docEncoding "UTF-8"
+        options.charSet "UTF-8"
+    }
+
     idea {
         module.iml.whenMerged { module ->
             // adding slf4j-simple with scope TEST to .iml


### PR DESCRIPTION
Hi,

building grails-core fails for me with the error below because java doc generation does not use utf-8 at all stages. To make this consistent l added the necessary options to `build.gradle`.

```
:grails-bootstrap:javadoc
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                   ^
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails  /build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                    ^
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                     ^
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                       ^
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                        ^
/Users/hauner/Development/Grails/grails-core.git/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java:669: error: unmappable character for encoding ASCII
 * Like {@link #userInput(String)} except that the user's entered characters will be replaced with ???*??? on the CLI,
                                                                                                         ^
6 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':grails-bootstrap:javadoc'.
> Javadoc generation failed.
```
