### PR TITLE
GRAILS-11464: Commands objects need to be autowired before binding

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/ControllersApi.java
+++ b/grails-plugin-controllers/src/main/groovy/org/codehaus/groovy/grails/plugins/web/api/ControllersApi.java
@@ -456,13 +456,14 @@ public class ControllersApi extends CommonWebApi {
                 shouldDoDataBinding = true;
             }
 
+            final ApplicationContext applicationContext = getApplicationContext(controllerInstance);
+            final AutowireCapableBeanFactory autowireCapableBeanFactory = applicationContext.getAutowireCapableBeanFactory();
+            autowireCapableBeanFactory.autowireBeanProperties(commandObjectInstance, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, false);
+
             if(shouldDoDataBinding) {
                 bindData(controllerInstance, commandObjectInstance, commandObjectBindingSource, Collections.EMPTY_MAP, null);
             }
 
-            final ApplicationContext applicationContext = getApplicationContext(controllerInstance);
-            final AutowireCapableBeanFactory autowireCapableBeanFactory = applicationContext.getAutowireCapableBeanFactory();
-            autowireCapableBeanFactory.autowireBeanProperties(commandObjectInstance, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, false);
         }
         return commandObjectInstance;
     }


### PR DESCRIPTION
https://jira.grails.org/browse/GRAILS-11464
