### PR TITLE
grails clean deletes the exploded war directory as well

### DIFF
--- a/grails-project-api/src/main/groovy/org/codehaus/groovy/grails/project/creation/GrailsProjectCleaner.groovy
+++ b/grails-project-api/src/main/groovy/org/codehaus/groovy/grails/project/creation/GrailsProjectCleaner.groovy
@@ -18,7 +18,6 @@ package org.codehaus.groovy.grails.project.creation
 import grails.build.logging.GrailsConsole
 import grails.util.BuildSettings
 import groovy.transform.CompileStatic
-
 import org.codehaus.groovy.grails.cli.api.BaseSettingsApi
 import org.codehaus.groovy.grails.cli.logging.GrailsConsoleAntBuilder
 import org.codehaus.groovy.grails.cli.support.GrailsBuildEventListener
@@ -32,10 +31,12 @@ import org.codehaus.groovy.grails.cli.support.GrailsBuildEventListener
 
 class GrailsProjectCleaner extends BaseSettingsApi {
     private static final GrailsConsole CONSOLE  = GrailsConsole.getInstance()
+    private File stagingDir
 
     AntBuilder ant
     GrailsProjectCleaner(BuildSettings settings, GrailsBuildEventListener buildEventListener) {
         super(settings, buildEventListener, false)
+        stagingDir = settings.projectWarExplodedDir
     }
 
     @CompileStatic
@@ -79,6 +80,7 @@ class GrailsProjectCleaner extends BaseSettingsApi {
 
         cleanCompiledSources()
         cleanWarFile()
+        cleanExplodedWar()
 
         if (triggerEvents) {
             buildEventListener.triggerEvent("CleanEnd")
@@ -159,8 +161,18 @@ class GrailsProjectCleaner extends BaseSettingsApi {
         if (triggerEvents) {
             buildEventListener.triggerEvent("CleanWarFileEnd")
         }
+    }
 
+    void cleanExplodedWar(boolean triggerEvents = true) {
+        if (triggerEvents) {
+            buildEventListener.triggerEvent("CleanExplodedWarStart")
+        }
+
+        AntBuilder ant = getAnt()
+        ant.delete(dir: stagingDir, failonerror: false)
+
+        if (triggerEvents) {
+            buildEventListener.triggerEvent("CleanExplodedWarEnd")
+        }
     }
 }
-
-

--- a/grails-project-api/src/test/groovy/org/codehaus/groovy/grails/project/creation/GrailsProjectCleanerSpec.groovy
+++ b/grails-project-api/src/test/groovy/org/codehaus/groovy/grails/project/creation/GrailsProjectCleanerSpec.groovy
@@ -1,0 +1,47 @@
+package org.codehaus.groovy.grails.project.creation
+
+import grails.util.BuildSettings
+import org.codehaus.groovy.grails.cli.logging.GrailsConsoleAntBuilder
+import org.codehaus.groovy.grails.cli.support.GrailsBuildEventListener
+import spock.lang.Specification
+
+class GrailsProjectCleanerSpec extends Specification {
+
+    private static STAGING_DIR = new File('/staging/dir')
+
+    private grailsAntMock,
+            buildSettingsMock,
+            listenerMock,
+            grailsProjectCleaner
+
+    def setup() {
+        grailsAntMock = GroovyMock(GrailsConsoleAntBuilder)
+        buildSettingsMock = new BuildSettings()
+        listenerMock = Stub(GrailsBuildEventListener)
+    }
+
+    def 'test that exploded war is deleted'() {
+        given:
+        grailsProjectCleaner = new GrailsProjectCleaner(buildSettingsMock, listenerMock)
+        grailsProjectCleaner.ant = grailsAntMock
+
+        when:
+        grailsProjectCleaner.cleanExplodedWar()
+
+        then:
+        1 * grailsAntMock.delete(_)
+    }
+
+    def 'test that exploded war directory is used'() {
+        given:
+        buildSettingsMock.projectWarExplodedDir = STAGING_DIR
+        grailsProjectCleaner = new GrailsProjectCleaner(buildSettingsMock, listenerMock)
+        grailsProjectCleaner.ant = grailsAntMock
+
+        when:
+        grailsProjectCleaner.cleanExplodedWar()
+
+        then:
+        1 * grailsAntMock.delete({ it.dir == STAGING_DIR })
+    }
+}

--- a/grails-scripts/src/main/scripts/_GrailsClean.groovy
+++ b/grails-scripts/src/main/scripts/_GrailsClean.groovy
@@ -57,3 +57,7 @@ target (cleanTestReports: "Cleans the test reports") {
 target (cleanWarFile: "Cleans the deployable .war file") {
     projectCleaner.cleanWarFile(false)
 }
+
+target (cleanExplodedWar: "Cleans the exploded .war directory") {
+    projectCleaner.cleanExplodedWar(false)
+}


### PR DESCRIPTION
Since version 1.1.1 https://jira.grails.org/browse/GRAILS-3443 it's possible to keep the exploded WAR directory as the final artifact after `grails war`. But unfortunately there is not way to delete this exploded war directory using `grails clean`. This may cause that already deleted files eventually being deployed, because they never get deleted in the exploded war directory.

This pull request adds the missing functionality to `grails clean`.
