### PR TITLE
Updated Junit to 4.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
     springLoadedVersion = "1.1.1"
     springVersion = "3.2.2.RELEASE"
     ehcacheVersion = "2.4.6"
-    junitVersion = "4.10"
+    junitVersion = "4.11"
     concurrentlinkedhashmapVersion = "1.3.1"
 }
 


### PR DESCRIPTION
Please see discussion on #292.  I was going include junit-dep to avoid multiple versions of junit, but Spock is now on 4.11 too and removed junit-dep.  

I ran the entire test suite and all tests pass! :)
