### PR TITLE
Use a new ClassLoader for each GSP

### DIFF
--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPagesTemplateEngine.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPagesTemplateEngine.java
@@ -650,7 +650,7 @@ public class GroovyPagesTemplateEngine extends ResourceAwareTemplateEngine imple
         if (!(classLoader instanceof GroovyPageClassLoader)) {
             classLoader = initGroovyClassLoader(classLoader);
         }
-        return (GroovyClassLoader)classLoader;
+        return new GroovyClassLoader(classLoader);
     }
 
     /**


### PR DESCRIPTION
Since ClassLoaders keep references to all classes they load, using one class loader for all GSPs means that all GSPs always stay in memory - even if they're never used again (such as if a new version of that GSP is loaded because its source changed). Using a new ClassLoader for each GSP solves that problem.
This further improves the memory use of Grails when doing GSP reloading, see 
GRAILS-11296
