### PR TITLE
Fix for GRAILS-10328 - Log level in Log4jConfig#propertyMissing should not be 'ERROR'

### DIFF
--- a/grails-plugin-log4j/src/main/groovy/org/codehaus/groovy/grails/plugins/log4j/Log4jConfig.groovy
+++ b/grails-plugin-log4j/src/main/groovy/org/codehaus/groovy/grails/plugins/log4j/Log4jConfig.groovy
@@ -88,7 +88,7 @@ class Log4jConfig {
             return LAYOUTS[name].newInstance()
         }
 
-        LogLog.error "Property missing when configuring log4j: $name"
+        LogLog.debug "Property missing when configuring log4j: $name"
 
         throw new MissingPropertyException("Property missing when configuring log4j: $name")
     }


### PR DESCRIPTION
http://jira.grails.org/browse/GRAILS-10328
