### PR TITLE
GRAILS-10221 Extension point bug

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
@@ -51,7 +51,7 @@ class RestfulController<T> {
         params.max = Math.min(max ?: 10, 100)
         def model = [:]
         model.put("${resourceName}Count".toString(), countResources())
-        respond listAllResources(params), model:model
+        respond listAllResources(), model:model
     }
 
     /**


### PR DESCRIPTION
The index() was calling the extension point with a parameter however the signature of the method does not accept a parameter.  This was an oversight on my part with the initial pull request.
