### PR TITLE
Update country codes and names

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/CountryTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/CountryTagLib.groovy
@@ -177,7 +177,9 @@ class CountryTagLib {
         "nru":"Nauru",
         "npl":"Nepal",
         "nld":"Netherlands",
-        "ant":"Netherlands Antilles",
+        "bes":"Bonaire, Sint Eustatius and Saba",
+        "cuw":"Curaçao",
+        "sxm":"Sint Maarten (Dutch part)"
         "abw":"Aruba",
         "ncl":"New Caledonia",
         "vut":"Vanuatu",
@@ -266,7 +268,8 @@ class CountryTagLib {
         "wlf":"Wallis and Futuna",
         "wsm":"Samoa",
         "yem":"Yemen",
-        "scg":"Serbia and Montenegro",
+        "srb":"Serbia",
+        "mne":"Montenegro"
         "zmb":"Zambia",
     ]
 


### PR DESCRIPTION
Changed:
Serbia and Montenegro to "Serbia" and "Montenegro" (http://www.iso.org/iso/iso_3166-3_newsletter_i-4.pdf),
Netherlands Antilles to "Bonaire, Sint Eustatius and Saba", "Curaçao" and "Sint Maarten (Dutch part)" (http://www.iso.org/iso/iso_3166-3_newsletter_i-6.pdf)
