### PR TITLE
[#GRAILS-10980] Add JSON Codec as a registered Codec

### DIFF
--- a/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/plugins/CodecsGrailsPlugin.groovy
+++ b/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/plugins/CodecsGrailsPlugin.groovy
@@ -33,6 +33,7 @@ import org.codehaus.groovy.grails.plugins.codecs.SHA256BytesCodec
 import org.codehaus.groovy.grails.plugins.codecs.SHA256Codec
 import org.codehaus.groovy.grails.plugins.codecs.URLCodec
 import org.codehaus.groovy.grails.plugins.codecs.XMLCodec
+import org.codehaus.groovy.grails.plugins.codecs.JSONCodec
 
 /**
  * Configures pluggable codecs.
@@ -48,6 +49,7 @@ class CodecsGrailsPlugin {
         HTMLCodec,
         HTML4Codec,
         XMLCodec,
+        JSONCodec,
         JavaScriptCodec,
         URLCodec,
         Base64Codec,


### PR DESCRIPTION
in grails 2.2.x encodeAsJSON() was available on linkedHashMaps and Strings, this disappeared / stopped working in 2.3.x. This fix adds it to the codecs list as a provided Artefact.
