### PR TITLE
Update jQuery to 1.9.0

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -102,7 +102,7 @@ task pluginsFromRepo {
     ext.plugins = [
         resources: "1.1.6",
         webxml: "1.4.1",
-        jquery: "1.8.3",
+        jquery: "1.9.0",
         'database-migration': "1.3.2",
         cache: "1.0.1"
     ]

--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -51,7 +51,7 @@ grails.project.dependency.resolution = {
     }
 
     plugins {
-        runtime ":jquery:1.8.3"
+        runtime ":jquery:1.9.0"
         runtime ":resources:1.1.6"
 
         // Uncomment these (or add new ones) to enable additional resources capabilities

--- a/grails-resources/src/grails/templates/maven/app.pom
+++ b/grails-resources/src/grails/templates/maven/app.pom
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.grails.plugins</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.8.3</version>
+            <version>1.9.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
I'm only updating jQuery on master as opposed to 2.2.x and 2.1.x because jQuery 1.9 has breaking changes from 1.8.3 (http://jquery.com/upgrade-guide/1.9/).

Also, I was able to release jQuery plugin version 1.9.0 (http://repo.grails.org/grails/simple/plugins-releases-local/org/grails/plugins/jquery/1.9.0/), but the plugin portal (http://grails.org/plugin/jquery) doesn't show the new version.  I have tried the "--ping-only" command a couple times with no success.  There must be some errors in the logs for the site explaining why it won't update.  Please let me know!
