### PR TITLE
Fix null pointer issue when attrs are not supplied to withTag

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -391,7 +391,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
     Closure withTag = { attrs, body ->
         def writer = out
         writer << "<${attrs.name}"
-        attrs.attrs.each { k,v ->
+        attrs.attrs?.each { k,v ->
             if (!v) return
             if (v instanceof Closure) {
                 writer << " $k=\""

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -764,6 +764,14 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals '<link href="/images/icons/iphone-icon.png?requestDataValueProcessorParamName=paramValue" rel="apple-touch-icon"/>\r\n', template
     }
 
+    void testWithTagWithNameAndAttrs() {
+        def template = '<g:withTag name="div" attrs="[class: 'foo']>body</g:withTag>'
+        assertOutputEquals '<div class="foo">body</div>', template
+        
+        template = '<g:withTag name="div">body</g:withTag>'
+        assertOutputEquals '<div>body</div>', template
+    }
+
     private void unRegisterRequestDataValueProcessor() {
         appCtx.getBean(ApplicationTagLib.name).requestDataValueProcessor = null
     }


### PR DESCRIPTION
This fixes as issue where the attrs attribute of the attrs parameter to the closure is not provided and a NullPointerException occurs. Unit tests included.
