### PR TITLE
Fix GRAILS-9834: '<g:external> : media="screen, projector" but should be media="screen, projection"'

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -276,7 +276,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
     }
 
     static SUPPORTED_TYPES = [
-        css:[type:"text/css", rel:'stylesheet', media:'screen, projector'],
+        css:[type:"text/css", rel:'stylesheet', media:'screen, projection'],
         js:[type:'text/javascript', writer:'js'],
 
         gif:[rel:'shortcut icon'],

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -743,7 +743,7 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals '<script src="/js/main.js" type="text/javascript"></script>\r\n', template
 
         template = '<g:external uri="/css/style.css"/>'
-        assertOutputEquals '<link href="/css/style.css" type="text/css" rel="stylesheet" media="screen, projector"/>\r\n', template
+        assertOutputEquals '<link href="/css/style.css" type="text/css" rel="stylesheet" media="screen, projection"/>\r\n', template
 
         template = '<g:external uri="/css/print.css" media="print"/>'
         assertOutputEquals '<link href="/css/print.css" type="text/css" rel="stylesheet" media="print"/>\r\n', template
@@ -757,7 +757,7 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals '<script src="/js/main.js?requestDataValueProcessorParamName=paramValue" type="text/javascript"></script>\r\n', template
 
         template = '<g:external uri="/css/style.css"/>'
-        assertOutputEquals '<link href="/css/style.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="screen, projector"/>\r\n', template
+        assertOutputEquals '<link href="/css/style.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="screen, projection"/>\r\n', template
 
         template = '<g:external uri="/css/print.css" media="print"/>'
         assertOutputEquals '<link href="/css/print.css?requestDataValueProcessorParamName=paramValue" type="text/css" rel="stylesheet" media="print"/>\r\n', template


### PR DESCRIPTION
new PR for **Grails 2.4.x** branch if this is still relevant.
- https://github.com/grails/grails-core/pull/329 (closed)
- https://jira.grails.org/browse/GRAILS-9834
