### PR TITLE
Bind the server listening socket to the address specified in serverHost

### DIFF
--- a/grails-project-api/src/main/groovy/org/codehaus/groovy/grails/project/container/GrailsProjectRunner.groovy
+++ b/grails-project-api/src/main/groovy/org/codehaus/groovy/grails/project/container/GrailsProjectRunner.groovy
@@ -81,13 +81,17 @@ class GrailsProjectRunner extends BaseSettingsApi {
         "https://${serverHost ?: 'localhost'}:$serverPortHttps$serverContextPath"
     }
 
+    ServerSocket createServerSocket (int port) {
+        return new ServerSocket(port, 50, serverHost ? InetAddress.getByName(serverHost) : null)
+    }
+
     /**
      * @return Whether the server is running
      */
     boolean isServerRunning() {
         ServerSocket serverSocket = null
         try {
-            serverSocket = new ServerSocket(serverPort)
+            serverSocket = createServerSocket(serverPort)
             return false
         } catch (e) {
             return true
@@ -215,7 +219,7 @@ class GrailsProjectRunner extends BaseSettingsApi {
 
             profile("start server") {
 
-                try { new ServerSocket(args.httpPort).close() }
+                try { createServerSocket(args.httpPort).close() }
                 catch (IOException e) {
                     grailsConsole.error("Server failed to start for port $args.httpPort: $e.message", e)
                     exit(1)
@@ -223,7 +227,7 @@ class GrailsProjectRunner extends BaseSettingsApi {
 
                 if (args.scheme == 'https') {
 
-                    try { new ServerSocket(args.httpsPort).close() }
+                    try { createServerSocket(args.httpsPort).close() }
                     catch (IOException e) {
                         grailsConsole.error("Server failed to start for port $args.httpsPort: $e.message", e)
                         exit(1)


### PR DESCRIPTION
Some server configurations require the HTTP server to listen on a specific
address or interface. Until now, there was no way to specify an address to
bind the listening socket to - the serverHost variable was cosmetic.
Grails now uses the serverHost variable, if it is specified, as the bind
address of the HTTP/HTTPS listening sockets.
