### PR TITLE
fix for GRAILS-9834 '<g:external> : media="screen, projector" but should be media="screen, projection"'

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -273,7 +273,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
     }
 
     static SUPPORTED_TYPES = [
-        css:[type:"text/css", rel:'stylesheet', media:'screen, projector'],
+        css:[type:"text/css", rel:'stylesheet', media:'screen, projection'],
         js:[type:'text/javascript', writer:'js'],
 
         gif:[rel:'shortcut icon'],

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -741,7 +741,7 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals '<script src="/js/main.js" type="text/javascript"></script>\r\n', template
 
         template = '<g:external uri="/css/style.css"/>'
-        assertOutputEquals '<link href="/css/style.css" type="text/css" rel="stylesheet" media="screen, projector"/>\r\n', template
+        assertOutputEquals '<link href="/css/style.css" type="text/css" rel="stylesheet" media="screen, projection"/>\r\n', template
 
         template = '<g:external uri="/css/print.css" media="print"/>'
         assertOutputEquals '<link href="/css/print.css" type="text/css" rel="stylesheet" media="print"/>\r\n', template
@@ -755,7 +755,7 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals '<script src="/js/main.js?requestDataValueProcessorParamName=paramValue" type="text/javascript"></script>\r\n', template
 
         template = '<g:external uri="/css/style.css"/>'
-        assertOutputEquals '<link href="/css/style.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="screen, projector"/>\r\n', template
+        assertOutputEquals '<link href="/css/style.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="screen, projection"/>\r\n', template
 
         template = '<g:external uri="/css/print.css" media="print"/>'
         assertOutputEquals '<link href="/css/print.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="print"/>\r\n', template


### PR DESCRIPTION
this patch fixes http://jira.grails.org/browse/GRAILS-9834
