### PR TITLE
Fix Java 7 WatchService implementation of DirectoryWatcher

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
@@ -32,10 +32,9 @@ import org.springframework.util.StringUtils;
  */
 public class DirectoryWatcher extends Thread {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DirectoryWatcher.class);
-    public static final String ENABLE_JAVA7_WATCH_SERVICE = "enable.java7.watchService";
+	private static final Logger LOG = LoggerFactory.getLogger(DirectoryWatcher.class);
 
-    private final AbstractDirectoryWatcher directoryWatcherDelegate;
+	private final AbstractDirectoryWatcher directoryWatcherDelegate;
 
     public static final String SVN_DIR_NAME = ".svn";
 
@@ -45,17 +44,12 @@ public class DirectoryWatcher extends Thread {
     public DirectoryWatcher() {
         setDaemon(true);
         AbstractDirectoryWatcher directoryWatcherDelegate;
-        if(Boolean.getBoolean(ENABLE_JAVA7_WATCH_SERVICE)) {
-            try {
-                directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.codehaus.groovy.grails.compiler.WatchServiceDirectoryWatcher").newInstance();
-            } catch (Exception e) {
-                LOG.info("Exception while trying to load WatchServiceDirectoryWatcher (this is probably Java 6 and WatchService isn't available). Falling back to PollingDirectoryWatcher.", e);
-                directoryWatcherDelegate = new PollingDirectoryWatcher();
-            }
-        }
-        else {
-            directoryWatcherDelegate = new PollingDirectoryWatcher();
-        }
+        try {
+			directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.codehaus.groovy.grails.compiler.WatchServiceDirectoryWatcher").newInstance();
+		} catch (Exception e) {
+			LOG.info("Exception while trying to load WatchServiceDirectoryWatcher (this is probably Java 6 and WatchService isn't available). Falling back to PollingDirectoryWatcher.", e);
+	        directoryWatcherDelegate = new PollingDirectoryWatcher();
+		}
         this.directoryWatcherDelegate = directoryWatcherDelegate;
     }
 

--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/WatchServiceDirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/WatchServiceDirectoryWatcher.java
@@ -13,6 +13,8 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -146,7 +148,14 @@ class WatchServiceDirectoryWatcher extends AbstractDirectoryWatcher {
 	            		return FileVisitResult.SKIP_SUBTREE;
 	            	}
 	    			WatchKey watchKey = dir.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY);
-	    			watchKeyToExtensionsMap.put(watchKey, fileExtensions);
+	    			final List<String> originalFileExtensions = watchKeyToExtensionsMap.get(watchKey);
+	    			if(originalFileExtensions==null){
+	    				watchKeyToExtensionsMap.put(watchKey, fileExtensions);
+	    			}else{
+	    				final HashSet<String> newFileExtensions = new HashSet<String>(originalFileExtensions);
+	    				newFileExtensions.addAll(fileExtensions);
+	    				watchKeyToExtensionsMap.put(watchKey, Collections.unmodifiableList(new ArrayList(newFileExtensions)));
+	    			}
 	                return FileVisitResult.CONTINUE;
 	            }
 	        });


### PR DESCRIPTION
The same WatchKey can be reused in a WatchService. When that happens, add on to (instead of replace) the file extensions associated with that WatchKey.

This pull request fixes the issue reported by @graemerocher at https://github.com/grails/grails-core/pull/477#issuecomment-42521225
