### PR TITLE
GRAILS-10601: If plugin watchedResources is outside grails-app directory and is for a source file, still call plugin onChange

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/GrailsProjectWatcher.java
@@ -248,8 +248,14 @@ public class GrailsProjectWatcher extends DirectoryWatcher {
         else {
             // add to class change event queue
             String className = GrailsResourceUtils.getClassName(file.getAbsolutePath());
-            if (className != null) {
-
+            if (className == null) {
+                try {
+                pluginManager.informOfFileChange(file);
+                } catch (Exception e) {
+                    LOG.error("Failed to reload file [" + file + "] with error: " + e.getMessage(), e);
+                }
+            }
+            else {
                 classChangeEventQueue.put(className, new ClassUpdate() {
                     public void run(Class<?> cls) {
                         try {


### PR DESCRIPTION
This pull requests is to address http://jira.grails.org/browse/GRAILS-10601
