### PR TITLE
GRAILS-11607 grails create-integration-test should create a class extending IntegrationSpec

### DIFF
--- a/grails-resources/src/grails/templates/testing/Integration.groovy
+++ b/grails-resources/src/grails/templates/testing/Integration.groovy
@@ -1,11 +1,6 @@
-@artifact.package@
+@artifact.package@import grails.test.spock.IntegrationSpec
 
-import spock.lang.*
-
-/**
- *
- */
-class @artifact.name@ extends Specification {
+class @artifact.name@ extends IntegrationSpec {
 
     def setup() {
     }

--- a/grails-scripts/src/main/scripts/CreateIntegrationTest.groovy
+++ b/grails-scripts/src/main/scripts/CreateIntegrationTest.groovy
@@ -32,7 +32,7 @@ target ('default': "Creates a new Grails integration test which loads the whole 
 
     for (name in argsMap["params"]) {
         name = purgeRedundantArtifactSuffix(name, 'Spec')
-        createIntegrationTest(name: name, suffix: "", testType:"Integration")
+        createIntegrationTest(name: name, suffix: "Integration", testType:"Integration")
     }
 }
 


### PR DESCRIPTION
Change target branch to 2.4.x, see https://github.com/grails/grails-core/pull/519
