### PR TITLE
Fix for null Url Mapping tokens

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/RegexUrlMapping.java
@@ -799,11 +799,7 @@ public class RegexUrlMapping extends AbstractUrlMapping {
 
     private int getStaticTokenCount(UrlMapping mapping) {
         String[] tokens = mapping.getUrlData().getTokens();
-        int count = 0;
-        for (String token : tokens) {
-            if (!isSingleWildcard(token) && !"".equals(token)) count++;
-        }
-        return count;
+		return tokens.length;
     }
 
     private boolean isSingleWildcard(String token) {

--- a/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/NullTokenUrlMappingSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/NullTokenUrlMappingSpec.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.grails.web.mapping
+
+import org.springframework.core.io.ByteArrayResource
+
+/**
+ */
+class NullTokenUrlMappingSpec extends AbstractUrlMappingsSpec{
+
+	def urlMappingsHolder = getUrlMappingsHolder {
+		"/stuff/image/id" {
+			controller = "stuff"
+			action = "image"
+		}
+		
+		"//stuff/image/id" {
+			controller = "stuff"
+			action = "image"
+		}
+
+	}
+	
+    void "match url with no null token"() {
+
+        when:
+            def infos = urlMappingsHolder.matchAll("//stuff/image/id")
+
+        then:
+            infos
+    }
+	
+    void "match url with null token"() {
+
+        when:
+            def infos = urlMappingsHolder.matchAll("/stuff/image/id")
+
+        then:
+            infos
+    }
+}


### PR DESCRIPTION
Grails Jira #11429.  Bug discovered in 2.2.3 when moving to java 1.7.
