### PR TITLE
Added support for including excluded dependencies when generating POM file.

### DIFF
--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
@@ -16,10 +16,15 @@
 package org.codehaus.groovy.grails.resolve.maven
 
 import org.codehaus.groovy.grails.resolve.Dependency
+import org.codehaus.groovy.grails.resolve.DependencyReport
 import org.codehaus.groovy.grails.resolve.maven.aether.AetherDependencyManager
 import org.codehaus.groovy.grails.resolve.maven.aether.config.GrailsAetherCoreDependencies
+import org.eclipse.aether.RepositorySystem
 import org.eclipse.aether.repository.Authentication
 import org.eclipse.aether.repository.RemoteRepository
+import org.eclipse.aether.resolution.DependencyRequest
+import org.eclipse.aether.resolution.DependencyResult
+
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Specification
@@ -509,4 +514,17 @@ class AetherDependencyManagerSpec extends Specification {
             dependencyManager.session.authenticationSelector.getAuthentication(repository) != null
     }
 
+    void "Test the resolution of a single dependency"() {
+        given: "A dependency manager instance"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.repositorySystem = Mock(RepositorySystem) {
+                resolveDependencies(_,_) >> { new DependencyResult(new DependencyRequest()) }
+            }
+        when: "A dependency is provided"
+            org.codehaus.groovy.grails.resolve.Dependency dependency = new org.codehaus.groovy.grails.resolve.Dependency('org.slf4j', 'slf4j-api', '1.7.2')
+            DependencyReport report = dependencyManager.resolveDependency(dependency)
+        then: "The dependency is resolved"
+            report != null
+            !report.hasError()
+    }
 }

--- a/grails-bootstrap/src/main/groovy/grails/util/PluginBuildSettings.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/util/PluginBuildSettings.groovy
@@ -32,10 +32,6 @@ import org.codehaus.groovy.grails.plugins.CompositePluginDescriptorReader
 import org.codehaus.groovy.grails.plugins.GrailsPluginInfo
 import org.codehaus.groovy.grails.plugins.PluginInfo
 import org.codehaus.groovy.grails.plugins.build.scopes.PluginScopeInfo
-import javax.xml.parsers.SAXParserFactory
-import groovy.xml.FactorySupport
-import javax.xml.parsers.ParserConfigurationException
-import javax.xml.XMLConstants
 
 /**
  * Uses the project BuildSettings object to discover information about the installed plugin
@@ -156,8 +152,10 @@ class PluginBuildSettings {
 
     @CompileStatic
     private populateSourceDirectories(PluginScopeInfo compileInfo, List<File> pluginDependencies) {
-        for (zip in pluginDependencies) {
-            registerPluginZipWithScope(zip, compileInfo)
+        if(pluginDependencies) {
+            for (zip in pluginDependencies) {
+                registerPluginZipWithScope(zip, compileInfo)
+            }
         }
     }
 

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/DependencyManager.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/DependencyManager.java
@@ -93,6 +93,13 @@ public interface DependencyManager {
     DependencyReport resolve();
 
     /**
+     * Resolves a single dependency.
+     * @param dependency A {@link Dependency} instance.
+     * @return The {@link DependencyReport} instance for the given dependency
+     */
+    DependencyReport resolveDependency(Dependency dependency);
+
+    /**
      * The direct dependencies of the application, not including framework or dependencies inherited from plugins
      *
      * @return Direct application dependencies

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/IvyDependencyManager.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/IvyDependencyManager.groovy
@@ -20,17 +20,14 @@ import grails.util.GrailsNameUtils
 import grails.util.Metadata
 import groovy.transform.CompileStatic
 import groovy.util.slurpersupport.GPathResult
-import org.apache.ivy.core.cache.ArtifactOrigin
-import org.apache.ivy.plugins.repository.Repository
-import org.apache.ivy.plugins.repository.Resource
-import org.apache.ivy.plugins.resolver.RepositoryResolver
-import org.codehaus.groovy.grails.resolve.ivy.IvyExcludeResolver
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
+import org.apache.ivy.core.cache.ArtifactOrigin
 import org.apache.ivy.core.event.EventManager
 import org.apache.ivy.core.module.descriptor.Artifact
 import org.apache.ivy.core.module.descriptor.Configuration
+import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor
 import org.apache.ivy.core.module.descriptor.DependencyDescriptor
 import org.apache.ivy.core.module.descriptor.ExcludeRule
 import org.apache.ivy.core.module.id.ModuleRevisionId
@@ -40,11 +37,15 @@ import org.apache.ivy.core.resolve.ResolveEngine
 import org.apache.ivy.core.resolve.ResolveOptions
 import org.apache.ivy.core.settings.IvySettings
 import org.apache.ivy.core.sort.SortEngine
+import org.apache.ivy.plugins.repository.Repository
+import org.apache.ivy.plugins.repository.Resource
 import org.apache.ivy.plugins.repository.TransferListener
+import org.apache.ivy.plugins.resolver.RepositoryResolver
+import org.codehaus.groovy.grails.io.support.IOUtils
 import org.codehaus.groovy.grails.plugins.VersionComparator
+import org.codehaus.groovy.grails.resolve.ivy.IvyExcludeResolver
 import org.codehaus.groovy.grails.resolve.ivy.IvyGraphNode
 import org.codehaus.groovy.grails.resolve.reporting.SimpleGraphRenderer
-import org.codehaus.groovy.grails.io.support.IOUtils
 
 /**
  * Implementation that uses Apache Ivy under the hood.
@@ -291,7 +292,7 @@ class IvyDependencyManager extends AbstractIvyDependencyManager implements Depen
         }
 
         // return an empty resolve report
-        initializeModuleDescriptor();
+        initializeModuleDescriptor()
         return new ResolveReport(moduleDescriptor)
     }
 
@@ -340,7 +341,7 @@ class IvyDependencyManager extends AbstractIvyDependencyManager implements Depen
         }
 
         // return an empty resolve report
-        initializeModuleDescriptor();
+        initializeModuleDescriptor()
         return new ResolveReport(moduleDescriptor)
     }
 
@@ -507,7 +508,18 @@ class IvyDependencyManager extends AbstractIvyDependencyManager implements Depen
     DependencyReport resolve() {
         final resolveReport = resolveDependencies()
         return new IvyDependencyReport("compile", resolveReport)
+    }
 
+    @Override
+    public DependencyReport resolveDependency(Dependency dependency) {
+        ModuleRevisionId revId = ModuleRevisionId.newInstance(dependency.group, dependency.name, dependency.version)
+
+        ResolveOptions options = new ResolveOptions()
+        options.setDownload(false)
+        options.setOutputReport(false)
+        options.setValidate(false)
+
+        return resolveEngine.resolve(DefaultModuleDescriptor.newDefaultInstance(revId), options)
     }
 
     @Override

--- a/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/maven/MavenPomGeneratorSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/maven/MavenPomGeneratorSpec.groovy
@@ -1,0 +1,152 @@
+package org.codehaus.groovy.grails.cli.maven
+
+import grails.util.BuildSettings
+import grails.util.Metadata
+import groovy.util.slurpersupport.GPathResult
+
+import org.apache.ivy.core.cache.ResolutionCacheManager
+import org.apache.ivy.core.module.id.ModuleRevisionId
+import org.apache.ivy.core.report.ResolveReport
+import org.apache.ivy.core.resolve.IvyNode
+import org.apache.ivy.core.resolve.ResolveEngine
+import org.apache.ivy.core.settings.IvySettings
+import org.apache.ivy.plugins.resolver.ChainResolver
+import org.codehaus.groovy.grails.resolve.Dependency
+import org.codehaus.groovy.grails.resolve.IvyDependencyManager
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * @author Jonathan Pearlin
+ */
+class MavenPomGeneratorSpec extends Specification {
+
+    @Shared
+    File pomFile = new File('build/pom.xml')
+
+    def setupSpec() {
+        if(pomFile.exists()) {
+            pomFile.delete()
+        }
+    }
+
+    def cleanup() {
+        if(pomFile.exists()) {
+            pomFile.delete()
+        }
+    }
+
+    def "test generating a pom file"() {
+        setup:
+            File pluginsDir = new File('build/plugins')
+            pluginsDir.mkdirs()
+            BuildSettings settings = Mock(BuildSettings) {
+                createConfigSlurper() >> { Mock(ConfigSlurper) }
+                getApplicationName() >> { 'grails-bootstrap-unit-tests' }
+                getBaseDir() >> { new File('build') }
+                getConfig() >> { Mock(ConfigObject) {
+                        toProperties() >> { new Properties() }
+                    }
+                }
+                getDependencyManager() >> { Mock(IvyDependencyManager) {
+                        getApplicationDependencies(_) >> {
+                            switch(it[0]) {
+                                case "compile":
+                                    [new Dependency('commons-lang', 'commons-lang', '3.0', false, 'slf4j-api', 'log4j:log4j')]
+                                    break
+                                case "runtime":
+                                    [new Dependency('commons-logging', 'commons-logging', '1.1.1')]
+                                    break
+                                case "test":
+                                    [new Dependency('org.spockframework', 'spock-core', '0.7-groovy-2.0')]
+                                    break
+                                case "provided":
+                                    [new Dependency('javax.servlet', 'servlet-api', '2.5')]
+                                    break
+                                case "build":
+                                    [new Dependency('org.grails', 'grails-bootstrap', '2.3.0')]
+                                    break
+                                default:
+                                    []
+                                    break
+                            }
+                        }
+                        getIvySettings() >> { Mock(IvySettings) {
+                                getResolutionCacheManager() >> { Mock(ResolutionCacheManager) {
+                                        getResolvedIvyPropertiesInCache(_) >> { new File('build/ivy-props.xml') }
+                                    }
+                                }
+                            }
+                        }
+                        getChainResolver() >> { Mock(ChainResolver) }
+                    }
+                }
+                getGrailsAppVersion() >> { '1.0.0' }
+                getGrailsHome() >> { new File('..') }
+                getGrailsVersion() >> { null }
+                getMetadata() >> { Mock(Metadata) {
+                        getApplicationVersion() >> { '1.0.0' }
+                    }
+                }
+                getProjectPluginsDir() >> { pluginsDir }
+            }
+            MavenPomGenerator generator = Spy(MavenPomGenerator, constructorArgs:[settings]) {
+                    getResolveEngine() >> { Mock(ResolveEngine) {
+                            resolve(_,_) >> { Mock(ResolveReport) {
+                                getDependencies() >> {
+                                    [Mock(IvyNode) {
+                                        getId() >> { ModuleRevisionId.newInstance('org.slf4j', 'slf4j-api', '1.7.0') }
+                                    },
+                                    Mock(IvyNode) {
+                                        getId() >> { ModuleRevisionId.newInstance('log4j', 'log4j', '1.2.16') }
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        when:
+            generator.generate('org.grails.test')
+        then:
+            pomFile.exists() == true
+            GPathResult pom = new XmlSlurper().parse(pomFile)
+            (pom.project.dependencies.find { dependency ->
+                dependency.groupId == 'commons-lang' &&
+                dependency.artifactId == 'commons-lang' &&
+                dependency.version == '3.0' &&
+                dependency.scope == 'compile' &&
+                (dependency.exclusions.find { exclusion -> exclusion.groupId == 'log4j' && exclusion.artifactId == 'log4j' } != null) == true &&
+                (dependency.exclusions.find { exclusion -> exclusion.groupId == 'org.slf4j' && exclusion.artifactId == 'slf4j-api' } != null) == true
+            } != null) == true
+            (pom.project.dependencies.find { dependency ->
+                dependency.groupId == 'commons-logging' &&
+                dependency.artifactId == 'commons-logging' &&
+                dependency.version == '1.1.1' &&
+                dependency.scope == 'runtime' &&
+                dependency.exclusions == null
+            } != null) == true
+            (pom.project.dependencies.find { dependency ->
+                dependency.groupId == 'org.spockframework' &&
+                dependency.artifactId == 'spock-core' &&
+                dependency.version == '0.7-groovy-2.0' &&
+                dependency.scope == 'test' &&
+                dependency.exclusions == null
+            } != null) == true
+            (pom.project.dependencies.find { dependency ->
+                dependency.groupId == 'javax.servlet' &&
+                dependency.artifactId == 'servlet-api' &&
+                dependency.version == '2.5' &&
+                dependency.scope == 'provided' &&
+                dependency.exclusions == null
+            } != null) == true
+            (pom.project.dependencies.find { dependency ->
+                dependency.groupId == 'org.grails' &&
+                dependency.artifactId == 'grails-bootstrap' &&
+                dependency.version == '2.3.0' &&
+                dependency.scope == 'provided' &&
+                dependency.exclusions == null
+            } != null) == true
+    }
+}

--- a/grails-resources/src/grails/templates/maven/project.pom
+++ b/grails-resources/src/grails/templates/maven/project.pom
@@ -42,6 +42,7 @@
             <artifactId>grails-plugin-services</artifactId>
             <version>\${grails.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.grails</groupId>
             <artifactId>grails-plugin-i18n</artifactId>
@@ -104,7 +105,6 @@
             <version>\${grails.version}</version>
             <scope>test</scope>
         </dependency>
-
         <% if (!pluginProject) { %>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -113,27 +113,38 @@
             <scope>runtime</scope>
         </dependency>
         <% } %>
-
         <% for (dep in dependencies) { %>
         <dependency>
             <groupId>${dep.group}</groupId>
             <artifactId>${dep.name}</artifactId>
             <version>${dep.version}</version>
             <scope>${dep.scope}</scope>
-            <% if (dep.type) { %><type>${dep.type}</type><% } %>
+            <% if (dep.type) { %>
+            <type>${dep.type}</type>
+            <% } %>
+            <% if (dep.excludes) { %>
+            <exclusions>
+                <% for (exclusion in dep.excludes) { %>
+                <exclusion>
+                    <groupId>${exclusion.group}</groupId>
+                    <artifactId>${exclusion.name}</artifactId>
+                </exclusion>
+                <% } %>
+            </exclusions>
+            <% } %>
         </dependency>
         <% } %>
-
         <% for (p in plugins) { %>
         <dependency>
             <groupId>${p.group}</groupId>
             <artifactId>${p.name}</artifactId>
             <version>${p.version}</version>
             <scope>${p.scope}</scope>
-            <% if (p.type) { %><type>${p.type}</type><% } %>
+            <% if (p.type) { %>
+            <type>${p.type}</type>
+            <% } %>
         </dependency>
         <% } %>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
Added logic to the MavenPomGenerator to honor the Ivy exclusions.  This change matches up the exclusion filters for a given dependency with its transitive dependencies in order to generate valid Maven XML.  I also added a new Spock test to validate the change.
