### PR TITLE
GRAILS-10941: stopping Grails with CTRL+C does not work on Windows at all

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
+++ b/grails-bootstrap/src/main/groovy/grails/build/logging/GrailsConsole.java
@@ -204,7 +204,9 @@ public class GrailsConsole {
      * is controlled by the jline.terminal system property.
      */
     protected Terminal createTerminal() {
-        return terminal = TerminalFactory.create();
+        terminal = TerminalFactory.create();
+        terminal.setEchoEnabled(true);
+        return terminal;
     }
 
     /**


### PR DESCRIPTION
see http://jira.grails.org/browse/GRAILS-10941
