### PR TITLE
GRAILS-9814 -Prevent all of ${basedir}/src folder from being packaged with a binary plugin

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/publishing/PluginPackager.groovy
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/plugins/publishing/PluginPackager.groovy
@@ -324,14 +324,6 @@ class PluginPackager {
                     }
                 }
             }
-            mkdir(dir:"${classesDir}/src")
-            copy(todir:"${classesDir}/src") {
-                fileset(dir:"${basedir}/src") {
-                    extraExcludes(basedir, "src", pluginProps?.pluginExcludes, ["groovy/**","java/**"]).each {
-                        exclude name: it
-                    }
-                }
-            }
 
             def stagingDir
             try {


### PR DESCRIPTION
Previously everything below ${basedir}/src was being packaged inside of a binary plugin. The binary plugin packaging should only deal with src/groovy and src/java as these are the directories supported by Grails convention. Anything else below src should be up to the user to deal with. The current behaviour was causing issues if you were building the plugin with maven and had resources under src/main/resources which is the standard mvn location. What was happening is that you would end up with 2 copies of your resources in your resultant binary plugin. One from mvn and one from the Grails packaging.

Fix is to remove the code that was copying  ${basedir}/src from the binary packaging. As per existing behaviour, contents under src/groovy and src/java will be copied if the includeSource flag is set. 
