### PR TITLE
Excluded artifacts are resolved resulting errors if they're not available

### DIFF
--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
@@ -59,6 +59,27 @@ class AetherDependencyManagerSpec extends Specification {
 
     }
 
+    @Issue('GPRELEASE-59')
+    void "Test that an excluded dependency that isn't available is excluded"() {
+        given:"A dependency with an exclusion of an unavailable artifact"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    compile('com.octo.captcha:jcaptcha:1.0') {
+                        excludes 'javax.servlet:servlet-api', 'com.jhlabs:imaging'
+                    }
+                }
+            }
+
+        when:"The dependency is resolved"
+            def compileFiles = dependencyManager.resolve('compile').allArtifacts
+        then:"The transitive dependency is excluded"
+            !compileFiles.any { File f -> f.name.contains('imaging')}
+    }
+
     @Issue('GRAILS-11055')
     void "Test that a transitive dependency excluded with the map syntax is actually excluded"() {
         given:"A dependency with an exclusion"

--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherExcludeResolverSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherExcludeResolverSpec.groovy
@@ -19,6 +19,7 @@ import org.codehaus.groovy.grails.resolve.Dependency
 import org.codehaus.groovy.grails.resolve.maven.aether.AetherDependencyManager
 import org.codehaus.groovy.grails.resolve.maven.aether.AetherExcludeResolver
 import spock.lang.Specification
+import spock.lang.Issue
 
 /**
  * @author Graeme Rocher
@@ -48,5 +49,32 @@ class AetherExcludeResolverSpec extends Specification{
         validatorExcludes.size() == 3
         validatorExcludes.find { Dependency d -> d.name == 'commons-beanutils'}
 
+    }
+
+    @Issue('GPRELEASE-59')
+    void "Test that an excluded dependency that isn't available is excluded"() {
+        given:"A dependency with an exclusion of an unavailable artifact"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    compile('com.octo.captcha:jcaptcha:1.0') {
+                        excludes 'javax.servlet:servlet-api', 'com.jhlabs:imaging'
+                    }
+                }
+            }
+        def excludeResolver = new AetherExcludeResolver(dependencyManager)
+
+        when:"The excludes are resolved"
+        final excludes = excludeResolver.resolveExcludes()
+        def validatorExcludes = !excludes.isEmpty() ? excludes.values().iterator().next() : null
+
+        then:"They are valid"
+        !excludes.isEmpty()
+        validatorExcludes.size() == 2
+        validatorExcludes.find { Dependency d -> d.name == 'imaging'}
+        validatorExcludes.find { Dependency d -> d.name == 'servlet-api'}
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ChainMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ChainMethodTests.groovy
@@ -1,58 +1,25 @@
 package org.codehaus.groovy.grails.web.metaclass
 
-import grails.util.MockRequestDataValueProcessor
+import static org.junit.Assert.assertEquals
+import grails.artefact.Artefact
+import grails.persistence.Entity
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
 
-import org.codehaus.groovy.grails.support.MockApplicationContext
 import org.codehaus.groovy.grails.web.servlet.GrailsFlashScope
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
-import org.springframework.web.servlet.support.RequestDataValueProcessor
+import org.junit.Test
 
 /**
  * @author Graeme Rocher
  * @since 1.0
  */
-class ChainMethodTests extends AbstractGrailsControllerTests {
+@TestFor(TestChainController)
+@Mock(TestChainBook)
+class ChainMethodTests {
 
-    void registerRequestDataValueProcessor() {
-        RequestDataValueProcessor requestDataValueProcessor = new MockRequestDataValueProcessor()
-        MockApplicationContext applicationContext = (MockApplicationContext)ctx
-        applicationContext.registerMockBean("requestDataValueProcessor",requestDataValueProcessor)
-    }
-    void unRegisterRequestDataValueProcessor() {
-        MockApplicationContext applicationContext = (MockApplicationContext)ctx
-        applicationContext.registerMockBean("requestDataValueProcessor",null)
-    }
-
-    protected void onSetUp() {
-        gcl.parseClass('''
-class TestChainController {
-    def save = {
-        def book = new TestChainBook(params)
-        if (!book.hasErrors() && book.save()) {
-            flash.message = "Book ${book.id} created"
-            redirect(action:"show",id:book.id)
-        }
-        else {
-            chain(action:'create',model:[book:book])
-        }
-    }
-
-    def testId = {
-        chain action: 'show', id: 5, model: [str: "Test param"]
-    }
-}
-class TestChainBook {
-    Long id
-    Long version
-    String title
-}
-''')
-    }
-
+    @Test
     void testChainMethodWithModel() {
-        def domainClass = ga.getDomainClass("TestChainBook").clazz
-        domainClass.metaClass.save = { false }
-        def controller = ga.getControllerClass("TestChainController").newInstance()
+        TestChainBook.metaClass.save = { false }
 
         controller.save()
 
@@ -69,33 +36,35 @@ class TestChainBook {
         assertEquals '/testChain/create', response.redirectedUrl
     }
 
-    void testChainMethodWithModelAndRequestDataValueProcessor() {
-        this.registerRequestDataValueProcessor()
-        def domainClass = ga.getDomainClass("TestChainBook").clazz
-        domainClass.metaClass.save = { false }
-        def controller = ga.getControllerClass("TestChainController").newInstance()
-
-        controller.save()
-
-        def flash = controller.flash
-
-        assert flash.chainModel.book
-
-        def id = System.identityHashCode(flash.chainModel.book)
-
-        assert flash.chainModel[GrailsFlashScope.ERRORS_PREFIX+id]
-
-        org.springframework.mock.web.MockHttpServletResponse response = controller.response
-
-        assertEquals '/testChain/create?requestDataValueProcessorParamName=paramValue', response.redirectedUrl
-        this.unRegisterRequestDataValueProcessor()
-    }
-
+    @Test
     void testChainMethodWithId() {
-        def controller = ga.getControllerClass("TestChainController").newInstance()
         controller.testId()
 
         assertEquals "Test param", controller.flash.chainModel.str
         assertEquals "/testChain/show/5", response.redirectedUrl
     }
 }
+
+@Artefact('Controller')
+class TestChainController {
+    def save = {
+        def book = new TestChainBook(params)
+        if (!book.hasErrors() && book.save()) {
+            flash.message = "Book ${book.id} created"
+            redirect(action:"show",id:book.id)
+        }
+        else {
+            chain(action:'create',model:[book:book])
+        }
+    }
+
+    def testId = {
+        chain action: 'show', id: 5, model: [str: "Test param"]
+    }
+}
+
+@Entity
+class TestChainBook {
+    String title
+}
+

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ChainMethodWithRequestDataValueProcessorSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/metaclass/ChainMethodWithRequestDataValueProcessorSpec.groovy
@@ -1,0 +1,31 @@
+
+
+package org.codehaus.groovy.grails.web.metaclass
+
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import grails.util.MockRequestDataValueProcessor
+
+import org.codehaus.groovy.grails.web.servlet.GrailsFlashScope
+
+import spock.lang.Specification
+
+
+@TestFor(TestChainController)
+@Mock(TestChainBook)
+class ChainMethodWithRequestDataValueProcessorSpec extends Specification {
+
+    def doWithSpring = {
+        requestDataValueProcessor MockRequestDataValueProcessor
+    }
+    
+    void 'test chain method with model and request data value processor'() {
+        when:
+        controller.save()
+        
+        then:
+        controller.flash.chainModel.book
+        controller.flash.chainModel[GrailsFlashScope.ERRORS_PREFIX+System.identityHashCode(controller.flash.chainModel.book)]
+        '/testChain/create?requestDataValueProcessorParamName=paramValue' == response.redirectedUrl
+    }
+}

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
@@ -1,100 +1,103 @@
 package org.codehaus.groovy.grails.web.servlet.mvc
 
+import grails.test.mixin.TestFor
+
 import org.codehaus.groovy.grails.web.sitemesh.GrailsLayoutDecoratorMapper
+import org.junit.Test
+import static org.junit.Assert.assertEquals
 
-class RenderDynamicMethodTests extends AbstractGrailsControllerTests {
+@TestFor(RenderDynamicMethodTestController)
+class RenderDynamicMethodTests  {
 
-    private testCtrl
-
-    protected void onSetUp() {
-        gcl.parseClass("grails.json.legacy.builder=false", "Config")
-    }
-
-    @Override
-    protected Collection<Class> getControllerClasses() {
-        [RenderDynamicMethodTestController]
-    }
-
-    protected void setUp() {
-        super.setUp()
-        testCtrl = ga.getControllerClass(RenderDynamicMethodTestController.name).newInstance()
-    }
-
+    @Test
     void testRenderTextWithLayout() {
-        testCtrl.renderTextWithLayout()
+        controller.renderTextWithLayout()
         assertEquals "text/html;charset=utf-8", response.contentType
         assertEquals "foo", response.contentAsString
         assert "bar" == request.getAttribute(GrailsLayoutDecoratorMapper.LAYOUT_ATTRIBUTE)
     }
+    
+    @Test
     void testRenderView() {
-        testCtrl.renderView()
+        controller.renderView()
 
-        assertEquals '/renderDynamicMethodTest/foo', testCtrl.modelAndView.viewName
+        assertEquals '/renderDynamicMethodTest/foo', controller.modelAndView.viewName
         assertEquals 'text/html;charset=utf-8', response.contentType
     }
 
+    @Test
     void testRenderText() {
-        testCtrl.renderText()
+        controller.renderText()
         assertEquals "text/html;charset=utf-8", response.contentType
         assertEquals "text", response.contentAsString
     }
 
+    @Test
     void testRenderStreamCharBuffer() {
-        testCtrl.renderStreamCharBuffer()
+        controller.renderStreamCharBuffer()
         assertEquals "text/html;charset=utf-8", response.contentType
         assertEquals "text", response.contentAsString
     }
 
+    @Test
     void testRenderGString() {
-        testCtrl.renderGString()
+        controller.renderGString()
         assertEquals "text/html;charset=utf-8", response.contentType
         assertEquals "text", response.contentAsString
     }
 
+    @Test
     void testRenderTextWithContentType() {
-        testCtrl.renderTextWithContentType()
+        controller.renderTextWithContentType()
         assertEquals "text/xml;charset=utf-16", response.contentType
         assertEquals "<foo>bar</foo>", response.contentAsString
     }
 
+    @Test
     void testRenderTextWithContentTypeAndCharset() {
-        testCtrl.renderTextWithContentTypeAndCharset()
+        controller.renderTextWithContentTypeAndCharset()
         assertEquals "text/xml;charset=utf-16", response.contentType
         assertEquals "<foo>bar</foo>", response.contentAsString
     }
 
+    @Test
     void testRenderXml() {
-        testCtrl.renderXml()
+        controller.renderXml()
         assertEquals "text/xml;charset=utf-8", response.contentType
         assertEquals "<foo><bar>hello</bar></foo>", response.contentAsString
     }
 
+    @Test
     void testRenderNonAsciiXml() {
-        testCtrl.renderNonAsciiXml()
+        controller.renderNonAsciiXml()
         assertEquals "text/xml;charset=utf-8", response.contentType
         assertEquals "<foo><bar>hello öäåÖÄÅ</bar></foo>", response.contentAsString
     }
 
+    @Test
     void testRenderJSON() {
-        testCtrl.renderJSON()
+        controller.renderJSON()
         assertEquals "application/json;charset=UTF-8", response.contentType
         assertEquals '{"foo":[{"bar":"hello"}]}', response.contentAsString
     }
 
+    @Test
     void testStatusAndText() {
-        testCtrl.renderStatusAndText()
+        controller.renderStatusAndText()
         assertEquals 'five oh three', response.contentAsString
         assertEquals 503, response.status
     }
 
+    @Test
     void testStatusOnly() {
-        testCtrl.renderStatusOnly()
+        controller.renderStatusOnly()
         assertEquals '', response.contentAsString
         assertEquals 404, response.status
     }
     
+    @Test
     void testRenderFile() {
-        testCtrl.renderFile()
+        controller.renderFile()
         assertEquals 'foo', response.contentAsString
         assertEquals 'text/plain;charset=utf-8', response.contentType
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SimpleGrailsControllerHelperTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/SimpleGrailsControllerHelperTests.groovy
@@ -1,114 +1,113 @@
 package org.codehaus.groovy.grails.web.servlet.mvc
 
-import grails.web.Action
-import org.springframework.web.context.request.RequestContextHolder
-import org.codehaus.groovy.grails.web.servlet.mvc.exceptions.UnknownControllerException
 import grails.artefact.Artefact
+import grails.test.mixin.Mock
+import grails.web.Action
 
-class SimpleGrailsControllerHelperTests extends AbstractGrailsControllerTests {
+import org.codehaus.groovy.grails.web.servlet.mvc.exceptions.UnknownControllerException
+import org.junit.Test
+import org.springframework.web.context.request.RequestContextHolder
 
-    @Override
-    protected Collection<Class> getControllerClasses() {
-        [Test1Controller, Test2Controller, Test3Controller, Test4Controller]
-    }
 
+@Mock([Test1Controller, Test2Controller, Test3Controller, Test4Controller])
+class SimpleGrailsControllerHelperTests  {
+
+    @Test
     void testConstructHelper() {
-        runTest {
-            def webRequest = RequestContextHolder.currentRequestAttributes()
-            def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-        }
+        def webRequest = RequestContextHolder.currentRequestAttributes()
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
     }
 
+    @Test
     void testAmbiguousGetterNameForAction() {
-            runTest {
-                def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-                def mv = helper.handleURI("/test3/list", webRequest)
-                assert !mv.getModel()["someAmbiguousActionName"]
-            }
-        }
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+        def mv = helper.handleURI("/test3/list", webRequest)
+        assert !mv.getModel()["someAmbiguousActionName"]
+    }
 
+    @Test
     void testCallsAfterInterceptorWithModel() {
-        runTest {
-            def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-            def mv = helper.handleURI("/test1/list", webRequest)
-            assert mv.getModel()["after"] == "value"
-        }
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+        def mv = helper.handleURI("/test1/list", webRequest)
+        assert mv.getModel()["after"] == "value"
     }
 
+    @Test
     void testCallsAfterInterceptorWithModelAndExplicitParam() {
-        runTest {
-            def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-            def mv = helper.handleURI("/test2/list", webRequest)
-            assert mv.getModel()["after"] == "value"
-        }
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+        def mv = helper.handleURI("/test2/list", webRequest)
+        assert mv.getModel()["after"] == "value"
     }
 
+    @Test
     void testCallsAfterInterceptorWithModelAndViewExplicitParams() {
-        runTest {
-            def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-            def mv = helper.handleURI("/test3/list", webRequest)
-            assert mv.getModel()["after"] == "/test3/list"
-        }
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+        def mv = helper.handleURI("/test3/list", webRequest)
+        assert mv.getModel()["after"] == "/test3/list"
     }
 
+    @Test
     void testReturnsNullIfAfterInterceptorReturnsFalse() {
-        runTest {
-            def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-            def mv = helper.handleURI("/test4/list", webRequest)
-            assert mv == null
-        }
+        def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+        def mv = helper.handleURI("/test4/list", webRequest)
+        assert mv == null
     }
 
+    @Test
     void testDontHandleFlowAction() {
-        runTest {
-            shouldFail(UnknownControllerException) {
-                def helper = new MixedGrailsControllerHelper(application:ga, applicationContext: appCtx, servletContext: servletContext)
-                def mv = helper.handleURI("/test1/testFlow", webRequest)
-            }
+        shouldFail(UnknownControllerException) {
+            def helper = new MixedGrailsControllerHelper(application:grailsApplication, applicationContext: mainContext, servletContext: servletContext)
+            def mv = helper.handleURI("/test1/testFlow", webRequest)
         }
     }
 }
 
 @Artefact("Controller")
 class Test1Controller {
-    @Action def list() {}
+    @Action def list() {
+
+    }
 
     def afterInterceptor = {
-         it.put("after", "value")
+        it.put("after", "value")
     }
 
     def testFlow = {
-         startFlow {
-             on "foo" to "bar"
-         }
+        startFlow { on "foo" to "bar" }
     }
 }
 
 @Artefact("Controller")
 class Test2Controller {
-    @Action def list() {}
+    @Action def list() {
+
+    }
 
     def afterInterceptor = { model ->
-         model.put("after", "value")
-         return "not a boolean"
+        model.put("after", "value")
+        return "not a boolean"
     }
 }
 
 @Artefact("Controller")
 class Test3Controller {
-    @Action def list() {}
-    @Action def getSomeAmbiguousActionName() {[a:true]}
+    @Action def list() {
+
+    }
+    @Action def getSomeAmbiguousActionName() {
+        [a:true]
+    }
     def afterInterceptor = { model, modelAndView ->
-         model.put("after", modelAndView.getViewName())
-         return true
+        model.put("after", modelAndView.getViewName())
+        return true
     }
 }
 
 @Artefact("Controller")
 class Test4Controller {
-    @Action def list() {}
+    @Action def list() {
 
-    def afterInterceptor = { model, modelAndView ->
-         return false
     }
+
+    def afterInterceptor = { model, modelAndView -> return false }
 }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/TagLibDynamicMethodsTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/servlet/mvc/TagLibDynamicMethodsTests.groovy
@@ -1,69 +1,60 @@
 package org.codehaus.groovy.grails.web.servlet.mvc
 
-import org.codehaus.groovy.grails.commons.test.*
+import grails.artefact.Artefact
+import grails.test.mixin.TestFor
+
 import org.codehaus.groovy.grails.commons.*
 import org.codehaus.groovy.grails.commons.spring.*
+import org.codehaus.groovy.grails.commons.test.*
 import org.codehaus.groovy.grails.plugins.*
-import org.springframework.web.context.request.*
-import org.codehaus.groovy.grails.web.servlet.mvc.*
 import org.codehaus.groovy.grails.web.servlet.*
+import org.junit.Test
+import static org.junit.Assert.*
 import org.springframework.mock.web.*
 import org.springframework.validation.*
+import org.springframework.web.context.request.*
 import org.springframework.web.servlet.*
 
-@SuppressWarnings("unused")
-class TagLibDynamicMethodsTests extends AbstractGrailsControllerTests {
+@TestFor(TestTagLib)
+class TagLibDynamicMethodsTests {
 
-    void onSetUp() {
-        gcl.parseClass """
-        class TestTagLib {
-           def myTag = {attrs, body -> body() }
-        }
-        """
-    }
-
+    @Test
     void testFlashObject() {
-        runTest {
-            def testTagLib = ga.getTagLibClass("TestTagLib").newInstance()
-            testTagLib.flash.test = "hello"
+        tagLib.flash.test = "hello"
 
-            assertEquals "hello", testTagLib.flash.test
-        }
+        assertEquals "hello", tagLib.flash.test
     }
 
+    @Test
     void testParamsObject() {
-        runTest {
-            def testTagLib = ga.getTagLibClass("TestTagLib").newInstance()
-            testTagLib.params.test = "hello"
+        tagLib.params.test = "hello"
 
-            assertEquals "hello", testTagLib.params.test
-        }
+        assertEquals "hello", tagLib.params.test
     }
 
+    @Test
     void testSessionObject() {
-        runTest {
-            def testTagLib = ga.getTagLibClass("TestTagLib").newInstance()
-            testTagLib.session.test = "hello"
+        tagLib.session.test = "hello"
 
-            assertEquals "hello", testTagLib.session.test
-        }
+        assertEquals "hello", tagLib.session.test
     }
 
+    @Test
     void testGrailsAttributesObject() {
-        runTest {
-            def testTagLib = ga.getTagLibClass("TestTagLib").newInstance()
-             assertNotNull(testTagLib.grailsAttributes)
-        }
+        assertNotNull(tagLib.grailsAttributes)
     }
 
+    @Test
     void testRequestObjects() {
-        runTest {
-            def testTagLib = ga.getTagLibClass("TestTagLib").newInstance()
+        assertNotNull(tagLib.request)
 
-            assertNotNull(testTagLib.request)
-
-            assertNotNull(testTagLib.response)
-            assertNotNull(testTagLib.servletContext)
-        }
+        assertNotNull(tagLib.response)
+        assertNotNull(tagLib.servletContext)
     }
 }
+
+@Artefact("TagLibrary")
+class TestTagLib {
+    def myTag = {attrs, body -> body() }
+ }
+

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfigTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/plugins/web/filters/FilterConfigTests.groovy
@@ -15,14 +15,13 @@
  */
 package org.codehaus.groovy.grails.plugins.web.filters
 
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
 
 /**
  * Test case for {@link FilterConfig}.
  *
  * @author pledbrook
  */
-class FilterConfigTests extends AbstractGrailsControllerTests {
+class FilterConfigTests extends GroovyTestCase {
     private static final int INT_PROP_VALUE = 1000
     private static final String STRING_PROP_VALUE = 'Test property'
 

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/binding/BindToPropertyThatIsNotReadableTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/binding/BindToPropertyThatIsNotReadableTests.groovy
@@ -1,21 +1,30 @@
 package org.codehaus.groovy.grails.web.binding
 
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
-import org.junit.Ignore
+import grails.persistence.Entity
+import grails.test.mixin.Mock
+
+import org.junit.Test
+import static org.junit.Assert.assertEquals
 
 /**
  * @author Graeme Rocher
  * @since 1.1
  */
-@Ignore
-class BindToPropertyThatIsNotReadableTests extends AbstractGrailsControllerTests {
+@Mock(PropertyNotReadableBook)
+class BindToPropertyThatIsNotReadableTests {
 
-    protected void onSetUp() {
-        gcl.parseClass '''
-import grails.persistence.*
+    @Test
+    void testBindToPropertyThatIsNotReadable() {
+        def b = new PropertyNotReadableBook()
+
+        b.properties = [calculatedField:[1,2,3], title:"blah"]
+
+        assertEquals 6, b.sum()
+    }
+}
 
 @Entity
-class Book {
+class PropertyNotReadableBook {
 
     String title
 
@@ -28,16 +37,4 @@ class Book {
     }
 
     int sum() { calculateField.sum() }
-}
-'''
-    }
-
-    void testBindToPropertyThatIsNotReadable() {
-        def Book = ga.getDomainClass("Book").clazz
-        def b = Book.newInstance()
-
-        b.properties = [calculatedField:[1,2,3], title:"blah"]
-
-        assertEquals 6, b.sum()
-    }
 }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/binding/DataBindingTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/binding/DataBindingTests.groovy
@@ -1,7 +1,13 @@
 package org.codehaus.groovy.grails.web.binding
 
+import grails.artefact.Artefact
+import grails.persistence.Entity
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+
 import org.codehaus.groovy.grails.plugins.testing.GrailsMockMultipartFile
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
+import org.junit.Test
+import static org.junit.Assert.*
 
  /**
  * Tests Grails data binding capabilities.
@@ -9,22 +15,390 @@ import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
  * @author Graeme Rocher
  * @since 1.0
  */
-class DataBindingTests extends AbstractGrailsControllerTests {
+@TestFor(TestController)
+@Mock(MyBean)
+class DataBindingTests  {
 
-    protected void onSetUp() {
-        gcl.parseClass('''
-package databindingtests
+    @Test
+    void testBindingPogoToDomainClass() {
+        def author = new Author()
+        def clown = new Clown(name: 'Bozo', hairColour: 'Orange')
 
-import grails.persistence.*
+        author.properties = clown
 
+        assert !author.hasErrors()
+        assert author.name == 'Bozo'
+        assert author.hairColour == 'Orange'
+    }
+
+    @Test
+    void testDateFormatError() {
+        def bean = new MyBean()
+
+        request.addParameter 'formattedDate', 'BAD'
+
+        bean.properties = request
+
+        assert bean.hasErrors()
+        assert bean.errors.errorCount == 1
+
+        def dateError = bean.errors.getFieldError('formattedDate')
+        assert dateError != null
+
+        assert dateError.defaultMessage == 'Unparseable date: "BAD"'
+    }
+
+    @Test
+    void testUpdatingSetElementByIdThatDoesNotExist() {
+        def city = new City()
+
+        request.addParameter 'people[0].id', '42'
+
+        city.properties = request
+
+        assert city.hasErrors()
+        assert city.errors.errorCount == 1
+
+        def error = city.errors.getFieldError('people')
+        assert error.defaultMessage == 'Illegal attempt to update element in [people] Set with id [42]. No such record was found.'
+    }
+
+    @Test
+    void testBindingObjectsWithHashcodeAndEqualsToASet() {
+        // GRAILS-9825 = this test fails with the spring binder
+        // and passes with GrailsWebDataBinder
+
+        def city = new City()
+
+        request.addParameter 'people[0].name', 'Jeff'
+        request.addParameter 'people[1].name', 'Jake'
+        request.addParameter 'people[1].birthDate', '2000-08-26 21:26:31.973'
+        request.addParameter 'people[2].name', 'Zack'
+
+        city.properties = request
+
+        assert city.people instanceof Set
+        assert city.people.size() == 3
+        assert city.people.find { it.name == 'Jeff' && it.birthDate == null} != null
+        assert city.people.find { it.name == 'Jake' && it.birthDate != null} != null
+        assert city.people.find { it.name == 'Zack' && it.birthDate == null} != null
+    }
+
+    @Test
+    void testBindingASinglePropertyWithSubscriptOperator() {
+        def person = new DataBindingTestsPerson()
+
+        person.properties['birthDate'] = '2013-04-15 21:26:31.973'
+
+        assert person.birthDate instanceof Date
+        def cal = Calendar.instance
+        cal.time = person.birthDate
+        assert Calendar.APRIL == cal.get(Calendar.MONTH)
+        assert 2013 == cal.get(Calendar.YEAR)
+    }
+
+    @Test
+    void testBindintToNestedArray() {
+        def author = new AuthorCommand()
+        request.addParameter 'beans[0].integers[0]', '42'
+
+        author.properties = request
+
+        assert author.beans.size() == 1
+        assert author.beans[0].integers.length == 1
+        assert author.beans[0].integers[0] == 42
+    }
+
+    @Test
+    void testFieldErrorObjectName() {
+        def myBean = new MyBean()
+
+        request.addParameter 'someIntProperty', 'bad integer'
+        myBean.properties = request
+        def errors = myBean.errors
+        def fieldError = errors.getFieldError('someIntProperty')
+
+        assert myBean.someIntProperty == null
+        assert fieldError.rejectedValue == 'bad integer'
+        assert fieldError.objectName == 'org.codehaus.groovy.grails.web.binding.MyBean'
+    }
+
+    @Test
+    void testBindingMalformedNumber() {
+        // GRAILS-6766
+        def myBean = new MyBean()
+
+        request.addParameter 'someFloatProperty', '21.12Rush'
+
+        myBean.properties = request
+
+        def errors = myBean.errors
+        def fieldError = errors.getFieldError('someFloatProperty')
+
+        // these fail with GrailsDataBinder and pass with GrailsWebDataBinder
+        assert myBean.someFloatProperty == null
+        assert fieldError.rejectedValue == '21.12Rush'
+    }
+
+    @Test
+    void testBinderDoesNotCreateExtraneousInstances() {
+        // GRAILS-9914
+        int originalCount = DataBindingTestsBook.instanceCount
+        def book = new DataBindingTestsBook(title: 'Some Book')
+
+        assert originalCount + 1 == DataBindingTestsBook.instanceCount
+
+        def bookReview = new BookReview(book: book)
+
+        assert 'Some Book' == bookReview.book.title
+
+        request.addParameter 'book.title', 'Some New Book'
+        bookReview.properties = request
+
+        assert 'Some New Book' == bookReview.book.title
+
+        // this fails with GrailsDataBinder and passes with GrailsWebDataBinder
+        assert originalCount + 1 == DataBindingTestsBook.instanceCount
+    }
+
+    @Test
+    void testBindEmbeddedWithMultipartFileAndDate() {
+        def e = new WithEncoding()
+        request.addFile(new GrailsMockMultipartFile("eDate.aFile", "foo".bytes))
+        request.addParameter("eDate.aDate", "struct")
+        request.addParameter("eDate.aDate_year", "1980")
+        request.addParameter("eDate.aDate_month", "02")
+        request.addParameter("eDate.aDate_day", "03")
+
+        e.properties = request
+
+        assert e.eDate.aFile != null
+        assert e.eDate.aDate != null
+
+    }
+    
+    @Test
+    void testBindingMapValue() {
+        def pet = new Pet()
+        pet.properties = [name: 'lemur', detailMap: [first: 'one', second: 'two'], owner: [name: 'Jeff'], foo: 'bar', bar: [a: 'a', b: 'b']]
+
+        assert pet.name == 'lemur'
+        assert pet.detailMap.first == 'one'
+        assert pet.detailMap.second == 'two'
+        assert !pet.hasErrors()
+    }
+
+    @Test
+    void testBindingNullToANullableDateThatAlreadyHasAValue() {
+        def person = new DataBindingTestsPerson()
+
+        params.name = 'Douglas Adams'
+        params.birthDate_year = '1952'
+        params.birthDate_day = '11'
+        params.birthDate_month = '3'
+        params.birthDate = 'struct'
+
+        person.properties = params
+        assertEquals 'Douglas Adams', person.name
+        assertNotNull person.birthDate
+
+        params.name = 'Douglas Adams'
+        params.birthDate_year = ''
+        params.birthDate_day = ''
+        params.birthDate_month = ''
+        params.birthDate = 'struct'
+
+        person.properties = params
+        assertEquals 'Douglas Adams', person.name
+        assertNull person.birthDate
+    }
+
+    @Test
+    void testNamedBinding() {
+        def author = new Author()
+
+        params.name = 'Douglas Adams'
+        params.hairColour = 'Grey'
+
+        author.properties['name'] = params
+        assertEquals 'Douglas Adams', author.name
+        assertNull author.hairColour
+    }
+
+    @Test
+    void testNamedBindingWithMultipleProperties() {
+        def author = new Author()
+
+        params.name = 'Douglas Adams'
+        params.hairColour = 'Grey'
+
+        author.properties['name', 'hairColour'] = params
+        assertEquals 'Douglas Adams', author.name
+        assertEquals 'Grey', author.hairColour
+    }
+
+    @Test
+    void testThreeLevelDataBinding() {
+        def b = new DataBindingTestsBook()
+
+        params.title = "The Stand"
+        params.author = [placeOfBirth: [name: 'Maine'], name: 'Stephen King']
+
+        b.properties = params
+
+        assertEquals "The Stand",b.title
+        assertEquals "Maine", b.author.placeOfBirth.name
+        assertEquals "Stephen King", b.author.name
+    }
+
+    @Test
+    void testConvertingBlankAndEmptyStringsToNull() {
+        def a = new Author()
+
+        params.name =  ''
+        params.hairColour = '  '
+
+        a.properties = params
+
+        assertNull a.name
+        assertNull a.hairColour
+    }
+
+    @Test
+    void testTypeConversionErrorsWithNestedAssociations() {
+        request.addParameter("author.name", "Stephen King")
+        request.addParameter("author.hairColour", "Black")
+
+        def b = new DataBindingTestsBook()
+
+        b.properties = params
+
+        def a = b.author
+
+        assert !a.hasErrors()
+        assert !b.hasErrors()
+    }
+
+    @Test
+    void testTypeConversionErrors() {
+
+        request.addParameter("site", "not_a_valid_URL")
+
+        def b = new DataBindingTestsBook()
+
+        b.properties = params
+
+        assert b.hasErrors()
+
+        def error = b.errors.getFieldError('site')
+    }
+
+    @Test
+    void testValidationAfterBindingFails() {
+        // binding should fail for this one
+        request.addParameter("someIntProperty", "foo")
+
+        // validation should fail for this one...
+        request.addParameter("someOtherIntProperty", "999")
+
+        // binding should fail for this one...
+        request.addParameter("thirdIntProperty", "bar")
+
+        request.addParameter("someFloatProperty", "21.12")
+
+        def myBean = new MyBean()
+
+        myBean.properties = params
+
+        assertEquals "wrong number of errors before validation", 2, myBean.errors.errorCount
+        assertFalse 'validation should have failed', myBean.validate()
+        assertEquals 'wrong number of errors after validation', 4, myBean.errors.errorCount
+    }
+
+    @Test
+    void testAssociationAutoCreation() {
+        request.addParameter("title", "The Stand")
+        request.addParameter("author.name", "Stephen King")
+
+        assertEquals "The Stand", params.title
+
+        def b = new DataBindingTestsBook()
+
+        b.properties = params
+        assertEquals "The Stand", b.title
+        assertEquals "Stephen King", b.author?.name
+    }
+
+    @Test
+    void testNullAssociations() {
+        request.addParameter("title", "The Stand")
+        request.addParameter("author.id", "null")
+
+        def b = new DataBindingTestsBook()
+
+        b.properties = params
+        assertEquals "Wrong 'title' property", "The Stand", b.title
+        assertNull "Expected null for property 'author'", b.author
+    }
+
+    @Test
+    void testAssociationsBinding() {
+        def authorClass = new Author()
+
+        Author.metaClass.static.get = { Serializable id ->
+            def result = new Author()
+            result.id = id as long
+            result.name = "Mocked ${id}"
+            result
+        }
+
+        request.addParameter("title", "The Stand")
+        request.addParameter("author.id", "5")
+
+        def b = new DataBindingTestsBook()
+
+        b.properties = params
+
+        assertEquals "Wrong 'title' property", "The Stand", b.title
+        assertNotNull "Association 'author' should be bound", b.author
+        assertEquals 5, b.author.id
+        assertEquals "Mocked 5", b.author.name
+    }
+
+    @Test
+    void testMultiDBinding() {
+        request.addParameter("author.name", "Stephen King")
+        request.addParameter("author.hairColour", "Black")
+        request.addParameter("title", "The Stand")
+
+        def a = new Author()
+
+        assertEquals "Stephen King",params['author'].name
+        a.properties = params['author']
+        assertEquals "Stephen King", a.name
+        assertEquals "Black", a.hairColour
+
+        def b = new DataBindingTestsBook()
+        b.properties = params
+        assertEquals "The Stand", b.title
+        assertEquals "Stephen King", b.author?.name
+    }
+}
+
+class Clown {
+    String name
+    String hairColour
+}
+
+@Artefact('Controller')
 class TestController {
     def index = {}
 }
 
 @Entity
-class Book {
+class DataBindingTestsBook {
     static instanceCount = 0
-    Book() {
+    DataBindingTestsBook() {
         instanceCount++
     }
     String title
@@ -34,7 +408,7 @@ class Book {
 
 @Entity
 class BookReview {
-    Book book
+    DataBindingTestsBook book
 }
 
 @Entity
@@ -65,10 +439,10 @@ class Author {
 @Entity
 class City {
     String name
-    static hasMany = [people: Person]
+    static hasMany = [people: DataBindingTestsPerson]
 }
 @Entity
-class Person {
+class DataBindingTestsPerson {
     String name
     Date birthDate
     static constraints = {
@@ -92,7 +466,7 @@ class Person {
             return false;
         if (!getClass().is(obj.getClass()))
             return false
-        Person other = (Person) obj;
+        DataBindingTestsPerson other = (DataBindingTestsPerson) obj;
         if (birthDate == null) {
             if (other.birthDate != null)
                 return false;
@@ -110,7 +484,7 @@ class Person {
 class Pet {
     String name
     Map detailMap
-    Person owner
+    DataBindingTestsPerson owner
 }
 
 @Entity
@@ -141,405 +515,4 @@ class AuthorCommand {
 @Entity
 class AuthorBean {
     Integer[] integers
-}
-        ''')
-    }
-
-    void testBindingPogoToDomainClass() {
-        def authorClass = ga.getDomainClass('databindingtests.Author').clazz
-        def author = authorClass.newInstance()
-        def clown = new Clown(name: 'Bozo', hairColour: 'Orange')
-
-        author.properties = clown
-
-        assert !author.hasErrors()
-        assert author.name == 'Bozo'
-        assert author.hairColour == 'Orange'
-    }
-
-    void testDateFormatError() {
-        def myBeanClass = ga.getDomainClass('databindingtests.MyBean')
-        def bean = myBeanClass.newInstance()
-
-        request.addParameter 'formattedDate', 'BAD'
-
-        bean.properties = request
-
-        assert bean.hasErrors()
-        assert bean.errors.errorCount == 1
-
-        def dateError = bean.errors.getFieldError('formattedDate')
-        assert dateError != null
-
-        assert dateError.defaultMessage == 'Unparseable date: "BAD"'
-    }
-
-    void testUpdatingSetElementByIdThatDoesNotExist() {
-        def cityClass = ga.getDomainClass('databindingtests.City')
-        def personClass = ga.getDomainClass('databindingtests.Person')
-        personClass.clazz.metaClass.static.get = { String id ->
-            null
-        }
-        def city = cityClass.newInstance()
-
-        request.addParameter 'people[0].id', '42'
-
-        city.properties = request
-
-        assert city.hasErrors()
-        assert city.errors.errorCount == 1
-
-        def error = city.errors.getFieldError('people')
-        assert error.defaultMessage == 'Illegal attempt to update element in [people] Set with id [42]. No such record was found.'
-    }
-
-    void testBindingObjectsWithHashcodeAndEqualsToASet() {
-        // GRAILS-9825 = this test fails with the spring binder
-        // and passes with GrailsWebDataBinder
-
-        def cityClass = ga.getDomainClass('databindingtests.City')
-        def city = cityClass.newInstance()
-
-        request.addParameter 'people[0].name', 'Jeff'
-        request.addParameter 'people[1].name', 'Jake'
-        request.addParameter 'people[1].birthDate', '2000-08-26 21:26:31.973'
-        request.addParameter 'people[2].name', 'Zack'
-
-        city.properties = request
-
-        assert city.people instanceof Set
-        assert city.people.size() == 3
-        assert city.people.find { it.name == 'Jeff' && it.birthDate == null} != null
-        assert city.people.find { it.name == 'Jake' && it.birthDate != null} != null
-        assert city.people.find { it.name == 'Zack' && it.birthDate == null} != null
-    }
-
-    void testBindingASinglePropertyWithSubscriptOperator() {
-        def personClass = ga.getDomainClass('databindingtests.Person')
-        def person = personClass.newInstance()
-
-        person.properties['birthDate'] = '2013-04-15 21:26:31.973'
-
-        assert person.birthDate instanceof Date
-        def cal = Calendar.instance
-        cal.time = person.birthDate
-        assert Calendar.APRIL == cal.get(Calendar.MONTH)
-        assert 2013 == cal.get(Calendar.YEAR)
-    }
-
-    void testBindintToNestedArray() {
-        def authorCommandClass = ga.getDomainClass('databindingtests.AuthorCommand')
-        def author = authorCommandClass.newInstance()
-        request.addParameter 'beans[0].integers[0]', '42'
-
-        author.properties = request
-
-        assert author.beans.size() == 1
-        assert author.beans[0].integers.length == 1
-        assert author.beans[0].integers[0] == 42
-    }
-
-    void testFieldErrorObjectName() {
-        def myBeanClass = ga.getDomainClass('databindingtests.MyBean')
-        def myBean = myBeanClass.newInstance()
-
-        request.addParameter 'someIntProperty', 'bad integer'
-        myBean.properties = request
-        def errors = myBean.errors
-        def fieldError = errors.getFieldError('someIntProperty')
-
-        assert myBean.someIntProperty == null
-        assert fieldError.rejectedValue == 'bad integer'
-        assert fieldError.objectName == 'databindingtests.MyBean'
-    }
-
-    void testBindingMalformedNumber() {
-        // GRAILS-6766
-        def myBeanClass = ga.getDomainClass('databindingtests.MyBean')
-        def myBean = myBeanClass.newInstance()
-
-        request.addParameter 'someFloatProperty', '21.12Rush'
-
-        myBean.properties = request
-
-        def errors = myBean.errors
-        def fieldError = errors.getFieldError('someFloatProperty')
-
-        // these fail with GrailsDataBinder and pass with GrailsWebDataBinder
-        assert myBean.someFloatProperty == null
-        assert fieldError.rejectedValue == '21.12Rush'
-    }
-
-    void testBinderDoesNotCreateExtraneousInstances() {
-        // GRAILS-9914
-        def bookReviewClass = ga.getDomainClass('databindingtests.BookReview')
-        def bookClass = ga.getDomainClass('databindingtests.Book')
-        def book = bookClass.clazz.newInstance(title: 'Some Book')
-
-        assert 1 == bookClass.clazz.instanceCount
-
-        def bookReview = bookReviewClass.clazz.newInstance(book: book)
-
-        assert 'Some Book' == bookReview.book.title
-
-        request.addParameter 'book.title', 'Some New Book'
-        bookReview.properties = request
-
-        assert 'Some New Book' == bookReview.book.title
-
-        // this fails with GrailsDataBinder and passes with GrailsWebDataBinder
-        assert 1 == bookClass.clazz.instanceCount
-    }
-
-    void testBindEmbeddedWithMultipartFileAndDate() {
-        def withEncodingClass = ga.getDomainClass("databindingtests.WithEncoding")
-
-        def e = withEncodingClass.newInstance()
-        request.addFile(new GrailsMockMultipartFile("eDate.aFile", "foo".bytes))
-        request.addParameter("eDate.aDate", "struct")
-        request.addParameter("eDate.aDate_year", "1980")
-        request.addParameter("eDate.aDate_month", "02")
-        request.addParameter("eDate.aDate_day", "03")
-
-        e.properties = request
-
-        assert e.eDate.aFile != null
-        assert e.eDate.aDate != null
-
-    }
-    void testBindingMapValue() {
-        def petClass = ga.getDomainClass('databindingtests.Pet')
-        def pet = petClass.newInstance()
-        pet.properties = [name: 'lemur', detailMap: [first: 'one', second: 'two'], owner: [name: 'Jeff'], foo: 'bar', bar: [a: 'a', b: 'b']]
-
-        assert pet.name == 'lemur'
-        assert pet.detailMap.first == 'one'
-        assert pet.detailMap.second == 'two'
-        assert !pet.hasErrors()
-    }
-
-    void testBindingNullToANullableDateThatAlreadyHasAValue() {
-        def c = ga.getControllerClass('databindingtests.TestController').newInstance()
-        def person = ga.getDomainClass('databindingtests.Person').newInstance()
-
-        def params = c.params
-        params.name = 'Douglas Adams'
-        params.birthDate_year = '1952'
-        params.birthDate_day = '11'
-        params.birthDate_month = '3'
-        params.birthDate = 'struct'
-
-        person.properties = params
-        assertEquals 'Douglas Adams', person.name
-        assertNotNull person.birthDate
-
-        params.name = 'Douglas Adams'
-        params.birthDate_year = ''
-        params.birthDate_day = ''
-        params.birthDate_month = ''
-        params.birthDate = 'struct'
-
-        person.properties = params
-        assertEquals 'Douglas Adams', person.name
-        assertNull person.birthDate
-    }
-
-    void testNamedBinding() {
-        def c = ga.getControllerClass('databindingtests.TestController').newInstance()
-        def author = ga.getDomainClass('databindingtests.Author').newInstance()
-
-        def params = c.params
-        params.name = 'Douglas Adams'
-        params.hairColour = 'Grey'
-
-        author.properties['name'] = params
-        assertEquals 'Douglas Adams', author.name
-        assertNull author.hairColour
-    }
-
-    void testNamedBindingWithMultipleProperties() {
-        def c = ga.getControllerClass('databindingtests.TestController').newInstance()
-        def author = ga.getDomainClass('databindingtests.Author').newInstance()
-
-        def params = c.params
-        params.name = 'Douglas Adams'
-        params.hairColour = 'Grey'
-
-        author.properties['name', 'hairColour'] = params
-        assertEquals 'Douglas Adams', author.name
-        assertEquals 'Grey', author.hairColour
-    }
-
-    void testThreeLevelDataBinding() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        def params = c.params
-        params.title = "The Stand"
-        params.author = [placeOfBirth: [name: 'Maine'], name: 'Stephen King']
-
-        b.properties = params
-
-        assertEquals "The Stand",b.title
-        assertEquals "Maine", b.author.placeOfBirth.name
-        assertEquals "Stephen King", b.author.name
-    }
-
-    void testConvertingBlankAndEmptyStringsToNull() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-        def a = ga.getDomainClass("databindingtests.Author").newInstance()
-
-        def params = c.params
-        params.name =  ''
-        params.hairColour = '  '
-
-        a.properties = params
-
-        assertNull a.name
-        assertNull a.hairColour
-    }
-
-    void testTypeConversionErrorsWithNestedAssociations() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        request.addParameter("author.name", "Stephen King")
-        request.addParameter("author.hairColour", "Black")
-
-        def params = c.params
-
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        b.properties = params
-
-        def a = b.author
-
-        assert !a.hasErrors()
-        assert !b.hasErrors()
-    }
-
-    void testTypeConversionErrors() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        request.addParameter("site", "not_a_valid_URL")
-
-        def params = c.params
-
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        b.properties = params
-
-        assert b.hasErrors()
-
-        def error = b.errors.getFieldError('site')
-    }
-
-    void testValidationAfterBindingFails() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        // binding should fail for this one
-        request.addParameter("someIntProperty", "foo")
-
-        // validation should fail for this one...
-        request.addParameter("someOtherIntProperty", "999")
-
-        // binding should fail for this one...
-        request.addParameter("thirdIntProperty", "bar")
-
-        request.addParameter("someFloatProperty", "21.12")
-
-        def params = c.params
-
-        def myBean = ga.getDomainClass("databindingtests.MyBean").newInstance()
-        addValidationMethods(myBean.class)
-
-        myBean.properties = params
-
-        assertEquals "wrong number of errors before validation", 2, myBean.errors.errorCount
-        assertFalse 'validation should have failed', myBean.validate()
-        assertEquals 'wrong number of errors after validation', 4, myBean.errors.errorCount
-    }
-
-    void testAssociationAutoCreation() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        request.addParameter("title", "The Stand")
-        request.addParameter("author.name", "Stephen King")
-
-        def params = c.params
-
-        assertEquals "The Stand", params.title
-
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        b.properties = params
-        assertEquals "The Stand", b.title
-        assertEquals "Stephen King", b.author?.name
-    }
-
-    void testNullAssociations() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        request.addParameter("title", "The Stand")
-        request.addParameter("author.id", "null")
-
-        def params = c.params
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        b.properties = params
-        assertEquals "Wrong 'title' property", "The Stand", b.title
-        assertNull "Expected null for property 'author'", b.author
-    }
-
-    void testAssociationsBinding() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        def authorClass = ga.getDomainClass("databindingtests.Author").getClazz()
-
-        authorClass.metaClass.static.get = { Serializable id ->
-            def result = authorClass.newInstance()
-            result.id = id as long
-            result.name = "Mocked ${id}"
-            result
-        }
-
-        request.addParameter("title", "The Stand")
-        request.addParameter("author.id", "5")
-
-        def params = c.params
-
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-
-        b.properties = params
-
-        assertEquals "Wrong 'title' property", "The Stand", b.title
-        assertNotNull "Association 'author' should be bound", b.author
-        assertEquals 5, b.author.id
-        assertEquals "Mocked 5", b.author.name
-    }
-
-    void testMultiDBinding() {
-        def c = ga.getControllerClass("databindingtests.TestController").newInstance()
-
-        request.addParameter("author.name", "Stephen King")
-        request.addParameter("author.hairColour", "Black")
-        request.addParameter("title", "The Stand")
-        def params = c.params
-
-        def a = ga.getDomainClass("databindingtests.Author").newInstance()
-
-        assertEquals "Stephen King",params['author'].name
-        a.properties = params['author']
-        assertEquals "Stephen King", a.name
-        assertEquals "Black", a.hairColour
-
-        def b = ga.getDomainClass("databindingtests.Book").newInstance()
-        b.properties = params
-        assertEquals "The Stand", b.title
-        assertEquals "Stephen King", b.author?.name
-    }
-}
-
-class Clown {
-    String name
-    String hairColour
 }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/converters/ConverterConfigurationTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/converters/ConverterConfigurationTests.groovy
@@ -2,37 +2,44 @@ package org.codehaus.groovy.grails.web.converters
 
 import grails.converters.JSON
 import grails.converters.XML
+import grails.persistence.Entity
+import grails.test.mixin.Mock
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
 
+import org.codehaus.groovy.grails.web.converters.marshaller.ClosureObjectMarshaller
 import org.codehaus.groovy.grails.web.converters.marshaller.json.DomainClassMarshaller as JsonClassMarshaller
 import org.codehaus.groovy.grails.web.converters.marshaller.xml.DomainClassMarshaller as XmlClassMarshaller
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
-import org.codehaus.groovy.grails.web.converters.marshaller.ClosureObjectMarshaller
+import org.junit.Test
+import static org.junit.Assert.assertEquals
 
 /**
  * Tests for the customizable Converter Configuration.
  *
  * @author Siegfried Puchbauer
  */
-class ConverterConfigurationTests extends AbstractGrailsControllerTests {
+@TestMixin(ControllerUnitTestMixin)
+@Mock(ConverterBook)
+class ConverterConfigurationTests {
 
+    @Test
     void testCustomClosureMarshallerRegistration() {
 
-        def bookClass = ga.getDomainClass("Book").clazz
-
-        JSON.registerObjectMarshaller(bookClass) {
+        JSON.registerObjectMarshaller(ConverterBook) {
             [id: it.id,
              title: it.title,
              foo: 'bar'
             ]
         }
 
-        def book = bookClass.newInstance()
+        def book = new ConverterBook()
         book.id = 4711
         book.title = "The Definitive Guide to Grails"
 
         assertEquals((book as JSON).toString(), """{"id":4711,"title":"The Definitive Guide to Grails","foo":"bar"}""")
     }
 
+    @Test
     void testDefaultConverterConfigurationObjectMarshallerRegistration() {
 
         JSON.registerObjectMarshaller(java.sql.Date) { it.toString() }
@@ -42,10 +49,11 @@ class ConverterConfigurationTests extends AbstractGrailsControllerTests {
         def objA = new java.sql.Date(System.currentTimeMillis())
         def objB = new java.sql.Time(System.currentTimeMillis())
 
-        assertEquals(([a:objA] as JSON).toString(), """{"a":"${objA}"}""")
-        assertEquals(([b:objB] as JSON).toString(), """{"b":"${objB}"}""")
+        assertEquals(([a:objA] as JSON).toString(), """{"a":"${objA}"}""".toString())
+        assertEquals(([b:objB] as JSON).toString(), """{"b":"${objB}"}""".toString())
     }
 
+    @Test
     void testMarshallerRegistrationOrder() {
 
         JSON.registerObjectMarshaller(Date) { "FAIL" }
@@ -55,17 +63,19 @@ class ConverterConfigurationTests extends AbstractGrailsControllerTests {
         assertEquals(([d: new Date()] as JSON).toString(), """{"d":"SUCCESS"}""")
     }
 
+    @Test
     void testMarshallerPriority() {
 
-        def om1 = new ClosureObjectMarshaller(Date, { "SUCCESS" })
-        def om2 = new ClosureObjectMarshaller(Date, { "FAIL" })
+        def om1 = new ClosureObjectMarshaller(ConverterWidget, { "SUCCESS" })
+        def om2 = new ClosureObjectMarshaller(ConverterWidget, { "FAIL" })
 
         JSON.registerObjectMarshaller(om1, 5)
         JSON.registerObjectMarshaller(om2, 3)
 
-        assertEquals(([d: new Date()] as JSON).toString(), """{"d":"SUCCESS"}""")
+        assertEquals(([d: new ConverterWidget()] as JSON).toString(), """{"d":"SUCCESS"}""")
     }
 
+    @Test
     void testNamedConfigurations() {
 
         JSON.registerObjectMarshaller(Date) { "DEFAULT" }
@@ -84,35 +94,37 @@ class ConverterConfigurationTests extends AbstractGrailsControllerTests {
         assertEquals((obj as JSON).toString(), """{"d":"DEFAULT"}""")
     }
 
+    @Test
     void testDomainWithVersionConfiguration() {
 
         JSON.createNamedConfig("with-version") {
-            it.registerObjectMarshaller(new JsonClassMarshaller(true, ga))
+            it.registerObjectMarshaller(new JsonClassMarshaller(true, grailsApplication))
         }
 
         XML.createNamedConfig("with-version") {
-            it.registerObjectMarshaller(new XmlClassMarshaller(true, ga))
+            it.registerObjectMarshaller(new XmlClassMarshaller(true, grailsApplication))
         }
 
         JSON.use("with-version") {
             assertEquals(
-                """{"class":"Book","id":4711,"version":0,"author":"Graeme Rocher","title":"The Definitive Guide to Grails"}""",
+                """{"class":"org.codehaus.groovy.grails.web.converters.ConverterBook","id":4711,"version":0,"author":"Graeme Rocher","title":"The Definitive Guide to Grails"}""",
                 (createBook() as JSON).toString())
         }
         XML.use("with-version") {
             assertEquals(
-                """<?xml version="1.0" encoding="UTF-8"?><book id="4711" version="0"><author>Graeme Rocher</author><title>The Definitive Guide to Grails</title></book>""",
+                """<?xml version="1.0" encoding="UTF-8"?><converterBook id="4711" version="0"><author>Graeme Rocher</author><title>The Definitive Guide to Grails</title></converterBook>""",
                 (createBook() as XML).toString())
         }
     }
 
+    @Test
     void testPrettyPrintConfiguration() {
 
         JSON.createNamedConfig("pretty-print") { cfg -> cfg.prettyPrint = true }
         XML.createNamedConfig("pretty-print") { cfg -> cfg.prettyPrint = true }
 
 def prettyJSON = """{
-  "class": "Book",
+  "class": "org.codehaus.groovy.grails.web.converters.ConverterBook",
   "id": 4711,
   "author": "Graeme Rocher",
   "title": "The Definitive Guide to Grails"
@@ -123,38 +135,33 @@ def prettyJSON = """{
         }
 
         def prettyXML = """<?xml version="1.0" encoding="UTF-8"?>
-<book id="4711">
+<converterBook id="4711">
   <author>
     Graeme Rocher
   </author>
   <title>
     The Definitive Guide to Grails
   </title>
-</book>"""
+</converterBook>"""
         XML.use("pretty-print") {
             assertEquals(prettyXML.replaceAll('[\r\n]', ''), (createBook() as XML).toString().replaceAll('[\r\n]', '').trim())
         }
     }
 
     protected createBook() {
-        def book = ga.getDomainClass("Book").clazz.newInstance()
+        def book = new ConverterBook()
         book.id = 4711
         book.version = 0
         book.title = "The Definitive Guide to Grails"
         book.author = "Graeme Rocher"
         book
     }
-
-    protected void onSetUp() {
-        gcl.parseClass """
-            @grails.persistence.Entity
-            class Book {
-               Long id
-               Long version
-               String title
-               String author
-
-            }
-        """
-    }
 }
+
+@Entity
+class ConverterBook {
+    String title
+    String author
+}
+
+class ConverterWidget{}

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingEvaluatorTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingEvaluatorTests.groovy
@@ -1,9 +1,14 @@
 package org.codehaus.groovy.grails.web.mapping
 
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
+
+import org.junit.Test
+import static org.junit.Assert.assertEquals
 import org.springframework.core.io.*
 
-class UrlMappingEvaluatorTests extends AbstractGrailsControllerTests {
+@TestMixin(ControllerUnitTestMixin)
+class UrlMappingEvaluatorTests  {
 
     def mappingScript = '''
 mappings {
@@ -41,6 +46,7 @@ mappings {
 }
 '''
 
+    @Test
     void testEvaluateMappings() {
         def res = new ByteArrayResource(mappingScript.bytes)
 

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingWithCustomValidatorTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingWithCustomValidatorTests.groovy
@@ -1,13 +1,17 @@
 package org.codehaus.groovy.grails.web.mapping
 
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
+
+import org.junit.Test
 import org.springframework.core.io.ByteArrayResource
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
 
 /**
  * @author Graeme Rocher
  * @since 1.0
  */
-class UrlMappingWithCustomValidatorTests extends AbstractGrailsControllerTests {
+@TestMixin(ControllerUnitTestMixin)
+class UrlMappingWithCustomValidatorTests {
 
     def topLevelMapping = '''
 mappings {
@@ -20,8 +24,7 @@ mappings {
 '''
     def UrlMappingsHolder holder
 
-    protected void setUp() {
-        super.setUp()
+    void setUp() {
         def res = new ByteArrayResource(topLevelMapping.bytes)
 
         def evaluator = new DefaultUrlMappingEvaluator(servletContext)
@@ -30,6 +33,7 @@ mappings {
         holder = new DefaultUrlMappingsHolder(mappings)
     }
 
+    @Test
     void testMatchWithCustomValidator() {
         def info = holder.match("/help/foo.html")
         assert info

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingsHolderTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/UrlMappingsHolderTests.groovy
@@ -1,10 +1,15 @@
 package org.codehaus.groovy.grails.web.mapping
 
-import org.codehaus.groovy.grails.validation.ConstrainedProperty;
-import org.springframework.core.io.*
-import org.codehaus.groovy.grails.web.servlet.mvc.*
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
 
-class UrlMappingsHolderTests extends AbstractGrailsControllerTests {
+import org.codehaus.groovy.grails.web.servlet.mvc.*
+import org.junit.Test
+import static org.junit.Assert.*
+import org.springframework.core.io.*
+
+@TestMixin(ControllerUnitTestMixin)
+class UrlMappingsHolderTests {
 
     def mappingScript = '''
 mappings {
@@ -51,10 +56,11 @@ mappings {
 }
 '''
 
+    @Test
     void testGetReverseMappingWithNamedArgsAndClosure() {
         def res = new ByteArrayResource(mappingWithNamedArgsAndClosure.bytes)
 
-        def evaluator = new DefaultUrlMappingEvaluator(appCtx)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
         def mappings = evaluator.evaluateMappings(res)
 
         def holder = new DefaultUrlMappingsHolder(mappings)
@@ -66,27 +72,27 @@ mappings {
         assertEquals "/author/Winter/Johnny", m.createURL(params, "utf-8")
     }
 
+    @Test
     void testGetReverseMappingWithNamedArgs() {
-        runTest {
-            def res = new ByteArrayResource(mappingWithNamedArgs.bytes)
+        def res = new ByteArrayResource(mappingWithNamedArgs.bytes)
 
-            def evaluator = new DefaultUrlMappingEvaluator(appCtx)
-            def mappings = evaluator.evaluateMappings(res)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
+        def mappings = evaluator.evaluateMappings(res)
 
-            def holder = new DefaultUrlMappingsHolder(mappings)
+        def holder = new DefaultUrlMappingsHolder(mappings)
 
-            def params = [lastName:'Winter', firstName:'Johnny']
-            def m = holder.getReverseMapping("product", "show", params)
-            assertNotNull "getReverseMapping returned null", m
+        def params = [lastName:'Winter', firstName:'Johnny']
+        def m = holder.getReverseMapping("product", "show", params)
+        assertNotNull "getReverseMapping returned null", m
 
-            assertEquals "/author/Winter/Johnny", m.createURL(params, "utf-8")
-        }
+        assertEquals "/author/Winter/Johnny", m.createURL(params, "utf-8")
     }
 
+    @Test
     void testGetReverseMappingWithExcessArgs() {
         def res = new ByteArrayResource(mappingScript.bytes)
 
-        def evaluator = new DefaultUrlMappingEvaluator(appCtx)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
         def mappings = evaluator.evaluateMappings(res)
 
         def holder = new DefaultUrlMappingsHolder(mappings)
@@ -101,9 +107,10 @@ mappings {
         assertEquals("/blog/foo/2007/3/17?some=other", url)
     }
 
+    @Test
     void testGetReverseMappingWithVariables() {
         def res = new ByteArrayResource(mappingScript2.bytes)
-        def evaluator = new DefaultUrlMappingEvaluator(appCtx)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
         def mappings = evaluator.evaluateMappings(res)
 
         def holder = new DefaultUrlMappingsHolder(mappings)
@@ -125,60 +132,58 @@ mappings {
         assertEquals "/specific/test", m.createURL(controller:"someController", action:"test", "utf-8")
     }
 
+    @Test
     void testGetReverseMappingWithFewerArgs() {
-        runTest {
-            def res = new ByteArrayResource(mappingScript.bytes)
+        def res = new ByteArrayResource(mappingScript.bytes)
 
-            def evaluator = new DefaultUrlMappingEvaluator(appCtx)
-            def mappings = evaluator.evaluateMappings(res)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
+        def mappings = evaluator.evaluateMappings(res)
 
-            // use un-cached holder for testing
-            def holder = new DefaultUrlMappingsHolder(mappings,null,true)
-            holder.setUrlCreatorMaxWeightedCacheCapacity(0)
-            holder.initialize()
+        // use un-cached holder for testing
+        def holder = new DefaultUrlMappingsHolder(mappings,null,true)
+        holder.setUrlCreatorMaxWeightedCacheCapacity(0)
+        holder.initialize()
 
-            // test with fewer arguments
-            def m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007])
+        // test with fewer arguments
+        def m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007])
 
-            assert m
-            assertEquals "blog", m.controllerName
-            assertEquals "show", m.actionName
-        }
+        assert m
+        assertEquals "blog", m.controllerName
+        assertEquals "show", m.actionName
     }
 
+    @Test
     void testGetReverseMappingWithExactArgs() {
-        runTest {
-            def res = new ByteArrayResource(mappingScript.bytes)
+        def res = new ByteArrayResource(mappingScript.bytes)
 
-            def evaluator = new DefaultUrlMappingEvaluator(appCtx)
-            def mappings = evaluator.evaluateMappings(res)
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
+        def mappings = evaluator.evaluateMappings(res)
 
-            // use un-cached holder for testing
-            def holder = new DefaultUrlMappingsHolder(mappings,null,true)
-            holder.setUrlCreatorMaxWeightedCacheCapacity(0)
-            holder.initialize()
+        // use un-cached holder for testing
+        def holder = new DefaultUrlMappingsHolder(mappings,null,true)
+        holder.setUrlCreatorMaxWeightedCacheCapacity(0)
+        holder.initialize()
 
-            // test with exact argument match
-            def m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007, month:3, day:17])
+        // test with exact argument match
+        def m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007, month:3, day:17])
 
-            assert m
-            assertEquals "blog", m.controllerName
-            assertEquals "show", m.actionName
-            assertEquals("/blog/foo/2007/3/17?test=test", m.createURL([controller:"blog",action:"show",entry:"foo",year:2007,month:3,day:17,test:'test'], "utf-8"))
+        assert m
+        assertEquals "blog", m.controllerName
+        assertEquals "show", m.actionName
+        assertEquals("/blog/foo/2007/3/17?test=test", m.createURL([controller:"blog",action:"show",entry:"foo",year:2007,month:3,day:17,test:'test'], "utf-8"))
 
-            // test with fewer arguments
-            m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007])
+        // test with fewer arguments
+        m = holder.getReverseMapping("blog", "show", [entry:"foo", year:2007])
 
-            assert m
-            assertEquals "blog", m.controllerName
-            assertEquals "show", m.actionName
+        assert m
+        assertEquals "blog", m.controllerName
+        assertEquals "show", m.actionName
 
-            m = holder.getReverseMapping("book", null, [author:"dierk", title:"GINA", test:3])
-            assert m
-            assertEquals "book", m.controllerName
+        m = holder.getReverseMapping("book", null, [author:"dierk", title:"GINA", test:3])
+        assert m
+        assertEquals "book", m.controllerName
 
-            m = holder.getReverseMapping(null, null, [:])
-            assert m
-        }
+        m = holder.getReverseMapping(null, null, [:])
+        assert m
     }
 }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/ViewUrlMappingTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/ViewUrlMappingTests.groovy
@@ -1,12 +1,17 @@
 package org.codehaus.groovy.grails.web.mapping
 
+import grails.test.mixin.TestMixin
+import grails.test.mixin.web.ControllerUnitTestMixin
+
+import org.junit.Test
+import static org.junit.Assert.*
 import org.springframework.core.io.ByteArrayResource
-import org.codehaus.groovy.grails.web.servlet.mvc.AbstractGrailsControllerTests
 
 /**
  * @author mike
  */
-class ViewUrlMappingTests extends AbstractGrailsControllerTests {
+@TestMixin(ControllerUnitTestMixin)
+class ViewUrlMappingTests  {
 
     def topLevelMapping = '''
 mappings {
@@ -19,8 +24,7 @@ mappings {
 '''
     def UrlMappingsHolder holder
 
-    protected void setUp() {
-        super.setUp()
+    void setUp() {
         def res = new ByteArrayResource(topLevelMapping.bytes)
 
         def evaluator = new DefaultUrlMappingEvaluator(servletContext)
@@ -29,10 +33,12 @@ mappings {
         holder = new DefaultUrlMappingsHolder(mappings)
     }
 
+    @Test
     void testParse() {
         assertNotNull holder
     }
 
+    @Test
     void testMatch() {
         UrlMappingInfo info = holder.match("/book/joyce/ullisses")
 
@@ -40,6 +46,7 @@ mappings {
         assertEquals "book.gsp", info.getViewName()
     }
 
+    @Test
     void testMatch2() {
         UrlMappingInfo info = holder.match("/book2/foo")
 
@@ -47,6 +54,7 @@ mappings {
         assertEquals "book.gsp", info.getViewName()
     }
 
+    @Test
     void testMatchToControllerAndView() {
         UrlMappingInfo info = holder.match("/book3")
 


### PR DESCRIPTION
Grails tries to resolve all dependencies - even those that are excluded. In this example, a dependency is being excluded and that excluded dependency isn't available anywhere. Since it's excluded, Grails shouldn't try to retrieve it, yet it does anyways. Since it can't find the dependency, it errors out.

See https://jira.grails.org/browse/GPRELEASE-59
https://groups.google.com/d/msg/grails-dev-discuss/CGFyXd7CgmY/c_J0beqc7rQJ
