### PR TITLE
update to Groovy 2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     datastoreVersion = "1.1.4.BUILD-SNAPSHOT"
     gantVersion = "1.9.6"
     gdocEngineVersion = "1.0.1"
-    groovyVersion = "2.0.6"
+    groovyVersion = "2.1.0"
     gradleGroovyVersion = groovyVersion
     gradleGroovyVersion = "1.8.2"
     ivyVersion = "2.2.0"

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
@@ -161,7 +161,7 @@ public class GrailsCoreDependencies {
 
                         // dependencies needed at compile time
                         ModuleRevisionId[] groovyDependencies = {
-                            ModuleRevisionId.newInstance("org.codehaus.groovy", "groovy-all", "2.0.6")
+                            ModuleRevisionId.newInstance("org.codehaus.groovy", "groovy-all", "2.1.0")
                         };
                         registerDependencies(dependencyManager, compileTimeDependenciesMethod, groovyDependencies, "jline");
 


### PR DESCRIPTION
Update to Groovy 2.1.0 to avoid http://jira.codehaus.org/browse/GROOVY-5868 in Groovy 2.0.6

Test suite passes with this update.
