### PR TITLE
upgrade to groovy 2.0.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     datastoreVersion = "1.1.4.BUILD-SNAPSHOT"
     gantVersion = "1.9.6"
     gdocEngineVersion = "1.0.1"
-    groovyVersion = "2.0.5"
+    groovyVersion = "2.0.6"
     gradleGroovyVersion = groovyVersion
     gradleGroovyVersion = "1.8.2"
     ivyVersion = "2.2.0"

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
@@ -161,7 +161,7 @@ public class GrailsCoreDependencies {
 
                         // dependencies needed at compile time
                         ModuleRevisionId[] groovyDependencies = {
-                            ModuleRevisionId.newInstance("org.codehaus.groovy", "groovy-all", "2.0.5")
+                            ModuleRevisionId.newInstance("org.codehaus.groovy", "groovy-all", "2.0.6")
                         };
                         registerDependencies(dependencyManager, compileTimeDependenciesMethod, groovyDependencies, "jline");
 


### PR DESCRIPTION
This updates the groovy version to 2.0.6. All the tests seems to pass except grails-test-suite-uber, which throws a groovyc error at me when I try to run it. I've posted to the mailing list asking for help on that, but I think that is a local problem rather than an issue with the version update.
