### PR TITLE
Update version of Tomcat plugin used to 7.0.40

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -106,7 +106,7 @@ task pluginsFromRepo {
         jquery: "1.10.0",
         resources: "1.2",
         scaffolding: "1.0.0",
-        tomcat: "7.0.39",
+        tomcat: "7.0.40",
         webxml: "1.4.1"
     ]
 

--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 
     compile "org.springframework:spring-jdbc:${springVersion}"
 
-    compile 'org.apache.tomcat:tomcat-jdbc:7.0.37'
+    compile 'org.apache.tomcat:tomcat-jdbc:7.0.40'
 
     runtime 'hsqldb:hsqldb:1.8.0.10', {
         ext.notInPom = true

--- a/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
+++ b/grails-resources/src/grails/grails-app/conf/BuildConfig.groovy
@@ -47,7 +47,7 @@ grails.project.dependency.resolution = {
 
     plugins {
         // plugins for the build system only
-        build ":tomcat:7.0.39"
+        build ":tomcat:7.0.40"
 
         // plugins for the compile step
         compile ":scaffolding:2.0.0.BUILD-SNAPSHOT"

--- a/grails-resources/src/grails/templates/maven/app.pom
+++ b/grails-resources/src/grails/templates/maven/app.pom
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.grails.plugins</groupId>
             <artifactId>tomcat</artifactId>
-            <version>7.0.37</version>
+            <version>7.0.40</version>
             <type>zip</type>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
Dependent on https://github.com/grails-plugins/grails-tomcat-plugin/pull/3 and new version of Tomcat plugin being released first.
