### PR TITLE
fix: GRAILS-10560  Unable to create absolute links when using PageRenderer to generate mail content

### DIFF
--- a/grails-test-suite-web/src/test/groovy/grails/gsp/PageRendererSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/gsp/PageRendererSpec.groovy
@@ -106,21 +106,6 @@ class PageRendererSpec extends Specification {
             """
     }
 
-    void "Test render page with absolute link"() {
-        given:
-        resourceLoader.resources.put("/foo/_bar.gsp", new ByteArrayResource("""
-				<g:link uri='/' absolute='true' base='http://some.other.host'>target</g:link>
-            """.bytes))
-        when:
-        def contents = pageRenderer.render(template:"/foo/bar", model:[:])
-        then:
-        contents != null
-
-        contents == """
-				<a href="http://some.other.host/">target</a>
-            """
-    }
-
     private PageRenderer getPageRenderer() {
         GroovyPagesTemplateEngine te = new GroovyPagesTemplateEngine()
 

--- a/grails-test-suite-web/src/test/groovy/grails/gsp/PageRendererSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/gsp/PageRendererSpec.groovy
@@ -106,6 +106,21 @@ class PageRendererSpec extends Specification {
             """
     }
 
+    void "Test render page with absolute link"() {
+        given:
+        resourceLoader.resources.put("/foo/_bar.gsp", new ByteArrayResource("""
+				<g:link uri='/' absolute='true' base='http://some.other.host'>target</g:link>
+            """.bytes))
+        when:
+        def contents = pageRenderer.render(template:"/foo/bar", model:[:])
+        then:
+        contents != null
+
+        contents == """
+				<a href="http://some.other.host/">target</a>
+            """
+    }
+
     private PageRenderer getPageRenderer() {
         GroovyPagesTemplateEngine te = new GroovyPagesTemplateEngine()
 

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/CachingLinkGenerator.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/CachingLinkGenerator.java
@@ -43,6 +43,7 @@ public class CachingLinkGenerator extends DefaultLinkGenerator {
     private static final String THIS_MAP = "(this Map)";
     private static final String URL_ATTRIBUTE = "url";
     private static final String URI_ATTRIBUTE = "uri";
+    private static final String BASE = "base";
 
     private Map<String, Object> linkCache;
 
@@ -149,9 +150,13 @@ public class CachingLinkGenerator extends DefaultLinkGenerator {
         StringBuilder sb=new StringBuilder();
         sb.append(prefix);
         if (getConfiguredServerBaseURL()==null && isAbsolute(attrs)) {
-            GrailsWebRequest webRequest = GrailsWebRequest.lookup();
-            if (webRequest != null) {
-                sb.append(webRequest.getBaseUrl());
+            if (attrs.get(BASE) != null) {
+                sb.append(attrs.get(BASE));
+            } else {
+                GrailsWebRequest webRequest = GrailsWebRequest.lookup();
+                if (webRequest != null) {
+                    sb.append(webRequest.getBaseUrl());
+                }
             }
         }
         appendMapKey(sb, attrs);

--- a/grails-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/LinkGeneratorSpec.groovy
+++ b/grails-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/LinkGeneratorSpec.groovy
@@ -205,6 +205,30 @@ class LinkGeneratorSpec extends Specification {
             cachedlink == "http://localhost:8081/blah/$resource.dir/$resource.file"
     }
 
+    def "caching should ignore request.baseUrl when base is provided for absolute links"() {
+
+        given:
+            final webRequest = GrailsWebUtil.bindMockWebRequest()
+            MockHttpServletRequest request = webRequest.currentRequest
+            baseUrl = null
+            def cachingGenerator = getGenerator(true)
+
+        when:
+            def cacheKey = cachingGenerator.makeKey(CachingLinkGenerator.RESOURCE_PREFIX, [:]);
+        then:
+            cacheKey == "resource[:][]"
+
+        when:
+            cacheKey = cachingGenerator.makeKey(CachingLinkGenerator.RESOURCE_PREFIX, [absolute:true]);
+        then:
+            cacheKey == "resourcehttp://localhost[absolute:true]"
+
+        when:
+            cacheKey = cachingGenerator.makeKey(CachingLinkGenerator.RESOURCE_PREFIX, [absolute:true, base: "http://some.other.host"]);
+        then:
+            cacheKey == "resourcehttp://some.other.host[absolute:true, base:http://some.other.host]"
+    }
+
     void cleanup() {
         RequestContextHolder.setRequestAttributes(null)
     }


### PR DESCRIPTION
Fix the reported issue by using attrs.base (when provided) instead of request.baseUrl for calculating the cache key of absolute links in CachingLinkGenerator.
