### PR TITLE
GRAILS-9644 - list() with args only returns one projection property

### DIFF
--- a/grails-hibernate/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
+++ b/grails-hibernate/src/main/groovy/grails/orm/HibernateCriteriaBuilder.java
@@ -1569,16 +1569,18 @@ public class HibernateCriteriaBuilder extends GroovyObjectSupport implements org
 
                     // Restore the previous projection, add settings for the pagination parameters,
                     // and then execute the query.
-                    if (projectionList != null && projectionList.getLength() > 0) {
-                        criteria.setProjection(projectionList);
-                    } else {
-                        criteria.setProjection(null);
-                    }
+                    boolean isProjection = (projectionList != null && projectionList.getLength() > 0);
+                    criteria.setProjection(isProjection ? projectionList : null);
+
                     for (Order orderEntry : orderEntries) {
                         criteria.addOrder(orderEntry);
                     }
                     if (resultTransformer == null) {
-                        criteria.setResultTransformer(CriteriaSpecification.ROOT_ENTITY);
+                        // GRAILS-9644 - Use projection transformer
+                        criteria.setResultTransformer( isProjection ?
+                            CriteriaSpecification.PROJECTION :
+                            CriteriaSpecification.ROOT_ENTITY
+                        );
                     }
                     else if (paginationEnabledList) {
                         // relevant to GRAILS-5692

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateCriteriaBuilderTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateCriteriaBuilderTests.groovy
@@ -893,7 +893,7 @@ class HibernateCriteriaBuilderTests extends AbstractGrailsHibernateTests {
 
         List results = parse("{ " +
                     "projections { " +
-                        "property('lastName',)" +
+                        "property('lastName')" +
                     "}" +
                 "}", "Test1",CriteriaBuilderTestClass.name)
 
@@ -1739,14 +1739,17 @@ class HibernateCriteriaBuilderTests extends AbstractGrailsHibernateTests {
 
         obj.invokeMethod("save", null)
 
-        List results = parse(".list([:]) { " +
-                    "projections { " +
-                        "property('firstName')" +
+        List results = parse(".list([:]) {\n" +
+                    "projections { \n" +
+                        "property('firstName')\n" +
+                        "property('lastName')\n" +
                     "}" +
-                "}", "Test1",CriteriaBuilderTestClass.name)
+                "}", "Test1", CriteriaBuilderTestClass.name)
 
-        assertEquals 1 , results.size()
-        assertTrue 'Result list should contain Strings', results[0] instanceof String
+        assertEquals 1, results.size()
+        assertEquals 2, results[0].size()
+        assertEquals "homer", results[0][0]
+        assertEquals "simpson", results[0][1]
     }
 
     void testCriteriaInvolvingNestedRelationshipsSomeOfWhichAreEmbedded() {


### PR DESCRIPTION
For criteria with projections the ROOT_ENTITY transformer was being used instead of the PROJECTION pass thru in cases where list() is called with args (paginationEnabledList = true)

Modified existing test case to expose and cover this problem by adding an additional property().
