### PR TITLE
GRAILS-11221: Fix forked mode classpath to prefer target/classes and res...

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/cli/fork/ForkedGrailsProcess.groovy
@@ -688,34 +688,34 @@ abstract class ForkedGrailsProcess {
     protected GroovyClassLoader createClassLoader(BuildSettings buildSettings) {
         def classLoader = new GroovyClassLoader()
 
+        // Prefer anything in application and plugin classes before other dependencies
+        classLoader.addURL(buildSettings.classesDir.toURI().toURL())
+        classLoader.addURL(buildSettings.pluginClassesDir.toURI().toURL())
+        classLoader.addURL(buildSettings.pluginBuildClassesDir.toURI().toURL())
+        classLoader.addURL(buildSettings.pluginProvidedClassesDir.toURI().toURL())
+
+        if(Environment.current == Environment.TEST) {
+            classLoader.addURL(buildSettings.testClassesDir.toURI().toURL())
+        }
+
+        // Load locally defined resources before other dependencies
+        classLoader.addURL(buildSettings.resourcesDir.toURI().toURL())
+
         if(Environment.current == Environment.TEST) {
             for (File f in buildSettings.testDependencies) {
                 classLoader.addURL(f.toURI().toURL())
             }
-
         }
         else {
             for (File f in buildSettings.runtimeDependencies) {
                 classLoader.addURL(f.toURI().toURL())
             }
         }
-
-
         for (File f in buildSettings.providedDependencies) {
             classLoader.addURL(f.toURI().toURL())
         }
 
-        classLoader.addURL(buildSettings.classesDir.toURI().toURL())
-        classLoader.addURL(buildSettings.pluginClassesDir.toURI().toURL())
-        classLoader.addURL(buildSettings.pluginBuildClassesDir.toURI().toURL())
-        classLoader.addURL(buildSettings.pluginProvidedClassesDir.toURI().toURL())
-        if(Environment.current == Environment.TEST) {
-            classLoader.addURL(buildSettings.testClassesDir.toURI().toURL())
-        }
-        classLoader.addURL(buildSettings.resourcesDir.toURI().toURL())
-
         def pluginSupport = new PluginPathDiscoverySupport(buildSettings)
-
         for (File f in pluginSupport.listJarsInPluginLibs()) {
             classLoader.addURL(f.toURI().toURL())
         }


### PR DESCRIPTION
...ources ahead of other BuildConfig dependencies.

This specifically fixes this issue but may actually address other cases where the classpath seems to vary in forked mode. For instance, for us, we had some src/java config.groovy classes that didn't seem to get picked up in forked mode (since they were in the resources directory). With this change, they are now working again.
