### PR TITLE
GRAILS-11116 Custom marshaller registrar bean does not work

### DIFF
--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/plugins/converters/ConvertersGrailsPlugin.groovy
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/plugins/converters/ConvertersGrailsPlugin.groovy
@@ -18,7 +18,6 @@ package org.codehaus.groovy.grails.plugins.converters
 import grails.converters.JSON
 import grails.converters.XML
 import grails.util.GrailsUtil
-
 import org.codehaus.groovy.grails.plugins.converters.api.ConvertersControllersApi
 import org.codehaus.groovy.grails.web.converters.configuration.ConvertersConfigurationInitializer
 import org.codehaus.groovy.grails.web.converters.configuration.ObjectMarshallerRegisterer
@@ -53,7 +52,6 @@ class ConvertersGrailsPlugin {
         xmlErrorsMarshaller(XmlErrorsMarshaller)
 
         convertersConfigurationInitializer(ConvertersConfigurationInitializer) { bean ->
-            grailsApplication = ref('grailsApplication')
             bean.initMethod = 'init'
         }
 

--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/plugins/converters/ConvertersGrailsPlugin.groovy
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/plugins/converters/ConvertersGrailsPlugin.groovy
@@ -52,7 +52,10 @@ class ConvertersGrailsPlugin {
 
         xmlErrorsMarshaller(XmlErrorsMarshaller)
 
-        convertersConfigurationInitializer(ConvertersConfigurationInitializer)
+        convertersConfigurationInitializer(ConvertersConfigurationInitializer) { bean ->
+            grailsApplication = ref('grailsApplication')
+            bean.initMethod = 'init'
+        }
 
         errorsXmlMarshallerRegisterer(ObjectMarshallerRegisterer) {
             marshaller = { XmlErrorsMarshaller om -> }
@@ -68,8 +71,6 @@ class ConvertersGrailsPlugin {
     }
 
     def doWithDynamicMethods = {applicationContext ->
-
-        applicationContext.convertersConfigurationInitializer.initialize(application)
 
         ConvertersPluginSupport.enhanceApplication(application, applicationContext)
 

--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.cfg.GrailsConfig;
+import org.codehaus.groovy.grails.plugins.converters.ConvertersPluginSupport;
 import org.codehaus.groovy.grails.support.proxy.DefaultProxyHandler;
 import org.codehaus.groovy.grails.support.proxy.ProxyHandler;
 import org.codehaus.groovy.grails.web.converters.Converter;
@@ -42,12 +43,18 @@ public class ConvertersConfigurationInitializer implements ApplicationContextAwa
 
     private ApplicationContext applicationContext;
 
+    private GrailsApplication grailsApplication;
+
     public ApplicationContext getApplicationContext() {
         return applicationContext;
     }
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    public void setGrailsApplication(GrailsApplication grailsApplication) {
+        this.grailsApplication = grailsApplication;
     }
 
     public final Log LOG = LogFactory.getLog(ConvertersConfigurationInitializer.class);
@@ -58,6 +65,13 @@ public class ConvertersConfigurationInitializer implements ApplicationContextAwa
         initXMLConfiguration(application);
         initDeepJSONConfiguration(application);
         initDeepXMLConfiguration(application);
+    }
+
+    /**
+     * Init method for spring bean creation process
+     */
+    public void init() {
+        initialize(grailsApplication);
     }
 
     private void initJSONConfiguration(GrailsApplication application) {

--- a/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
+++ b/grails-plugin-converters/src/main/groovy/org/codehaus/groovy/grails/web/converters/configuration/ConvertersConfigurationInitializer.java
@@ -17,16 +17,11 @@ package org.codehaus.groovy.grails.web.converters.configuration;
 
 import grails.converters.JSON;
 import grails.converters.XML;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.codehaus.groovy.grails.commons.GrailsApplication;
 import org.codehaus.groovy.grails.commons.cfg.GrailsConfig;
-import org.codehaus.groovy.grails.plugins.converters.ConvertersPluginSupport;
+import org.codehaus.groovy.grails.plugins.support.aware.GrailsApplicationAware;
 import org.codehaus.groovy.grails.support.proxy.DefaultProxyHandler;
 import org.codehaus.groovy.grails.support.proxy.ProxyHandler;
 import org.codehaus.groovy.grails.web.converters.Converter;
@@ -35,11 +30,15 @@ import org.codehaus.groovy.grails.web.converters.marshaller.ProxyUnwrappingMarsh
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author Siegfried Puchbauer
  * @since 1.1
  */
-public class ConvertersConfigurationInitializer implements ApplicationContextAware {
+public class ConvertersConfigurationInitializer implements ApplicationContextAware, GrailsApplicationAware {
 
     private ApplicationContext applicationContext;
 


### PR DESCRIPTION
This is the final attempt to fix this bug. This time instead of trying to change the logic of ConvertersConfigurationIntializer we ensure that initialization is done right after the given bean is initialized by the plugin. Previously it assumed that there wont be any marshaller registered before the initialize method is called in doWithDynamicMethods event hook.

All tests passed this time :)
