### PR TITLE
GRAILS-11535: Add cglib dependency to grails-test

### DIFF
--- a/grails-test/build.gradle
+++ b/grails-test/build.gradle
@@ -36,4 +36,5 @@ dependencies {
 
     // needed for Spock
     compile 'org.objenesis:objenesis:1.4'
+    testCompile "cglib:cglib:${cglibVersion}"
 }


### PR DESCRIPTION
This change addresses GRAILS-11535
