### PR TITLE
GRAILS-8976 enable autowiring of Filters during unit test

### DIFF
--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
@@ -75,13 +75,18 @@ class FilterConfig extends ControllersApi {
      */
     def propertyMissing(String propertyName) {
         // Delegate to the parent definition if it has this property.
-        if (filtersDefinition.metaClass.hasProperty(filtersDefinition, propertyName)) {
+        if (wiredFiltersDefinition.metaClass.hasProperty(wiredFiltersDefinition, propertyName)) {
             def getterName = GrailsClassUtils.getGetterName(propertyName)
-            metaClass."$getterName" = {-> delegate.filtersDefinition.getProperty(propertyName) }
-            return filtersDefinition."$propertyName"
+            metaClass."$getterName" = {-> delegate.wiredFiltersDefinition.getProperty(propertyName) }
+            return wiredFiltersDefinition."$propertyName"
         }
 
         throw new MissingPropertyException(propertyName, filtersDefinition.getClass())
+    }
+
+    def getWiredFiltersDefinition() {
+        final grailsFilter = grailsApplication.getArtefact(FiltersConfigArtefactHandler.TYPE, filtersDefinition.class.name)
+        applicationContext."${grailsFilter.fullName}"
     }
 
     /**
@@ -90,7 +95,7 @@ class FilterConfig extends ControllersApi {
      */
     def methodMissing(String methodName, args) {
         // Delegate to the parent definition if it has this method.
-        List<MetaMethod> respondsTo = filtersDefinition.metaClass.respondsTo(filtersDefinition, methodName, args)
+        List<MetaMethod> respondsTo = wiredFiltersDefinition.metaClass.respondsTo(wiredFiltersDefinition, methodName, args)
         if (respondsTo) {
             // Use DelegateMetaMethod to proxy calls to actual MetaMethod for subsequent calls to this method
             DelegateMetaMethod dmm=new DelegateMetaMethod(respondsTo[0], FilterConfigDelegateMetaMethodTargetStrategy.instance)
@@ -98,7 +103,7 @@ class FilterConfig extends ControllersApi {
             metaClass.registerInstanceMethod(dmm)
 
             // for this invocation we still have to make the call
-            return respondsTo[0].invoke(filtersDefinition, args)
+            return respondsTo[0].invoke(wiredFiltersDefinition, args)
         }
 
         // Ideally, we would throw a MissingMethodException here
@@ -106,12 +111,12 @@ class FilterConfig extends ControllersApi {
         // if it's in the initialisation phase, the MME gets swallowed somewhere.
         if (!initialised) {
             throw new IllegalStateException(
-                    "Invalid filter definition in ${filtersDefinition.getClass().name} - trying "
+                    "Invalid filter definition in ${wiredFiltersDefinition.getClass().name} - trying "
                     + "to call method '${methodName}' outside of an interceptor.")
         }
 
         // The required method was not found on the parent filter definition either.
-        throw new MissingMethodException(methodName, filtersDefinition.getClass(), args)
+        throw new MissingMethodException(methodName, wiredFiltersDefinition.getClass(), args)
     }
 
     String toString() {"FilterConfig[$name, scope=$scope]"}

--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/FiltersUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/FiltersUnitTestMixin.groovy
@@ -86,7 +86,10 @@ class FiltersUnitTestMixin extends ControllerUnitTestMixin {
                 arguments = [FiltersConfigArtefactHandler.TYPE, grailsFilter.fullName]
 
             }
-            "$grailsFilter.fullName"(grailsFilter.clazz)
+            "$grailsFilter.fullName"(grailsFilter.clazz) { bean ->
+                bean.scope = 'prototype'
+                bean.autowire = true
+            }
         }
 
         FiltersGrailsPlugin.reloadFilters(grailsApplication, applicationContext)

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/FiltersUnitTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/FiltersUnitTestMixinTests.groovy
@@ -1,13 +1,16 @@
 package grails.test.mixin
 
+import grails.test.GrailsMock
 import grails.test.mixin.web.FiltersUnitTestMixin
 import org.junit.Before
 import org.junit.Test
+import org.springframework.beans.factory.config.MethodInvokingFactoryBean
 
 @TestMixin(FiltersUnitTestMixin)
 class FiltersUnitTestMixinTests {
 
     AuthorController controller
+    GrailsMock autowiredServiceMock
 
     @Before
     void setUp() {
@@ -72,6 +75,46 @@ class FiltersUnitTestMixinTests {
         assert request.filterView == null
         assert request.exception != null
     }
+
+    @Test
+    void testFilterIsAutoWired() {
+        defineBeans {
+            autowiredService(MethodInvokingFactoryBean) {
+                targetObject = this
+                targetMethod = 'mockAutowiredService'
+            }
+        }
+        mockFilters(AutowiredFilters)
+
+        withFilters(action:"list") {
+            controller.list()
+        }
+
+        autowiredServiceMock.verify()
+    }
+
+    @Test
+    void testFilterIsAutoWiredWithBeansDefinedAfterMocking() {
+        mockFilters(AutowiredFilters)
+        defineBeans {
+            autowiredService(MethodInvokingFactoryBean) {
+                targetObject = this
+                targetMethod = 'mockAutowiredService'
+            }
+        }
+
+        withFilters(action:"list") {
+            controller.list()
+        }
+
+        autowiredServiceMock.verify()
+    }
+
+    AutowiredService mockAutowiredService() {
+        this.autowiredServiceMock = mockFor(AutowiredService)
+        this.autowiredServiceMock.demand.setupSession(1) {}
+        return this.autowiredServiceMock.createMock()
+    }
 }
 
 class AuthorController {
@@ -124,4 +167,22 @@ class ExceptionThrowingFilters {
             }
         }
     }
+}
+
+class AutowiredFilters {
+
+    def autowiredService
+
+    def filters = {
+        all(controller:"author", action:"list") {
+            before = {
+                autowiredService.setupSession()
+            }
+        }
+    }
+}
+
+class AutowiredService {
+
+    void setupSession() {}
 }


### PR DESCRIPTION
This is a start on enabling auto wiring for filters in unit tests. Tried to make the change transparent to any other code relying on these classes. Probably needs some touch-up here and there.
