### PR TITLE
GRAILS-10753 Console Colors in Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ ext {
     ehcacheVersion = "2.4.6"
     junitVersion = "4.11"
     concurrentlinkedhashmapVersion = "1.3.1"
+    cglibVersion = "2.2.2"
+    objenesisVersion = "1.2"
 }
 
 version = grailsVersion
@@ -186,6 +188,9 @@ subprojects { project ->
                 exclude group:'junit', module: 'junit-dep'
                 exclude group:'org.codehaus.groovy', module: 'groovy-all'
             }
+            // Required by Spock's Mocking
+            testCompile "cglib:cglib:${cglibVersion}"
+            testCompile "org.objenesis:objenesis:${objenesisVersion}"
         }
     }
 

--- a/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
+++ b/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
@@ -34,9 +34,7 @@ import java.util.Stack;
 
 import grails.util.Environment;
 import jline.Terminal;
-
 import jline.TerminalFactory;
-import jline.TerminalSupport;
 import jline.console.ConsoleReader;
 import jline.console.history.FileHistory;
 import jline.console.history.History;
@@ -726,7 +724,7 @@ public class GrailsConsole {
         }
 
         lastMessage = "";
-        msg = isAnsiEnabled() ? outputCategory(ansi(), ">").fg(DEFAULT).a(msg).toString() : msg;
+        msg = isAnsiEnabled() ? outputCategory(ansi(), ">").fg(DEFAULT).a(msg).reset().toString() : msg;
         try {
             return readLine(msg, secure);
         } finally {
@@ -867,7 +865,7 @@ public class GrailsConsole {
         cursorMove = 0;
         try {
             if (isAnsiEnabled()) {
-                Ansi ansi = outputErrorLabel(userInputActive ? moveDownToSkipPrompt()  : ansi(), label).a(message);
+                Ansi ansi = outputErrorLabel(userInputActive ? moveDownToSkipPrompt()  : ansi(), label).a(message).reset();
 
                 if (message.endsWith(LINE_SEPARATOR)) {
                     out.print(ansi);

--- a/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grails.build.logging
+
+import jline.console.ConsoleReader
+import org.fusesource.jansi.Ansi
+import spock.lang.Specification
+
+import java.util.regex.Pattern
+
+/**
+ * Tests of the GrailsConsole.
+ *
+ * Only the following methods output ansi sequences or color codes directly:
+ * - outputMessage
+ * - error
+ * - userInput
+ *
+ * The goal of the test is to verify that the RESET sequence is written to the output after
+ * the invocation of the aforementioned methods
+ *
+ * @author Tom Bujok
+ * @since 2.3
+ */
+class GrailsConsoleSpec extends Specification {
+
+    static final String RESET = Pattern.quote(Ansi.ansi().reset().toString())
+
+    PrintStream out
+    GrailsConsole console
+    String output
+
+    def setup() {
+        InputStream systemIn = Mock(InputStream)
+        systemIn.read(* _) >> -1
+        out = Mock(PrintStream)
+
+        console = GrailsConsole.getInstance()
+        console.ansiEnabled = true
+        console.out = out
+        console.reader = new ConsoleReader(systemIn, out)
+
+        output = ""
+    }
+
+    def "outputMessage - verify the reset marker at the end of the output"() {
+        when:
+        console.outputMessage("MSG", 1)
+
+        then:
+        out./print.*/(* _) >> { def args -> output += args.join('') }
+        assert assertResetMarkAtTheEndOfOutput(output)
+    }
+
+    def "error - verify the reset marker at the end of the output"() {
+        when:
+        console.error("LABEL", "MSG")
+
+        then:
+        out./print.*/(* _) >> { def args -> output += args.join('') }
+        assert assertResetMarkAtTheEndOfOutput(output)
+    }
+
+    def "userInput - verify the reset marker at the end of the output"() {
+        when:
+        console.userInput("QUESTION")
+
+        then:
+        out./write.*/(* _) >> { def args -> output = new String(args[0], args[1], args[2]) }
+        assert assertResetMarkAtTheEndOfOutput(output)
+    }
+
+    def assertResetMarkAtTheEndOfOutput(def output) {
+        return output ==~ /.*$RESET/
+    }
+
+}

--- a/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
@@ -18,6 +18,7 @@ package grails.build.logging
 
 import jline.console.ConsoleReader
 import org.fusesource.jansi.Ansi
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.regex.Pattern
@@ -57,6 +58,7 @@ class GrailsConsoleSpec extends Specification {
         output = ""
     }
 
+    @Issue('GRAILS-10753')
     def "outputMessage - verify the reset marker at the end of the output"() {
         when:
         console.outputMessage("MSG", 1)
@@ -66,6 +68,7 @@ class GrailsConsoleSpec extends Specification {
         assert assertResetMarkAtTheEndOfOutput(output)
     }
 
+    @Issue('GRAILS-10753')
     def "error - verify the reset marker at the end of the output"() {
         when:
         console.error("LABEL", "MSG")
@@ -75,6 +78,7 @@ class GrailsConsoleSpec extends Specification {
         assert assertResetMarkAtTheEndOfOutput(output)
     }
 
+    @Issue('GRAILS-10753')
     def "userInput - verify the reset marker at the end of the output"() {
         when:
         console.userInput("QUESTION")


### PR DESCRIPTION
GrailsConsole makes sure now that whenever the ANSI escape codes are output to the console they are followed by the reset sequence, so that the console is reset to its default statue after every operation. Like that it is not “stateful” when it comes to colouring, formatting, etc.
It also applies to the userInput operation, so that even if the prompt question is coloured the reset mark precedes the user’s input. It ensures that if the java-process is killed in-between, the console is reset to the default state.
