### PR TITLE
Adjust on the attrs.get(ATTRIBUTE_PARAMS) process.

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/codehaus/groovy/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -111,9 +111,9 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
             def uri = attrs.get(ATTRIBUTE_URI).toString()
             writer << uri
             
-            def paramsAttribute = attrs.get(ATTRIBUTE_PARAMS)
-            Map params = paramsAttribute && (paramsAttribute instanceof Map) ? (Map)paramsAttribute : null
-            if(params) {
+            def params = attrs.get(ATTRIBUTE_PARAMS)
+
+            if(params instanceof Map) {
                 def charset = GrailsWebUtil.DEFAULT_ENCODING
                 def paramString = params.collect { k, v -> 
                     def encodedKey = URLEncoder.encode(k as String, charset)
@@ -149,7 +149,7 @@ class DefaultLinkGenerator implements LinkGenerator, PluginManagerAware {
                 String httpMethod;
                 final methodAttribute = urlAttrs.get(ATTRIBUTE_METHOD)
                 final paramsAttribute = urlAttrs.get(ATTRIBUTE_PARAMS)
-                Map params = paramsAttribute && (paramsAttribute instanceof Map) ? (Map)paramsAttribute : [:]
+                Map params = paramsAttribute instanceof Map ? paramsAttribute : [:]
 
                 if (resourceAttribute) {
                     String resource


### PR DESCRIPTION
def paramsAttribute = attrs.get(ATTRIBUTE_PARAMS)
Map params = paramsAttribute && (paramsAttribute instanceof Map) ? (Map)paramsAttribute : null
if (params) 

Here, we have three steps to prepare our "params", but my suggestion is refactor this piece of code in a more groovy way.
With this update we avoid two step, we've got a little improvement of performance and a piece of code a little bit clean.

steps: 
1 - create: params Attribute
2 - check if params Attribute is true
3 - verify the type
4 - and cast to Map
5 - if false return null

I think that here we can adjust for this:

def params = attrs.get(ATTRIBUTE_PARAMS)
if (params Map)

steps:
1 - create: params
2 - check if params is a Map

So, as groovy has a autocast for this kind of code, we just need to check if this guy is a Map and verify its boolean value.

OBS: on the 152 line: We just need to check if paramsAttribute is a Map and Groovy will solve the rest.

At the moment I don't have an environment for test this pull. So, please, if you will merge, just retest the "LinkGeneratorSpec.groovy".
