### PR TITLE
Minimal suport to enable forked mode debugging in GGTS.

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/BuildSettings.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/util/BuildSettings.groovy
@@ -1484,7 +1484,31 @@ class BuildSettings extends AbstractBuildSettings {
     }
 
     private getForkConfig() {
-        config.grails.project.fork
+        def result = config.grails.project.fork;
+		String syspropDebugArgs = System.getProperty("grails.project.fork.run.debugArgs");
+		if (syspropDebugArgs) {
+			//TODO; some way to copy over existing properties
+			//  The code below doesn't appear to work in all cases and sometimes results in 
+			//  errors like this: 
+			//  org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast 
+			//object 'groovy.util.ConfigObject@8cf401' with class 'groovy.util.ConfigObject' 
+//			def oldMap = result?.run;
+//			result.run = [
+//				maxMemory: oldMap?.maxMemory, 
+//				minMemory: oldMap?.minMemory
+//			];
+			result.run = [:];
+			result.run.debug = true;
+			result.run.debugArgs = syspropDebugArgs;
+		}
+		syspropDebugArgs = System.getProperty("grails.project.fork.test.debugArgs");
+		if (syspropDebugArgs) {
+			//TODO; some way to copy over existing properties
+			result.test = [:];
+			result.test.debug = true;
+			result.test.debugArgs = syspropDebugArgs;
+		}
+		return result;
     }
 
     protected File makeAbsolute(File dir) {

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -42,6 +42,7 @@ abstract class ForkedGrailsProcess {
     int minMemory = 64
     int maxPerm = 256
     boolean debug = false
+	String debugArgs = "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005";
     boolean reloading = true
     boolean forkReserve
     File reloadingAgent
@@ -249,8 +250,8 @@ abstract class ForkedGrailsProcess {
         File tempFile = storeExecutionContext(executionContext)
 
         List<String> cmd = ["java", "-Xmx${maxMemory}M".toString(), "-Xms${minMemory}M".toString(), "-XX:MaxPermSize=${maxPerm}m".toString(), "-Dgrails.fork.active=true", "-Dgrails.build.execution.context=${tempFile.canonicalPath}".toString(), "-cp", classpathString]
-        if (debug && !isReserve) {
-            cmd.addAll(["-Xdebug", "-Xnoagent", "-Dgrails.full.stacktrace=true", "-Djava.compiler=NONE", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005"])
+		if (debug && !isReserve) {
+            cmd.addAll(["-Xdebug", "-Xnoagent", "-Dgrails.full.stacktrace=true", "-Djava.compiler=NONE", debugArgs])
         }
         final console = GrailsConsole.getInstance()
         if (isReserve) {


### PR DESCRIPTION
This is just to give an idea of what's needed. I didn't quite get things to work properly in terms of keeping any memory related settings that may be provided in the user's BuildConfig.groovy.

I.e. we would like to override the 'debug' and 'debugArgs' via system properties but keep the settings otherwise provided by the user.

I imagine that what's coded up here will revert memory settings to the Grails defaults and forget about any potential settings in BuildConfig.

Related issue in Jira:
http://jira.grails.org/browse/GRAILS-9836
