### PR TITLE
GRAILS-9773 Configurable persistence context configuration

### DIFF
--- a/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/plugins/orm/hibernate/HibernatePluginSupport.groovy
+++ b/grails-hibernate/src/main/groovy/org/codehaus/groovy/grails/plugins/orm/hibernate/HibernatePluginSupport.groovy
@@ -93,13 +93,18 @@ class HibernatePluginSupport {
         }
 
         def datasourceNames = []
+        def persistenceInterceptorDatasourceNames = []
         if (getSpringConfig().containsBean('dataSource')) {
             datasourceNames << GrailsDomainClassProperty.DEFAULT_DATA_SOURCE
+            persistenceInterceptorDatasourceNames << GrailsDomainClassProperty.DEFAULT_DATA_SOURCE
         }
 
         for (name in application.config.keySet()) {
             if (name.startsWith('dataSource_')) {
                 datasourceNames << name - 'dataSource_'
+                if( application.config[name].persistenceInterceptor ) {
+                    persistenceInterceptorDatasourceNames << name - 'dataSource_'
+                }
             }
         }
 
@@ -116,7 +121,7 @@ class HibernatePluginSupport {
         hibernateEventListeners(HibernateEventListeners)
 
         persistenceInterceptor(AggregatePersistenceContextInterceptor) {
-            dataSourceNames = datasourceNames
+            dataSourceNames = persistenceInterceptorDatasourceNames
         }
 
         for (String datasourceName in datasourceNames) {


### PR DESCRIPTION
Only wire up the default datasource for persistence interception by default, but allow configuration of secondary datasources for persistence interception.

The behavior of only wiring up the default datasource described in [GRAILS-9773](http://jira.grails.org/browse/GRAILS-9773) is actually caused by a bug in `HibernatePersistenceContextInterceptor` that is fixed in https://github.com/SpringSource/grails-data-mapping/pull/122. This change will continue that behavior explicitly but also allo create a config option (https://github.com/grails/grails-doc/pull/137).
