### PR TITLE
Update incorrect Javadoc on #isDaemonProcess()

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -186,7 +186,7 @@ abstract class ForkedGrailsProcess {
     }
 
     /**
-     * @return Whether this process is a reserve process. A reserve process is an additional JVM, bootstrapped and idle that can resume execution at a later date
+     * @return Whether this process should be launched using a running daemon process. 
      */
     protected boolean isDaemonProcess() {
         System.getProperty("grails.fork.daemon")!=null


### PR DESCRIPTION
We were trying to figure out what the forkReserve option was about and noticed the javadoc on #isDaemonProcess() was incorrectly duplicated from #isReserveProcess().
