### PR TITLE
GRAILS-11333: Handle already absolute URLs

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -65,17 +65,19 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware{
         def writer = new StringBuilder()
         // prefer URI attribute
         if (attrs.get(ATTRIBUTE_URI) != null) {
-            final base = handleAbsolute(attrs)
-            if (base != null) {
-                writer << base
-            }
-            else {
-                final cp = attrs.get(ATTRIBUTE_CONTEXT_PATH)
-                if (cp == null) cp = getContextPath()
-                if (cp != null)
-                    writer << cp
-            }
             final uriPath = attrs.get(ATTRIBUTE_URI).toString()
+            if(!isAbsoluteUri(uriPath)){
+                final base = handleAbsolute(attrs)
+                if (base != null) {
+                    writer << base
+                }
+                else {
+                    final cp = attrs.get(ATTRIBUTE_CONTEXT_PATH)
+                    if (cp == null) cp = getContextPath()
+                    if (cp != null)
+                        writer << cp
+                }
+            }
             writer << uriPath
         }
         else {
@@ -241,6 +243,15 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware{
             }
 
             throw new IllegalStateException("Attribute absolute='true' specified but no grails.serverURL set in Config")
+        }
+    }
+
+    private boolean isUriAbsolute(String uri){
+	try{
+            return new URI(uri).absolute
+	}catch(Exception e){
+            // assume unparseable URIs are absolute
+            return true
         }
     }
 


### PR DESCRIPTION
When a "uri" is provided to the link method and the "absolute" parameter is true, check if the provided uri is already absolute before trying to make it absolute.
