### PR TITLE
AbstractTypeConvertingMap: unnecessary parse Date

### DIFF
--- a/grails-web-common/src/main/groovy/grails/web/util/AbstractTypeConvertingMap.java
+++ b/grails-web-common/src/main/groovy/grails/web/util/AbstractTypeConvertingMap.java
@@ -371,6 +371,10 @@ public abstract class AbstractTypeConvertingMap extends GroovyObjectSupport impl
      */
     public Date getDate(String name, String format) {
         Object value = get(name);
+        if (value instanceof Date) {
+            return (Date)value;
+        }
+        
         if (value != null) {
             try {
                 return new SimpleDateFormat(format).parse(value.toString());


### PR DESCRIPTION
If value is already a Date, just return it
