### PR TITLE
Support assigning 0 to http/https port for OS assigned port.

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/api/BaseSettingsApi.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/api/BaseSettingsApi.java
@@ -134,10 +134,24 @@ public class BaseSettingsApi {
         return serverPort;
     }
 
+    public void setServerPort(Integer port) {
+        if (port != null) {
+            System.setProperty("server.port", port.toString());
+            System.setProperty("grails.server.port.http", port.toString());
+        }
+    }
+
     public int getServerPortHttps() {
         int serverPortHttps = Integer.valueOf(getPropertyValue("server.port.https", 8443).toString());
         serverPortHttps = Integer.valueOf(getPropertyValue("grails.server.port.https", serverPortHttps).toString());
         return serverPortHttps;
+    }
+
+    public void setServerPortHttps(Integer port) {
+        if (port != null) {
+            System.setProperty("server.port.https", port.toString());
+            System.setProperty("grails.server.port.https", port.toString());
+        }
     }
 
     public String getServerHost() {

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -147,6 +147,11 @@ abstract class ForkedGrailsProcess {
     ExecutionContext readExecutionContext() {
         String location = System.getProperty("grails.build.execution.context")
 
+        return readExecutionContext(location)
+    }
+
+    @CompileStatic
+    ExecutionContext readExecutionContext(String location) {
         if (location != null) {
             final file = new File(location)
             if (file.exists()) {

--- a/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/InlineExplodedTomcatServer.groovy
+++ b/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/InlineExplodedTomcatServer.groovy
@@ -92,8 +92,6 @@ class InlineExplodedTomcatServer extends TomcatServer {
         new TomcatLoader(classLoader)
     }
 
-
-
     void doStart(String host, int httpPort, int httpsPort) {
         preStart()
 
@@ -113,7 +111,7 @@ class InlineExplodedTomcatServer extends TomcatServer {
         tomcat.port = httpPort
         tomcat.connector.URIEncoding = 'UTF-8'
 
-        if (httpsPort) {
+        if (httpsPort >= 0) {
             def sslConnector = loadInstance('org.apache.catalina.connector.Connector')
             sslConnector.scheme = "https"
             sslConnector.secure = true
@@ -139,8 +137,18 @@ class InlineExplodedTomcatServer extends TomcatServer {
 
         tomcat.start()
         if(Environment.isFork()) {
-            IsolatedTomcat.startKillSwitch(tomcat, httpPort)
+            IsolatedTomcat.startKillSwitch(tomcat, tomcat.connector.getLocalPort())
         }
+    }
+
+    int getLocalHttpPort() {
+        return tomcat.connector.getLocalPort()
+    }
+
+    int getLocalHttpsPort() {
+        tomcat.service.findConnectors().find {
+            it.scheme == 'https'
+        }?.getLocalPort() ?: -1
     }
 
     void stop() {

--- a/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/TomcatKillSwitch.java
+++ b/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/TomcatKillSwitch.java
@@ -30,7 +30,7 @@ public class TomcatKillSwitch implements Runnable {
 
     public void run() {
         System.setProperty("TomcatKillSwitch.active", "true");
-        int killListenerPort = serverPort + 1;
+        int killListenerPort = serverPort - 1;
         ServerSocket serverSocket = createKillSwitch(killListenerPort);
         if (serverSocket != null) {
             try {

--- a/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/TomcatServer.groovy
+++ b/grails-plugin-tomcat/src/main/groovy/org/grails/plugins/tomcat/TomcatServer.groovy
@@ -121,7 +121,7 @@ abstract class TomcatServer implements EmbeddableServer {
     }
 
     void start(String host, int port) {
-        doStart(host ?: DEFAULT_HOST, port ?: DEFAULT_PORT, 0)
+        doStart(host ?: DEFAULT_HOST, port, -1)
     }
 
     void startSecure() {
@@ -141,7 +141,7 @@ abstract class TomcatServer implements EmbeddableServer {
             }
         }
 
-        doStart(host ?: DEFAULT_HOST, httpPort ?: DEFAULT_PORT, httpsPort ?: DEFAULT_SECURE_PORT)
+        doStart(host ?: DEFAULT_HOST, (httpPort >= 0) ? httpPort : DEFAULT_PORT, (httpsPort >= 0) ? httpsPort : DEFAULT_SECURE_PORT)
     }
 
     protected File getWorkDirFile(String path) {

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/project/container/GrailsProjectRunner.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/project/container/GrailsProjectRunner.groovy
@@ -164,7 +164,7 @@ class GrailsProjectRunner extends BaseSettingsApi {
     EmbeddableServer runServer( Map args ) {
         try {
             eventListener.triggerEvent("StatusUpdate","Running Grails application")
-            def message = "Server running. Browse to http://${args.host ?: 'localhost'}:${args.httpPort}$serverContextPath"
+
 
             EmbeddableServer server = args["server"]
             if (server.hasProperty('eventListener')) {
@@ -174,6 +174,7 @@ class GrailsProjectRunner extends BaseSettingsApi {
                 server.grailsConfig = config
             }
 
+            def httpsMessage = ""
             profile("start server") {
 
                 try { new ServerSocket(args.httpPort).close() }
@@ -194,12 +195,15 @@ class GrailsProjectRunner extends BaseSettingsApi {
                     server.startSecure args.host, args.httpPort, args.httpsPort
 
                     // Update the message to reflect the fact we are running HTTPS as well.
-                    message += " or https://${args.host ?: 'localhost'}:${args.httpsPort}$serverContextPath"
+                    setServerPortHttps(server.localHttpsPort)
+                    httpsMessage = " or https://${args.host ?: 'localhost'}:${server.localHttpsPort}$serverContextPath"
                 }
                 else {
                     server.start args.host, args.httpPort
                 }
             }
+            setServerPort(server.localHttpPort)
+            def message = "Server running. Browse to http://${args.host ?: 'localhost'}:${server.localHttpPort}$serverContextPath" + httpsMessage
             eventListener.triggerEvent("StatusFinal", message)
 
             boolean isWindows = System.getProperty("os.name").toLowerCase().indexOf("windows") != -1

--- a/scripts/StopApp.groovy
+++ b/scripts/StopApp.groovy
@@ -29,7 +29,7 @@ target('default': "Stops a forked Grails application") {
 
     try {
         grailsConsole.updateStatus "Stopping Grails Server..."
-        def url = "http://${serverHost ?: 'localhost'}:${serverPort+1}"
+        def url = "http://${serverHost ?: 'localhost'}:${serverPort-1}"
         grailsConsole.verbose "URL to stop server is $url"
         new URL(url).getText(connectTimeout: 10000, readTimeout: 10000)
         grailsConsole.updateStatus "Server Stopped"

--- a/scripts/_GrailsTest.groovy
+++ b/scripts/_GrailsTest.groovy
@@ -191,6 +191,9 @@ target(allTests: "Runs the project's tests.") {
 
                 "${phase}TestPhasePreparation"()
 
+                //Let's plugins know that the test phase is ready (i.e. functional tests ready and port has been binded)
+                event("TestPhasePrepared", [phase])
+
                 // Now run all the tests registered for this phase.
                 types.each(processTests)
             }
@@ -392,7 +395,7 @@ functionalTestPhasePreparation = {
         grails.util.Holders.grailsApplication = null
         packageApp()
         testOptions.https ? runAppHttps() : runApp()
-        
+
         appCtx = ApplicationHolder.application.mainContext
         initPersistenceContext()
     }
@@ -400,7 +403,7 @@ functionalTestPhasePreparation = {
     if (testOptions.containsKey('baseUrl')) {
         functionalBaseUrl = testOptions.baseUrl
     } else {
-        functionalBaseUrl = (testOptions.httpsBaseUrl ? 'https' : 'http') + "://localhost:$serverPort$serverContextPath/"
+        functionalBaseUrl = (testOptions.httpsBaseUrl ? 'https' : 'http') + "://localhost:${getServerPort()}$serverContextPath/"
     }
 
     System.setProperty(grailsSettings.FUNCTIONAL_BASE_URL_PROPERTY, functionalBaseUrl)


### PR DESCRIPTION
Enables support for assigning `server.port=0` and `server.port.https=0` and have the OS assign an available port. This is to facilitate testing on CI servers with multiple jobs, allowing Grails to bind to an available port.

Tested manually in the following scenarios:
`grails -Dserver.port=0 run-app`
`grails -Dserver.port.https=0 run-app -https`
`grails -Dserver.port=0 run-war`
`grails -Dserver.port.https=0 run-war -https`
`grails -Dserver.port=0 run-app` (with grails.project.fork.run=true)
`grails -Dserver.port.https=0 run-app -https` (with grails.project.fork.run=true)

Notes
1) Needed to move the Tomcat kill switch port to `server.port - 1` instead of `+ 1`. This is because when running both http and https as 0, they will typically be assigned sequential ports which causes the kill switch and https to use the same port.
2) Needed to add a new event in the test phase `testPhasePrepared`. This executes after Tomcat is initialized and will allow plugins (i.e. Geb) to get the actual server ports (instead of 0).

I was hoping that this could go into 2.2.5 since I think there will a number of people who won't be upgrading to 2.3 for a while. This patch should work fine in 2.3.x as well although the changes to the Tomcat plugin will need to be transferred to its repo.
