### PR TITLE
Fix for GRAILS-10917

### DIFF
--- a/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/api/ControllersRestApi.groovy
+++ b/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/api/ControllersRestApi.groovy
@@ -119,7 +119,7 @@ class ControllersRestApi {
                 def target = errors instanceof BeanPropertyBindingResult ? errors.getTarget() : null
                 Renderer<Errors> errorsRenderer = registry.findContainerRenderer(mimeType, Errors.class, target)
                 if (errorsRenderer) {
-                    final context = new ServletRenderContext(webRequest, (Map)args.model)
+                    final context = new ServletRenderContext(webRequest, [model: args.model])
                     if (args.view) {
                         context.viewName = args.view
                     }

--- a/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
@@ -30,25 +30,24 @@ import spock.lang.Specification
 
 @TestFor(BookController)
 @Mock(Book)
-@Ignore
 class RespondMethodSpec extends Specification{
 
     void setup() {
         def ga = grailsApplication
         ga.config.grails.mime.types =
             [ html: ['text/html','application/xhtml+xml'],
-            xml: ['text/xml', 'application/xml'],
-            text: 'text/plain',
-            js: 'text/javascript',
-            rss: 'application/rss+xml',
-            atom: 'application/atom+xml',
-            css: 'text/css',
-            csv: 'text/csv',
-            all: '*/*',
-            json: ['application/json','text/json'],
-            form: 'application/x-www-form-urlencoded',
-            multipartForm: 'multipart/form-data'
-        ]
+                xml: ['text/xml', 'application/xml'],
+                text: 'text/plain',
+                js: 'text/javascript',
+                rss: 'application/rss+xml',
+                atom: 'application/atom+xml',
+                css: 'text/css',
+                csv: 'text/csv',
+                all: '*/*',
+                json: ['application/json','text/json'],
+                form: 'application/x-www-form-urlencoded',
+                multipartForm: 'multipart/form-data'
+            ]
 
         defineBeans {
             mimeTypes(MimeTypesFactoryBean) {
@@ -57,107 +56,147 @@ class RespondMethodSpec extends Specification{
         }
     }
 
+    @Ignore
     void "Test that the respond method produces the correct model for a domain instance and no specific content type"() {
         given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
+        def book = new Book(title: "The Stand").save(flush:true)
 
         when:"The respond method is used to render a response"
-            webRequest.actionName = 'show'
-            controller.show(book)
-            def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
+        webRequest.actionName = 'show'
+        controller.show(book)
+        def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
 
         then:"A modelAndView and view is produced"
-            modelAndView != null
-            modelAndView instanceof ModelAndView
-            modelAndView.model.book == book
-            modelAndView.viewName == 'show'
+        modelAndView != null
+        modelAndView instanceof ModelAndView
+        modelAndView.model.book == book
+        modelAndView.viewName == 'show'
     }
 
+    void "Test that the respond method produces the correct model for a domain instance and content type is HTML"() {
+        given:"A book instance"
+        def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+        webRequest.actionName = 'showWithModel'
+        controller.showWithModel(book)
+        def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
+
+        then:"A modelAndView and view is produced"
+        modelAndView != null
+        modelAndView instanceof ModelAndView
+        modelAndView.model == [book: book, extra: true]
+        modelAndView.viewName == 'showWithModel'
+    }
+
+    void "Test that the respond method produces errors HTML for a domain instance that has errors and a content type of HTML"() {
+        given:"A book instance"
+        def book = new Book(title: "")
+        book.validate()
+
+        when:"The respond method is used to render a response"
+        webRequest.actionName = 'showWithModel'
+        controller.showWithModel(book)
+        def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
+
+        then:"A modelAndView and view is produced"
+        modelAndView != null
+        modelAndView instanceof ModelAndView
+        modelAndView.model == [book: book, extra: true]
+        modelAndView.viewName == 'showWithModel'
+    }
+
+    @Ignore
     void "Test that the respond method produces XML for a domain instance and a content type of XML"() {
         given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
+        def book = new Book(title: "The Stand").save(flush:true)
 
         when:"The respond method is used to render a response"
-            response.format = 'xml'
-
-            def result = controller.show(book)
-
-        then:"A modelAndView and view is produced"
-            result == null
-            response.contentType == 'text/xml'
-            response.xml.title.text() == 'The Stand'
-    }
-
-    void "Test that the respond method produces XML for a list of domains and a content type of XML"() {
-        given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-            response.format = 'xml'
-            def result = controller.index()
-
-        then:"A modelAndView and view is produced"
-            result == null
-            response.contentType == 'text/xml'
-    }
-
-    void "Test that the respond method produces errors XML for a domain instance that has errors and a content type of XML"() {
-        given:"A book instance"
-            def book = new Book(title: "")
-            book.validate()
-
-        when:"The respond method is used to render a response"
-            response.format = 'xml'
-
-            def result = controller.show(book)
-
-        then:"A modelAndView and view is produced"
-            result == null
-            response.contentType == 'text/xml'
-            response.xml.error.message.text() == 'Property [title] of class [class grails.rest.web.Book] cannot be null'
-    }
-
-    void "Test that the respond method produces JSON for a domain instance and a content type of JSON"() {
-        given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-            response.format = 'json'
+        response.format = 'xml'
 
         def result = controller.show(book)
 
         then:"A modelAndView and view is produced"
-            result == null
-            response.contentType == 'application/json'
-            response.json.title == 'The Stand'
+        result == null
+        response.contentType == 'text/xml'
+        response.xml.title.text() == 'The Stand'
     }
 
+    @Ignore
+    void "Test that the respond method produces XML for a list of domains and a content type of XML"() {
+        given:"A book instance"
+        def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+        response.format = 'xml'
+        def result = controller.index()
+
+        then:"A modelAndView and view is produced"
+        result == null
+        response.contentType == 'text/xml'
+    }
+
+    @Ignore
+    void "Test that the respond method produces errors XML for a domain instance that has errors and a content type of XML"() {
+        given:"A book instance"
+        def book = new Book(title: "")
+        book.validate()
+
+        when:"The respond method is used to render a response"
+        response.format = 'xml'
+
+        def result = controller.show(book)
+
+        then:"A modelAndView and view is produced"
+        result == null
+        response.contentType == 'text/xml'
+        response.xml.error.message.text() == 'Property [title] of class [class grails.rest.web.Book] cannot be null'
+    }
+
+    @Ignore
+    void "Test that the respond method produces JSON for a domain instance and a content type of JSON"() {
+        given:"A book instance"
+        def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+        response.format = 'json'
+
+        def result = controller.show(book)
+
+        then:"A modelAndView and view is produced"
+        result == null
+        response.contentType == 'application/json'
+        response.json.title == 'The Stand'
+    }
+
+    @Ignore
     void "Test that the respond method produces a 404 for a format not supported"() {
         given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
+        def book = new Book(title: "The Stand").save(flush:true)
 
         when:"The respond method is used to render a response"
-            response.format = 'xml'
+        response.format = 'xml'
 
-            def result = controller.showWithFormats(book.id)
+        def result = controller.showWithFormats(book.id)
 
         then:"A modelAndView and view is produced"
-            response.status == 404
+        response.status == 404
     }
 
+    @Ignore
     void "Test that the respond method produces JSON for an action that specifies explicit formats"() {
         given:"A book instance"
-            def book = new Book(title: "The Stand").save(flush:true)
+        def book = new Book(title: "The Stand").save(flush:true)
 
         when:"The respond method is used to render a response"
-            response.format = 'json'
+        response.format = 'json'
 
-            def result = controller.showWithFormats(book.id)
+        def result = controller.showWithFormats(book.id)
 
         then:"A modelAndView and view is produced"
-            result == null
-            response.contentType == 'application/json'
-            response.json.title == 'The Stand'
+        result == null
+        response.contentType == 'application/json'
+        response.json.title == 'The Stand'
     }
 }
 
@@ -165,6 +204,10 @@ class RespondMethodSpec extends Specification{
 class BookController {
     def show(Book b) {
         respond b
+    }
+
+    def showWithModel(Book b) {
+        respond b, model: [extra: true]
     }
 
     def index() {

--- a/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
@@ -30,24 +30,25 @@ import spock.lang.Specification
 
 @TestFor(BookController)
 @Mock(Book)
+//@Ignore
 class RespondMethodSpec extends Specification{
 
     void setup() {
         def ga = grailsApplication
         ga.config.grails.mime.types =
             [ html: ['text/html','application/xhtml+xml'],
-                xml: ['text/xml', 'application/xml'],
-                text: 'text/plain',
-                js: 'text/javascript',
-                rss: 'application/rss+xml',
-                atom: 'application/atom+xml',
-                css: 'text/css',
-                csv: 'text/csv',
-                all: '*/*',
-                json: ['application/json','text/json'],
-                form: 'application/x-www-form-urlencoded',
-                multipartForm: 'multipart/form-data'
-            ]
+            xml: ['text/xml', 'application/xml'],
+            text: 'text/plain',
+            js: 'text/javascript',
+            rss: 'application/rss+xml',
+            atom: 'application/atom+xml',
+            css: 'text/css',
+            csv: 'text/csv',
+            all: '*/*',
+            json: ['application/json','text/json'],
+            form: 'application/x-www-form-urlencoded',
+            multipartForm: 'multipart/form-data'
+        ]
 
         defineBeans {
             mimeTypes(MimeTypesFactoryBean) {
@@ -59,18 +60,111 @@ class RespondMethodSpec extends Specification{
     @Ignore
     void "Test that the respond method produces the correct model for a domain instance and no specific content type"() {
         given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
+            def book = new Book(title: "The Stand").save(flush:true)
 
         when:"The respond method is used to render a response"
-        webRequest.actionName = 'show'
-        controller.show(book)
-        def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
+            webRequest.actionName = 'show'
+            controller.show(book)
+            def modelAndView = webRequest.request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW)
 
         then:"A modelAndView and view is produced"
-        modelAndView != null
-        modelAndView instanceof ModelAndView
-        modelAndView.model.book == book
-        modelAndView.viewName == 'show'
+            modelAndView != null
+            modelAndView instanceof ModelAndView
+            modelAndView.model.book == book
+            modelAndView.viewName == 'show'
+    }
+
+    @Ignore
+    void "Test that the respond method produces XML for a domain instance and a content type of XML"() {
+        given:"A book instance"
+            def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+            response.format = 'xml'
+
+            def result = controller.show(book)
+
+        then:"A modelAndView and view is produced"
+            result == null
+            response.contentType == 'text/xml'
+            response.xml.title.text() == 'The Stand'
+    }
+
+    @Ignore
+    void "Test that the respond method produces XML for a list of domains and a content type of XML"() {
+        given:"A book instance"
+            def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+            response.format = 'xml'
+            def result = controller.index()
+
+        then:"A modelAndView and view is produced"
+            result == null
+            response.contentType == 'text/xml'
+    }
+
+    @Ignore
+    void "Test that the respond method produces errors XML for a domain instance that has errors and a content type of XML"() {
+        given:"A book instance"
+            def book = new Book(title: "")
+            book.validate()
+
+        when:"The respond method is used to render a response"
+            response.format = 'xml'
+
+            def result = controller.show(book)
+
+        then:"A modelAndView and view is produced"
+            result == null
+            response.contentType == 'text/xml'
+            response.xml.error.message.text() == 'Property [title] of class [class grails.rest.web.Book] cannot be null'
+    }
+
+    @Ignore
+    void "Test that the respond method produces JSON for a domain instance and a content type of JSON"() {
+        given:"A book instance"
+            def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+            response.format = 'json'
+
+        def result = controller.show(book)
+
+        then:"A modelAndView and view is produced"
+            result == null
+            response.contentType == 'application/json'
+            response.json.title == 'The Stand'
+    }
+
+    @Ignore
+    void "Test that the respond method produces a 404 for a format not supported"() {
+        given:"A book instance"
+            def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+            response.format = 'xml'
+
+            def result = controller.showWithFormats(book.id)
+
+        then:"A modelAndView and view is produced"
+            response.status == 404
+    }
+
+    @Ignore
+    void "Test that the respond method produces JSON for an action that specifies explicit formats"() {
+        given:"A book instance"
+            def book = new Book(title: "The Stand").save(flush:true)
+
+        when:"The respond method is used to render a response"
+            response.format = 'json'
+
+            def result = controller.showWithFormats(book.id)
+
+        then:"A modelAndView and view is produced"
+            result == null
+            response.contentType == 'application/json'
+            response.json.title == 'The Stand'
     }
 
     void "Test that the respond method produces the correct model for a domain instance and content type is HTML"() {
@@ -104,99 +198,6 @@ class RespondMethodSpec extends Specification{
         modelAndView instanceof ModelAndView
         modelAndView.model == [book: book, extra: true]
         modelAndView.viewName == 'showWithModel'
-    }
-
-    @Ignore
-    void "Test that the respond method produces XML for a domain instance and a content type of XML"() {
-        given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-        response.format = 'xml'
-
-        def result = controller.show(book)
-
-        then:"A modelAndView and view is produced"
-        result == null
-        response.contentType == 'text/xml'
-        response.xml.title.text() == 'The Stand'
-    }
-
-    @Ignore
-    void "Test that the respond method produces XML for a list of domains and a content type of XML"() {
-        given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-        response.format = 'xml'
-        def result = controller.index()
-
-        then:"A modelAndView and view is produced"
-        result == null
-        response.contentType == 'text/xml'
-    }
-
-    @Ignore
-    void "Test that the respond method produces errors XML for a domain instance that has errors and a content type of XML"() {
-        given:"A book instance"
-        def book = new Book(title: "")
-        book.validate()
-
-        when:"The respond method is used to render a response"
-        response.format = 'xml'
-
-        def result = controller.show(book)
-
-        then:"A modelAndView and view is produced"
-        result == null
-        response.contentType == 'text/xml'
-        response.xml.error.message.text() == 'Property [title] of class [class grails.rest.web.Book] cannot be null'
-    }
-
-    @Ignore
-    void "Test that the respond method produces JSON for a domain instance and a content type of JSON"() {
-        given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-        response.format = 'json'
-
-        def result = controller.show(book)
-
-        then:"A modelAndView and view is produced"
-        result == null
-        response.contentType == 'application/json'
-        response.json.title == 'The Stand'
-    }
-
-    @Ignore
-    void "Test that the respond method produces a 404 for a format not supported"() {
-        given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-        response.format = 'xml'
-
-        def result = controller.showWithFormats(book.id)
-
-        then:"A modelAndView and view is produced"
-        response.status == 404
-    }
-
-    @Ignore
-    void "Test that the respond method produces JSON for an action that specifies explicit formats"() {
-        given:"A book instance"
-        def book = new Book(title: "The Stand").save(flush:true)
-
-        when:"The respond method is used to render a response"
-        response.format = 'json'
-
-        def result = controller.showWithFormats(book.id)
-
-        then:"A modelAndView and view is produced"
-        result == null
-        response.contentType == 'application/json'
-        response.json.title == 'The Stand'
     }
 }
 


### PR DESCRIPTION
A small commit fixed during GGX 2013, regarding the model being passed in case of errors when using the respond keyword. 

I unignored the test class and ignored all the separated tests to allow the 2 tests I added to run. I think my tests don't cause issues on the build server since they don't test the contentType, which seems to fail on the build server as well as my machine (JDK issue?) 
