### PR TITLE
JDK-based Maven profile activiation fix

### DIFF
--- a/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/AetherDependencyManager.groovy
+++ b/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/AetherDependencyManager.groovy
@@ -472,6 +472,7 @@ class AetherDependencyManager implements DependencyManager {
 
             final modelRequest = new DefaultModelBuildingRequest()
             modelRequest.setPomFile(pomFile)
+            modelRequest.setSystemProperties(System.properties)
             modelRequest.setModelResolver(new GrailsModelResolver(repositorySystem, session, repositories))
             ModelBuildingResult modelBuildingResult = modelBuilder.build(modelRequest)
             final mavenDependencies = modelBuildingResult.getEffectiveModel().getDependencies()


### PR DESCRIPTION
When using an external POM file that contains a Maven profile that is activated based on the current JDK in combination with the Grails CLI, you will receive the following error from Maven/Aether:

```
[ERROR] Failed to determine Java version for profile java7 @ <GAV of the POM file containing the profile>
    at org.apache.maven.model.building.DefaultModelProblemCollector.newModelBuildingException(DefaultModelProblemCollector.java:195)
    at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:416)
    at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:368)
    at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:359)
    at grails.util.BuildSettings.doResolve(BuildSettings.groovy:513)
    at grails.util.BuildSettings.doResolve(BuildSettings.groovy)
    at grails.util.BuildSettings$_getDefaultBuildDependencies_closure17.doCall(BuildSettings.groovy:774)
    at grails.util.BuildSettings$_getDefaultBuildDependencies_closure17.doCall(BuildSettings.groovy)
    at grails.util.BuildSettings.getDefaultBuildDependencies(BuildSettings.groovy:768)
    at grails.util.BuildSettings.getBuildDependencies(BuildSettings.groovy:673)
```

The issue here is that the [DefaultModelBuilder](https://github.com/apache/maven/blob/maven-3.1.1/maven-model-builder/src/main/java/org/apache/maven/model/building/DefaultModelBuilder.java) uses the [JdkVersionProfileActivator](https://github.com/apache/maven/blob/maven-3.1.1/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/JdkVersionProfileActivator.java) to validate the Maven profile contained in the POM file.  The activator in turn  looks for the presence of the `java.version` system property to determine if the profile should be activate based on the version of the JVM running the project.  However, because Grails is programmatically setting up the model building request, Maven/Aether does not have access to the system properties.  Therefore, we must pass the system properties through to the programmatically created `DefaultModelBuildingRequest` to ensure that the Maven/Aether model validation code has access to all the properties it needs to check in order to successfully validate the POM file.

This change has been tested with a project that uses JDK-based profile activation to verify that it does indeed solve the issue referenced above.
