### PR TITLE
GRAILS-8809 fix for relative image URLs on windows

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/PdfBuilder.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/PdfBuilder.groovy
@@ -47,7 +47,9 @@ class PdfBuilder {
         File htmlFile = new File(guideDir, "single.html")
         File outputFile = new File(guideDir, "single.pdf")
 
-        String xml = createXml(htmlFile, baseDir.absolutePath)
+        String base = baseDir.toPath().toUri().toString()
+        base += base.endsWith('/')?'':'/'
+        String xml = createXml(htmlFile, base)
         createPdf xml, outputFile, guideDir
     }
 
@@ -57,7 +59,7 @@ class PdfBuilder {
         // fix inner anchors
         xml = xml.replaceAll('<a href="\\.\\./guide/single\\.html', '<a href="')
         // fix image refs to absolute paths
-        xml = xml.replaceAll('src="\\.\\./img/', "src=\"file://${base}/img/")
+        xml = xml.replaceAll('src="\\.\\./img/', "src=\"${base}img/")
 
         // convert tabs to spaces otherwise they only take up one space
         xml = xml.replaceAll('\t', '    ')


### PR DESCRIPTION
`baseDir.absolutePath` (line 50) returns on a windows system a path with backslashes. These will be removed by the `replaceAll` statement in line 60. A better way to create a file-URL from the basepath is to use `baseDir.toPath().toUri().toString()` which will return on *nix and windows systems a valid file-URL.
`baseDir.toPath().toUri().toString()` returns a trailing slash if baseDir is a directory, no slash otherwise. To ensure that we always have a trailing slash, I've added the line `base += base.endsWith('/')?'':'/'`
