### PR TITLE
make current BUILD-SNAPSHOT build and run under windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     gdocEngineVersion = "1.0.1"
     groovyVersion = "2.2.0-rc-1"
     ivyVersion = "2.3.0"
-    jansiVersion = "1.2.1"
+    jansiVersion = "1.11"
     jlineVersion = "2.11"
     jnaVersion = "4.0.0"
     slf4jVersion = "1.7.5"
@@ -142,9 +142,7 @@ subprojects { project ->
     configure([compileGroovy, compileTestGroovy]) {
         groovyOptions.fork(memoryInitialSize: '128M', memoryMaximumSize: '1G')
         groovyOptions.encoding = "UTF-8"
-        groovyOptions.useAnt = true
         groovyOptions.stacktrace = true
-        options.useAnt = true
         options.encoding = "UTF-8"
     }
 

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsApplication.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsApplication.java
@@ -46,6 +46,7 @@ import org.codehaus.groovy.grails.plugins.support.aware.GrailsConfigurationAware
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
@@ -341,11 +342,19 @@ public class DefaultGrailsApplication extends GroovyObjectSupport implements Gra
 
     public void setMainContext(ApplicationContext context) {
         mainContext = context;
-        if (context != null) {
-            if (mainContext.containsBean("pluginManager")) {
-                mainContext.getBean("pluginManager", GrailsPluginManager.class).setApplicationContext(context);
+        if (mainContext == null) {
+            return;
+        }
+        if (!mainContext.containsBean("pluginManager")) {
+            return;
+        }
+        if (mainContext instanceof ConfigurableApplicationContext) {
+            if (!((ConfigurableApplicationContext) mainContext).isActive()) {
+                // unrefreshed context - plugin manager will get the context from GrailsRuntimeConfiguration
+                return;
             }
         }
+        mainContext.getBean("pluginManager", GrailsPluginManager.class).setApplicationContext(context);
     }
 
     /**


### PR DESCRIPTION
for reference: http://grails.1312388.n4.nabble.com/cannot-build-grails-core-master-on-windows-td4651083.html

the build.gradle modifications allow a successful build on windows.

i had one more error with run.app: DefaultGrailsApplication tried to get the pluginManager from an unrefreshed context. this looks like coming from a reloading-background (GRAILS-10573). but at least on the initial start of the app (which is where the context is not-yet refreshed), the context gets set on the pluginManager in GrailsRuntimeConfigurator afterwards (when its refreshed).

because now i have tested these changes again only on windows, it would be really cool if a core dev could give this a try :)

thanks, zyro
