### PR TITLE
Add cglib dependency to the Grails project test scope

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/resolve/GrailsCoreDependencies.java
@@ -38,6 +38,7 @@ public class GrailsCoreDependencies {
     protected final String jaxbVersion = "2.0";
     protected String servletApiVersion = "3.0.1";
     protected String spockVersion = "0.7-groovy-2.0";
+    protected String cglibVersion = "2.2.2";
     protected String junitVersion = "4.11";
 
     public boolean java5compatible;
@@ -100,6 +101,7 @@ public class GrailsCoreDependencies {
             testDependencies = Arrays.asList(
                 new Dependency("org.grails", "grails-plugin-testing", grailsVersion, true),
                 new Dependency("org.spockframework", "spock-core", spockVersion, true,spockExcludes),
+                new Dependency("cglib", "cglib-nodep", cglibVersion, true),
                 new Dependency("junit", "junit", junitVersion, true)
             );
         }

--- a/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/resolve/IvyDependencyManagerTests.groovy
+++ b/grails-bootstrap/src/test/groovy/org/codehaus/groovy/grails/resolve/IvyDependencyManagerTests.groovy
@@ -679,7 +679,7 @@ class IvyDependencyManagerTests extends GroovyTestCase {
         assertTrue("all default dependencies should be inherited", manager.dependencyDescriptors.every { it.inherited == true })
         assertEquals 11, manager.dependencyDescriptors.findAll { it.scope == 'compile'}.size()
         assertEquals 3, manager.dependencyDescriptors.findAll { it.scope == 'runtime'}.size()
-        assertEquals 3, manager.dependencyDescriptors.findAll { it.scope == 'test'}.size()
+        assertEquals 4, manager.dependencyDescriptors.findAll { it.scope == 'test'}.size()
         assertEquals 4, manager.dependencyDescriptors.findAll { it.scope == 'build'}.size()
         assertEquals 1, manager.dependencyDescriptors.findAll { it.scope == 'provided'}.size()
         assertEquals 1, manager.dependencyDescriptors.findAll { it.scope == 'docs'}.size()


### PR DESCRIPTION
This change addresses https://jira.grails.org/browse/GRAILS-11535

I tested this change by creating a new grails project. I ran "grails dependency-report". Then I made this change and ran "grails dependency-report" again. The only difference was the addition of these lines to the "test" scope:

```
+--- cglib:cglib:2.2.2
|    \--- asm:asm:3.3.1
```
