### PR TITLE
GRAILS-10198 - Removing Grails full namespace from SynchronizerToken

### DIFF
--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/FormTagLibTests.groovy
@@ -29,13 +29,13 @@ class FormTagLibTests extends AbstractGrailsTagTests {
     void testFormTagWithTrueUseToken() {
         def template = '<g:form url="/foo/bar" useToken="true"></g:form>'
         assertOutputContains('<form action="/foo/bar" method="post" >', template)
-        assertOutputContains('<input type="hidden" name="org.codehaus.groovy.grails.SYNCHRONIZER_TOKEN" value="', template)
-        assertOutputContains('<input type="hidden" name="org.codehaus.groovy.grails.SYNCHRONIZER_URI" value="', template)
+        assertOutputContains('<input type="hidden" name="SYNCHRONIZER_TOKEN" value="', template)
+        assertOutputContains('<input type="hidden" name="SYNCHRONIZER_URI" value="', template)
 
         template = '<g:form url="/foo/bar" useToken="${2 * 3 == 6}"></g:form>'
         assertOutputContains('<form action="/foo/bar" method="post" >', template)
-        assertOutputContains('<input type="hidden" name="org.codehaus.groovy.grails.SYNCHRONIZER_TOKEN" value="', template)
-        assertOutputContains('<input type="hidden" name="org.codehaus.groovy.grails.SYNCHRONIZER_URI" value="', template)
+        assertOutputContains('<input type="hidden" name="SYNCHRONIZER_TOKEN" value="', template)
+        assertOutputContains('<input type="hidden" name="SYNCHRONIZER_URI" value="', template)
     }
 
     void testFormTagWithNonTrueUseToken() {

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SynchronizerTokensHolder.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SynchronizerTokensHolder.groovy
@@ -26,9 +26,9 @@ import javax.servlet.http.HttpSession
  */
 class SynchronizerTokensHolder implements Serializable {
 
-    public static final String HOLDER = "org.codehaus.groovy.grails.SYNCHRONIZER_TOKENS_HOLDER"
-    public static final String TOKEN_KEY = "org.codehaus.groovy.grails.SYNCHRONIZER_TOKEN"
-    public static final String TOKEN_URI = "org.codehaus.groovy.grails.SYNCHRONIZER_URI"
+    public static final String HOLDER = "SYNCHRONIZER_TOKENS_HOLDER"
+    public static final String TOKEN_KEY = "SYNCHRONIZER_TOKEN"
+    public static final String TOKEN_URI = "SYNCHRONIZER_URI"
 
     protected Map<String, Set<UUID>> currentTokens = [:]
 


### PR DESCRIPTION
exposing Grails full namespace to the DOM disclose critical application stack information to the public
