### PR TITLE
Fix for GRAILS-11647 It's not possible to override collection properties with custom Hibernate User types (master branch) 

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/DefaultGrailsDomainClass.java
+++ b/grails-core/src/main/groovy/org/grails/core/DefaultGrailsDomainClass.java
@@ -262,7 +262,7 @@ public class DefaultGrailsDomainClass extends AbstractGrailsClass implements Gra
 
             Class currentPropType = currentProp.getType();
             // establish if the property is a one-to-many
-            // if it is a Set and there are relationships defined
+            // if it is a Set/Collection and there are relationships defined
             // and it is defined as persistent
             if (currentPropType != null) {
                 if (Collection.class.isAssignableFrom(currentPropType) || Map.class.isAssignableFrom(currentPropType)) {
@@ -388,9 +388,9 @@ public class DefaultGrailsDomainClass extends AbstractGrailsClass implements Gra
                 property.setBasicCollectionType(true);
             }
         }
-        else if (!Map.class.isAssignableFrom(property.getType())) {
-            // no relationship defined for set.
-            // set not persistent
+        else if (!Collection.class.isAssignableFrom(property.getType()) && !Map.class.isAssignableFrom(property.getType())) {
+            // no relationship defined for set/collection.
+            // set/collection not persistent
             property.setPersistent(false);
         }
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassTests.groovy
@@ -71,6 +71,22 @@ class Book {
         assert dc.properties.find { it.name == 'auteur'} != null
     }
 
+    void testListPersistentProperties() {
+        def cls = gcl.parseClass('''
+class Book {
+    Long id
+    Long version
+    String title
+    List<String> authors
+}
+''')
+
+        def dc = new DefaultGrailsDomainClass(cls)
+
+        assert dc.persistentProperties.size() == 2
+        assert dc.properties.size() == 4
+    }
+
     void testManyToManyIntegrity() {
         gcl.parseClass """
                 class Test {


### PR DESCRIPTION
This is a follow up for GRAILS-10335 which I fix a year ago. It turns out that even with that patch it's not possible to handle the mapping of a Collection with a custom hibernate user type. The problem is that the collection property is marked as not persistant, so when the execution flows reach the code in that patch, as the property is not persistent, it's ignored.

Reading the comments around the code (in the patch), the Set properties are handled and also Collections but these are only handle in one place but not in the other one. With this patch, collections are also handled.
I've created a test and a patch and I'm going to submit the patch agains master, 2.4.x and 2.3.x branches.
