### PR TITLE
GRAILS-11333: Handle already absolute URLs

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -65,17 +65,19 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware{
         def writer = new StringBuilder()
         // prefer URI attribute
         if (attrs.get(ATTRIBUTE_URI) != null) {
-            final base = handleAbsolute(attrs)
-            if (base != null) {
-                writer << base
-            }
-            else {
-                final cp = attrs.get(ATTRIBUTE_CONTEXT_PATH)
-                if (cp == null) cp = getContextPath()
-                if (cp != null)
-                    writer << cp
-            }
             final uriPath = attrs.get(ATTRIBUTE_URI).toString()
+            if(!isUriAbsolute(uriPath)){
+                final base = handleAbsolute(attrs)
+                if (base != null) {
+                    writer << base
+                }
+                else {
+                    final cp = attrs.get(ATTRIBUTE_CONTEXT_PATH)
+                    if (cp == null) cp = getContextPath()
+                    if (cp != null)
+                        writer << cp
+                }
+            }
             writer << uriPath
         }
         else {
@@ -241,6 +243,15 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware{
             }
 
             throw new IllegalStateException("Attribute absolute='true' specified but no grails.serverURL set in Config")
+        }
+    }
+
+    private boolean isUriAbsolute(String uri){
+	try{
+            return new URI(uri).absolute
+	}catch(Exception e){
+            // assume unparseable URIs are absolute
+            return true
         }
     }
 

--- a/grails-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/LinkGeneratorSpec.groovy
+++ b/grails-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/LinkGeneratorSpec.groovy
@@ -18,11 +18,26 @@ class LinkGeneratorSpec extends Specification {
 
     def baseUrl = "http://myserver.com/foo"
     def context = "/bar"
+    def someAbsoluteUrl = "http://www.grails.org/"
     def resource = null
     def linkParams = [:]
     def pluginManager
 
     def mainCssResource = [dir:'css', file:'main.css']
+
+    def "Test absolute link"() {
+        when:
+            linkParams.uri = someAbsoluteUrl
+            linkParams.absolute = true
+        then:
+            link == someAbsoluteUrl
+
+        when:
+            linkParams.uri = someAbsoluteUrl
+
+        then:
+            link == someAbsoluteUrl
+    }
 
     def "Test create link with root URI"() {
         when:


### PR DESCRIPTION
When a "uri" is provided to the link method and the "absolute" parameter is true, check if the provided uri is already absolute before trying to make it absolute.

Note that this pull request is fixed and doesn't have any embarrassingly bad problems like grails/grails-core/pull/488 had. I ran "gradlew test" in "grails-web" and all tests pass.
