### PR TITLE
upgrade of concurrentlinkedhashmap_lru

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -242,7 +242,7 @@ SECTION 2: Apache License, V2.0
    >>> commons-lang-2.6
    >>> commons-pool-1.5.6
    >>> commons-validator-1.3.1
-   >>> concurrentlinkedhashmap-lru-1.2_jdk5
+   >>> concurrentlinkedhashmap-lru-1.3.1
    >>> ehcache-core-2.4.6
    >>> gant_groovy1.7-1.9.6
    >>> groovy-all-2.0.2
@@ -963,7 +963,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> concurrentlinkedhashmap-lru-1.2_jdk5
+>>> concurrentlinkedhashmap-lru-1.3.1
 
 Copyright 2011 Benjamin Manes
 
@@ -985,7 +985,7 @@ ADDITIONAL LICENSE INFORMATION:
 
 > Creative Commons Attribution License  2.5
 
-C:\Documents and Settings\dileep.antony\My Documents\Downloads\concurrentlinkedhashmap-lru-1.2_jdk5-sources.jar\com\googlecode\concurrentlinkedhashmap\ThreadSafe.java
+C:\Documents and Settings\dileep.antony\My Documents\Downloads\concurrentlinkedhashmap-lru-1.3.1-sources.jar\com\googlecode\concurrentlinkedhashmap\ThreadSafe.java
 
 Copyright (c) 2005 Brian Goetz
 Released under the Creative Commons Attribution License

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     hibernateVersion = "3.6.10.Final"
     ehcacheVersion = "2.4.6"
     junitVersion = "4.10"
-    concurrentlinkedhashmapVersion = "1.2_jdk5"
+    concurrentlinkedhashmapVersion = "1.3.1"
 }
 
 version = grailsVersion


### PR DESCRIPTION
as discussed some time ago on grails-dev I've updated the dependency of concurrentlinkedhashmap_lru to 1.3.1.

Since this change must be in sync with the same update for grails-data-mapping, please apply the both pull-requests at the same time. Also, any new build of grails-core needs to have a updated 1.1.4-SNAPSHOT of grails-datastore-core deployed to repo.grails.org.

The core issue is that concurrentlinkedhashmap_lru 1.2_jdk5 and 1.3.1 are not backwards compatible.
