### PR TITLE
Fix NPE in DomainClassMarshaller

### DIFF
--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/marshaller/json/DomainClassMarshaller.java
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/marshaller/json/DomainClassMarshaller.java
@@ -133,7 +133,7 @@ public class DomainClassMarshaller extends IncludeExcludePropertyMarshaller<JSON
                 Object referenceObject = beanWrapper.getPropertyValue(property.getName());
                 if (isRenderDomainClassRelations()) {
                     if (referenceObject == null) {
-                        writer.value(null);
+                        writer.valueNull();
                     }
                     else {
                         referenceObject = proxyHandler.unwrapIfProxy(referenceObject);


### PR DESCRIPTION
I found an NPE in DomainClassMarshaller which is caused by changes in JSONWriter in commit 0aa1ec82ba236cac3f8cf6d4c139b67a26a19b3c.  A call to writer.value(null) causes JSONWriter.value(Number) to be called, which in turn throws the NPE. In that commit method valueNull() was introduced, so I use it instead.

I'm not sure if line 160 (json.value(null)) must be changed, too.
