### PR TITLE
another attempt to get rid of the deprecated groovyOptions.useAnt gradle setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,9 +142,7 @@ subprojects { project ->
     configure([compileGroovy, compileTestGroovy]) {
         groovyOptions.fork(memoryInitialSize: '128M', memoryMaximumSize: '1G')
         groovyOptions.encoding = "UTF-8"
-        groovyOptions.useAnt = true
         groovyOptions.stacktrace = true
-        options.useAnt = true
         options.encoding = "UTF-8"
     }
 


### PR DESCRIPTION
if no grails ClassInjector ast transforms are found by the context classloader, fall back to the current classloader.

this seems to be necessary because of gradles classloader isolation when using useAnt=false.
with ant/groovyc, the grails ClassInjector transforms are accessible via the context classloader.
with gradles internal compiler ("useAnt=false"), the transforms are only accessible via the current classloader.
- formerly failing unit tests pass (locally, grails-plugin-rest/src/test/**)
- sucessful build ("gradlew install")

as im not yet super-experienced with changes this deep in grails-core, please review.

thanks, zyro
