### PR TITLE
 GRAILS-11351 handle -D parameter with whitespaces

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParser.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParser.java
@@ -125,6 +125,9 @@ public class CommandLineParser {
             if (arg == null) continue;
             String trimmed = arg.trim();
             if (trimmed != null && trimmed.length()>0) {
+                if (trimmed.charAt(0) == '"' && trimmed.charAt(trimmed.length() - 1) == '"') {
+                    trimmed = trimmed.substring(1, trimmed.length() - 1);
+                }
                 if (trimmed.charAt(0) == '-') {
                     processOption(cl, trimmed);
                 }

--- a/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParserSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/cli/parsing/CommandLineParserSpec.groovy
@@ -145,6 +145,33 @@ class CommandLineParserSpec extends Specification {
             cl.optionValue('host') == "localhost"
     }
 
+    void "Test parse command with environment, sys props with whitespaces, arguments and undeclared options with values"() {
+        when:
+            def parser = new CommandLineParser()
+            def cl = parser.parse("prod", "run-app", "\"-DmyProp=value with whitespace\"", "foo", "bar", "--host=localhost")
+
+       then:
+            cl.commandName == 'run-app'
+            cl.environment == 'production'
+            cl.systemProperties.size() == 1
+            cl.systemProperties['myProp'] == 'value with whitespace'
+            cl.remainingArgs.size() == 2
+            cl.remainingArgs == ['foo', 'bar']
+            cl.hasOption('host')
+            cl.optionValue('host') == "localhost"
+    }
+
+    void "Test parse command with sys props with whitespaces in different order"() {
+        when:
+            def parser = new CommandLineParser()
+            def cl = parser.parse("\"-DmyProp=value with whitespace\"", "clean")
+
+        then:
+            cl.commandName == 'clean'
+            cl.systemProperties.size() == 1
+            cl.systemProperties['myProp'] == 'value with whitespace'
+    }
+
     @Ignore
     void "Test help message with declared options"() {
         when:
@@ -242,6 +269,33 @@ class CommandLineParserSpec extends Specification {
             cl.hasOption('host')
             cl.optionValue('host') == "localhost"
 
+    }
+    
+    void "Test parse string command with environment, sys props with whitespaces, arguments and undeclared options with values"() {
+        when:
+            def parser = new CommandLineParser()
+            def cl = parser.parseString("prod run-app \"-DmyProp=value with whitespace\" foo bar --host=localhost")
+
+       then:
+            cl.commandName == 'run-app'
+            cl.environment == 'production'
+            cl.systemProperties.size() == 1
+            cl.systemProperties['myProp'] == 'value with whitespace'
+            cl.remainingArgs.size() == 2
+            cl.remainingArgs == ['foo', 'bar']
+            cl.hasOption('host')
+            cl.optionValue('host') == "localhost"
+    }
+
+    void "Test parse string command with sys props with whitespaces in different order"() {
+        when:
+            def parser = new CommandLineParser()
+            def cl = parser.parseString("\"-DmyProp=value with whitespace\" clean")
+
+        then:
+            cl.commandName == 'clean'
+            cl.systemProperties.size() == 1
+            cl.systemProperties['myProp'] == 'value with whitespace'
     }
 
     void "Test that parseString handles quoted arguments with double quotes"() {


### PR DESCRIPTION
This fixes the issue that command line parameter with whitespaces are handled the wrong way.

`grails "-DghprbPullTitle=Title with spaces" clean`
grails fails with this error message

```
Script 'With' not found, did you mean:
1) IntegrateWith
2) Init
3) CreateUnitTest
```

Maybe this is a bit _the easy way_ fixing this issue. Hope this helps to fix this issue soon :)
