### PR TITLE
GRAILS-11421 - prettyPrint stack trace throws exception if stackTrace is empty

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/exceptions/DefaultStackTracePrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/exceptions/DefaultStackTracePrinter.groovy
@@ -25,7 +25,7 @@ class DefaultStackTracePrinter implements StackTracePrinter {
 
     String prettyPrint(Throwable t) {
         if (t == null) return ''
-	    if (!t.stackTrace) return 'No stack trace available'
+        if (!t.stackTrace) return 'No stack trace available'
         final sw = new StringWriter()
         def sb = new PrintWriter(sw)
         def mln = Math.max(4, t.stackTrace.lineNumber.max())

--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/exceptions/DefaultStackTracePrinter.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/exceptions/DefaultStackTracePrinter.groovy
@@ -25,6 +25,7 @@ class DefaultStackTracePrinter implements StackTracePrinter {
 
     String prettyPrint(Throwable t) {
         if (t == null) return ''
+	    if (!t.stackTrace) return 'No stack trace available'
         final sw = new StringWriter()
         def sb = new PrintWriter(sw)
         def mln = Math.max(4, t.stackTrace.lineNumber.max())


### PR DESCRIPTION
See https://jira.grails.org/browse/GRAILS-11421
