### PR TITLE
Fix for Grails10425

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
@@ -24,6 +24,7 @@ import groovy.transform.CompileStatic
 import org.codehaus.groovy.grails.web.binding.bindingsource.DataBindingSourceRegistry
 import org.codehaus.groovy.grails.web.binding.bindingsource.HalJsonDataBindingSourceCreator
 import org.codehaus.groovy.grails.web.mime.MimeType
+import org.codehaus.groovy.grails.web.util.WebUtils
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.datastore.mapping.model.types.Association
 import org.grails.datastore.mapping.model.types.ToOne
@@ -164,7 +165,10 @@ class HalJsonRenderer<T> extends AbstractLinkingRenderer<T> {
     }
 
     protected void writeLinkForCurrentPath(RenderContext context, MimeType mimeType, JsonWriter writer) {
-        final href = linkGenerator.link(uri: context.resourcePath, method: HttpMethod.GET.toString(), absolute: absoluteLinks)
+        final uriWithoutContext = context.resourcePath.substring(
+                WebUtils.retrieveGrailsWebRequest().contextPath.length())
+        final href = linkGenerator.link(uri: uriWithoutContext, method: HttpMethod.GET.toString(),
+                absolute: absoluteLinks)
         final resourceRef = href
         final locale = context.locale
         def link = new Link(RELATIONSHIP_SELF, href)


### PR DESCRIPTION
Fix for Grails10425.Removed contextPath from uri.  The existing tests pass , however need a strategy to set context path for testing.
