### PR TITLE
Fix broken travis ci build

### DIFF
--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -43,7 +43,6 @@ dependencies {
         exclude group: 'javassist', module: 'javassist'
     }
 
-
     // Required for tag library support
     testCompile 'taglibs:standard:1.1.2'
     testCompile "javax.servlet:jstl:1.1.2"
@@ -61,61 +60,54 @@ compileTestGroovy {
     groovyOptions.listFiles = true
 }
 
-test {
-    maxParallelForks = 2
+def parallelTestConfig = {
+    maxParallelForks = 2 // Travis provides only 2 cores
     forkEvery = 30
-    jvmArgs = ['-Xmx768M','-XX:MaxPermSize=192m']
-    excludes = ["**/*TestCase.class",
-                "**/*\$*.class",
-                "**/ContentFormatControllerTests.class",
-                "**/JSONBindingTests.class",
-                "**/AutoParams*MarshallingTests.class",
-                "**/JSONBindingToNullTests.class",
-                "**/ControllerWithXmlConvertersTests.class",
-                "**/GroovyPageAttributesTests.class",
-                "**/BindingExcludeTests.class",
-                "**/NestedXmlBindingTests.class",
-		"**/GSPResponseWriterSpec.class",
-		"**/RespondMethodSpec.class",
-        "**/ContentNegotiationSpec.class",
-        "**/pages/ext/jsp/*.class"]
+    jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
 }
 
-task isolatedTestsOne(type:Test) {
-    includes = ["**/ContentFormatControllerTests.class"]
-}
-task isolatedTestsTwo(type:Test) {
-    includes = ["**/JSONBindingTests.class",
-                "**/AutoParams*MarshallingTests.class",
-                "**/ContentNegotiationSpec.class",
-                "**/pages/ext/jsp/*.class"]
-}
-task isolatedTestsThree(type:Test) {
-    includes = ["**/JSONBindingToNullTests.class",
-                "**/ControllerWithXmlConvertersTests.class"]
-}
-task isolatedTestsFour(type:Test) {
-    includes = ["**/BindingExcludeTests.class"]
-}
-task isolatedTestsFive(type:Test) {
-    includes = ["**/GroovyPageAttributesTests.class"]
-}
-task isolatedTestsSix(type:Test) {
-    includes = ["**/NestedXmlBindingTests.class"]
-}
-task isolatedTestsSeven(type:Test) {
-    maxParallelForks = 1
-    includes = ["**/GSPResponseWriterSpec.class"]
-}
-task isolatedRespondMethodTests(type:Test) {
-    maxParallelForks = 1
-    includes = ["**/RespondMethodSpec.class"]
-}
-test.dependsOn isolatedTestsOne, isolatedTestsTwo, isolatedTestsThree, isolatedTestsFour, isolatedTestsFive, isolatedTestsSix, isolatedTestsSeven, isolatedRespondMethodTests
+def excludedTestClasses = ["**/*TestCase.class",
+                           "**/*\$*.class"]
+def testsToBeExecutedInIsolation = ["**/ContentFormatControllerTests.class",
+                                    "**/JSONBindingTests.class",
+                                    "**/AutoParams*MarshallingTests.class",
+                                    "**/JSONBindingToNullTests.class",
+                                    "**/ControllerWithXmlConvertersTests.class",
+                                    "**/GroovyPageAttributesTests.class",
+                                    "**/BindingExcludeTests.class",
+                                    "**/NestedXmlBindingTests.class",
+                                    "**/GSPResponseWriterSpec.class",
+                                    "**/RespondMethodSpec.class",
+                                    "**/ContentNegotiationSpec.class",
+                                    "**/pages/ext/jsp/*.class"]
 
-/*
 test {
-	jvmArgs '-Xmx1024m', '-Xdebug', '-Xnoagent', '-Dgrails.full.stacktrace=true', '-Djava.compiler=NONE',
-	        '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+    configure parallelTestConfig
+    excludes = ["grails/", "org/grails/", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
 }
-*/
+
+task execGrailsPackageTests(type: Test) {
+    configure parallelTestConfig
+    excludes = testsToBeExecutedInIsolation + excludedTestClasses
+    includes = ["grails/"]
+}
+
+task execOrgGrailsPackageTests(type: Test) {
+    configure parallelTestConfig
+    excludes = testsToBeExecutedInIsolation + excludedTestClasses
+    includes = ["org/grails/"]
+}
+
+task execOrgCodehausPackageTests(type: Test) {
+    configure parallelTestConfig
+    excludes = testsToBeExecutedInIsolation + excludedTestClasses
+    includes = ["org/codehaus/"]
+}
+
+task execIsolatedTests(type: Test) {
+    forkEvery = 1
+    excludes = excludedTestClasses
+    includes = testsToBeExecutedInIsolation
+}
+
+test.dependsOn execGrailsPackageTests, execOrgGrailsPackageTests, execOrgCodehausPackageTests, execIsolatedTests

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -62,9 +62,9 @@ compileTestGroovy {
 }
 
 test {
-    maxParallelForks = 4
+    maxParallelForks = 2
     forkEvery = 30
-    jvmArgs = ['-Xmx1024M','-XX:MaxPermSize=192m']
+    jvmArgs = ['-Xmx768M','-XX:MaxPermSize=192m']
     excludes = ["**/*TestCase.class",
                 "**/*\$*.class",
                 "**/ContentFormatControllerTests.class",

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -83,7 +83,7 @@ def testsToBeExecutedInIsolation = ["**/ContentFormatControllerTests.class",
 
 test {
     configure parallelTestConfig
-    excludes = ["grails/", "org/grails/", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
+    excludes = ["grails/", "org/grails/web", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
 }
 
 task execGrailsPackageTests(type: Test) {
@@ -92,10 +92,10 @@ task execGrailsPackageTests(type: Test) {
     includes = ["grails/"]
 }
 
-task execOrgGrailsPackageTests(type: Test) {
+task execOrgGrailsWebPackageTests(type: Test) {
     configure parallelTestConfig
     excludes = testsToBeExecutedInIsolation + excludedTestClasses
-    includes = ["org/grails/"]
+    includes = ["org/grails/web"]
 }
 
 task execOrgCodehausPackageTests(type: Test) {
@@ -110,4 +110,4 @@ task execIsolatedTests(type: Test) {
     includes = testsToBeExecutedInIsolation
 }
 
-test.dependsOn execGrailsPackageTests, execOrgGrailsPackageTests, execOrgCodehausPackageTests, execIsolatedTests
+test.dependsOn execGrailsPackageTests, execOrgGrailsWebPackageTests, execOrgCodehausPackageTests, execIsolatedTests

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -62,11 +62,10 @@ compileTestGroovy {
 
 ext {
     isTravisRun = System.getenv().get("TRAVIS")
-    maxParallelForks = Math.max(2, (int) (Runtime.runtime.availableProcessors() / 2))
 }
 
 def defaultTestConfig = {
-    maxParallelForks = maxParallelForks
+    maxParallelForks = 2
     forkEvery = 30
     jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
     if (isTravisRun) {

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -66,7 +66,7 @@ ext {
 
 def defaultTestConfig = {
     maxParallelForks = 2
-    forkEvery = 30
+    forkEvery = 10
     jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
     if (isTravisRun) {
         afterSuite {

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -83,7 +83,7 @@ def testsToBeExecutedInIsolation = ["**/ContentFormatControllerTests.class",
 
 test {
     configure parallelTestConfig
-    excludes = ["grails/", "org/grails/web", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
+    excludes = ["grails/", "org/grails/web/taglib/", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
 }
 
 task execGrailsPackageTests(type: Test) {
@@ -92,10 +92,10 @@ task execGrailsPackageTests(type: Test) {
     includes = ["grails/"]
 }
 
-task execOrgGrailsWebPackageTests(type: Test) {
+task execOrgGrailsWebTaglibPackageTests(type: Test) {
     configure parallelTestConfig
     excludes = testsToBeExecutedInIsolation + excludedTestClasses
-    includes = ["org/grails/web"]
+    includes = ["org/grails/web/taglib/"]
 }
 
 task execOrgCodehausPackageTests(type: Test) {
@@ -110,4 +110,4 @@ task execIsolatedTests(type: Test) {
     includes = testsToBeExecutedInIsolation
 }
 
-test.dependsOn execGrailsPackageTests, execOrgGrailsWebPackageTests, execOrgCodehausPackageTests, execIsolatedTests
+test.dependsOn execGrailsPackageTests, execOrgGrailsWebTaglibPackageTests, execOrgCodehausPackageTests, execIsolatedTests

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -62,10 +62,11 @@ compileTestGroovy {
 
 ext {
     isTravisRun = System.getenv().get("TRAVIS")
+    maxParallelForks = Math.max(2, (int) (Runtime.runtime.availableProcessors() / 2))
 }
 
 def defaultTestConfig = {
-    maxParallelForks = 2
+    maxParallelForks = maxParallelForks
     forkEvery = 30
     jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
     if (isTravisRun) {

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -69,7 +69,10 @@ def defaultTestConfig = {
     forkEvery = 30
     jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
     if (isTravisRun) {
-        afterTest { descriptor, result -> println "${descriptor.className}.${descriptor.name}: ${result.resultType}" }
+        afterSuite {
+            System.out << '.'
+            System.out.flush()
+        }
     }
 }
 

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -62,52 +62,45 @@ compileTestGroovy {
 
 def parallelTestConfig = {
     maxParallelForks = 2 // Travis provides only 2 cores
-    forkEvery = 30
+    forkEvery = 10
     jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
 }
 
-def excludedTestClasses = ["**/*TestCase.class",
-                           "**/*\$*.class"]
-def testsToBeExecutedInIsolation = ["**/ContentFormatControllerTests.class",
-                                    "**/JSONBindingTests.class",
-                                    "**/AutoParams*MarshallingTests.class",
-                                    "**/JSONBindingToNullTests.class",
-                                    "**/ControllerWithXmlConvertersTests.class",
-                                    "**/GroovyPageAttributesTests.class",
-                                    "**/BindingExcludeTests.class",
-                                    "**/NestedXmlBindingTests.class",
-                                    "**/GSPResponseWriterSpec.class",
-                                    "**/RespondMethodSpec.class",
-                                    "**/ContentNegotiationSpec.class",
-                                    "**/pages/ext/jsp/*.class"]
+def longRunningTests = ["org/grails/web/taglib/"]
+def isolatedTests = ["**/ContentFormatControllerTests.class",
+                     "**/JSONBindingTests.class",
+                     "**/AutoParams*MarshallingTests.class",
+                     "**/JSONBindingToNullTests.class",
+                     "**/ControllerWithXmlConvertersTests.class",
+                     "**/GroovyPageAttributesTests.class",
+                     "**/BindingExcludeTests.class",
+                     "**/NestedXmlBindingTests.class",
+                     "**/GSPResponseWriterSpec.class",
+                     "**/RespondMethodSpec.class",
+                     "**/ContentNegotiationSpec.class",
+                     "**/pages/ext/jsp/*.class"]
 
-test {
+task execLongRunningTests(type: Test) {
     configure parallelTestConfig
-    excludes = ["grails/", "org/grails/web/taglib/", "org/codehaus/"] + testsToBeExecutedInIsolation + excludedTestClasses
-}
-
-task execGrailsPackageTests(type: Test) {
-    configure parallelTestConfig
-    excludes = testsToBeExecutedInIsolation + excludedTestClasses
-    includes = ["grails/"]
-}
-
-task execOrgGrailsWebTaglibPackageTests(type: Test) {
-    configure parallelTestConfig
-    excludes = testsToBeExecutedInIsolation + excludedTestClasses
-    includes = ["org/grails/web/taglib/"]
-}
-
-task execOrgCodehausPackageTests(type: Test) {
-    configure parallelTestConfig
-    excludes = testsToBeExecutedInIsolation + excludedTestClasses
-    includes = ["org/codehaus/"]
+    excludes = isolatedTests
+    includes = longRunningTests
 }
 
 task execIsolatedTests(type: Test) {
+    configure parallelTestConfig
     forkEvery = 1
-    excludes = excludedTestClasses
-    includes = testsToBeExecutedInIsolation
+    excludes = longRunningTests
+    includes = isolatedTests
 }
 
-test.dependsOn execGrailsPackageTests, execOrgGrailsWebTaglibPackageTests, execOrgCodehausPackageTests, execIsolatedTests
+task createCombinedReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+    reportOn execLongRunningTests, execIsolatedTests, test
+}
+
+test {
+    configure parallelTestConfig
+    excludes = longRunningTests + isolatedTests
+}
+
+test.dependsOn execLongRunningTests, execIsolatedTests

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -60,13 +60,19 @@ compileTestGroovy {
     groovyOptions.listFiles = true
 }
 
-def parallelTestConfig = {
-    maxParallelForks = 2 // Travis provides only 2 cores
-    forkEvery = 10
-    jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
+ext {
+    isTravisRun = System.getenv().get("TRAVIS")
 }
 
-def longRunningTests = ["org/grails/web/taglib/"]
+def defaultTestConfig = {
+    maxParallelForks = 2
+    forkEvery = 30
+    jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
+    if (isTravisRun) {
+        afterTest { descriptor, result -> println "${descriptor.className}.${descriptor.name}: ${result.resultType}" }
+    }
+}
+
 def isolatedTests = ["**/ContentFormatControllerTests.class",
                      "**/JSONBindingTests.class",
                      "**/AutoParams*MarshallingTests.class",
@@ -80,27 +86,20 @@ def isolatedTests = ["**/ContentFormatControllerTests.class",
                      "**/ContentNegotiationSpec.class",
                      "**/pages/ext/jsp/*.class"]
 
-task execLongRunningTests(type: Test) {
-    configure parallelTestConfig
-    excludes = isolatedTests
-    includes = longRunningTests
-}
-
 task execIsolatedTests(type: Test) {
-    configure parallelTestConfig
+    configure defaultTestConfig
     forkEvery = 1
-    excludes = longRunningTests
     includes = isolatedTests
 }
 
 task createCombinedReport(type: TestReport) {
     destinationDir = file("$buildDir/reports/allTests")
-    reportOn execLongRunningTests, execIsolatedTests, test
+    reportOn execIsolatedTests, test
 }
 
 test {
-    configure parallelTestConfig
-    excludes = longRunningTests + isolatedTests
+    configure defaultTestConfig
+    excludes = isolatedTests
 }
 
-test.dependsOn execLongRunningTests, execIsolatedTests
+test.dependsOn execIsolatedTests


### PR DESCRIPTION
Travis failed continuously because the project `grails-test-suite-web` was configured to run with 4 executors using the JVM memory setting `-Xmx1024M`. IMHO this easily exceeds the Travis worker memory configuration which is set to 3 GB. Reducing the number of parallel test runs to _2_ and lowering the memory footprint by changing the JVM memory setting to _`-Xmx768M`_ will fix this problem.

Another issues was that the `grails-tests-suite-web` project took way to long to complete. Running all tests  takes more than 10mins which unfortunately is the configured timeout for console inactivity. Until someone finds a better solution after every test suite run a `.` is logged. This happens only if the environment variable `TRAVIS` is set.

In addition there is the new task `createCombinedReport` which creates a combined test report for both test tasks (`test`, `execIsolatedTests`).
