### PR TITLE
Change Default log4j Config to be a map

### DIFF
--- a/grails-resources/src/grails/grails-app/conf/Config.groovy
+++ b/grails-resources/src/grails/grails-app/conf/Config.groovy
@@ -94,7 +94,7 @@ environments {
 }
 
 // log4j configuration
-log4j = {
+log4j.main = {
     // Example of changing the log pattern for the default console appender:
     //
     //appenders {


### PR DESCRIPTION
Change default config to take advantage of the multiple log4j configuration [option](http://jira.grails.org/browse/GRAILS-7314).
