### PR TITLE
Catch Throwable when trying to get WatchServiceDirectoryWatcher

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/compiler/DirectoryWatcher.java
@@ -46,7 +46,7 @@ public class DirectoryWatcher extends Thread {
         AbstractDirectoryWatcher directoryWatcherDelegate;
         try {
 			directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.codehaus.groovy.grails.compiler.WatchServiceDirectoryWatcher").newInstance();
-		} catch (Exception e) {
+		} catch (Throwable e) {
 			LOG.info("Exception while trying to load WatchServiceDirectoryWatcher (this is probably Java 6 and WatchService isn't available). Falling back to PollingDirectoryWatcher.", e);
 	        directoryWatcherDelegate = new PollingDirectoryWatcher();
 		}


### PR DESCRIPTION
Catch Throwable (not just Exception) when trying to get WatchServiceDirectoryWatcher. IBM Java, at least, throws an Error (which does not extend Exception) which isn't caught.
