### PR TITLE
Remove workaround for GROOVY-6147

### DIFF
--- a/grails-web-gsp/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPagesMetaUtils.groovy
+++ b/grails-web-gsp/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPagesMetaUtils.groovy
@@ -17,7 +17,6 @@ package org.codehaus.groovy.grails.web.pages
 
 import grails.util.Environment
 import groovy.transform.CompileStatic
-import groovy.transform.TypeCheckingMode
 
 import org.codehaus.groovy.grails.commons.GrailsMetaClassUtils
 import org.codehaus.groovy.grails.web.util.TagLibraryMetaUtils
@@ -48,7 +47,6 @@ class GroovyPagesMetaUtils {
         args instanceof Object[] ? (Object[])args : [args] as Object[]
     }
 
-    @CompileStatic(TypeCheckingMode.SKIP) // workaround for GROOVY-6147 bug
     static Object methodMissingForTagLib(MetaClass mc, Class type, TagLibraryLookup gspTagLibraryLookup, String namespace, String name, Object argsParam, boolean addMethodsToMetaClass) {
         Object[] args = makeObjectArray(argsParam)
         final GroovyObject tagBean = gspTagLibraryLookup.lookupTagLibrary(namespace, name)


### PR DESCRIPTION
https://jira.codehaus.org/browse/GROOVY-6147 was fixed in Groovy 2.1.4 and Grails is using a later version than that (Groovy 2.4.x is using Groovy 2.3.x).
