### PR TITLE
allow plugins to define @Configuration beans

### DIFF
--- a/grails-core/src/main/groovy/org/grails/plugins/CoreGrailsPlugin.groovy
+++ b/grails-core/src/main/groovy/org/grails/plugins/CoreGrailsPlugin.groovy
@@ -40,6 +40,7 @@ import grails.core.support.proxy.DefaultProxyHandler
 import org.springframework.beans.factory.config.CustomEditorConfigurer
 import org.springframework.beans.factory.config.MethodInvokingFactoryBean
 import org.springframework.beans.factory.xml.XmlBeanDefinitionReader
+import org.springframework.context.annotation.ConfigurationClassPostProcessor
 import org.springframework.core.io.Resource
 import org.springframework.util.ClassUtils
 
@@ -60,6 +61,9 @@ class CoreGrailsPlugin implements GrailsApplicationAware {
         xmlns context:"http://www.springframework.org/schema/context"
         xmlns grailsContext:"http://grails.org/schema/context"
         def application = grailsApplication
+
+        // enable post-processing of @Configuration beans defined by plugins
+        grailsConfigurationClassPostProcessor ConfigurationClassPostProcessor
 
         addBeanFactoryPostProcessor(new MapBasedSmartPropertyOverrideConfigurer(application))
         final springEnvironment = getUnrefreshedApplicationContext().getEnvironment()


### PR DESCRIPTION
adding a second `ConfigurationClassPostProcessor` following these comments: https://github.com/grails/grails-core/commit/61219075e8272c0c1ed9f4a89e061295dd72586d#commitcomment-8098202

this change allows plugins to define `@Configuration` beans, meaning they are getting post-processed properly.

when the `ConfigurationClassPostProcessor` that gets automatically registered by spring is applied, bean definitions from plugins are not yet available.
