### PR TITLE
GRAILS-10753 Console Colors in Windows - optional fix

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
+++ b/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
@@ -337,7 +337,7 @@ public class GrailsConsole {
     private void assertAllowInput() {
         assertAllowInput(null);
     }
-    
+
     private void assertAllowInput(String prompt) {
         if (reader == null) {
             String msg = "User input is not enabled, cannot obtain input stream";
@@ -867,7 +867,7 @@ public class GrailsConsole {
         cursorMove = 0;
         try {
             if (isAnsiEnabled()) {
-                Ansi ansi = outputErrorLabel(userInputActive ? moveDownToSkipPrompt()  : ansi(), label).a(message);
+                Ansi ansi = outputErrorLabel(userInputActive ? moveDownToSkipPrompt() : ansi(), label).a(message);
 
                 if (message.endsWith(LINE_SEPARATOR)) {
                     out.print(ansi);
@@ -894,6 +894,16 @@ public class GrailsConsole {
         if (!(System.err instanceof GrailsConsoleErrorPrintStream)) {
             System.setErr(new GrailsConsoleErrorPrintStream(originalSystemErr));
         }
+    }
+
+    /**
+     * Makes sure that the console has been reset to the default state and that the out stream has been flushed.
+     */
+    public void cleanup() {
+        if (isAnsiEnabled()) {
+            out.print(ansi().reset().toString());
+        }
+        flush();
     }
 
     public void flush() {

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
@@ -142,7 +142,7 @@ public class GrailsScriptRunner {
             }
         } catch (ParseException e) {
             console.error("Error processing command line arguments: " + e.getMessage());
-            System.exit(1);
+            exitWithStatus(1);
             return;
         }
 
@@ -176,7 +176,7 @@ public class GrailsScriptRunner {
 
         if (commandLine.hasOption(CommandLine.VERSION_ARGUMENT)) {
             console.log("Grails version: " + build.getGrailsVersion());
-            System.exit(0);
+            exitWithStatus(0);
         }
 
         if (commandLine.hasOption(CommandLine.HELP_ARGUMENT)) {
@@ -185,7 +185,7 @@ public class GrailsScriptRunner {
             } else {
                 console.log("The '-help' option is deprecated; use 'grails help'");
             }
-            System.exit(0);
+            exitWithStatus(0);
         }
 
         boolean resolveDeps = commandLine.hasOption(CommandLine.REFRESH_DEPENDENCIES_ARGUMENT);
@@ -225,8 +225,7 @@ public class GrailsScriptRunner {
 
             try {
                 int exitCode = scriptRunner.executeCommand(commandLine, script.name, script.env);
-                GrailsConsole.getInstance().flush();
-                System.exit(exitCode);
+                exitWithStatus(exitCode);
             }
             catch (ScriptNotFoundException ex) {
                 console.error("Script not found: " + ex.getScriptName());
@@ -272,8 +271,12 @@ public class GrailsScriptRunner {
         else {
             grailsConsole.error(error, t);
         }
-        grailsConsole.flush();
-        System.exit(1);
+        exitWithStatus(1);
+    }
+
+    private static void exitWithStatus(int status) {
+        GrailsConsole.getInstance().cleanup();
+        System.exit(status);
     }
 
     private static ScriptAndArgs processArgumentsAndReturnScriptName(CommandLine commandLine) {
@@ -364,7 +367,7 @@ public class GrailsScriptRunner {
         }
         catch (Exception e) {
             console.error("There was an error loading the BuildConfig: " + e.getMessage(), e);
-            System.exit(1);
+            exitWithStatus(1);
         }
         finally {
             System.setProperty("disable.grails.plugin.transform", "false");
@@ -744,7 +747,7 @@ public class GrailsScriptRunner {
             String selection = console.userInput("Please make a selection or enter Q to quit: ");
 
             if ("Q".equalsIgnoreCase(selection)) {
-                System.exit(0);
+                exitWithStatus(0);
             }
 
             try {

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/api/BaseSettingsApi.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/api/BaseSettingsApi.java
@@ -381,7 +381,7 @@ public class BaseSettingsApi {
         if (System.getProperty("grails.cli.testing") != null || System.getProperty("grails.disable.exit") != null) {
             throw new ScriptExitException(code);
         }
-        GrailsConsole.getInstance().flush();
+        GrailsConsole.getInstance().cleanup();
         System.exit(code);
     }
 

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -116,7 +116,7 @@ abstract class ForkedGrailsProcess {
                                 final contextFile = readLine(sockIn)
                                 if (contextFile) {
                                     if ("exit" == contextFile) {
-                                        System.exit(0)
+                                        exitWithStatus(0)
                                     }
                                     else {
                                         def loadedContext = readExecutionContext(contextFile)
@@ -148,7 +148,11 @@ abstract class ForkedGrailsProcess {
                 // ignore
             }
         }
+    }
 
+    private static exitWithStatus(int status) {
+        GrailsConsole.instance.cleanup()
+        System.exit(status)
     }
 
     boolean isDaemonRunning() {
@@ -242,7 +246,7 @@ abstract class ForkedGrailsProcess {
 
         def lockDir = new File(executionContext.projectWorkDir, "process-lock")
         if (lockDir.mkdir()) {
-            System.exit 0
+            exitWithStatus(0)
         } else {
             // someone is already connected; let the process finish
         }
@@ -440,7 +444,7 @@ abstract class ForkedGrailsProcess {
 
                 GrailsConsole.instance.error("Forked Grails VM exited with error")
                 if(!InteractiveMode.active) {
-                    System.exit(1)
+                    exitWithStatus(1)
                 }
             }
         }

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/compile/ForkedGrailsCompiler.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/compile/ForkedGrailsCompiler.groovy
@@ -48,7 +48,8 @@ class ForkedGrailsCompiler extends ForkedGrailsProjectClassExecutor {
             new ForkedGrailsCompiler().run()
             System.exit(0)
         } catch (Throwable e) {
-            GrailsConsole.getInstance().error("Error running forked compilation: " + e.getMessage(), e)
+            GrailsConsole.instance.error("Error running forked compilation: " + e.getMessage(), e)
+            GrailsConsole.instance.cleanup()
             System.exit(1)
         }
     }

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/testing/ForkedGrailsTestRunner.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/testing/ForkedGrailsTestRunner.groovy
@@ -75,7 +75,8 @@ class ForkedGrailsTestRunner extends ForkedGrailsProjectClassExecutor {
         try {
             System.exit( new ForkedGrailsTestRunner().run() )
         } catch (Throwable e) {
-            GrailsConsole.getInstance().error("Error running forked test-app: " + e.getMessage(), e)
+            GrailsConsole.instance.error("Error running forked test-app: " + e.getMessage(), e)
+            GrailsConsole.instance.cleanup()
             System.exit(1)
         }
     }

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/interactive/InteractiveMode.groovy
@@ -230,6 +230,7 @@ class InteractiveMode {
 
     protected void goodbye() {
         updateStatus "Goodbye"
+        GrailsConsole.instance.cleanup()
         System.exit(0)
     }
 

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/support/ClasspathConfigurer.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/support/ClasspathConfigurer.java
@@ -108,7 +108,7 @@ public class ClasspathConfigurer {
         if (!dependenciesExternallyConfigured && buildDependencies.isEmpty()) {
             GrailsConsole.getInstance().error("Required Grails build dependencies were not found. This is normally due to internet connectivity issues (such as a misconfigured proxy) or missing repositories in grails-app/conf/BuildConfig.groovy. Please verify your configuration to continue.");
             cleanResolveCache(settings);
-
+            GrailsConsole.getInstance().cleanup();
             System.exit(1);
         }
         addDependenciesToURLs(excludes, urls, buildDependencies);
@@ -160,6 +160,7 @@ public class ClasspathConfigurer {
         grailsConsole.error(buildResolveReport.getResolveError().getMessage());
         grailsConsole.addStatus("Run 'grails dependency-report' for further information.");
         if (exitOnResolveError) {
+            grailsConsole.cleanup();
             System.exit(1);
         }
     }


### PR DESCRIPTION
Outputs the ANSI reset sequence and flushes the stream before the System.exit() invocations to make sure that the console has been reset to its default state. 
The potential problem could occur when the out stream has not been fully flushed and the System.exit() invocation finished. 
Last characters of the out stream contain the ANSI reset sequence - if they are not flushed the console keeps the formatting of the previous message.
