### PR TITLE
Fix for GRAILS-11647 It's not possible to override collection properties with custom Hibernate User types (2.4.x branch)

### DIFF
--- a/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClass.java
+++ b/grails-core/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClass.java
@@ -255,7 +255,7 @@ public class DefaultGrailsDomainClass extends AbstractGrailsClass implements Gra
 
             Class currentPropType = currentProp.getType();
             // establish if the property is a one-to-many
-            // if it is a Set and there are relationships defined
+            // if it is a Set/Collection and there are relationships defined
             // and it is defined as persistent
             if (currentPropType != null) {
                 if (Collection.class.isAssignableFrom(currentPropType) || Map.class.isAssignableFrom(currentPropType)) {
@@ -381,9 +381,9 @@ public class DefaultGrailsDomainClass extends AbstractGrailsClass implements Gra
                 property.setBasicCollectionType(true);
             }
         }
-        else if (!Map.class.isAssignableFrom(property.getType())) {
-            // no relationship defined for set.
-            // set not persistent
+        else if (!Collection.class.isAssignableFrom(property.getType()) && !Map.class.isAssignableFrom(property.getType())) {
+            // no relationship defined for set/collection.
+            // set/collection not persistent
             property.setPersistent(false);
         }
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsDomainClassTests.groovy
@@ -66,6 +66,22 @@ class Book {
         assert dc.properties.find { it.name == 'auteur'} != null
     }
 
+    void testListPersistentProperties() {
+        def cls = gcl.parseClass('''
+class Book {
+    Long id
+    Long version
+    String title
+    List<String> authors
+}
+''')
+
+        def dc = new DefaultGrailsDomainClass(cls)
+
+        assert dc.persistentProperties.size() == 2
+        assert dc.properties.size() == 4
+    }
+
     void testManyToManyIntegrity() {
         gcl.parseClass """
                 class Test {


### PR DESCRIPTION
The same as #531 but for branch 2.4.x
