### PR TITLE
Fix for GRAILS-10291 "Method name must not be null" exception when using...

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethod.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/web/metaclass/ForwardMethod.groovy
@@ -32,6 +32,7 @@ import org.springframework.context.ApplicationContext
  */
 class ForwardMethod {
 
+    public static final String IN_PROGRESS = "org.codehaus.groovy.grails.FORWARD_IN_PROGRESS"
     public static final String CALLED = "org.codehaus.groovy.grails.FORWARD_CALLED"
 
     private UrlConverter urlConverter
@@ -51,6 +52,7 @@ class ForwardMethod {
         BeanUtils.populate(urlInfo, params)
 
         def model = params.model instanceof Map ? params.model : Collections.EMPTY_MAP
+        request.setAttribute(IN_PROGRESS, true)
         String uri = WebUtils.forwardRequestForUrlMappingInfo(request, response, urlInfo, model, true)
         request.setAttribute(CALLED, true)
         return uri

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/AbstractGrailsControllerHelper.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/AbstractGrailsControllerHelper.java
@@ -72,6 +72,7 @@ public abstract class AbstractGrailsControllerHelper implements ApplicationConte
 
     private static final Log LOG = LogFactory.getLog(AbstractGrailsControllerHelper.class);
     private static final String PROPERTY_CHAIN_MODEL = "chainModel";
+    private static final String FORWARD_IN_PROGRESS = "org.codehaus.groovy.grails.FORWARD_IN_PROGRESS";
     private static final String FORWARD_CALLED = "org.codehaus.groovy.grails.FORWARD_CALLED";
 
     public ServletContext getServletContext() {
@@ -134,7 +135,7 @@ public abstract class AbstractGrailsControllerHelper implements ApplicationConte
 
         // Step 2: lookup the controller in the application.
         GrailsControllerClass controllerClass=null;
-        if(!WebUtils.isIncludeRequest(request)) {
+        if (!WebUtils.isIncludeRequest(request) && request.getAttribute(FORWARD_IN_PROGRESS) == null) {
 
             Object attribute = grailsWebRequest.getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS, WebRequest.SCOPE_REQUEST);
             if (attribute instanceof GrailsControllerClass) {


### PR DESCRIPTION
This is a proposed fix for Fix for GRAILS-10291 "Method name must not be null" exception when using custom onUnauthorized method in grails-shiro plugin's ShiroSecurityFilters which calls filter.forward rather than filter.redirect"

AbstractGrailsControllerHelper#handleURI needs to avoid getting the controller cached in the request to handle the forward. This couldn't be accomplished by looking for the presence of the existing "org.codehaus.groovy.grails.FORWARD_CALLED" attribute added to the request by ForwardMethod, because it is added after the call to AbstractGrailsControllerHelper#handleURI. Modifying ForwardMethod to add that attribute sooner causes other problems, such as CompositeInterceptor killing processing of the request prematurely. So the approach of this fix is for ForwardMethod to add a new attribute "org.codehaus.groovy.grails.FORWARD_IN_PROGRESS" to the request that AbstractGrailsControllerHelper#handleURI sees as an indication that it should not use the controller cached in the request.
