### PR TITLE
Separate options from arguments when calling cygpath

### DIFF
--- a/grails-resources/src/grails/home/bash/startGrails
+++ b/grails-resources/src/grails/home/bash/startGrails
@@ -306,7 +306,7 @@ if $cygwin; then
     for arg in "$@" ; do
     	CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
     	if [ $CHECK -ne 0 ] ; then
-	    	convArg=`cygpath --path --ignore --mixed "$arg"`
+	    	convArg=`cygpath --path --ignore --mixed -- "$arg"`
     	else
 			convArg=$arg
     	fi


### PR DESCRIPTION
Calling `grails run --stacktrace` throws an error when startGrails is attempting to convert the arguments to a windows format.  By using a `--`, we separate the options to cygpath from the arguments cygpath tries to convert.
