### PR TITLE
HAL renderer should ignore null values for embedded single ended domain ...

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/hal/HalJsonRenderer.groovy
@@ -236,11 +236,11 @@ class HalJsonRenderer<T> extends AbstractLinkingRenderer<T> {
             for (entry in associationMap.entrySet()) {
                 final property = entry.key
                 final isSingleEnded = property instanceof ToOne
-                writer.name(property.name)
 
                 if (isSingleEnded) {
                     Object value = entry.value
                     if (value != null) {
+                        writer.name(property.name)
                         final associatedEntity = property.associatedEntity
                         if (associatedEntity) {
                             writtenObjects << value
@@ -249,6 +249,7 @@ class HalJsonRenderer<T> extends AbstractLinkingRenderer<T> {
                         }
                     }
                 } else {
+                    writer.name(property.name)
                     final associatedEntity = property.associatedEntity
                     if (associatedEntity) {
                         writer.beginArray()

--- a/grails-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalJsonRendererSpec.groovy
+++ b/grails-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/render/hal/HalJsonRendererSpec.groovy
@@ -733,6 +733,37 @@ class HalJsonRendererSpec extends Specification{
 
     }
 
+    @Issue('GRAILS-11100')
+    void "Test that the HAL renderer ignores null values for embedded single ended domain objects" () {
+        given:"A HAL renderer"
+        HalJsonRenderer renderer = getRenderer()
+        renderer.prettyPrint = true
+
+        when:"A domain object is rendered"
+        def webRequest = GrailsWebUtil.bindMockWebRequest()
+        webRequest.request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, "/product/Macbook")
+        def response = webRequest.response
+        def renderContext = new ServletRenderContext(webRequest)
+        def product = new Product(name: "MacBook", numberInStock: 10, category: null)
+        renderer.render(product, renderContext)
+
+        then:"The resulting HAL is correct"
+        response.contentType == GrailsWebUtil.getContentType(HalJsonRenderer.MIME_TYPE.name, GrailsWebUtil.DEFAULT_ENCODING)
+        response.contentAsString =='''{
+  "_links": {
+    "self": {
+      "href": "http://localhost/products",
+      "hreflang": "en",
+      "type": "application/hal+json"
+    }
+  },
+  "name": "MacBook",
+  "numberInStock": 10,
+  "_embedded": {}
+}'''
+    }
+
+
     protected HalJsonCollectionRenderer getCollectionRenderer() {
         def renderer = new HalJsonCollectionRenderer(Product)
         renderer.mappingContext = mappingContext


### PR DESCRIPTION
"Single Ended" Embedded Domain Objects can be null and need to be handled.
See GRAILS-11100: HalJsonRenderer: Empty embedded property fails with Dangling name error. 
