### PR TITLE
Fix GRAILS-10763 problem with comments inside UrlMappings configuration.

### DIFF
--- a/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/ResponseCodeUrlMappingVisitor.groovy
+++ b/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/ResponseCodeUrlMappingVisitor.groovy
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2004-2005 Graeme Rocher
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.grails.web.mapping
+
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport
+import org.codehaus.groovy.ast.PropertyNode
+import org.codehaus.groovy.ast.expr.MethodCallExpression
+import org.codehaus.groovy.ast.stmt.ExpressionStatement
+import org.codehaus.groovy.control.SourceUnit
+
+class ResponseCodeUrlMappingVisitor extends ClassCodeVisitorSupport {
+    boolean insideMapping = false
+    List<String> responseCodes = []
+
+    public void visitProperty(PropertyNode node){
+        if (node?.name == "mappings") {
+            insideMapping = true
+        }
+        super.visitProperty(node)
+        if (node?.name == "mappings") {
+            insideMapping = false
+        }
+    }
+    public void visitMethodCallExpression(MethodCallExpression call) {
+        if (insideMapping && call.methodAsString =~ /^\d{3}$/ && !responseCodes.contains(call.methodAsString)) {
+            responseCodes << call.methodAsString
+        }
+        super.visitMethodCallExpression(call)
+    }
+
+    public void visitExpressionStatement(ExpressionStatement statement) {
+        super.visitExpressionStatement(statement)
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        return null;
+    }
+}

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/web/mapping/UrlMappingsGrailsPluginTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/plugins/web/mapping/UrlMappingsGrailsPluginTests.groovy
@@ -46,20 +46,31 @@ class UrlMappingsGrailsPluginTests extends GroovyTestCase {
 
 private static class MockGetTextMethod {
     String content
-    
+
     MockGetTextMethod(String content) {
         this.content = content
     }
-    
+
     public String getText(String encoding) {
         return content
     }
  }
 
- 
+private static class MockUrlMappings {
+    String content
+
+    MockUrlMappings(String content) {
+        this.content = content
+    }
+
+    public String getText(String encoding) {
+        return "class UrlMappings { static mappings = { \n$content\n }}";
+    }
+ }
+
     void testNoDuplicateErrorCodes() {
         FileSystemResource.metaClass.getFile = {->
-            [ eachLine: { Closure c -> c.call('"404"(controller:"foo")') }]
+            new MockUrlMappings('"404"(controller:"foo")')
         }
 
         UrlMappingsGrailsPlugin.metaClass.getWatchedResources ={->
@@ -80,7 +91,7 @@ private static class MockGetTextMethod {
 
     void testErrorPageWebXmlPositioning() {
         FileSystemResource.metaClass.getFile = {->
-            [ eachLine: { Closure c -> c.call('"404"(controller:"foo")') }]
+            new MockUrlMappings('"404"(controller:"foo")')
         }
 
         UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
@@ -95,6 +106,241 @@ private static class MockGetTextMethod {
         sw = new StreamingMarkupBuilder().bind{ out << xml }
 
         assertEquals '<web-app><filter><filter-name>sitemesh</filter-name><filter-class>org.codehaus.groovy.grails.web.sitemesh.GrailsPageFilter</filter-class></filter><filter><filter-name>urlMapping</filter-name><filter-class>org.codehaus.groovy.grails.web.mapping.filter.UrlMappingsFilter</filter-class></filter><filter-mapping><filter-name>sitemesh</filter-name><url-pattern>/*</url-pattern></filter-mapping><filter-mapping><filter-name>urlMapping</filter-name><url-pattern>/*</url-pattern><dispatcher>FORWARD</dispatcher><dispatcher>REQUEST</dispatcher></filter-mapping><listener><listener-class>org.springframework.web.util.Log4jConfigListener</listener-class></listener><listener><listener-class>org.codehaus.groovy.grails.web.context.GrailsContextLoaderListener</listener-class></listener><servlet><servlet-name>grails</servlet-name><servlet-class>org.codehaus.groovy.grails.web.servlet.GrailsDispatcherServlet</servlet-class><load-on-startup>1</load-on-startup></servlet><servlet><servlet-name>grails-errorhandler</servlet-name><servlet-class>org.codehaus.groovy.grails.web.servlet.ErrorHandlingServlet</servlet-class></servlet><servlet-mapping><servlet-name>grails</servlet-name><url-pattern>*.dispatch</url-pattern></servlet-mapping><servlet-mapping><servlet-name>grails-errorhandler</servlet-name><url-pattern>/grails-errorhandler</url-pattern></servlet-mapping><welcome-file-list><welcome-file>index.html</welcome-file><welcome-file>index.jsp</welcome-file><welcome-file>index.gsp</welcome-file></welcome-file-list><error-page><error-code>404</error-code><location>/grails-errorhandler</location></error-page></web-app>', sw.toString()
+    }
+
+    void testCommentsOnUrlMappingsBeginningOfLine() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings('// "404"(controller:"foo")')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertFalse content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testCommentsOnUrlMappingsMultiLineComment() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings('/* \n "404"(controller:"foo") \n */')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertFalse content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testCommentsOnUrlMappingsMultiLineCommentBeforeGoodMapping() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings('/* "404"(controller:"foo") */ "400"(controller:"foo")')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertFalse content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>400</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testCommentCharactersInsideStrings() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings('''\
+                "/*" (controller: "foo")
+                "bar" (controller: "bar")
+                "400" (controller: "error")
+                "404" (controller: "error")
+                "*/" (controller: "foo")
+            ''')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>400</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testCommentCharactersInsideMultilineStrings() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings(
+                "'''\\\n" +
+                "Test /*\n" +
+                "'''\n"+
+                "\"400\" (controller: \"error\")\n" +
+                "/*Test*/\n"+
+                "\"404\" (controller: \"error\")\n"
+            )
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>400</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testCommentCharactersInsideRegularExpressions() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockUrlMappings('''\
+                /\\/*/ (controller: "foo")
+                "404" (controller: "error")
+                /* Comment */
+                "foo" (controller: "foo")
+            ''')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
+    }
+
+    void testProblemWithSomeUrlMappingsAndRegexps() {
+        FileSystemResource.metaClass.getFile = {->
+            new MockGetTextMethod('''\
+                /*****************************
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+                ******************************/
+                class UrlMappings {
+                    static mappings = {
+                        "404" (controller: "error")
+                    }
+                }
+            ''')
+        }
+
+        UrlMappingsGrailsPlugin.metaClass.getWatchedResources = { ->
+            new FileSystemResource("/dummy/path")
+        }
+        def plugin = new UrlMappingsGrailsPlugin()
+        def xml = new XmlSlurper().parseText(text)
+
+        plugin.doWithWebDescriptor(xml)
+
+        def sw = new StringWriter()
+        sw = new StreamingMarkupBuilder().bind{ out << xml }
+
+        def content = sw.toString()
+
+        assertTrue content.contains(
+            "<error-page>" +
+                "<error-code>404</error-code>" +
+                "<location>/grails-errorhandler</location>" +
+            "</error-page>")
     }
 
 


### PR DESCRIPTION
This patch fixes the issues with the comments inside the UrlMappings and the problems with the regular expressions of my first patch.

On the last test in "UrlMappingsGrailsPluginTests.groovy" reproduced the issue with the stackoverflow problem with the regexp. I've left the test in order to be more strict (doing a broken test and then solving the problem).

The final solution compiles de different files *UrlMappings.groovy and creates their AST. Then a visitor find the "response codes" and uses them inside the plugin to create the final web.xml

http://jira.grails.org/browse/GRAILS-10763
