### PR TITLE
fix travis build (web-test-suite)

### DIFF
--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -43,7 +43,6 @@ dependencies {
         exclude group: 'javassist', module: 'javassist'
     }
 
-
     // Required for tag library support
     testCompile 'taglibs:standard:1.1.2'
     testCompile "javax.servlet:jstl:1.1.2"
@@ -61,61 +60,49 @@ compileTestGroovy {
     groovyOptions.listFiles = true
 }
 
-test {
-    maxParallelForks = 4
-    forkEvery = 30
-    jvmArgs = ['-Xmx1024M','-XX:MaxPermSize=192m']
-    excludes = ["**/*TestCase.class",
-                "**/*\$*.class",
-                "**/ContentFormatControllerTests.class",
-                "**/JSONBindingTests.class",
-                "**/AutoParams*MarshallingTests.class",
-                "**/JSONBindingToNullTests.class",
-                "**/ControllerWithXmlConvertersTests.class",
-                "**/GroovyPageAttributesTests.class",
-                "**/BindingExcludeTests.class",
-                "**/NestedXmlBindingTests.class",
-		"**/GSPResponseWriterSpec.class",
-		"**/RespondMethodSpec.class",
-        "**/ContentNegotiationSpec.class",
-        "**/pages/ext/jsp/*.class"]
+ext {
+    isTravisRun = System.getenv().get("TRAVIS")
 }
 
-task isolatedTestsOne(type:Test) {
-    includes = ["**/ContentFormatControllerTests.class"]
+def defaultTestConfig = {
+    maxParallelForks = 2
+    forkEvery = 10
+    jvmArgs = ['-Xmx768M', '-XX:MaxPermSize=192m'] // Travis provides up to 3GB of Memory
+    if (isTravisRun) {
+        afterSuite {
+            System.out << '.'
+            System.out.flush()
+        }
+    }
 }
-task isolatedTestsTwo(type:Test) {
-    includes = ["**/JSONBindingTests.class",
-                "**/AutoParams*MarshallingTests.class",
-                "**/ContentNegotiationSpec.class",
-                "**/pages/ext/jsp/*.class"]
-}
-task isolatedTestsThree(type:Test) {
-    includes = ["**/JSONBindingToNullTests.class",
-                "**/ControllerWithXmlConvertersTests.class"]
-}
-task isolatedTestsFour(type:Test) {
-    includes = ["**/BindingExcludeTests.class"]
-}
-task isolatedTestsFive(type:Test) {
-    includes = ["**/GroovyPageAttributesTests.class"]
-}
-task isolatedTestsSix(type:Test) {
-    includes = ["**/NestedXmlBindingTests.class"]
-}
-task isolatedTestsSeven(type:Test) {
-    maxParallelForks = 1
-    includes = ["**/GSPResponseWriterSpec.class"]
-}
-task isolatedRespondMethodTests(type:Test) {
-    maxParallelForks = 1
-    includes = ["**/RespondMethodSpec.class"]
-}
-test.dependsOn isolatedTestsOne, isolatedTestsTwo, isolatedTestsThree, isolatedTestsFour, isolatedTestsFive, isolatedTestsSix, isolatedTestsSeven, isolatedRespondMethodTests
 
-/*
-test {
-	jvmArgs '-Xmx1024m', '-Xdebug', '-Xnoagent', '-Dgrails.full.stacktrace=true', '-Djava.compiler=NONE',
-	        '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005'
+def isolatedTests = ["**/ContentFormatControllerTests.class",
+                     "**/JSONBindingTests.class",
+                     "**/AutoParams*MarshallingTests.class",
+                     "**/JSONBindingToNullTests.class",
+                     "**/ControllerWithXmlConvertersTests.class",
+                     "**/GroovyPageAttributesTests.class",
+                     "**/BindingExcludeTests.class",
+                     "**/NestedXmlBindingTests.class",
+                     "**/GSPResponseWriterSpec.class",
+                     "**/RespondMethodSpec.class",
+                     "**/ContentNegotiationSpec.class",
+                     "**/pages/ext/jsp/*.class"]
+
+task execIsolatedTests(type: Test) {
+    configure defaultTestConfig
+    forkEvery = 1
+    includes = isolatedTests
 }
-*/
+
+task createCombinedReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+    reportOn execIsolatedTests, test
+}
+
+test {
+    configure defaultTestConfig
+    excludes = isolatedTests
+}
+
+test.dependsOn execIsolatedTests


### PR DESCRIPTION
Travis failed continuously because the project `grails-test-suite-web` was configured to run with 4 executors using the JVM memory setting `-Xmx1024M`. IMHO this easily exceeds the Travis worker memory configuration which is set to 3 GB. Reducing the number of parallel test runs to _2_ and lowering the memory footprint by changing the JVM memory setting to _`-Xmx768M`_ will fix this problem.

Another issues was that the `grails-tests-suite-web` project took way to long to complete. Running all tests  takes more than 10mins which unfortunately is the configured timeout for console inactivity. Until someone finds a better solution after every test suite run a `.` is logged. This happens only if the environment variable `TRAVIS` is set.

In addition there is the new task `createCombinedReport` which creates a combined test report for both test tasks (`test`, `execIsolatedTests`).
