### PR TITLE
Fix for Grails-3488

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassProperty.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassProperty.java
@@ -67,6 +67,7 @@ public class DefaultGrailsDomainClassProperty implements GrailsDomainClassProper
     private GrailsDomainClass component;
     private boolean basicCollectionType;
     private Map<String, Object> defaultConstraints;
+    private boolean explicitSaveUpdateCascade = false;
 
     /**
      * Constructor.
@@ -444,6 +445,14 @@ public class DefaultGrailsDomainClassProperty implements GrailsDomainClassProper
             }
         }
         otherSide = property;
+    }
+
+    public boolean isExplicitSaveUpdateCascade() {
+        return explicitSaveUpdateCascade;
+    }
+
+    public void setExplicitSaveUpdateCascade(boolean explicitSaveUpdateCascade) {
+        this.explicitSaveUpdateCascade = explicitSaveUpdateCascade;
     }
 
     public boolean isInherited() {

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/GrailsDomainClassProperty.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/GrailsDomainClassProperty.java
@@ -188,6 +188,23 @@ public interface GrailsDomainClassProperty {
     void setOtherSide(GrailsDomainClassProperty referencedProperty);
 
     /**
+     * Check whether this property is set up to receive save-update cascading via the Mapping DSL rather than
+     * using 'belongsTo'.
+     * @return True if this property is explicitly defined to receive save and update cascades, false otherwise.
+     */
+    boolean isExplicitSaveUpdateCascade();
+
+    /**
+     * Sets whether the domain class property is explicitly set up to receive
+     * save and update cascades via a means other than 'belongsTo'.  Specifically,
+     * the cascades will have been set up via the Mapping DSL.
+     *
+     * @param explicitSaveUpdateCascade Whether this property is explicity defined, via
+     * the mapping DSL, to receive save and update cascades.
+     */
+    void setExplicitSaveUpdateCascade(boolean explicitSaveUpdateCascade);
+
+    /**
      * Whether the property is inherited from a super class.
      * @return true if its inherited
      */

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/validation/GrailsDomainClassValidator.java
@@ -232,7 +232,7 @@ public class GrailsDomainClassValidator implements CascadingValidator, GrailsApp
 
         GrailsDomainClass associatedDomainClass = getAssociatedDomainClass(associatedObject, persistentProperty);
 
-        if (associatedDomainClass == null || !isOwningInstance(bean, associatedDomainClass)) {
+        if (associatedDomainClass == null || !isOwningInstance(bean, associatedDomainClass) && !persistentProperty.isExplicitSaveUpdateCascade()) {
             return;
         }
 

--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateDomainClassProperty.java
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsHibernateDomainClassProperty.java
@@ -51,6 +51,7 @@ public class GrailsHibernateDomainClassProperty implements GrailsDomainClassProp
     private GrailsDomainClassProperty otherSide;
     private boolean owingSide;
     private String columnName;
+    private boolean explicitSaveUpdateCascade;
 
     public GrailsHibernateDomainClassProperty(GrailsHibernateDomainClass domainClass, String propertyName) {
         this.domainClass = domainClass;
@@ -106,6 +107,14 @@ public class GrailsHibernateDomainClassProperty implements GrailsDomainClassProp
 
     public void setOtherSide(GrailsDomainClassProperty referencedProperty) {
         otherSide = referencedProperty;
+    }
+
+    public boolean isExplicitSaveUpdateCascade() {
+        return explicitSaveUpdateCascade;
+    }
+
+    public void setExplicitSaveUpdateCascade(boolean explicitSaveUpdateCascade) {
+        this.explicitSaveUpdateCascade = explicitSaveUpdateCascade;
     }
 
     public GrailsDomainClassProperty getOtherSide() {

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
@@ -1108,6 +1108,43 @@ class Alert {
         assertEquals(Column.DEFAULT_SCALE, enumColumn.scale)
     }
 
+    void testTrackSaveUpdateCascade() {
+        assertTrue(getCustomCascadedProperty('save-update').isExplicitSaveUpdateCascade())
+    }
+
+    void testTrackAllCascade() {
+        assertTrue(getCustomCascadedProperty('all').isExplicitSaveUpdateCascade())
+    }
+
+    void testTrackAllDeleteOrphanCascade() {
+        assertTrue(getCustomCascadedProperty('all-delete-orphan').isExplicitSaveUpdateCascade())
+    }
+
+    void testTrackNonSaveUpdateCascade() {
+        assertTrue(!getCustomCascadedProperty('delete').isExplicitSaveUpdateCascade())
+    }
+
+    private GrailsDomainClassProperty getCustomCascadedProperty(String cascadeValue) {
+        new DefaultGrailsDomainClass(cl.parseClass('''
+class CascadeChild {
+    Long id
+    Long version
+}'''))
+
+        GrailsDomainClass cascadeParent = new DefaultGrailsDomainClass(
+            cl.parseClass("""\
+class CascadeParent {
+    Long id
+    Long version
+    CascadeChild child
+    static mapping = {
+        child cascade: '${cascadeValue}'
+    }
+}"""))
+        GrailsDomainBinder.evaluateMapping(cascadeParent)
+        return cascadeParent.persistentProperties.find { it.name == 'child' }
+    }
+
     private org.hibernate.mapping.Collection findCollection(DefaultGrailsDomainConfiguration config, String role) {
         config.collectionMappings.find { it.role == role }
     }


### PR DESCRIPTION
I added support for cascading validation when the mapping ORM DSL is used.  With these changes, validation will cascade if the 'cascade' property for a field is set to 'save-update', 'all', or 'all-delete-orphan'.

Jira: http://jira.grails.org/browse/GRAILS-3488
