### PR TITLE
Fix issue where calling validate() after a domain class is reloaded with...

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/plugins/orm/hibernate/HibernatePluginSupport.groovy
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/plugins/orm/hibernate/HibernatePluginSupport.groovy
@@ -379,16 +379,16 @@ Using Grails' default naming strategy: '${ImprovedNamingStrategy.name}'"""
                            proxyIfReloadEnabled = false
                        }
                     }
-    
-                    if(event.source instanceof Class) {
-                        GrailsDomainClass dc = application.getDomainClass(event.source.name)
-                        if (!dc.abstract && GrailsHibernateUtil.usesDatasource(dc, datasourceName)) {
-                            "${dc.fullName}Validator$suffix"(HibernateDomainClassValidator) {
-                                messageSource = ref("messageSource")
-                                domainClass = ref("${dc.fullName}DomainClass")
-                                sessionFactory = ref("sessionFactory$suffix")
-                                grailsApplication = ref("grailsApplication", true)
-                            }
+                }
+
+                if(event.source instanceof Class) {
+                    GrailsDomainClass dc = application.getDomainClass(event.source.name)
+                    if (!dc.abstract && GrailsHibernateUtil.usesDatasource(dc, datasourceName)) {
+                        "${dc.fullName}Validator$suffix"(HibernateDomainClassValidator) {
+                            messageSource = ref("messageSource")
+                            domainClass = ref("${dc.fullName}DomainClass")
+                            sessionFactory = ref("sessionFactory$suffix")
+                            grailsApplication = ref("grailsApplication", true)
                         }
                     }
                 }


### PR DESCRIPTION
... hibernate.reload = false causes NPE

In testing the hibernate.reload = false changes, I found that validate() throws an NPE b/c the GrailsDomainClass reference is not valid unless the Validator bean is registered again. This change moves the Validator re-register out of the check for reloading. In my testing, it didn't add any significant time to the reload and I was able to reload and save(), get(), etc. the class with no problems.
