### PR TITLE
test-app respects -https setting

### DIFF
--- a/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/runner/phase/FunctionalTestPhaseConfigurer.groovy
+++ b/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/runner/phase/FunctionalTestPhaseConfigurer.groovy
@@ -62,6 +62,8 @@ class FunctionalTestPhaseConfigurer extends DefaultTestPhaseConfigurer {
         Holders.grailsApplication = null
 
         warMode = testOptions.war ? true : false
+        https = testOptions.https ? true : false
+        
         final packager = projectRunner.projectPackager
         packager.packageApplication()
         final isServerRunning = projectRunner.isServerRunning()


### PR DESCRIPTION
When we run `grails -https test-app functional:`, currently it completely disregards the `-https` setting and starts the app in `http` only mode.

See [associated question](https://stackoverflow.com/questions/21442175/grails-test-app-https) on StackOverflow for details.
