### PR TITLE
[GRAILS-10623] Fixed issue, controllerClass and controllerNamespace now available in filters

### DIFF
--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpSession
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
+import org.codehaus.groovy.grails.commons.GrailsControllerClass
 import org.codehaus.groovy.grails.plugins.web.api.ControllersApi
 import org.codehaus.groovy.grails.web.servlet.FlashScope
 import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
@@ -266,6 +267,15 @@ class FilterConfig extends ControllersApi {
     String getControllerName() {
         return super.getControllerName(this)
     }
+
+    String getControllerNamespace() {
+        return super.getControllerNamespace(this)
+    }
+
+    GrailsControllerClass getControllerClass() {
+        return super.getControllerClass(this)
+    }
+
 
     GrailsWebRequest getWebRequest() {
         return super.getWebRequest(this)

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpSession
 
 import org.codehaus.groovy.grails.commons.GrailsApplication
 import org.codehaus.groovy.grails.commons.GrailsClassUtils
-import org.codehaus.groovy.grails.commons.GrailsControllerClass
 import org.codehaus.groovy.grails.plugins.web.api.ControllersApi
 import org.codehaus.groovy.grails.web.servlet.FlashScope
 import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
@@ -272,7 +271,7 @@ class FilterConfig extends ControllersApi {
         return super.getControllerNamespace(this)
     }
 
-    GrailsControllerClass getControllerClass() {
+    GroovyObject getControllerClass() {
         return super.getControllerClass(this)
     }
 

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfig.groovy
@@ -271,7 +271,7 @@ class FilterConfig extends ControllersApi {
         return super.getControllerNamespace(this)
     }
 
-    GroovyObject getControllerClass() {
+    Object getControllerClass() {
         return super.getControllerClass(this)
     }
 

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
@@ -112,8 +112,8 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         return request.getAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE)?.toString()
     }
 
-    GroovyObject controllerClass(request) {
-     return (GroovyObject)request.getAttribute(GrailsApplicationAttributes.CONTROLLER)
+    def controllerClass(request) {
+     return request.getAttribute(GrailsApplicationAttributes.CONTROLLER)
     }
 
     /**
@@ -140,7 +140,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         if (filterConfig.before) {
 
             String controllerName = controllerName(request)
-            GroovyObject controllerClass = controllerClass(request)
+            def controllerClass   = controllerClass(request)
             String controllerNamespace = controllerNamespace(request)
             String actionName = actionName(request)
             String uri = uri(request)
@@ -166,7 +166,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         }
 
         String controllerName = controllerName(request)
-        GroovyObject controllerClass = controllerClass(request)
+        def controllerClass = controllerClass(request)
         String controllerNamespace = controllerNamespace(request)
         String actionName = actionName(request)
         String uri = uri(request)
@@ -220,7 +220,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
 
         String controllerName = controllerName(request)
         String controllerNamespace = controllerNamespace(request)
-        GroovyObject controllerClass = controllerClass(request)
+        def controllerClass = controllerClass(request)
         String actionName = actionName(request)
         String uri = uri(request)
 

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
@@ -230,7 +230,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         callable.call(e)
     }
 
-    boolean accept(String controllerName, String actionName, String uri, String controllerNamespace, GroovyObject controllerClass) {
+    boolean accept(String controllerName, String actionName, String uri, String controllerNamespace, controllerClass) {
         boolean matched=true
 
         if (uriPattern) {

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-import org.codehaus.groovy.grails.commons.DefaultGrailsControllerClass
+import org.codehaus.groovy.grails.commons.GrailsControllerClass
 import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
 import org.codehaus.groovy.grails.web.servlet.view.NullView
 import org.codehaus.groovy.grails.web.util.WebUtils
@@ -44,6 +44,8 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
 
     def controllerRegex
     def controllerExcludeRegex
+    def controllerNamespaceRegex
+    def controllerNamespaceExcludeRegex
     def actionRegex
     def actionExcludeRegex
     def uriPattern
@@ -74,6 +76,16 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
             controllerExcludeRegex = Pattern.compile((useRegex)?scope.controllerExclude:scope.controllerExclude.replaceAll("\\*", ".*"))
         }
 
+        if(scope.namespace) {
+            controllerNamespaceRegex = Pattern.compile((useRegex)?scope.namespace:scope.namespace.replaceAll("\\*", ".*"))
+        } else {
+            controllerNamespaceRegex = Pattern.compile(".*")
+        }
+
+        if(scope.namespaceExclude) {
+            controllerNamespaceExcludeRegex = Pattern.compile((useRegex)?scope.namespaceExclude:scope.namespaceExclude.replaceAll("\\*", ".*"))
+        }
+
         if (scope.action) {
             actionRegex = Pattern.compile((useRegex)?scope.action:scope.action.replaceAll("\\*", ".*"))
         }
@@ -100,6 +112,17 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         return request.getAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE)?.toString()
     }
 
+    GrailsControllerClass controllerClass(request) {
+     return (GrailsControllerClass)request.getAttribute(GrailsApplicationAttributes.CONTROLLER)
+    }
+
+    /**
+    * Returns the namespace of the controller targeted by the given request.
+    **/
+    String controllerNamespace(request) {
+     return request.getAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE)?.toString()
+    }
+
     /**
      * Returns the name of the action targeted by the given request.
      */
@@ -117,10 +140,12 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         if (filterConfig.before) {
 
             String controllerName = controllerName(request)
+            GrailsControllerClass controllerClass = controllerClass(request)
+            String controllerNamespace = controllerNamespace(request)
             String actionName = actionName(request)
             String uri = uri(request)
 
-            if (!accept(controllerName, actionName, uri)) return true
+            if (!accept(controllerName, actionName, uri, controllerNamespace, controllerClass)) return true
 
             def callable = filterConfig.before.clone()
             def result = callable.call()
@@ -141,10 +166,12 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         }
 
         String controllerName = controllerName(request)
+        GrailsControllerClass controllerClass = controllerClass(request)
+        String controllerNamespace = controllerNamespace(request)
         String actionName = actionName(request)
         String uri = uri(request)
 
-        if (!accept(controllerName, actionName, uri)) return
+        if (!accept(controllerName, actionName, uri, controllerNamespace, controllerClass)) return
 
         def callable = filterConfig.after.clone()
         def currentModel = modelAndView?.model
@@ -192,16 +219,18 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         }
 
         String controllerName = controllerName(request)
+        String controllerNamespace = controllerNamespace(request)
+        GrailsControllerClass controllerClass = controllerClass(request)
         String actionName = actionName(request)
         String uri = uri(request)
 
-        if (!accept(controllerName, actionName, uri)) return
+        if (!accept(controllerName, actionName, uri, controllerNamespace, controllerClass)) return
 
         def callable = filterConfig.afterView.clone()
         callable.call(e)
     }
 
-    boolean accept(String controllerName, String actionName, String uri) {
+    boolean accept(String controllerName, String actionName, String uri, String controllerNamespace, GrailsControllerClass controllerClass) {
         boolean matched=true
 
         if (uriPattern) {
@@ -222,11 +251,18 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
                 if (matched && controllerExcludeRegex) {
                     matched = !doesMatch(controllerExcludeRegex, controllerName)
                 }
+                if(matched && controllerNamespaceRegex) {
+                    if(!controllerNamespace) {
+                        controllerNamespace = ''
+                    }
+                    matched = doesMatch(controllerNamespaceRegex, controllerNamespace)
+                    if(matched && controllerNamespaceExcludeRegex) {
+                        matched = !doesMatch(controllerNamespaceExcludeRegex, controllerNamespace)
+                    }
+                }
             }
-            if (matched && filterConfig.scope.action) {
+            if (matched && (filterConfig.scope.action)) {
                 if (!actionName && controllerName) {
-                    def controllerClass = grailsApplication?.getArtefactByLogicalPropertyName(
-                       DefaultGrailsControllerClass.CONTROLLER, controllerName)
                     actionName = controllerClass?.getDefaultAction()
                 }
                 matched = doesMatch(actionRegex, actionName)

--- a/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
+++ b/grails-plugin-filters/src/main/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterToHandlerAdapter.groovy
@@ -20,7 +20,7 @@ import java.util.regex.Pattern
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-import org.codehaus.groovy.grails.commons.GrailsControllerClass
+import groovy.lang.GroovyObject;
 import org.codehaus.groovy.grails.web.servlet.GrailsApplicationAttributes
 import org.codehaus.groovy.grails.web.servlet.view.NullView
 import org.codehaus.groovy.grails.web.util.WebUtils
@@ -112,8 +112,8 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         return request.getAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE)?.toString()
     }
 
-    GrailsControllerClass controllerClass(request) {
-     return (GrailsControllerClass)request.getAttribute(GrailsApplicationAttributes.CONTROLLER)
+    GroovyObject controllerClass(request) {
+     return (GroovyObject)request.getAttribute(GrailsApplicationAttributes.CONTROLLER)
     }
 
     /**
@@ -140,7 +140,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         if (filterConfig.before) {
 
             String controllerName = controllerName(request)
-            GrailsControllerClass controllerClass = controllerClass(request)
+            GroovyObject controllerClass = controllerClass(request)
             String controllerNamespace = controllerNamespace(request)
             String actionName = actionName(request)
             String uri = uri(request)
@@ -166,7 +166,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         }
 
         String controllerName = controllerName(request)
-        GrailsControllerClass controllerClass = controllerClass(request)
+        GroovyObject controllerClass = controllerClass(request)
         String controllerNamespace = controllerNamespace(request)
         String actionName = actionName(request)
         String uri = uri(request)
@@ -220,7 +220,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
 
         String controllerName = controllerName(request)
         String controllerNamespace = controllerNamespace(request)
-        GrailsControllerClass controllerClass = controllerClass(request)
+        GroovyObject controllerClass = controllerClass(request)
         String actionName = actionName(request)
         String uri = uri(request)
 
@@ -230,7 +230,7 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
         callable.call(e)
     }
 
-    boolean accept(String controllerName, String actionName, String uri, String controllerNamespace, GrailsControllerClass controllerClass) {
+    boolean accept(String controllerName, String actionName, String uri, String controllerNamespace, GroovyObject controllerClass) {
         boolean matched=true
 
         if (uriPattern) {
@@ -263,7 +263,9 @@ class FilterToHandlerAdapter implements HandlerInterceptor, InitializingBean, Gr
             }
             if (matched && (filterConfig.scope.action)) {
                 if (!actionName && controllerName) {
-                    actionName = controllerClass?.getDefaultAction()
+                    if(controllerClass && controllerClass.respondsTo("getDefaultAction")) {
+                        actionName = controllerClass?.getDefaultAction()
+                    }
                 }
                 matched = doesMatch(actionRegex, actionName)
                 if (matched && actionExcludeRegex) {

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/filters/FilterToHandlerAdapterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/filters/FilterToHandlerAdapterTests.groovy
@@ -28,9 +28,9 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.uri = "/restricted/**"
         filterAdapter.afterPropertiesSet()
 
-        assert filterAdapter.accept("Ignore", "index", "/restricted/1")
-        assert filterAdapter.accept("Ignore", "index", "/restricted/1/2")
-        assert !filterAdapter.accept("Ignore", "index", "/foo/1/2")
+        assert filterAdapter.accept("Ignore", "index", "/restricted/1", null, null)
+        assert filterAdapter.accept("Ignore", "index", "/restricted/1/2", null, null)
+        assert !filterAdapter.accept("Ignore", "index", "/foo/1/2", null, null)
     }
 
     void testURIMapping2() {
@@ -41,10 +41,10 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.find = true
         filterAdapter.afterPropertiesSet()
 
-        assert filterAdapter.accept("Controller", "index", "/restricted/1")
-        assert filterAdapter.accept("Controller", "index", "/restricted/1/2")
-        assert filterAdapter.accept("Controller", "index", "/foo/1/2")
-        assert !filterAdapter.accept("Contoller", "index", "/foo/1/2")
+        assert filterAdapter.accept("Controller", "index", "/restricted/1", null, null)
+        assert filterAdapter.accept("Controller", "index", "/restricted/1/2", null, null)
+        assert filterAdapter.accept("Controller", "index", "/foo/1/2", null, null)
+        assert !filterAdapter.accept("Contoller", "index", "/foo/1/2", null, null)
     }
 
     void testURIMapping3() {
@@ -58,10 +58,10 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.regex = true
         filterAdapter.afterPropertiesSet()
 
-        assert !filterAdapter.accept("Controller", "index", "/restricted/1")
-        assert !filterAdapter.accept("Controller", "index", "/restricted/1/2")
-        assert !filterAdapter.accept("Controller", "index", "/foo/1/2")
-        assert filterAdapter.accept("Contoller", "index", "/foo/1/2")
+        assert !filterAdapter.accept("Controller", "index", "/restricted/1", null, null)
+        assert !filterAdapter.accept("Controller", "index", "/restricted/1/2", null, null)
+        assert !filterAdapter.accept("Controller", "index", "/foo/1/2", null, null)
+        assert filterAdapter.accept("Contoller", "index", "/foo/1/2", null, null)
     }
 
     void testDefaultActionWithControllerMatchAndActionWildcard() {
@@ -72,7 +72,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "*"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept("demo", null, "/ignored")
+        assertTrue filterAdapter.accept("demo", null, "/ignored", null, null)
     }
 
     void testDefaultActionWithControllerMismatchAndActionWildcard() {
@@ -83,7 +83,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "*"
         filterAdapter.afterPropertiesSet()
 
-        assertFalse filterAdapter.accept("auth", null, "/ignored")
+        assertFalse filterAdapter.accept("auth", null, "/ignored", null, null)
     }
 
     void testDefaultActionWithControllerMatchAndActionMismatch() {
@@ -94,7 +94,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "foo"
         filterAdapter.afterPropertiesSet()
 
-        assertFalse filterAdapter.accept("demo", null, "/ignored")
+        assertFalse filterAdapter.accept("demo", null, "/ignored", null, null)
     }
 
     void testDefaultActionWithControllerMatchAndActionMatch() {
@@ -110,7 +110,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "index"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept("demo", null, "/ignored")
+        assertTrue filterAdapter.accept("demo", null, "/ignored",null, (GroovyObject)DemoController)
     }
 
     void testDefaultActionWithControllerMatchAndNoActionSpecifiedInConfig() {
@@ -120,7 +120,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.controller = "demo"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept("demo", null, "/ignored")
+        assertTrue filterAdapter.accept("demo", null, "/ignored", null, null)
     }
 
     void testAppRootWithWildcardedControllerAndAction() {
@@ -131,7 +131,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "*"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept(null, null, '/')
+        assertTrue filterAdapter.accept(null, null, '/', null, null)
     }
 
     void testAppRootWithWildcardedControllerAndActionRegex() {
@@ -143,7 +143,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.regex = true
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept(null, null, '/')
+        assertTrue filterAdapter.accept(null, null, '/', null, null)
     }
 
     void testAppRootWithWildcardedControllerAndNoAction() {
@@ -153,7 +153,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.controller = "*"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept(null, null, '/')
+        assertTrue filterAdapter.accept(null, null, '/', null, null)
     }
 
     void testAppRootWithWildcardedControllerAndSpecificAction() {
@@ -164,7 +164,7 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "something"
         filterAdapter.afterPropertiesSet()
 
-        assertFalse filterAdapter.accept(null, null, '/')
+        assertFalse filterAdapter.accept(null, null, '/', null, null)
     }
 
     void testAppRootWithSpecificControllerAndWildcardedAction() {
@@ -175,7 +175,18 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "*"
         filterAdapter.afterPropertiesSet()
 
-        assertFalse filterAdapter.accept(null, null, '/')
+        assertFalse filterAdapter.accept(null, null, '/', null, null)
+    }
+
+    void testNamespaceMismatchControllerMismatchAndActionWildcard() {
+        def filterAdapter = new FilterToHandlerAdapter()
+        filterAdapter.filterConfig = new Expando()
+        filterAdapter.filterConfig.scope = new Expando()
+        filterAdapter.filterConfig.scope.controller = "demo"
+        filterAdapter.filterConfig.scope.action = "*"
+        filterAdapter.filterConfig.scope.namespace = "demo"
+        filterAdapter.afterPropertiesSet()
+        assertFalse filterAdapter.accept("demo", null, "/ignored", "namespace", null)
     }
 }
 class DemoController {

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/filters/FilterToHandlerAdapterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/filters/FilterToHandlerAdapterTests.groovy
@@ -4,6 +4,7 @@ import grails.web.CamelCaseUrlConverter
 import grails.web.UrlConverter
 
 import org.codehaus.groovy.grails.commons.DefaultGrailsApplication
+import org.codehaus.groovy.grails.commons.DefaultGrailsControllerClass
 import org.codehaus.groovy.grails.plugins.web.filters.FilterToHandlerAdapter
 import org.codehaus.groovy.grails.support.MockApplicationContext
 
@@ -110,7 +111,8 @@ class FilterToHandlerAdapterTests extends GroovyTestCase {
         filterAdapter.filterConfig.scope.action = "index"
         filterAdapter.afterPropertiesSet()
 
-        assertTrue filterAdapter.accept("demo", null, "/ignored",null, (GroovyObject)DemoController)
+        def controllerClass = application?.getArtefactByLogicalPropertyName(DefaultGrailsControllerClass.CONTROLLER, "demo")
+        assertTrue filterAdapter.accept("demo", null, "/ignored",null,controllerClass)
     }
 
     void testDefaultActionWithControllerMatchAndNoActionSpecifiedInConfig() {

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.codehaus.groovy.grails.commons.GrailsApplication;
+import org.codehaus.groovy.grails.commons.GrailsControllerClass;
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
 import org.codehaus.groovy.grails.support.encoding.Encoder;
@@ -196,6 +197,22 @@ public class CommonWebApi implements GrailsApplicationAware, ServletContextAware
      */
     public String getControllerName(Object instance) {
         return currentRequestAttributes().getControllerName();
+    }
+
+    /**
+     * Obtains the currently executing controller namespace
+     * @return The controller name
+     */
+    public String getControllerNamespace(Object instance) {
+        return currentRequestAttributes().getControllerNamespace();
+    }
+
+    /**
+     * Obtains the currently executing controllerClass
+     * @return The controller class
+     */
+    public GrailsControllerClass getControllerClass(Object instance) {
+        return currentRequestAttributes().getControllerClass();
     }
 
     /**

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
@@ -21,7 +21,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import groovy.lang.GroovyObject;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
@@ -211,7 +210,7 @@ public class CommonWebApi implements GrailsApplicationAware, ServletContextAware
      * Obtains the currently executing controllerClass
      * @return The controller class
      */
-    public GroovyObject getControllerClass(Object instance) {
+    public Object getControllerClass(Object instance) {
         return currentRequestAttributes().getControllerClass();
     }
 

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/CommonWebApi.java
@@ -21,9 +21,9 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
+import groovy.lang.GroovyObject;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
-import org.codehaus.groovy.grails.commons.GrailsControllerClass;
+
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
 import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
 import org.codehaus.groovy.grails.support.encoding.Encoder;
@@ -211,7 +211,7 @@ public class CommonWebApi implements GrailsApplicationAware, ServletContextAware
      * Obtains the currently executing controllerClass
      * @return The controller class
      */
-    public GrailsControllerClass getControllerClass(Object instance) {
+    public GroovyObject getControllerClass(Object instance) {
         return currentRequestAttributes().getControllerClass();
     }
 

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/DefaultGrailsApplicationAttributes.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/DefaultGrailsApplicationAttributes.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.GrailsTagLibClass;
+import org.codehaus.groovy.grails.commons.DefaultGrailsControllerClass;
 import org.codehaus.groovy.grails.commons.TagLibArtefactHandler;
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
 import org.codehaus.groovy.grails.web.metaclass.ControllerDynamicMethods;
@@ -132,6 +133,9 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
             if (controller != null) {
                 controllerName = (String)controller.getProperty(ControllerDynamicMethods.CONTROLLER_NAME_PROPERTY);
                 request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, controllerName);
+                if(((DefaultGrailsControllerClass)controller).getNamespace() != null) {
+                    request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE, ((DefaultGrailsControllerClass)controller).getNamespace());
+                }
             }
         }
         return controllerName != null ? controllerName : "";

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/DefaultGrailsApplicationAttributes.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/DefaultGrailsApplicationAttributes.java
@@ -29,7 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.GrailsTagLibClass;
-import org.codehaus.groovy.grails.commons.DefaultGrailsControllerClass;
+import org.codehaus.groovy.grails.commons.GrailsControllerClass;
 import org.codehaus.groovy.grails.commons.TagLibArtefactHandler;
 import org.codehaus.groovy.grails.plugins.GrailsPluginManager;
 import org.codehaus.groovy.grails.web.metaclass.ControllerDynamicMethods;
@@ -133,9 +133,13 @@ public class DefaultGrailsApplicationAttributes implements GrailsApplicationAttr
             if (controller != null) {
                 controllerName = (String)controller.getProperty(ControllerDynamicMethods.CONTROLLER_NAME_PROPERTY);
                 request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, controllerName);
-                if(((DefaultGrailsControllerClass)controller).getNamespace() != null) {
-                    request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE, ((DefaultGrailsControllerClass)controller).getNamespace());
+                if(controller instanceof GrailsControllerClass) {
+                    String namespace = ((GrailsControllerClass)controller).getNamespace();
+                    if(namespace != null) {
+                        request.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE, namespace);
+                    }
                 }
+
             }
         }
         return controllerName != null ? controllerName : "";

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/GrailsApplicationAttributes.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/GrailsApplicationAttributes.java
@@ -61,6 +61,7 @@ public interface GrailsApplicationAttributes extends ApplicationAttributes {
     String REQUEST_REDIRECTED_ATTRIBUTE = "org.codehaus.groovy.grails.request_redirected";
     String ACTION_NAME_ATTRIBUTE = "org.codehaus.groovy.grails.ACTION_NAME_ATTRIBUTE";
     String CONTROLLER_NAME_ATTRIBUTE = "org.codehaus.groovy.grails.CONTROLLER_NAME_ATTRIBUTE";
+    String CONTROLLER_NAMESPACE_ATTRIBUTE = "org.codehaus.groovy.grails.CONTROLLER_NAMESPACE_ATTRIBUTE";
     String GRAILS_CONTROLLER_CLASS = "org.codehaus.groovy.grails.GRAILS_CONTROLLER_CLASS";
     String APP_URI_ATTRIBUTE = "org.codehaus.groovy.grails.APP_URI_ATTRIBUTE";
     String RENDERING_ERROR_ATTRIBUTE = "org.codehaus.groovy.grails.RENDERING_ERROR_ATTRIBUTE";

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -270,6 +270,10 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
         getCurrentRequest().setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, controllerName);
     }
 
+    public void setControllerNamespace(String controllerNamespace) {
+     getCurrentRequest().setAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE, controllerNamespace);
+    }
+
     /**
      * @return the actionName
      */
@@ -282,6 +286,20 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
      */
     public String getControllerName() {
         return (String)getCurrentRequest().getAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE);
+    }
+
+    /**
+     * @return the controllerClass
+     */
+    public GrailsControllerClass getControllerClass() {
+        return (GrailsControllerClass)getCurrentRequest().getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS);
+    }
+
+    /**
+    * @return the controllerNamespace
+    */
+    public String getControllerNamespace() {
+        return (String)getCurrentRequest().getAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE);
     }
 
     public void setRenderView(boolean renderView) {
@@ -307,8 +325,7 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
      */
     public boolean isFlowRequest() {
         GrailsApplication application = getAttributes().getGrailsApplication();
-        GrailsControllerClass controllerClass = (GrailsControllerClass)application.getArtefactByLogicalPropertyName(
-                ControllerArtefactHandler.TYPE, getControllerName());
+        GrailsControllerClass controllerClass = getControllerClass();
 
         if (controllerClass == null) return false;
 

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import groovy.lang.GroovyObject;
 import org.codehaus.groovy.grails.commons.ControllerArtefactHandler;
 import org.codehaus.groovy.grails.commons.DefaultGrailsCodecClass;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
@@ -291,8 +290,8 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
     /**
      * @return the controllerClass
      */
-    public GroovyObject getControllerClass() {
-        return (GroovyObject)getCurrentRequest().getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS);
+    public Object getControllerClass() {
+        return getCurrentRequest().getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS);
     }
 
     /**
@@ -325,10 +324,10 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
      */
     public boolean isFlowRequest() {
         GrailsApplication application = getAttributes().getGrailsApplication();
-        GroovyObject controllerClassGroovyObject = getControllerClass();
+        Object controllerClassObject = getControllerClass();
         GrailsControllerClass controllerClass = null;
-        if(controllerClassGroovyObject instanceof GrailsControllerClass) {
-            controllerClass = (GrailsControllerClass) controllerClassGroovyObject;
+        if(controllerClassObject instanceof GrailsControllerClass) {
+            controllerClass = (GrailsControllerClass) controllerClassObject;
         }
 
         if (controllerClass == null) return false;

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
+import groovy.lang.GroovyObject;
 import org.codehaus.groovy.grails.commons.ControllerArtefactHandler;
 import org.codehaus.groovy.grails.commons.DefaultGrailsCodecClass;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
@@ -291,8 +291,8 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
     /**
      * @return the controllerClass
      */
-    public GrailsControllerClass getControllerClass() {
-        return (GrailsControllerClass)getCurrentRequest().getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS);
+    public GroovyObject getControllerClass() {
+        return (GroovyObject)getCurrentRequest().getAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS);
     }
 
     /**
@@ -325,7 +325,11 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
      */
     public boolean isFlowRequest() {
         GrailsApplication application = getAttributes().getGrailsApplication();
-        GrailsControllerClass controllerClass = getControllerClass();
+        GroovyObject controllerClassGroovyObject = getControllerClass();
+        GrailsControllerClass controllerClass = null;
+        if(controllerClassGroovyObject instanceof GrailsControllerClass) {
+            controllerClass = (GrailsControllerClass) controllerClassGroovyObject;
+        }
 
         if (controllerClass == null) return false;
 
@@ -333,7 +337,7 @@ public class GrailsWebRequest extends DispatcherServletWebRequest implements Par
         if (actionName == null) actionName = controllerClass.getDefaultAction();
         if (actionName == null) return false;
 
-        if (controllerClass != null && controllerClass.isFlowAction(actionName)) return true;
+        if (controllerClass.isFlowAction(actionName)) return true;
         return false;
     }
 

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/util/WebUtils.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/util/WebUtils.java
@@ -44,6 +44,7 @@ import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.grails.commons.ControllerArtefactHandler;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.GrailsClass;
+import org.codehaus.groovy.grails.commons.GrailsControllerClass;
 import org.codehaus.groovy.grails.web.mapping.UrlMappingInfo;
 import org.codehaus.groovy.grails.web.mapping.UrlMappingsHolder;
 import org.codehaus.groovy.grails.web.mime.MimeType;
@@ -210,12 +211,12 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
     public static View resolveView(HttpServletRequest request, String viewName, String controllerName, ViewResolver viewResolver) throws Exception {
         return viewResolver.resolveViewName(addViewPrefix(viewName, controllerName), GrailsWebRequest.lookup(request).getLocale());
     }
-    
+
     public static String addViewPrefix(String viewName) {
         GrailsWebRequest webRequest = GrailsWebRequest.lookup();
         return addViewPrefix(viewName, webRequest != null ? webRequest.getControllerName() : null);
     }
-    
+
     public static String addViewPrefix(String viewName, String controllerName) {
         if (!viewName.startsWith(String.valueOf(SLASH))) {
             StringBuilder buf = new StringBuilder();
@@ -723,6 +724,9 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
                 webRequest.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAME_ATTRIBUTE, controller.getLogicalPropertyName(), WebRequest.SCOPE_REQUEST);
                 webRequest.setAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS, controller, WebRequest.SCOPE_REQUEST);
                 webRequest.setAttribute(GrailsApplicationAttributes.GRAILS_CONTROLLER_CLASS_AVAILABLE, Boolean.TRUE, WebRequest.SCOPE_REQUEST);
+                if(((GrailsControllerClass)controller).getNamespace() != null) {
+                    webRequest.setAttribute(GrailsApplicationAttributes.CONTROLLER_NAMESPACE_ATTRIBUTE, ((GrailsControllerClass)controller).getNamespace(), WebRequest.SCOPE_REQUEST);
+                }
             }
 
         }


### PR DESCRIPTION
Fixed based on a previous PR. This fixes the issues detecting during builds. It provides functionality for filtering scoped to a namespace using a namespaceRegex filter and namespaceExcludes. It also fixes a few areas where fetching class by logicalPropertyName was no longer correct due to the controller potentially having the same name in a different namespace. (Uses the request attribute GRAILS_CONTROLLER_CLAS instead).
