### PR TITLE
Excluded artifacts are resolved resulting errors if they're not available

### DIFF
--- a/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/AetherExcludeResolver.groovy
+++ b/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/AetherExcludeResolver.groovy
@@ -42,7 +42,11 @@ class AetherExcludeResolver implements ExcludeResolver {
         for (Dependency d in applicationDependencies) {
             newDependencyManager.parseDependencies {
                 delegate.dependencies {
-                    compile "$d.group:$d.name:$d.version"
+                    compile "$d.group:$d.name:$d.version", {
+                        if(d.excludeArray){
+                            excludes d.excludeArray
+                        }
+                    }
                 }
             }
         }

--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
@@ -59,6 +59,27 @@ class AetherDependencyManagerSpec extends Specification {
 
     }
 
+    @Issue('GPRELEASE-59')
+    void "Test that an excluded dependency that isn't available is excluded"() {
+        given:"A dependency with an exclusion of an unavailable artifact"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    compile('com.octo.captcha:jcaptcha:1.0') {
+                        excludes 'javax.servlet:servlet-api', 'com.jhlabs:imaging'
+                    }
+                }
+            }
+
+        when:"The dependency is resolved"
+            def compileFiles = dependencyManager.resolve('compile').allArtifacts
+        then:"The transitive dependency is excluded"
+            !compileFiles.any { File f -> f.name.contains('imaging')}
+    }
+
     @Issue('GRAILS-11055')
     void "Test that a transitive dependency excluded with the map syntax is actually excluded"() {
         given:"A dependency with an exclusion"

--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherExcludeResolverSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherExcludeResolverSpec.groovy
@@ -19,6 +19,7 @@ import org.codehaus.groovy.grails.resolve.Dependency
 import org.codehaus.groovy.grails.resolve.maven.aether.AetherDependencyManager
 import org.codehaus.groovy.grails.resolve.maven.aether.AetherExcludeResolver
 import spock.lang.Specification
+import spock.lang.Issue
 
 /**
  * @author Graeme Rocher
@@ -48,5 +49,33 @@ class AetherExcludeResolverSpec extends Specification{
         validatorExcludes.size() == 3
         validatorExcludes.find { Dependency d -> d.name == 'commons-beanutils'}
 
+    }
+
+    @Issue('GPRELEASE-59')
+    void "Test that an excluded dependency that isn't available is excluded"() {
+        given:"A dependency with an exclusion of an unavailable artifact"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                }
+                dependencies {
+                    compile('com.octo.captcha:jcaptcha:1.0') {
+                        excludes 'javax.servlet:servlet-api', 'com.jhlabs:imaging'
+                    }
+                }
+            }
+        def excludeResolver = new AetherExcludeResolver(dependencyManager)
+
+        when:"The excludes are resolved"
+        final excludes = excludeResolver.resolveExcludes()
+        def validatorExcludes = !excludes.isEmpty() ? excludes.values().iterator().next() : null
+
+        then:"They are valid"
+        !excludes.isEmpty()
+        validatorExcludes.size() == 3
+        validatorExcludes.find { Dependency d -> d.name == 'commons-collections'}
+        validatorExcludes.find { Dependency d -> d.name == 'commons-logging'}
+        validatorExcludes.find { Dependency d -> d.name == 'jcaptcha-api'}
     }
 }


### PR DESCRIPTION
Grails tries to resolve all dependencies - even those that are excluded. In this example, a dependency is being excluded and that excluded dependency isn't available anywhere. Since it's excluded, Grails shouldn't try to retrieve it, yet it does anyways. Since it can't find the dependency, it errors out.

See https://jira.grails.org/browse/GPRELEASE-59
https://groups.google.com/d/msg/grails-dev-discuss/CGFyXd7CgmY/c_J0beqc7rQJ
