### PR TITLE
GRAILS-9811: Binary plugin i18n problem

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/BinaryGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/BinaryGrailsPlugin.java
@@ -43,7 +43,6 @@ import org.springframework.core.io.Resource;
 @SuppressWarnings("rawtypes")
 public class BinaryGrailsPlugin extends DefaultGrailsPlugin {
 
-    public static final String BASE_MESSAGES_PROPERTIES = "grails-app/i18n/messages";
     public static final String VIEWS_PROPERTIES = "views.properties";
 
     private BinaryGrailsPluginDescriptor descriptor;
@@ -187,10 +186,10 @@ public class BinaryGrailsPlugin extends DefaultGrailsPlugin {
         }
 
         Properties properties = new Properties();
-        final String defaultName = BASE_MESSAGES_PROPERTIES;
+        final String defaultName = getBaseMessagesProperties();
         attemptLoadProperties(descriptorResource, properties, defaultName);
 
-        for (String filename : calculateFilenamesForLocale("grails-app/i18n/messages", locale)) {
+        for (String filename : calculateFilenamesForLocale(defaultName, locale)) {
             attemptLoadProperties(descriptorResource, properties, filename);
         }
 
@@ -207,6 +206,10 @@ public class BinaryGrailsPlugin extends DefaultGrailsPlugin {
             LOG.debug("Failed to load plugin [" + this + "] properties for name [" +
                     defaultName + "]: " + e.getMessage(), e);
         }
+    }
+
+    private String getBaseMessagesProperties() {
+        return "grails-app/i18n/" + getName() + "-messages"
     }
 
     /**

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/BinaryGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/BinaryGrailsPlugin.java
@@ -209,7 +209,7 @@ public class BinaryGrailsPlugin extends DefaultGrailsPlugin {
     }
 
     private String getBaseMessagesProperties() {
-        return "grails-app/i18n/" + getName() + "-messages"
+        return "grails-app/i18n/" + getName() + "-messages";
     }
 
     /**

--- a/grails-core/src/test/groovy/org/codehaus/groovy/grails/plugins/BinaryPluginSpec.groovy
+++ b/grails-core/src/test/groovy/org/codehaus/groovy/grails/plugins/BinaryPluginSpec.groovy
@@ -52,7 +52,7 @@ class BinaryPluginSpec extends Specification {
 /WEB-INF/grails-app/views/bar/list.gsp=org.codehaus.groovy.grails.plugins.MyView
 '''.bytes)
             resource.relativesResources['grails-app/i18n'] = new ByteArrayResource(''.bytes)
-            resource.relativesResources['grails-app/i18n/messages.properties'] = new ByteArrayResource('''
+            resource.relativesResources['grails-app/i18n/testBinary-messages.properties'] = new ByteArrayResource('''
 foo.bar=one
 '''.bytes)
             def binaryPlugin = new BinaryGrailsPlugin(TestBinaryGrailsPlugin, descriptor, new DefaultGrailsApplication())


### PR DESCRIPTION
Fixed location of default messages file inside the binary plugin jars so that it includes the name of the plugin, which is how it is packaged and is also consistent with how messages files are named within source plugins
