### PR TITLE
Override max and offset in g:sortableColumn explicitly

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/RenderTagLib.groovy
@@ -527,12 +527,14 @@ class RenderTagLib implements RequestConstants {
         def linkParams = [:]
         if (params.id) linkParams.put("id", params.id)
         def paramsAttr = attrs.remove("params")
-        if (paramsAttr) linkParams.putAll(paramsAttr)
         linkParams.sort = property
 
         // propagate "max" and "offset" standard params
         if (params.max) linkParams.max = params.max
         if (params.offset) linkParams.offset = params.offset
+        
+        // copy all defined params in tag attribute and explicitly override existing ones
+        if (paramsAttr) linkParams.putAll(paramsAttr)
 
         // determine and add sorting order for this column to link params
         attrs.class = (attrs.class ? "${attrs.class} sortable" : "sortable")


### PR DESCRIPTION
Currenntly there is no possibility to explicit override `max` and `offset` params in GSP `params` attribute of tag `g:sortableColumn`. This is fixed now.
