### PR TITLE
GRAILS-11394 Grails WAR includes junit-4.11.jar which should be a test-only dependency

### DIFF
--- a/grails-web/build.gradle
+++ b/grails-web/build.gradle
@@ -28,7 +28,6 @@ dependencies {
         exclude group: 'commons-logging', module:'commons-logging'
     }
     compile 'opensymphony:sitemesh:2.4'
-    compile "junit:junit:${junitVersion}"
 
     compile "org.springframework:spring-webmvc:${springVersion}"
 


### PR DESCRIPTION
I've removed JUnit compile dependency from grails-web, which caused putting junit and hamcrest-core jars into the final war. 
