### PR TITLE
Fixed for GRAILS-9778 - Cygwin shows empty path

### DIFF
--- a/grails-resources/src/grails/home/bash/startGrails
+++ b/grails-resources/src/grails/home/bash/startGrails
@@ -263,7 +263,9 @@ if $cygwin; then
     GRAILS_HOME=`cygpath --path --mixed "$GRAILS_HOME"`
     JAVA_HOME=`cygpath --path --mixed "$JAVA_HOME"`
     STARTER_CONF=`cygpath --path --mixed "$STARTER_CONF"`
-    CP=`cygpath --path --mixed "$CP"`
+    if [ "x$CP" != "x" ] ; then
+        CP=`cygpath --path --mixed "$CP"`
+    fi
     TOOLS_JAR=`cygpath --path --mixed "$TOOLS_JAR"`
     STARTER_CLASSPATH=`cygpath --path --mixed "$STARTER_CLASSPATH"`
 	# We build the pattern for arguments to be converted via cygpath


### PR DESCRIPTION
Here's a pull request for Issue: GRAILS-9778.

I took the solution from this discussion:
http://grails.1312388.n4.nabble.com/Grails-bug-with-cygwin-terminal-td4639236.html
