### PR TITLE
GRAILS-11029 removeFrom missing check otherSide attribute

### DIFF
--- a/grails-plugin-domain-class/src/main/groovy/org/codehaus/groovy/grails/plugins/DomainClassGrailsPlugin.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/codehaus/groovy/grails/plugins/DomainClassGrailsPlugin.groovy
@@ -383,7 +383,7 @@ class DomainClassGrailsPlugin {
                     metaClass."removeFrom${collectionName}" = {Object arg ->
                         if (otherDomainClass.clazz.isInstance(arg)) {
                             delegate[prop.name]?.remove(arg)
-                            if (prop.bidirectional) {
+                            if (prop.bidirectional && prop.otherSide) {
                                 if (prop.manyToMany) {
                                     String name = prop.otherSide.name
                                     arg[name]?.remove(delegate)


### PR DESCRIPTION
Made improvement on condition of removeFrom due to following exception during manyToMany relation removeFrom method invocation.

```
Cannot get property 'name' on null object. Stacktrace follows:
Message: Cannot get property 'name' on null object
```

see details 
http://stackoverflow.com/questions/21311359/domain-multiple-inheritance-and-manytomany-relation-removefrom-not-working
