### PR TITLE
Supported accessing directly to forked daemon

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -113,7 +113,14 @@ abstract class ForkedGrailsProcess {
                                         System.exit(0)
                                     }
                                     else {
-                                        this.executionContext = readExecutionContext(contextFile)
+                                        def loadedContext = readExecutionContext(contextFile)
+                                        if (loadedContext) {
+                                            this.executionContext = loadedContext
+                                        } else {
+                                            // Forked daemon is regarded as command when contextFile cannot be loaded.
+                                            executionContext.argsMap["params"] = contextFile.split(/\s/)
+                                        }
+
                                         callable.call(clientSocket)
                                     }
                                 }


### PR DESCRIPTION
Forked daemon is regarded as command when contextFile cannot be loaded.
I think it's handy for direct use from IDE like improx plugin in future. How about it?
