### PR TITLE
Add http PATCH method support to rest controllers.

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/Resource.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/Resource.groovy
@@ -37,7 +37,7 @@ import java.lang.annotation.Target
 public @interface Resource {
 
     /**
-     * @return Whether this is a read-only resource (one that doesn't allow DELETE, POST or PUT requests)
+     * @return Whether this is a read-only resource (one that doesn't allow DELETE, POST, PUT or PATCH requests)
      */
     boolean readOnly() default false
 

--- a/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
@@ -32,7 +32,7 @@ import org.springframework.http.HttpStatus
 @Artefact("Controller")
 @Transactional(readOnly = true)
 class RestfulController<T> {
-    static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
+    static allowedMethods = [save: "POST", update: "PUT", patch: "PATCH", delete: "DELETE"]
 
     Class<T> resource
     String resourceName
@@ -118,6 +118,15 @@ class RestfulController<T> {
             return
         }
         respond queryForResource(params.id)
+    }
+
+    /**
+     * Updates a resource for the given id
+     * @param id
+     */
+    @Transactional
+    def patch() {
+        update()
     }
 
     /**

--- a/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-plugin-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -87,10 +87,11 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
     public static final String ACTION_SHOW = "show";
     public static final String ACTION_EDIT = "edit";
     public static final String ACTION_UPDATE = "update";
+    public static final String ACTION_PATCH = "patch";
     public static final String ACTION_DELETE = "delete";
     public static final String ACTION_SAVE = "save";
-    public static final List<String> DEFAULT_RESOURCES_INCLUDES = Arrays.asList(ACTION_INDEX, ACTION_CREATE, ACTION_SAVE,ACTION_SHOW,ACTION_EDIT, ACTION_UPDATE, ACTION_DELETE);
-    public static final List<String> DEFAULT_RESOURCE_INCLUDES = Arrays.asList(ACTION_CREATE,ACTION_SAVE,ACTION_SHOW, ACTION_EDIT, ACTION_UPDATE, ACTION_DELETE);
+    public static final List<String> DEFAULT_RESOURCES_INCLUDES = Arrays.asList(ACTION_INDEX, ACTION_CREATE, ACTION_SAVE,ACTION_SHOW,ACTION_EDIT, ACTION_UPDATE, ACTION_PATCH, ACTION_DELETE);
+    public static final List<String> DEFAULT_RESOURCE_INCLUDES = Arrays.asList(ACTION_CREATE,ACTION_SAVE,ACTION_SHOW, ACTION_EDIT, ACTION_UPDATE, ACTION_PATCH, ACTION_DELETE);
     private static final Log LOG = LogFactory.getLog(UrlMappingBuilder.class);
     private GroovyClassLoader classLoader = new GroovyClassLoader();
     private UrlMappingParser urlParser = new DefaultUrlMappingParser();
@@ -642,6 +643,12 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                 configureUrlMapping(updateUrlMapping);
             }
 
+            if (includes.contains(ACTION_PATCH)) {
+                // PATCH /$controller/$id -> action:'patch'
+                UrlMapping patchUrlMapping = createPatchActionResourcesRestfulMapping(controllerName, pluginName, namespace,version,urlData, constrainedPropertyList);
+                configureUrlMapping(patchUrlMapping);
+            }
+
             if (includes.contains(ACTION_DELETE)) {
                 // DELETE /$controller/$id -> action:'delete'
                 UrlMapping deleteUrlMapping = createDeleteActionResourcesRestfulMapping(controllerName, pluginName, namespace,version,urlData, constrainedPropertyList);
@@ -661,6 +668,13 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             List<ConstrainedProperty> updateUrlMappingConstraints = createConstraintsWithIdAndFormat(constrainedPropertyList);
 
             return new RegexUrlMapping(updateUrlMappingData,controllerName, ACTION_UPDATE,  namespace, pluginName, null, HttpMethod.PUT.toString(),version,updateUrlMappingConstraints.toArray(new ConstrainedProperty[updateUrlMappingConstraints.size()]) , servletContext);
+        }
+
+        protected UrlMapping createPatchActionResourcesRestfulMapping(String controllerName, Object pluginName, Object namespace, String version, UrlMappingData urlData, List<ConstrainedProperty> constrainedList) {
+            UrlMappingData patchUrlMappingData = createRelativeUrlDataWithIdAndFormat(urlData);
+            List<ConstrainedProperty> patchUrlMappingConstraints = createConstraintsWithIdAndFormat(constrainedList);
+
+            return new RegexUrlMapping(patchUrlMappingData,controllerName, ACTION_PATCH,  namespace, pluginName, null, HttpMethod.PATCH.toString(),version,patchUrlMappingConstraints.toArray(new ConstrainedProperty[patchUrlMappingConstraints.size()]) , servletContext);
         }
 
         protected UrlMapping createEditActionResourcesRestfulMapping(String controllerName, Object pluginName, Object namespace, String version, UrlMappingData urlData, List<ConstrainedProperty> constrainedPropertyList) {
@@ -766,6 +780,12 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                 configureUrlMapping(updateUrlMapping);
             }
 
+            if (includes.contains(ACTION_PATCH)) {
+                // PATCH /$controller -> action:'patch'
+                UrlMapping patchUrlMapping = createPatchActionResourceRestfulMapping(controllerName, pluginName, namespace,version,urlData, constrainedPropertyList);
+                configureUrlMapping(patchUrlMapping);
+            }
+
             if (includes.contains(ACTION_DELETE)) {
                 // DELETE /$controller -> action:'delete'
                 UrlMapping deleteUrlMapping = createDeleteActionResourceRestfulMapping(controllerName, pluginName, namespace,version,urlData, constrainedPropertyList);
@@ -785,6 +805,13 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             List<ConstrainedProperty> updateUrlMappingConstraints = createFormatOnlyConstraints(constrainedPropertyList);
 
             return new RegexUrlMapping(updateUrlMappingData,controllerName, ACTION_UPDATE, namespace, pluginName, null, HttpMethod.PUT.toString(),version, updateUrlMappingConstraints.toArray(new ConstrainedProperty[updateUrlMappingConstraints.size()]) , servletContext);
+        }
+
+        protected UrlMapping createPatchActionResourceRestfulMapping(String controllerName, Object pluginName, Object namespace, String version, UrlMappingData urlData, List<ConstrainedProperty> constrainedList) {
+            UrlMappingData patchUrlMappingData = createFormatOnlyUrlMappingData(urlData);
+            List<ConstrainedProperty> patchUrlMappingConstraints = createFormatOnlyConstraints(constrainedList);
+
+            return new RegexUrlMapping(patchUrlMappingData,controllerName, ACTION_PATCH, namespace, pluginName, null, HttpMethod.PATCH.toString(),version, patchUrlMappingConstraints.toArray(new ConstrainedProperty[patchUrlMappingConstraints.size()]) , servletContext);
         }
 
         protected UrlMapping createEditActionResourceRestfulMapping(String controllerName, Object pluginName, Object namespace, String version, UrlMappingData urlData, ConstrainedProperty[] constraintArray) {

--- a/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/RestfulResourceMappingSpec.groovy
+++ b/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/RestfulResourceMappingSpec.groovy
@@ -3,7 +3,6 @@ package org.codehaus.groovy.grails.web.mapping
 import static org.springframework.http.HttpMethod.*
 import grails.web.CamelCaseUrlConverter
 
-import org.springframework.http.HttpMethod
 import org.springframework.mock.web.MockServletContext
 
 import spock.lang.Issue
@@ -167,14 +166,14 @@ class RestfulResourceMappingSpec extends Specification{
         def locationsMappings = urlMappings.findAll { it.controllerName == 'location' }
         
         then: 'There are the correct number of mappings'
-        urlMappings.size() == 35
+        urlMappings.size() == 40
         
         and: 'Each controller has 7 mappings'
-        bookMappings.size() == 7
-        authorMappings.size() == 7
-        titleMappings.size() == 7
-        sellersMappings.size() == 7
-        locationsMappings.size() == 7
+        bookMappings.size() == 8
+        authorMappings.size() == 8
+        titleMappings.size() == 8
+        sellersMappings.size() == 8
+        locationsMappings.size() == 8
         
         and: 'the book mappings have the expected constrained properties'
         bookMappings.find { it.actionName == 'index' }.constraints*.propertyName == ['format']
@@ -183,6 +182,7 @@ class RestfulResourceMappingSpec extends Specification{
         bookMappings.find { it.actionName == 'show' }.constraints*.propertyName == ['id', 'format']
         bookMappings.find { it.actionName == 'edit' }.constraints*.propertyName == ['id']
         bookMappings.find { it.actionName == 'update' }.constraints*.propertyName == ['id', 'format']
+        bookMappings.find { it.actionName == 'patch' }.constraints*.propertyName == ['id', 'format']
         bookMappings.find { it.actionName == 'delete' }.constraints*.propertyName == ['id', 'format']
         
         and: 'the author mappings have the expected constrained properties'
@@ -192,6 +192,7 @@ class RestfulResourceMappingSpec extends Specification{
         authorMappings.find { it.actionName == 'show' }.constraints*.propertyName == ['bookId', 'id', 'format']
         authorMappings.find { it.actionName == 'edit' }.constraints*.propertyName == ['bookId', 'id']
         authorMappings.find { it.actionName == 'update' }.constraints*.propertyName == ['bookId', 'id', 'format']
+        authorMappings.find { it.actionName == 'patch' }.constraints*.propertyName == ['bookId', 'id', 'format']
         authorMappings.find { it.actionName == 'delete' }.constraints*.propertyName == ['bookId', 'id', 'format']
         
         and: 'the title mappings have the expected constrained properties'
@@ -201,6 +202,7 @@ class RestfulResourceMappingSpec extends Specification{
         titleMappings.find { it.actionName == 'show' }.constraints*.propertyName == ['bookId', 'id', 'format']
         titleMappings.find { it.actionName == 'edit' }.constraints*.propertyName == ['bookId', 'id']
         titleMappings.find { it.actionName == 'update' }.constraints*.propertyName == ['bookId', 'id', 'format']
+        titleMappings.find { it.actionName == 'patch' }.constraints*.propertyName == ['bookId', 'id', 'format']
         titleMappings.find { it.actionName == 'delete' }.constraints*.propertyName == ['bookId', 'id', 'format']
         
         and: 'the seller mappings have the expected constrained properties'
@@ -210,6 +212,7 @@ class RestfulResourceMappingSpec extends Specification{
         sellersMappings.find { it.actionName == 'show' }.constraints*.propertyName == ['bookId', 'id', 'format']
         sellersMappings.find { it.actionName == 'edit' }.constraints*.propertyName == ['bookId', 'id']
         sellersMappings.find { it.actionName == 'update' }.constraints*.propertyName == ['bookId', 'id', 'format']
+        sellersMappings.find { it.actionName == 'patch' }.constraints*.propertyName == ['bookId', 'id', 'format']
         sellersMappings.find { it.actionName == 'delete' }.constraints*.propertyName == ['bookId', 'id', 'format']
 
         and: 'the location mappings have the expected constrained properties'
@@ -219,6 +222,7 @@ class RestfulResourceMappingSpec extends Specification{
         locationsMappings.find { it.actionName == 'show' }.constraints*.propertyName == ['bookId', 'sellerId', 'id', 'format']
         locationsMappings.find { it.actionName == 'edit' }.constraints*.propertyName == ['bookId', 'sellerId', 'id']
         locationsMappings.find { it.actionName == 'update' }.constraints*.propertyName == ['bookId', 'sellerId', 'id', 'format']
+        locationsMappings.find { it.actionName == 'patch' }.constraints*.propertyName == ['bookId', 'sellerId', 'id', 'format']
         locationsMappings.find { it.actionName == 'delete' }.constraints*.propertyName == ['bookId', 'sellerId', 'id', 'format']
     }
     
@@ -236,8 +240,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URL mappings are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are eight of them in total"
-            urlMappings.size() == 20
+        then:"There are correct number of them in total"
+            urlMappings.size() == 23
 
         expect:
             urlMappingsHolder.matchAll('/books/1/authors/create', 'GET')
@@ -258,12 +262,12 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URL mappings are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are eight of them in total"
-            urlMappings.size() == 8
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 9
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             urlMappingsHolder.allowedMethods('/books') == [POST, GET] as Set
-            urlMappingsHolder.allowedMethods('/books/1') == [GET, DELETE, PUT] as Set
+            urlMappingsHolder.allowedMethods('/books/1') == [GET, DELETE, PUT, PATCH] as Set
             urlMappingsHolder.matchAll('/books', 'GET')
             urlMappingsHolder.matchAll('/books', 'GET')[0].actionName == 'index'
             urlMappingsHolder.matchAll('/books', 'GET')[0].httpMethod == 'GET'
@@ -279,6 +283,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books', 'POST')
@@ -288,6 +293,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1', 'DELETE')
             urlMappingsHolder.matchAll('/books/1', 'DELETE')[0].actionName == 'delete'
@@ -305,14 +314,15 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are fourteen of them in total"
-            urlMappings.size() == 14
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 16
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             !urlMappingsHolder.matchAll('/author/create', 'GET')
             !urlMappingsHolder.matchAll('/author/edit', 'GET')
             !urlMappingsHolder.matchAll('/author', 'POST')
             !urlMappingsHolder.matchAll('/author', 'PUT')
+            !urlMappingsHolder.matchAll('/author', 'PATCH')
             !urlMappingsHolder.matchAll('/author', 'DELETE')
             !urlMappingsHolder.matchAll('/author', 'GET')
             urlMappingsHolder.matchAll('/books/create', 'GET')
@@ -324,6 +334,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books', 'POST')
@@ -333,6 +344,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1', 'DELETE')
             urlMappingsHolder.matchAll('/books/1', 'DELETE')[0].actionName == 'delete'
@@ -351,6 +366,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/authors/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/authors/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/authors/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/authors/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/authors/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books/1/authors', 'POST')
@@ -360,6 +376,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/authors/1', 'PUT')
             urlMappingsHolder.matchAll('/books/1/authors/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1/authors/1', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1/authors/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1/authors/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1/authors/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1/authors/1', 'DELETE')
             urlMappingsHolder.matchAll('/books/1/authors/1', 'DELETE')[0].actionName == 'delete'
@@ -380,14 +400,15 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are seven of them in total"
-            urlMappings.size() == 13
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 15
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             !urlMappingsHolder.matchAll('/author/create', 'GET')
             !urlMappingsHolder.matchAll('/author/edit', 'GET')
             !urlMappingsHolder.matchAll('/author', 'POST')
             !urlMappingsHolder.matchAll('/author', 'PUT')
+            !urlMappingsHolder.matchAll('/author', 'PATCH')
             !urlMappingsHolder.matchAll('/author', 'DELETE')
             !urlMappingsHolder.matchAll('/author', 'GET')
             urlMappingsHolder.matchAll('/books/create', 'GET')
@@ -399,6 +420,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books', 'POST')
@@ -408,6 +430,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1', 'DELETE')
             urlMappingsHolder.matchAll('/books/1', 'DELETE')[0].actionName == 'delete'
@@ -423,6 +449,7 @@ class RestfulResourceMappingSpec extends Specification{
 
             !urlMappingsHolder.matchAll('/books/1/author/create', 'POST')
             !urlMappingsHolder.matchAll('/books/1/author/create', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/author/create', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/author/create', 'DELETE')
 
             urlMappingsHolder.matchAll('/books/1/author/edit', 'GET')
@@ -430,6 +457,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/author/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/author/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/author/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/author/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/author/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books/1/author', 'POST')
@@ -439,6 +467,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/author', 'PUT')
             urlMappingsHolder.matchAll('/books/1/author', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1/author', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1/author', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1/author', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1/author', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1/author', 'DELETE')
             urlMappingsHolder.matchAll('/books/1/author', 'DELETE')[0].actionName == 'delete'
@@ -457,8 +489,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are seven of them in total"
-            urlMappings.size() == 7
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 8
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             urlMappingsHolder.matchAll('/books/create', 'GET')
@@ -470,6 +502,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books', 'POST')
@@ -479,6 +512,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books/1', 'DELETE')
             urlMappingsHolder.matchAll('/books/1', 'DELETE')[0].actionName == 'delete'
@@ -497,8 +534,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are seven of them in total"
-            urlMappings.size() == 6
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 7
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
 
@@ -512,6 +549,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/books/1/edit', 'POST')
             !urlMappingsHolder.matchAll('/books/1/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/books/1/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/books/1/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/books', 'POST')
@@ -522,7 +560,9 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
 
-
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/books/1', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/books', 'GET')
             urlMappingsHolder.matchAll('/books', 'GET')[0].actionName == 'index'
@@ -554,8 +594,6 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/books/1', 'PUT')[0].httpMethod == 'PUT'
 
-
-
             urlMappingsHolder.matchAll('/books', 'GET')
             urlMappingsHolder.matchAll('/books', 'GET')[0].actionName == 'index'
             urlMappingsHolder.matchAll('/books', 'GET')[0].httpMethod == 'GET'
@@ -572,8 +610,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
         def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are six of them in total"
-        urlMappings.size() == 6
+        then:"There are the correct number of them in total"
+        urlMappings.size() == 7
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
         urlMappingsHolder.matchAll('/admin/book/create', 'GET')
@@ -582,6 +620,7 @@ class RestfulResourceMappingSpec extends Specification{
 
         !urlMappingsHolder.matchAll('/admin/book/create', 'POST')
         !urlMappingsHolder.matchAll('/admin/book/create', 'PUT')
+        !urlMappingsHolder.matchAll('/admin/book/create', 'PATCH')
         !urlMappingsHolder.matchAll('/admin/book/create', 'DELETE')
 
         urlMappingsHolder.matchAll('/admin/book/edit', 'GET')
@@ -589,6 +628,7 @@ class RestfulResourceMappingSpec extends Specification{
         urlMappingsHolder.matchAll('/admin/book/edit', 'GET')[0].httpMethod == 'GET'
         !urlMappingsHolder.matchAll('/admin/book/edit', 'POST')
         !urlMappingsHolder.matchAll('/admin/book/edit', 'PUT')
+        !urlMappingsHolder.matchAll('/admin/book/edit', 'PATCH')
         !urlMappingsHolder.matchAll('/admin/book/edit', 'DELETE')
 
         urlMappingsHolder.matchAll('/admin/book', 'POST')
@@ -598,6 +638,10 @@ class RestfulResourceMappingSpec extends Specification{
         urlMappingsHolder.matchAll('/admin/book', 'PUT')
         urlMappingsHolder.matchAll('/admin/book', 'PUT')[0].actionName == 'update'
         urlMappingsHolder.matchAll('/admin/book', 'PUT')[0].httpMethod == 'PUT'
+
+        urlMappingsHolder.matchAll('/admin/book', 'PATCH')
+        urlMappingsHolder.matchAll('/admin/book', 'PATCH')[0].actionName == 'patch'
+        urlMappingsHolder.matchAll('/admin/book', 'PATCH')[0].httpMethod == 'PATCH'
 
         urlMappingsHolder.matchAll('/admin/book', 'DELETE')
         urlMappingsHolder.matchAll('/admin/book', 'DELETE')[0].actionName == 'delete'
@@ -617,8 +661,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are six of them in total"
-            urlMappings.size() == 6
+        then:"There are the correct number of them in total"
+            urlMappings.size() == 7
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             urlMappingsHolder.matchAll('/book/create', 'GET')
@@ -627,6 +671,7 @@ class RestfulResourceMappingSpec extends Specification{
 
             !urlMappingsHolder.matchAll('/book/create', 'POST')
             !urlMappingsHolder.matchAll('/book/create', 'PUT')
+            !urlMappingsHolder.matchAll('/book/create', 'PATCH')
             !urlMappingsHolder.matchAll('/book/create', 'DELETE')
 
             urlMappingsHolder.matchAll('/book/edit', 'GET')
@@ -634,6 +679,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/book/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/book/edit', 'POST')
             !urlMappingsHolder.matchAll('/book/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/book/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/book/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/book', 'POST')
@@ -643,6 +689,10 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/book', 'PUT')
             urlMappingsHolder.matchAll('/book', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/book', 'PUT')[0].httpMethod == 'PUT'
+
+            urlMappingsHolder.matchAll('/book', 'PATCH')
+            urlMappingsHolder.matchAll('/book', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/book', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/book', 'DELETE')
             urlMappingsHolder.matchAll('/book', 'DELETE')[0].actionName == 'delete'
@@ -662,8 +712,8 @@ class RestfulResourceMappingSpec extends Specification{
         when:"The URLs are obtained"
             def urlMappings = urlMappingsHolder.urlMappings
 
-        then:"There are six of them in total"
-            urlMappings.size() == 5
+        then:"There are correct of them in total"
+            urlMappings.size() == 6
 
         expect:"That the appropriate URLs are matched for the appropriate HTTP methods"
             !urlMappingsHolder.matchAll('/book', 'DELETE')
@@ -673,6 +723,7 @@ class RestfulResourceMappingSpec extends Specification{
 
             !urlMappingsHolder.matchAll('/book/create', 'POST')
             !urlMappingsHolder.matchAll('/book/create', 'PUT')
+            !urlMappingsHolder.matchAll('/book/create', 'PATCH')
             !urlMappingsHolder.matchAll('/book/create', 'DELETE')
 
             urlMappingsHolder.matchAll('/book/edit', 'GET')
@@ -680,6 +731,7 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/book/edit', 'GET')[0].httpMethod == 'GET'
             !urlMappingsHolder.matchAll('/book/edit', 'POST')
             !urlMappingsHolder.matchAll('/book/edit', 'PUT')
+            !urlMappingsHolder.matchAll('/book/edit', 'PATCH')
             !urlMappingsHolder.matchAll('/book/edit', 'DELETE')
 
             urlMappingsHolder.matchAll('/book', 'POST')
@@ -690,7 +742,9 @@ class RestfulResourceMappingSpec extends Specification{
             urlMappingsHolder.matchAll('/book', 'PUT')[0].actionName == 'update'
             urlMappingsHolder.matchAll('/book', 'PUT')[0].httpMethod == 'PUT'
 
-
+            urlMappingsHolder.matchAll('/book', 'PATCH')
+            urlMappingsHolder.matchAll('/book', 'PATCH')[0].actionName == 'patch'
+            urlMappingsHolder.matchAll('/book', 'PATCH')[0].httpMethod == 'PATCH'
 
             urlMappingsHolder.matchAll('/book', 'GET')
             urlMappingsHolder.matchAll('/book', 'GET')[0].actionName == 'show'
@@ -709,6 +763,7 @@ class RestfulResourceMappingSpec extends Specification{
             linkGenerator.link(controller:"book", action:"edit", method:"GET") == "http://localhost/book/edit"
             linkGenerator.link(controller:"book", action:"delete", method:"DELETE") == "http://localhost/book"
             linkGenerator.link(controller:"book", action:"update", method:"PUT") == "http://localhost/book"
+            linkGenerator.link(controller:"book", action:"patch", method:"PATCH") == "http://localhost/book"
             linkGenerator.link(controller:"book", action:"create") == "http://localhost/book/create"
             linkGenerator.link(controller:"book", action:"create", method:"GET") == "http://localhost/book/create"
     }
@@ -726,6 +781,7 @@ class RestfulResourceMappingSpec extends Specification{
             linkGenerator.link(controller:"book", action:"edit", id:1, method:"GET") == "http://localhost/books/1/edit"
             linkGenerator.link(controller:"book", action:"delete", id:1, method:"DELETE") == "http://localhost/books/1"
             linkGenerator.link(controller:"book", action:"update", id:1, method:"PUT") == "http://localhost/books/1"
+            linkGenerator.link(controller:"book", action:"patch", id:1, method:"PATCH") == "http://localhost/books/1"
     }
 
     void "Test it is possible to link to a single resource nested within another resource"() {
@@ -744,6 +800,7 @@ class RestfulResourceMappingSpec extends Specification{
             linkGenerator.link(resource:"book/author", action:"edit", bookId:1) == "http://localhost/books/1/author/edit"
             linkGenerator.link(resource:"book/author", action:"delete", bookId:1) == "http://localhost/books/1/author"
             linkGenerator.link(resource:"book/author", action:"update", bookId:1) == "http://localhost/books/1/author"
+            linkGenerator.link(resource:"book/author", action:"patch", bookId:1) == "http://localhost/books/1/author"
 
             linkGenerator.link(controller:"author", action:"create", method:"GET", params:[bookId:1]) == "http://localhost/books/1/author/create"
             linkGenerator.link(controller:"author", action:"save", method:"POST", params:[bookId:1]) == "http://localhost/books/1/author"
@@ -751,7 +808,7 @@ class RestfulResourceMappingSpec extends Specification{
             linkGenerator.link(controller:"author", action:"edit", method:"GET", params:[bookId:1]) == "http://localhost/books/1/author/edit"
             linkGenerator.link(controller:"author", action:"delete", method:"DELETE", params:[bookId:1]) == "http://localhost/books/1/author"
             linkGenerator.link(controller:"author", action:"update", method:"PUT", params:[bookId:1]) == "http://localhost/books/1/author"
-
+            linkGenerator.link(controller:"author", action:"patch", method:"PATCH", params:[bookId:1]) == "http://localhost/books/1/author"
 
             linkGenerator.link(controller:"book", action:"create", method:"GET") == "http://localhost/books/create"
             linkGenerator.link(controller:"book", action:"save", method:"POST") == "http://localhost/books"
@@ -759,6 +816,7 @@ class RestfulResourceMappingSpec extends Specification{
             linkGenerator.link(controller:"book", action:"edit", id:1, method:"GET") == "http://localhost/books/1/edit"
             linkGenerator.link(controller:"book", action:"delete", id:1, method:"DELETE") == "http://localhost/books/1"
             linkGenerator.link(controller:"book", action:"update", id:1, method:"PUT") == "http://localhost/books/1"
+            linkGenerator.link(controller:"book", action:"patch", id:1, method:"PATCH") == "http://localhost/books/1"
 
     }
 
@@ -779,6 +837,7 @@ class RestfulResourceMappingSpec extends Specification{
         linkGenerator.link(resource:"book/author", action:"edit", id:1,bookId:1) == "http://localhost/books/1/authors/1/edit"
         linkGenerator.link(resource:"book/author", action:"delete", id:1,bookId:1) == "http://localhost/books/1/authors/1"
         linkGenerator.link(resource:"book/author", action:"update", id:1,bookId:1) == "http://localhost/books/1/authors/1"
+        linkGenerator.link(resource:"book/author", action:"patch", id:1,bookId:1) == "http://localhost/books/1/authors/1"
 
         linkGenerator.link(controller:"author", action:"create", method:"GET", params:[bookId:1]) == "http://localhost/books/1/authors/create"
         linkGenerator.link(controller:"author", action:"save", method:"POST", params:[bookId:1]) == "http://localhost/books/1/authors"
@@ -786,7 +845,7 @@ class RestfulResourceMappingSpec extends Specification{
         linkGenerator.link(controller:"author", action:"edit", id:1,method:"GET", params:[bookId:1]) == "http://localhost/books/1/authors/1/edit"
         linkGenerator.link(controller:"author", action:"delete", id:1,method:"DELETE", params:[bookId:1]) == "http://localhost/books/1/authors/1"
         linkGenerator.link(controller:"author", action:"update", id:1,method:"PUT", params:[bookId:1]) == "http://localhost/books/1/authors/1"
-
+        linkGenerator.link(controller:"author", action:"patch", id:1,method:"PATCH", params:[bookId:1]) == "http://localhost/books/1/authors/1"
 
         linkGenerator.link(controller:"book", action:"create", method:"GET") == "http://localhost/books/create"
         linkGenerator.link(controller:"book", action:"save", method:"POST") == "http://localhost/books"
@@ -794,6 +853,7 @@ class RestfulResourceMappingSpec extends Specification{
         linkGenerator.link(controller:"book", action:"edit", id:1, method:"GET") == "http://localhost/books/1/edit"
         linkGenerator.link(controller:"book", action:"delete", id:1, method:"DELETE") == "http://localhost/books/1"
         linkGenerator.link(controller:"book", action:"update", id:1, method:"PUT") == "http://localhost/books/1"
+        linkGenerator.link(controller:"book", action:"patch", id:1, method:"PATCH") == "http://localhost/books/1"
 
     }
 
@@ -820,6 +880,7 @@ class RestfulResourceMappingSpec extends Specification{
         linkGenerator.link(controller:"book", action:"edit", id:1, method:"GET") == "http://localhost/books/1/edit"
         linkGenerator.link(controller:"book", action:"delete", id:1, method:"DELETE") == "http://localhost/books/1"
         linkGenerator.link(controller:"book", action:"update", id:1, method:"PUT") == "http://localhost/books/1"
+        linkGenerator.link(controller:"book", action:"patch", id:1, method:"PATCH") == "http://localhost/books/1"
 
     }
 

--- a/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingsWithHttpMethodSpec.groovy
+++ b/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingsWithHttpMethodSpec.groovy
@@ -13,6 +13,7 @@ class UrlMappingsWithHttpMethodSpec extends Specification{
          "/foo"( controller:"bar", action:"save", method:"POST" )
          "/foo2"( controller:"bar", action:"save", method:"PUT" )
          "/foo"( controller:"bar", action:"update", method:"PUT" )
+         "/foo"( controller:"bar", action:"patch", method:"PATCH" )
          "/bar"( controller:"bar", action:"list", method:"*" )
          "/bar2"( controller:"bar", action:"list" )
 
@@ -27,7 +28,7 @@ class UrlMappingsWithHttpMethodSpec extends Specification{
             def mappings = evaluator.evaluateMappings mappings
 
         then:"The mapping only accepts POST requests"
-            mappings.size() == 5
+            mappings.size() == 6
             mappings[0].httpMethod == 'POST'
             mappings[1].httpMethod == 'PUT'
 
@@ -60,6 +61,7 @@ class UrlMappingsWithHttpMethodSpec extends Specification{
             linkGenerator.link( controller:"bar", action:"list", method:'GET') == 'http://localhost/bar'
             linkGenerator.link( controller:"bar", action:"save", method:"POST" ) == 'http://localhost/foo'
             linkGenerator.link( controller:"bar", action:"save", method:"PUT" ) == 'http://localhost/foo2'
+            linkGenerator.link( controller:"bar", action:"patch", method:"PATCH" ) == 'http://localhost/foo'
             linkGenerator.link( controller:"bar", action:"list") == 'http://localhost/bar'
 
     }

--- a/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/reporting/AnsiConsoleUrlMappingsRendererSpec.groovy
+++ b/grails-plugin-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/reporting/AnsiConsoleUrlMappingsRendererSpec.groovy
@@ -34,6 +34,7 @@ class AnsiConsoleUrlMappingsRendererSpec extends Specification{
  |   GET    | /books/${bookId}/authors                                   | Action: index            |
  |   GET    | /books/${bookId}/authors/${id}/edit                        | Action: edit             |
  |  DELETE  | /books/${bookId}/authors/${id}                             | Action: delete           |
+ |  PATCH   | /books/${bookId}/authors/${id}                             | Action: patch            |
  |   PUT    | /books/${bookId}/authors/${id}                             | Action: update           |
  |   GET    | /books/${bookId}/authors/${id}                             | Action: show             |
 
@@ -43,6 +44,7 @@ Controller: book
  |   GET    | /books                                                     | Action: index            |
  |   GET    | /books/${id}/edit                                          | Action: edit             |
  |  DELETE  | /books/${id}                                               | Action: delete           |
+ |  PATCH   | /books/${id}                                               | Action: patch            |
  |   PUT    | /books/${id}                                               | Action: update           |
  |   GET    | /books/${id}                                               | Action: show             |
 
@@ -50,6 +52,7 @@ Controller: publisher
  |   GET    | /books/${bookId}/authors/${authorId}/publisher/edit        | Action: edit             |
  |   GET    | /books/${bookId}/authors/${authorId}/publisher/create      | Action: create           |
  |  DELETE  | /books/${bookId}/authors/${authorId}/publisher             | Action: delete           |
+ |  PATCH   | /books/${bookId}/authors/${authorId}/publisher             | Action: patch            |
  |   PUT    | /books/${bookId}/authors/${authorId}/publisher             | Action: update           |
  |   GET    | /books/${bookId}/authors/${authorId}/publisher             | Action: show             |
  |   POST   | /books/${bookId}/authors/${authorId}/publisher             | Action: save             |
@@ -89,6 +92,7 @@ Controller: foo
  |   GET    | /foo                                              | Action: index            |
  |   GET    | /foo/${id}/edit                                   | Action: edit             |
  |  DELETE  | /foo/${id}                                        | Action: delete           |
+ |  PATCH   | /foo/${id}                                        | Action: patch            |
  |   PUT    | /foo/${id}                                        | Action: update           |
  |   GET    | /foo/${id}                                        | Action: show             |
 

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ControllerUnitTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ControllerUnitTestMixinTests.groovy
@@ -265,6 +265,12 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
         assert response.contentAsString == 'action 1'
 
         response.reset()
+        request.method = "PATCH"
+        controller.action1()
+        assert response.status == HttpServletResponse.SC_OK
+        assert response.contentAsString == 'action 1'
+
+        response.reset()
         request.method = "DELETE"
         controller.action1()
         assert response.status == HttpServletResponse.SC_OK
@@ -287,6 +293,11 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
         assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
 
         response.reset()
+        request.method = 'PATCH'
+        controller.action2()
+        assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
+
+        response.reset()
         request.method = 'DELETE'
         controller.action2()
         assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
@@ -299,6 +310,12 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
 
         response.reset()
         request.method = 'PUT'
+        controller.action3()
+        assert response.status == HttpServletResponse.SC_OK
+        assert response.contentAsString == 'action 3'
+
+        response.reset()
+        request.method = 'PATCH'
         controller.action3()
         assert response.status == HttpServletResponse.SC_OK
         assert response.contentAsString == 'action 3'
@@ -332,6 +349,12 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
         assert response.contentAsString == 'method 1'
 
         response.reset()
+        request.method = "PATCH"
+        controller.method1()
+        assert response.status == HttpServletResponse.SC_OK
+        assert response.contentAsString == 'method 1'
+
+        response.reset()
         request.method = "DELETE"
         controller.method1()
         assert response.status == HttpServletResponse.SC_OK
@@ -354,6 +377,11 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
         assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
 
         response.reset()
+        request.method = 'PATCH'
+        controller.method2()
+        assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
+
+        response.reset()
         request.method = 'DELETE'
         controller.method2()
         assert response.status == HttpServletResponse.SC_METHOD_NOT_ALLOWED
@@ -366,6 +394,12 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
 
         response.reset()
         request.method = 'PUT'
+        controller.method3()
+        assert response.status == HttpServletResponse.SC_OK
+        assert response.contentAsString == 'method 3'
+
+        response.reset()
+        request.method = 'PATCH'
         controller.method3()
         assert response.status == HttpServletResponse.SC_OK
         assert response.contentAsString == 'method 3'
@@ -421,7 +455,7 @@ class ControllerUnitTestMixinTests extends GroovyTestCase {
 
 class TestController {
 
-    static allowedMethods = [action2: 'POST', action3: ['POST', 'PUT'], method2: 'POST', method3: ['POST', 'PUT']]
+    static allowedMethods = [action2: 'POST', action3: ['POST', 'PUT', 'PATCH'], method2: 'POST', method3: ['POST', 'PUT', 'PATCH']]
 
     def action1 = {
         render 'action 1'

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ResourceAnnotationRestfulControllerSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ResourceAnnotationRestfulControllerSpec.groovy
@@ -150,6 +150,28 @@ class Video {
 
     }
 
+    void "Test the patch action performs an update on a valid domain instance"() {
+        when:"Patch is called for a domain instance that doesn't exist"
+            request.method = 'PATCH'
+            controller.patch()
+
+        then:"A 404 error is returned"
+            status == 404
+
+        when:"A valid domain instance is passed to the update action"
+            def video = domainClass.newInstance(title: 'Title').save(flush: true)
+            response.reset()
+            request.contentType = FORM_CONTENT_TYPE
+            params.id = video.id
+            params.title = 'Game of Thrones'
+            controller.patch()
+
+        then:"A redirect is issues to the show action"
+            response.status == 200
+            domainClass.get(video.id).title == 'Game of Thrones'
+
+    }
+
     void "Test that the delete action deletes an instance if it exists"() {
         when:"The delete action is called for a null instance"
             controller.delete()

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSpec.groovy
@@ -180,9 +180,10 @@ class RestfulControllerSpec extends Specification {
 @Entity
 class Video {
     String title
-
+    Integer numberOfMinutes
     static constraints = {
         title blank:false
+        numberOfMinutes nullable: true
     }
 }
 

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSuperClassSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSuperClassSpec.groovy
@@ -68,6 +68,22 @@ class RestfulControllerSuperClassSpec extends Specification {
 
     }
 
+    void "Test the patch action returns the correct model, status and location"() {
+        given: "An existing domain object and Restful controller"
+            def video = new Video(title:'Existing').save()
+        when:"The patch action is executed on controller"
+            request.method = 'PATCH'
+            controller.params['id']=video.id
+            controller.params['title'] = 'Updated'
+            controller.patch()
+
+        then:"The model is created successfully"
+            model.video != null
+            response.status == HttpStatus.OK.value()
+            response.getHeader('Location') != null
+
+    }
+
 
 }
 

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSuperClassSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSuperClassSpec.groovy
@@ -75,10 +75,12 @@ class RestfulControllerSuperClassSpec extends Specification {
             request.method = 'PATCH'
             controller.params['id']=video.id
             controller.params['title'] = 'Updated'
+            controller.params.numberOfMinutes = '42'
             controller.patch()
 
         then:"The model is created successfully"
             model.video != null
+            model.video.numberOfMinutes == 42
             response.status == HttpStatus.OK.value()
             response.getHeader('Location') != null
 

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsControllerClass2Tests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsControllerClass2Tests.java
@@ -187,7 +187,7 @@ public class DefaultGrailsControllerClass2Tests extends TestCase {
     public void testAllowedMethods() throws Exception {
         GroovyClassLoader cl = new GrailsAwareClassLoader();
         Class<?> clazz = cl.parseClass("@grails.artefact.Artefact(\"Controller\") class TestController { \n" +
-                "static def allowedMethods = [actionTwo:'POST', actionThree:['POST', 'PUT']]\n" +
+                "static def allowedMethods = [actionTwo:'POST', actionThree:['POST', 'PUT', 'PATCH']]\n" +
                 "def actionOne = { return 'test' }\n " +
                 "def actionTwo = { return 'test' }\n " +
                 "def actionThree = { return 'test' }\n " +
@@ -197,16 +197,19 @@ public class DefaultGrailsControllerClass2Tests extends TestCase {
 
         assertTrue("actionOne should have accepted a GET", grailsClass.isHttpMethodAllowedForAction(controller, "GET", "actionOne"));
         assertTrue("actionOne should have accepted a PUT", grailsClass.isHttpMethodAllowedForAction(controller, "PUT", "actionOne"));
+        assertTrue("actionOne should have accepted a PATCH", grailsClass.isHttpMethodAllowedForAction(controller, "PATCH", "actionOne"));
         assertTrue("actionOne should have accepted a DELETE", grailsClass.isHttpMethodAllowedForAction(controller, "DELETE", "actionOne"));
         assertTrue("actionOne should have accepted a POST", grailsClass.isHttpMethodAllowedForAction(controller, "POST", "actionOne"));
 
         assertFalse("actionTwo should not have accepted a GET", grailsClass.isHttpMethodAllowedForAction(controller, "GET", "actionTwo"));
         assertFalse("actionTwo should not have accepted a PUT", grailsClass.isHttpMethodAllowedForAction(controller, "PUT", "actionTwo"));
+        assertFalse("actionTwo should not have accepted a PATCH", grailsClass.isHttpMethodAllowedForAction(controller, "PATCH", "actionTwo"));
         assertFalse("actionTwo should not have accepted a DELETE", grailsClass.isHttpMethodAllowedForAction(controller, "DELETE", "actionTwo"));
         assertTrue("actionTwo should have accepted a POST", grailsClass.isHttpMethodAllowedForAction(controller, "POST", "actionTwo"));
 
         assertFalse("actionThree should not have accepted a GET", grailsClass.isHttpMethodAllowedForAction(controller, "GET", "actionThree"));
         assertTrue("actionThree should have accepted a PUT", grailsClass.isHttpMethodAllowedForAction(controller, "PUT", "actionThree"));
+        assertTrue("actionThree should have accepted a PATCH", grailsClass.isHttpMethodAllowedForAction(controller, "PATCH", "actionThree"));
         assertFalse("actionThree should not have accepted a DELETE", grailsClass.isHttpMethodAllowedForAction(controller, "DELETE", "actionThree"));
         assertTrue("actionThree should have accepted a POST", grailsClass.isHttpMethodAllowedForAction(controller, "POST", "actionThree"));
     }
@@ -222,11 +225,13 @@ public class DefaultGrailsControllerClass2Tests extends TestCase {
 
         assertTrue("actionOne should have accepted a GET", grailsClass.isHttpMethodAllowedForAction(controller, "GET", "actionOne"));
         assertTrue("actionOne should have accepted a PUT", grailsClass.isHttpMethodAllowedForAction(controller, "PUT", "actionOne"));
+        assertTrue("actionOne should have accepted a PATCH", grailsClass.isHttpMethodAllowedForAction(controller, "PATCH", "actionOne"));
         assertTrue("actionOne should have accepted a DELETE", grailsClass.isHttpMethodAllowedForAction(controller, "DELETE", "actionOne"));
         assertTrue("actionOne should have accepted a POST", grailsClass.isHttpMethodAllowedForAction(controller, "POST", "actionOne"));
 
         assertTrue("actionTwo should have accepted a GET", grailsClass.isHttpMethodAllowedForAction(controller, "GET", "actionTwo"));
         assertTrue("actionTwo should have accepted a PUT", grailsClass.isHttpMethodAllowedForAction(controller, "PUT", "actionTwo"));
+        assertTrue("actionTwo should have accepted a PATCH", grailsClass.isHttpMethodAllowedForAction(controller, "PATCH", "actionTwo"));
         assertTrue("actionTwo should have accepted a DELETE", grailsClass.isHttpMethodAllowedForAction(controller, "DELETE", "actionTwo"));
         assertTrue("actionTwo should have accepted a POST", grailsClass.isHttpMethodAllowedForAction(controller, "POST", "actionTwo"));
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -75,6 +75,28 @@ class GrailsParameterMapTests extends GroovyTestCase {
         assert '' == params.foo
     }
 
+    void testParseRequestBodyForPatchRequest() {
+        def request = new MockHttpServletRequest()
+        request.content = 'foo=bar&one=two'.bytes
+        request.method = 'PATCH'
+        request.contentType = "application/x-www-form-urlencoded"
+
+        def params = new GrailsParameterMap(request)
+
+        assert 'bar' == params.foo
+        assert 'two' == params.one
+
+        params = new GrailsParameterMap(request)
+        assert params.foo == null // should be null, request can't be parsed twice
+
+        request.content = 'foo='.bytes
+        request.removeAttribute(GrailsParameterMap.REQUEST_BODY_PARSED)
+
+        params = new GrailsParameterMap(request)
+
+        assert '' == params.foo
+    }
+
     void testPlusOperator() {
         mockRequest.addParameter("album", "Foxtrot")
 

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SimpleGrailsControllerTests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SimpleGrailsControllerTests.java
@@ -75,7 +75,7 @@ public class SimpleGrailsControllerTests extends TestCase {
             "}");
 
         Class<?> restrictedControllerClass = cl.parseClass("@grails.artefact.Artefact(\"Controller\") class RestrictedController {\n"+
-                "static allowedMethods=[action1:'POST', action3:['PUT', 'DELETE'], action4: 'pOsT', action5: ['pUt', 'DeLeTe']]\n" +
+                "static allowedMethods=[action1:'POST', action3:['PUT', 'PATCH', 'DELETE'], action4: 'pOsT', action5: ['pUt', 'pAtCh', 'DeLeTe']]\n" +
                 "def action1 = {}\n" +
                 "def action2 = {}\n" +
                 "def action3 = {}\n" +
@@ -162,26 +162,31 @@ public class SimpleGrailsControllerTests extends TestCase {
         assertNotNull(controllerClass);
         assertResponseStatusCode("restricted","action1","/restricted/action1", "GET", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action1","/restricted/action1", "PUT", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertResponseStatusCode("restricted","action1","/restricted/action1", "PATCH", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action1","/restricted/action1", "POST", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action1","/restricted/action1", "DELETE", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
 
         assertResponseStatusCode("restricted","action2","/restricted/action2", "GET", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action2","/restricted/action2", "PUT", HttpServletResponse.SC_OK);
+        assertResponseStatusCode("restricted","action2","/restricted/action2", "PATCH", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action2","/restricted/action2", "POST", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action2","/restricted/action2", "DELETE", HttpServletResponse.SC_OK);
 
         assertResponseStatusCode("restricted","action3","/restricted/action3", "GET", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action3","/restricted/action3", "PUT", HttpServletResponse.SC_OK);
+        assertResponseStatusCode("restricted","action3","/restricted/action3", "PATCH", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action3","/restricted/action3", "POST", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action3","/restricted/action3", "DELETE", HttpServletResponse.SC_OK);
 
         assertResponseStatusCode("restricted","action4","/restricted/action4", "GET", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action4","/restricted/action4", "PUT", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+        assertResponseStatusCode("restricted","action4","/restricted/action4", "PATCH", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action4","/restricted/action4", "POST", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action4","/restricted/action4", "DELETE", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
 
         assertResponseStatusCode("restricted","action5","/restricted/action5", "GET", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action5","/restricted/action5", "PUT", HttpServletResponse.SC_OK);
+        assertResponseStatusCode("restricted","action5","/restricted/action5", "PATCH", HttpServletResponse.SC_OK);
         assertResponseStatusCode("restricted","action5","/restricted/action5", "POST", HttpServletResponse.SC_METHOD_NOT_ALLOWED);
         assertResponseStatusCode("restricted","action5","/restricted/action5", "DELETE", HttpServletResponse.SC_OK);
     }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/RestfulMappingTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/RestfulMappingTests.groovy
@@ -10,7 +10,7 @@ class RestfulMappingTests extends AbstractGrailsMappingTests {
 mappings {
   "/books" {
       controller = "book"
-      action = [GET:"list", DELETE:"delete", POST:"update", PUT:"save"]
+      action = [GET:"list", DELETE:"delete", POST:"update", PUT:"save", PATCH:"patch"]
   }
 }
 '''
@@ -57,6 +57,12 @@ mappings {
         assertEquals "book", info.controllerName
         assertEquals "save", info.actionName
 
+        webRequest.currentRequest.method = "PATCH"
+
+        info = holder.match("/books")
+        assertEquals "book", info.controllerName
+        assertEquals "patch", info.actionName
+
     }
 
     void testRestfulMappings() {
@@ -89,6 +95,12 @@ mappings {
         info = holder.match("/books")
         assertEquals "book", info.controllerName
         assertEquals "save", info.actionName
+
+        webRequest.currentRequest.method = "PATCH"
+
+        info = holder.match("/books")
+        assertEquals "book", info.controllerName
+        assertEquals "patch", info.actionName
     }
 
     void testRestfulMappings2() {

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/filter/RestfulMappingsFilterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/filter/RestfulMappingsFilterTests.groovy
@@ -24,7 +24,7 @@ class RestfulMappingsFilterTests extends AbstractGrailsMappingTests {
 mappings {
   "/books" {
       controller = "book"
-      action = [GET:"list", DELETE:"delete", POST:"update", PUT:"save"]
+      action = [GET:"list", DELETE:"delete", POST:"update", PATCH:"patch", PUT:"save"]
   }
 }
 '''
@@ -35,6 +35,7 @@ class BookController {
   def list = {}
   def delete = {}
   def update = {}
+  def patch = {}
   def save = {}
 }
 '''
@@ -82,5 +83,9 @@ class BookController {
         request.method = "PUT"
         filter.doFilterInternal(request, response, null)
         assertEquals "/grails/book/save.dispatch", response.forwardedUrl
+
+        request.method = "PATCH"
+        filter.doFilterInternal(request, response, null)
+        assertEquals "/grails/book/patch.dispatch", response.forwardedUrl
     }
 }

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -50,6 +50,7 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
         index:"GET",
         edit:"GET",
         update:"PUT",
+        patch:"PATCH",
         delete:"DELETE"
     ]
 
@@ -58,7 +59,8 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
         GET:"index",
         POST:"save",
         DELETE:"delete",
-        PUT:"UPDATE"
+        PUT:"update",
+        PATCH:"patch"
     ]
     String configuredServerBaseURL
     String contextPath

--- a/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
+++ b/grails-web/src/main/groovy/org/codehaus/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
@@ -85,7 +85,7 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
     public GrailsParameterMap(HttpServletRequest request) {
         this.request = request;
         final Map requestMap = new LinkedHashMap(request.getParameterMap());
-        if (requestMap.isEmpty() && "PUT".equals(request.getMethod()) && request.getAttribute(REQUEST_BODY_PARSED) == null) {
+        if (requestMap.isEmpty() && ("PUT".equals(request.getMethod()) || "PATCH".equals(request.getMethod())) && request.getAttribute(REQUEST_BODY_PARSED) == null) {
             // attempt manual parse of request body. This is here because some containers don't parse the request body automatically for PUT request
             String contentType = request.getContentType();
             if ("application/x-www-form-urlencoded".equals(contentType)) {
@@ -94,7 +94,7 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
                     request.setAttribute(REQUEST_BODY_PARSED, true);
                     requestMap.putAll(WebUtils.fromQueryString(contents));
                 } catch (Exception e) {
-                    LOG.error("Error processing form encoded PUT request", e);
+                    LOG.error("Error processing form encoded " + request.getMethod() + " request", e);
                 }
             }
         }


### PR DESCRIPTION
When issuing a PATCH request a resource should be "patched", that is updated only with the properties submitted maintaining the rest of its properties. In contrast to POST requests, the later update the whole resource regardless of any data already there.
