### PR TITLE
GRAILS-10135: DirectoryWatcher: Use Java 7's WatchService API when available

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/AbstractDirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/AbstractDirectoryWatcher.java
@@ -1,0 +1,95 @@
+package org.codehaus.groovy.grails.compiler;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import org.codehaus.groovy.grails.compiler.DirectoryWatcher.FileChangeListener;
+
+/**
+ * Backend for {@link DirectoryWatcher}
+ * @author Craig Andrews
+ * @since 2.4
+ * @see WatchServiceDirectoryWatcher
+ * @see PollingDirectoryWatcher
+ * @see DirectoryWatcher
+ */
+abstract class AbstractDirectoryWatcher implements Runnable {
+    private List<FileChangeListener> listeners = new ArrayList<FileChangeListener>();
+    volatile protected boolean active = true; //must be volatile as it's read by multiple threads and the value should be reflected in all of them
+    protected long sleepTime = 3000;
+
+    /**
+     * Sets whether to stop the directory watcher
+     *
+     * @param active False if you want to stop watching
+     */
+    public void setActive(boolean active) {
+    	this.active = active;
+    }
+
+    /**
+     * Sets the amount of time to sleep between checks
+     *
+     * @param sleepTime The sleep time
+     */
+    public void setSleepTime(long sleepTime) {
+        this.sleepTime = sleepTime;
+    }
+
+    /**
+     * Adds a file listener that can react to change events
+     *
+     * @param listener The file listener
+     */
+    public void addListener(FileChangeListener listener) {
+        listeners.add(listener);
+    }
+
+    /**
+     * Adds a file to the watch list
+     *
+     * @param fileToWatch The file to watch
+     */
+    public abstract void addWatchFile(File fileToWatch);
+
+    /**
+     * Adds a directory to watch for the given file and extensions.
+     * No String in the fileExtensions list can start with a dot (DirectoryWatcher guarantees that)
+     *
+     * @param dir The directory
+     * @param fileExtensions The extensions
+     */
+    public abstract void addWatchDirectory(File dir, List<String> fileExtensions);
+
+    protected void fireOnChange(File file) {
+        for (FileChangeListener listener : listeners) {
+            listener.onChange(file);
+        }
+    }
+
+    protected void fireOnNew(File file) {
+        for (FileChangeListener listener : listeners) {
+            listener.onNew(file);
+        }
+    }
+
+    protected boolean isValidDirectoryToMonitor(File file){
+    	return file.isDirectory() && ! file.isHidden() && !DirectoryWatcher.SVN_DIR_NAME.equals(file.getName());
+    }
+
+    protected boolean isValidFileToMonitor(File file, Collection<String> fileExtensions) {
+        String name = file.getName();
+        String path = file.getAbsolutePath();
+        boolean isSvnFile = path.indexOf(File.separator + DirectoryWatcher.SVN_DIR_NAME + File.separator) > 0;
+        return !isSvnFile &&
+        		!file.isDirectory() &&
+                !file.isHidden() &&
+                !file.getName().startsWith(".") &&
+                (fileExtensions.contains("*") || fileExtensions.contains(StringUtils.getFilenameExtension(name)));
+    }
+
+}

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/PollingDirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/PollingDirectoryWatcher.java
@@ -1,0 +1,130 @@
+package org.codehaus.groovy.grails.compiler;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Implementation of a {@link AbstractDirectoryWatcher} that uses polling.
+ * This implementation is used where {@link java.nio.WatchService} isn't available (pre Java 7).
+ * @author Craig Andrews
+ * @since 2.4
+ * @see WatchServiceDirectoryWatcher
+ * @see DirectoryWatcher
+ */
+class PollingDirectoryWatcher extends AbstractDirectoryWatcher {
+
+    protected Collection<String> extensions = new ConcurrentLinkedQueue<String>();
+
+    private Map<File, Long> lastModifiedMap = new ConcurrentHashMap<File, Long>();
+    private Map<File, Collection<String>> directoryToExtensionsMap = new ConcurrentHashMap<File, Collection<String>>();
+    private Map<File, Long> directoryWatch = new ConcurrentHashMap<File, Long>();
+
+	@Override
+	public void run() {
+        int count = 0;
+        while (active) {
+            Set<File> files = lastModifiedMap.keySet();
+            for (File file : files) {
+                long currentLastModified = file.lastModified();
+                Long cachedTime = lastModifiedMap.get(file);
+                if (currentLastModified > cachedTime) {
+                    lastModifiedMap.put(file, currentLastModified);
+                    fireOnChange(file);
+                }
+            }
+            try {
+                count++;
+                if (count > 2) {
+                    count = 0;
+                    checkForNewFiles();
+                }
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+	}
+
+	@Override
+	public void addWatchFile(File fileToWatch) {
+        lastModifiedMap.put(fileToWatch, fileToWatch.lastModified());
+	}
+
+	@Override
+	public void addWatchDirectory(File dir, List<String> fileExtensions) {
+		if(!isValidDirectoryToMonitor(dir)){
+			return;
+		}
+        trackDirectoryExtensions(dir, fileExtensions);
+        cacheFilesForDirectory(dir, fileExtensions, false);
+	}
+
+    private void trackDirectoryExtensions(File dir, List<String> fileExtensions) {
+        Collection<String> existingExtensions = directoryToExtensionsMap.get(dir);
+        if(existingExtensions == null) {
+            directoryToExtensionsMap.put(dir, new ArrayList<String>(fileExtensions));
+        }
+        else {
+            existingExtensions.addAll(fileExtensions);
+        }
+    }
+
+    private void checkForNewFiles() {
+        for (File directory : directoryWatch.keySet()) {
+            final Long currentTimestamp = directoryWatch.get(directory);
+
+            if (currentTimestamp < directory.lastModified()) {
+                Collection<String> extensions = directoryToExtensionsMap.get(directory);
+                if(extensions == null) {
+                    extensions = this.extensions;
+                }
+                cacheFilesForDirectory(directory, extensions, true);
+            }
+        }
+    }
+
+    private void cacheFilesForDirectory(File directory, Collection<String> fileExtensions, boolean fireEvent) {
+        addExtensions(fileExtensions);
+
+        directoryWatch.put(directory, directory.lastModified());
+        File[] files = directory.listFiles();
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+        	if(isValidDirectoryToMonitor(file)) {
+                cacheFilesForDirectory(file, fileExtensions, fireEvent);
+        	}
+            else if (isValidFileToMonitor(file, fileExtensions)) {
+                if (!lastModifiedMap.containsKey(file) && fireEvent) {
+                    fireOnNew(file);
+                }
+                lastModifiedMap.put(file, file.lastModified());
+            }
+        }
+    }
+
+    private void addExtensions(Collection<String> toAdd) {
+        for (String extension : toAdd) {
+            extension = removeStartingDotIfPresent(extension);
+            if (!extensions.contains(extension)) {
+                extensions.add(extension);
+            }
+        }
+    }
+
+    private String removeStartingDotIfPresent(String extension) {
+        if (extension.startsWith(".")) {
+            extension = extension.substring(1);
+        }
+        return extension;
+    }
+
+}

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/WatchServiceDirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/WatchServiceDirectoryWatcher.java
@@ -1,0 +1,157 @@
+package org.codehaus.groovy.grails.compiler;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of a {@link AbstractDirectoryWatcher} that uses {@link java.nio.WatchService}.
+ * This implementation is used for Java 7 and later.
+ * @author Craig Andrews
+ * @since 2.4
+ * @see WatchServiceDirectoryWatcher
+ * @see DirectoryWatcher
+ */
+class WatchServiceDirectoryWatcher extends AbstractDirectoryWatcher {
+
+	private static final Logger LOG = LoggerFactory.getLogger(WatchServiceDirectoryWatcher.class);
+    private Map<WatchKey, List<String>> watchKeyToExtensionsMap = new ConcurrentHashMap<WatchKey, List<String>>();
+    private Set<Path> individualWatchedFiles = new HashSet<Path>();
+
+	private final WatchService watchService;
+
+    @SuppressWarnings("unchecked")
+    private static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>)event;
+    }
+
+	public WatchServiceDirectoryWatcher(){
+		try {
+			watchService = FileSystems.getDefault().newWatchService();
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void run() {
+        while (active) {
+			try {
+				WatchKey watchKey = watchService.poll(sleepTime, TimeUnit.MILLISECONDS);
+				if(watchKey!=null){
+					List<WatchEvent<?>> watchEvents = watchKey.pollEvents();
+					for(WatchEvent<?> watchEvent : watchEvents){
+						WatchEvent.Kind<?> kind = watchEvent.kind();
+		                if (kind == StandardWatchEventKinds.OVERFLOW) {
+		                	// TODO how is this supposed to be handled? I think the best thing to do is ignore it, but I'm not positive
+		                	LOG.warn("WatchService Overflow occurred");
+		                    continue;
+		                }
+						WatchEvent<Path> pathWatchEvent = cast(watchEvent);
+						Path name = pathWatchEvent.context();
+						Path dir = (Path) watchKey.watchable();
+						Path child = dir.resolve(name).toAbsolutePath();
+						File childFile = child.toFile();
+						if(individualWatchedFiles.contains(child)){
+							if(kind == StandardWatchEventKinds.ENTRY_CREATE){
+								fireOnNew(childFile);
+							}else if(kind == StandardWatchEventKinds.ENTRY_MODIFY){
+								fireOnChange(childFile);
+							}else if(kind == StandardWatchEventKinds.ENTRY_DELETE){
+								// do nothing... there's no way to communicate deletions
+							}
+						}else{
+							List<String> fileExtensions = watchKeyToExtensionsMap.get(watchKey);
+							if(fileExtensions==null){
+								throw new IllegalStateException("No file extensions list found for path not being watched");
+							}
+							if(kind==StandardWatchEventKinds.ENTRY_CREATE){
+								// new directory created, so watch its contents
+								addWatchDirectory(child,fileExtensions);
+							}
+							if(isValidFileToMonitor(childFile,fileExtensions)){
+								if(kind == StandardWatchEventKinds.ENTRY_CREATE){
+									fireOnNew(childFile);
+								}else if(kind == StandardWatchEventKinds.ENTRY_MODIFY){
+									fireOnChange(childFile);
+								}else if(kind == StandardWatchEventKinds.ENTRY_DELETE){
+									// do nothing... there's no way to communicate deletions
+								}
+							}
+						}
+					}
+					watchKey.reset();
+				}
+			} catch (InterruptedException e) {
+				// ignore
+			}
+        }
+        try {
+			watchService.close();
+		} catch (IOException e) {
+			LOG.debug("Exception while closing watchService", e);
+		}
+	}
+
+	@Override
+	public void addWatchFile(File fileToWatch) {
+		if(!isValidFileToMonitor(fileToWatch, Arrays.asList("*"))) return;
+		try {
+			Path pathToWatch = fileToWatch.toPath().toAbsolutePath();
+			individualWatchedFiles.add(pathToWatch);
+			pathToWatch.getParent().register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void addWatchDirectory(File dir, final List<String> fileExtensions) {
+		Path dirPath = dir.toPath();
+		addWatchDirectory(dirPath, fileExtensions);
+	}
+
+	private void addWatchDirectory(Path dir, final List<String> fileExtensions) {
+		if(!isValidDirectoryToMonitor(dir.toFile())){
+			return;
+		}
+		try {
+			//add the subdirectories too
+			Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+	            @Override
+	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+	                throws IOException
+	            {
+	            	if(!isValidDirectoryToMonitor(dir.toFile())){
+	            		return FileVisitResult.SKIP_SUBTREE;
+	            	}
+	    			WatchKey watchKey = dir.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
+	    			watchKeyToExtensionsMap.put(watchKey, fileExtensions);
+	                return FileVisitResult.CONTINUE;
+	            }
+	        });
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}


### PR DESCRIPTION
When WatchService is available at runtime, use it as means of implementing DirectoryWatcher. If it's not available, use the existing polling method.

See http://jira.grails.org/browse/GRAILS-10135
