### PR TITLE
fixing copy'n'paste error from GrailsTestCompiler

### DIFF
--- a/grails-plugin-testing/src/main/groovy/org/codehaus/groovy/grails/test/compiler/GrailsIntegrationTestCompiler.groovy
+++ b/grails-plugin-testing/src/main/groovy/org/codehaus/groovy/grails/test/compiler/GrailsIntegrationTestCompiler.groovy
@@ -31,7 +31,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class GrailsIntegrationTestCompiler extends Grailsc{
 
-    public GrailsTestCompiler() {
+    public GrailsIntegrationTestCompiler() {
         setEncoding("UTF-8");
     }
 


### PR DESCRIPTION
- it was a method, not a constructor as intended
- detected problem with CodeNarc's MethodName rule
