### PR TITLE
GRAILS-9874 improved to resolve an error message for typeMismatch

### DIFF
--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/GrailsWebDataBinderSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/GrailsWebDataBinderSpec.groovy
@@ -39,9 +39,17 @@ import com.google.gson.internal.LazilyParsedNumber
 @Mock([Author, Child, CollectionContainer, DataBindingBook, Fidget, Parent, Publication, Publisher, Team, Widget])
 class GrailsWebDataBinderSpec extends Specification {
 
+    def binder
+    def messageSource
+
+    void setup() {
+        binder = new GrailsWebDataBinder(grailsApplication)
+        messageSource = new StaticMessageSource()
+        binder.messageSource = messageSource
+    }
+
     void 'Test string trimming'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author()
 
         when:
@@ -79,7 +87,6 @@ class GrailsWebDataBinderSpec extends Specification {
     void 'Test binding an invalid String to an object reference does not result in an empty instance being bound'() {
         // GRAILS-3159
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def publication = new Publication()
 
         when:
@@ -91,7 +98,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding empty and blank String'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def obj = new Author()
 
         when:
@@ -126,7 +132,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to primitives from Strings'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def obj = new PrimitiveContainer()
 
         when:
@@ -152,7 +157,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding null to id of element nested in a List'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def obj = new CollectionContainer()
         def map = [:]
 
@@ -191,7 +195,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test id binding'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author(name: 'David Foster Wallace').save(flush: true)
         def publication = new Publication()
 
@@ -234,53 +237,52 @@ class GrailsWebDataBinderSpec extends Specification {
 
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: [id: null]])
-        
+
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: [id: 'null']])
-        
+
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: [id: '']])
-        
+
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: 'null'])
-        
+
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: ''])
-        
+
         then:
         publication.author == null
-        
+
         when:
         publication.author = new Author()
         binder.bind publication, new SimpleMapDataBindingSource([author: null])
-        
+
         then:
         publication.author == null
     }
 
     void 'Test id binding with a non dataSource aware binding source'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author(name: 'David Foster Wallace').save(flush: true)
         def publication = new Publication()
 
@@ -304,7 +306,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to the one side of a one to many'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author(name: 'Graeme').save()
         def pub = new Publication(title: 'DGG', author: author)
 
@@ -332,7 +333,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to a hasMany List'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def publisher = new Publisher()
 
         when:
@@ -354,7 +354,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test bindable'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def widget = new Widget()
 
         when:
@@ -367,7 +366,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to a collection of String'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def book = new DataBindingBook()
 
         when:
@@ -380,7 +378,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to a collection of Integer'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def book = new DataBindingBook()
 
         when:
@@ -393,7 +390,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to a collection of primitive'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def parent = new Parent()
 
         when:
@@ -424,7 +420,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test unbinding a Map entry'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def team = new Team()
 
         when:
@@ -448,7 +443,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to a Map for new instance with quoted key'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def team = new Team()
 
         when:
@@ -464,7 +458,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test autoGrowCollectionLimit with Maps of String'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def team = new Team()
         binder.autoGrowCollectionLimit = 2
         def bindingSource = [:]
@@ -486,7 +479,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test autoGrowCollectionLimit with Maps of domain objects'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def team = new Team()
         binder.autoGrowCollectionLimit = 2
         def bindingSource = [:]
@@ -510,7 +502,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to Set with subscript'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def pub = new Publisher()
         pub.addToAuthors(name: 'Author One')
 
@@ -524,9 +515,6 @@ class GrailsWebDataBinderSpec extends Specification {
     }
 
     void 'Test binding existing entities to a new Set'() {
-        given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
-
         when:
         def a1 = new Author(name: 'Author One').save()
         def a2 = new Author(name: 'Author Two').save(flush:true)
@@ -546,9 +534,6 @@ class GrailsWebDataBinderSpec extends Specification {
     }
 
     void 'Test binding a String to an domain class object reference in a Collection'() {
-        given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
-
         when:
         def a1 = new Author(name: 'Author One').save()
         def a2 = new Author(name: 'Author Two').save(flush:true)
@@ -569,7 +554,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding a gson LazilyParsedNumber to a domain class object reference'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author(name: 'Lewis Black')
 
         when:
@@ -591,7 +575,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding a String to a domain class object reference'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author(name: 'Lewis Black')
 
         when:
@@ -627,7 +610,6 @@ class GrailsWebDataBinderSpec extends Specification {
         a3.id != null
 
         when:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         // the subscript values are not important, the ids drive selection from the Set
         binder.bind publisher, new SimpleMapDataBindingSource(['authors[123]': [id: a3.id, name: 'Author Tres'],
                                 'authors[456]': [id: a1.id, name: 'Author Uno'],
@@ -644,7 +626,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test updating a Set element by id that does not exist'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def bindingErrors = []
         def listener = { BindingError error ->
             bindingErrors << error
@@ -667,9 +648,6 @@ class GrailsWebDataBinderSpec extends Specification {
     }
 
     void 'Test updating nested entities retrieved by id'() {
-        given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
-
         when:
         def publisher = new Publisher(name: 'Apress').save()
         def publication = new Publication(title: 'Definitive Guide To Grails', author: new Author(name: 'Author Name'))
@@ -688,7 +666,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test using @BindUsing to initialize property with a type other than the declared type'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def author = new Author()
 
         when:
@@ -707,7 +684,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding to different collection types'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def obj = new CollectionContainer()
         def map = [:]
 
@@ -760,13 +736,12 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test binding format code'() {
         given:
-        def messageSource = new StaticMessageSource()
         messageSource.addMessage 'my.date.format', Locale.US, 'MMddyyyy'
         messageSource.addMessage 'my.date.format', Locale.UK, 'ddMMyyyy'
         def child = new Child()
 
         when:
-        def binder = new GrailsWebDataBinder(grailsApplication)  {
+        binder = new GrailsWebDataBinder(grailsApplication)  {
             Locale getLocale() {
                 Locale.US
             }
@@ -799,7 +774,6 @@ class GrailsWebDataBinderSpec extends Specification {
 
     void 'Test that binding errors are populated on a @Validateable instance'() {
         given:
-        def binder = new GrailsWebDataBinder(grailsApplication)
         def obj = new SomeValidateableClass()
 
         when: 'binding with just a binding source'

--- a/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/GrailsWebDataBinderSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/codehaus/groovy/grails/orm/GrailsWebDataBinderSpec.groovy
@@ -853,6 +853,28 @@ class GrailsWebDataBinderSpec extends Specification {
         afterBindingArgs[0].object.is obj
         afterBindingArgs[0].propertyName == 'someNumber'
     }
+
+    void 'Test typeMismatch error codes'() {
+        given:
+        def obj = new SomeValidateableClass()
+
+        when:
+        binder.bind obj, [someNumber: 'not a number'] as SimpleMapDataBindingSource
+
+        then:
+        obj.hasErrors()
+        obj.errors.errorCount == 1
+        obj.errors['someNumber'].codes == [
+            "org.codehaus.groovy.grails.orm.SomeValidateableClass.someNumber.typeMismatch.error",
+            "org.codehaus.groovy.grails.orm.SomeValidateableClass.someNumber.typeMismatch",
+            "someValidateableClass.someNumber.typeMismatch.error",
+            "someValidateableClass.someNumber.typeMismatch",
+            "typeMismatch.org.codehaus.groovy.grails.orm.SomeValidateableClass.someNumber",
+            "typeMismatch.someNumber",
+            "typeMismatch.java.lang.Integer",
+            "typeMismatch"
+        ]
+    }
 }
 
 @Entity

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/binding/GrailsWebDataBinder.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/binding/GrailsWebDataBinder.groovy
@@ -112,7 +112,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
      */
     void bind(object, DataBindingSource source, String filter, List whiteList, List blackList, DataBindingListener listener) {
         def bindingResult = new BeanPropertyBindingResult(object, object.getClass().name)
-        def errorHandlingListener = new GrailsWebDataBindingListener(bindingResult)
+        def errorHandlingListener = new GrailsWebDataBindingListener(bindingResult, messageSource)
 
         def listenerWrapper = new DataBindingEventMulticastListener(listeners: [errorHandlingListener, listener])
         super.bind object, source, filter, whiteList, blackList, listenerWrapper

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/binding/GrailsWebDataBindingListener.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/binding/GrailsWebDataBindingListener.groovy
@@ -15,11 +15,17 @@
  */
 package org.codehaus.groovy.grails.web.binding
 
+import grails.util.GrailsNameUtils
+
 import groovy.transform.CompileStatic
+
+import java.util.Locale
 
 import org.grails.databinding.errors.BindingError
 import org.grails.databinding.events.DataBindingListenerAdapter
 import org.springframework.context.support.DefaultMessageSourceResolvable
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
 import org.springframework.validation.BindingResult
 import org.springframework.validation.Errors
 import org.springframework.validation.FieldError
@@ -27,25 +33,39 @@ import org.springframework.validation.FieldError
 @CompileStatic
 class GrailsWebDataBindingListener extends DataBindingListenerAdapter {
     private final BindingResult bindingResult
+    private final MessageSource messageSource
 
-    GrailsWebDataBindingListener(BindingResult bindingResult) {
+    GrailsWebDataBindingListener(BindingResult bindingResult, MessageSource messageSource) {
         this.bindingResult = bindingResult
+        this.messageSource = messageSource
     }
 
     @Override
     void bindingError(BindingError error) {
-        Object[] o = getArgumentsForBindError(error.object?.getClass()?.getName(), error.getPropertyName())
-        def codes = bindingResult.resolveMessageCodes('typeMismatch', error.getPropertyName())
-        def cause = error.cause
-        def defaultMessage = cause ? cause.message : 'Data Binding Failed'
-        def fieldError = new FieldError(error.object?.getClass()?.getName(), error.getPropertyName(), error.getRejectedValue(), true, codes as String[], o, defaultMessage)
+        String className = error.object?.getClass()?.getName()
+        String classAsPropertyName = GrailsNameUtils.getPropertyNameRepresentation(className)
+        String propertyName = error.getPropertyName()
+        String[] codes = [
+            className + '.' + propertyName + '.typeMismatch.error',
+            className + '.' + propertyName + '.typeMismatch',
+            classAsPropertyName + '.' + propertyName + '.typeMismatch.error',
+            classAsPropertyName + '.' + propertyName + '.typeMismatch',
+            bindingResult.resolveMessageCodes('typeMismatch', propertyName),
+        ].flatten() as String[]
+        Object[] args = [getPropertyName(className, classAsPropertyName, propertyName)] as Object[]
+        def defaultMessage = error.cause?.message ?: 'Data Binding Failed'
+        def fieldError = new FieldError(className, propertyName, error.getRejectedValue(), true, codes, args, defaultMessage)
         bindingResult.addError(fieldError)
     }
 
-    protected Object[] getArgumentsForBindError(String objectName, String field) {
-        def codes = [
-            objectName + Errors.NESTED_PATH_SEPARATOR + field,
-            field] as String[]
-        [new DefaultMessageSourceResolvable(codes, field)] as Object[]
+    protected String getPropertyName(String className, String classAsPropertyName, String propertyName) {
+        final Locale locale = LocaleContextHolder.getLocale()
+        String propertyNameCode = className + '.' + propertyName + ".label"
+        String resolvedPropertyName = messageSource.getMessage(propertyNameCode, null, propertyName, locale)
+        if (resolvedPropertyName.equals(propertyName)) {
+            propertyNameCode = classAsPropertyName + '.' + propertyName + ".label"
+            resolvedPropertyName = messageSource.getMessage(propertyNameCode, null, propertyName, locale)
+        }
+        return resolvedPropertyName
     }
 }


### PR DESCRIPTION
- fixed resolving a property name by messageSource
- supported variety codes for an individual property as validation error messages:
  
  ```
  my.sample.MyDomain.myProperty.typeMismatch.error
  my.sample.MyDomain.myProperty.typeMismatch
  myDomain.myProperty.typeMismatch.error
  myDomain.myProperty.typeMismatch
  typeMismatch.my.sample.MyDomain
  typeMismatch.myProperty
  typeMismatch.<type of myProperty>
  typeMismatch
  ```
