### PR TITLE
GRAILS-10201 Don't use cached controller if a controller or filter forwa...

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/AbstractGrailsControllerHelper.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/AbstractGrailsControllerHelper.java
@@ -134,7 +134,7 @@ public abstract class AbstractGrailsControllerHelper implements ApplicationConte
 
         // Step 2: lookup the controller in the application.
         GrailsControllerClass controllerClass=null;
-        if(!WebUtils.isIncludeRequest(request)) {
+        if(!WebUtils.isIncludeRequest(request) && request.getAttribute(FORWARD_CALLED) == null) {
 
             Object attribute = grailsWebRequest.getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS, WebRequest.SCOPE_REQUEST);
             if (attribute instanceof GrailsControllerClass) {


### PR DESCRIPTION
If a forward method was called on a controller or filter, the controller cached in the request may not be the controller the forward dictates. In that case, don't use the cached controller.
