### PR TITLE
GRAILS-6713 exit with exit code 1 if script is not found

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/GrailsScriptRunner.java
@@ -228,7 +228,8 @@ public class GrailsScriptRunner {
                 System.exit(exitCode);
             }
             catch (ScriptNotFoundException ex) {
-                console.error("Script not found: " + ex.getScriptName());
+                String msg = "Script not found: " + ex.getScriptName();
+                exitWithError(msg, null);
             }
             catch (Throwable t) {
                 String msg = "Error executing script " + script.name + ": " + t.getMessage();


### PR DESCRIPTION
The change contains no tests, as we were not sure how to test this properly.
One possibility is to write a test in GrailsBuildHelperTests, but these tests only use mock-classes, and not the main method in GrailsScriptRunner.
Another way of testing it is to use AbstractCliTestCase in a separate Grails-project, as we have done manually.

The test would look something like this:

```
class RunMissingScriptTests extends AbstractCliTestCase {

    void testMissingScriptShouldFailWithExitCode(){
        execute (['missingscript', '-non-interactive'])
        assert waitForProcess() == 1
    }

}
```

Contribution from Hackergarten Oslo 2014
