### PR TITLE
Make "extensions" field private

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
@@ -35,7 +35,7 @@ import org.springframework.util.StringUtils;
 public class DirectoryWatcher extends Thread {
 
     public static final String SVN_DIR_NAME = ".svn";
-    protected Collection<String> extensions = new ConcurrentLinkedQueue<String>();
+    private Collection<String> extensions = new ConcurrentLinkedQueue<String>();
     private List<FileChangeListener> listeners = new ArrayList<FileChangeListener>();
 
     private Map<File, Long> lastModifiedMap = new ConcurrentHashMap<File, Long>();


### PR DESCRIPTION
extensions is an implementation detail that (in any code I can find) is not accessed outside of this class. To keep the interface small and not reveal implementation details that consumers can use to potentially create problems, this field shouldn't be protected - it should be private.
