### PR TITLE
GRAILS-8978: Respect grails.views.gsp.htmlcodec configuration

### DIFF
--- a/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsCodecClass.java
+++ b/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsCodecClass.java
@@ -35,6 +35,7 @@ import org.codehaus.groovy.grails.support.encoding.EncodingStateRegistryLookup;
 import org.codehaus.groovy.grails.support.encoding.EncodingStateRegistryLookupHolder;
 import org.codehaus.groovy.grails.support.encoding.StreamingEncoder;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.Ordered;
 import org.springframework.util.ReflectionUtils;
 
@@ -42,33 +43,39 @@ import org.springframework.util.ReflectionUtils;
  * @author Jeff Brown
  * @since 0.4
  */
-public class DefaultGrailsCodecClass extends AbstractInjectableGrailsClass implements GrailsCodecClass, Ordered {
+public class DefaultGrailsCodecClass extends AbstractInjectableGrailsClass implements InitializingBean, GrailsCodecClass, Ordered {
     public static final String CODEC = CodecArtefactHandler.TYPE;
     private Encoder encoder;
     private Decoder decoder;
     private static int instantionCounter=0;
     private int order = 100 + instantionCounter++;
+    private boolean initialized = false;
 
     public DefaultGrailsCodecClass(Class<?> clazz) {
         super(clazz, CODEC);
+    }
+
+    public void afterPropertiesSet() {
         initializeCodec();
     }
 
     private void initializeCodec() {
+        if (initialized) return;
+        initialized = true;
         Integer orderSetting = getPropertyOrStaticPropertyOrFieldValue("order", Integer.class);
         if (orderSetting != null) {
             order = orderSetting;
         }
         if (Encoder.class.isAssignableFrom(getClazz())) {
             encoder = (Encoder)getReferenceInstance();
-            autowireCodecBean(encoder);
+            encoder = (Encoder)autowireCodecBean(encoder);
             if (encoder instanceof Ordered) {
                 order = ((Ordered)encoder).getOrder();
             }
         }
         if (Decoder.class.isAssignableFrom(getClazz())) {
             decoder = (Decoder)getReferenceInstance();
-            autowireCodecBean(decoder);
+            decoder = (Decoder)autowireCodecBean(decoder);
             if (decoder instanceof Ordered) {
                 order = ((Ordered)decoder).getOrder();
             }
@@ -77,11 +84,11 @@ public class DefaultGrailsCodecClass extends AbstractInjectableGrailsClass imple
             CodecFactory codecFactory=null;
             if (CodecFactory.class.isAssignableFrom(getClazz())) {
                 codecFactory=(CodecFactory)getReferenceInstance();
-                autowireCodecBean(codecFactory);
+                codecFactory=(CodecFactory)autowireCodecBean(codecFactory);
             }
             if (codecFactory==null) {
                 codecFactory=getPropertyOrStaticPropertyOrFieldValue("codecFactory", CodecFactory.class);
-                autowireCodecBean(codecFactory);
+                codecFactory=(CodecFactory)autowireCodecBean(codecFactory);
             }
             if (codecFactory==null) {
                 codecFactory=new ClosureCodecFactory();
@@ -101,11 +108,14 @@ public class DefaultGrailsCodecClass extends AbstractInjectableGrailsClass imple
         }
     }
 
-    protected void autowireCodecBean(Object existingBean) {
+    protected Object autowireCodecBean(Object existingBean) {
         if (existingBean != null && grailsApplication != null && grailsApplication.getMainContext() != null) {
-            grailsApplication.getMainContext().getAutowireCapableBeanFactory().autowireBeanProperties(
+            AutowireCapableBeanFactory beanFactory = grailsApplication.getMainContext().getAutowireCapableBeanFactory();
+            beanFactory.autowireBeanProperties(
                     existingBean, AutowireCapableBeanFactory.AUTOWIRE_BY_NAME, false);
+            existingBean = beanFactory.initializeBean(existingBean, "codec");
         }
+        return existingBean;
     }
 
     private class ClosureCodecFactory implements CodecFactory {
@@ -302,6 +312,10 @@ public class DefaultGrailsCodecClass extends AbstractInjectableGrailsClass imple
     }
 
     public void configureCodecMethods() {
+        // for compatibility. Not everything (especially unit tests written by existing Grails applications) call afterPropertiesSet(), but everything calls
+        // configureCodecMethods() at least once
+        initializeCodec();
+
         new CodecMetaClassSupport().configureCodecMethods(this);
     }
 

--- a/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/plugins/codecs/HTMLCodec.java
+++ b/grails-plugin-codecs/src/main/groovy/org/codehaus/groovy/grails/plugins/codecs/HTMLCodec.java
@@ -22,6 +22,8 @@ import org.codehaus.groovy.grails.support.encoding.CodecIdentifier;
 import org.codehaus.groovy.grails.support.encoding.Decoder;
 import org.codehaus.groovy.grails.support.encoding.Encoder;
 
+import org.springframework.beans.factory.InitializingBean;
+
 /**
  * Encodes and decodes strings to and from HTML.
  *
@@ -29,9 +31,10 @@ import org.codehaus.groovy.grails.support.encoding.Encoder;
  * @author Lari Hotari
  * @since 1.1
  */
-public final class HTMLCodec implements CodecFactory, GrailsApplicationAware {
+public final class HTMLCodec implements CodecFactory, GrailsApplicationAware, InitializingBean {
     public static final String CONFIG_PROPERTY_GSP_HTMLCODEC = "grails.views.gsp.htmlcodec";
     static final String CODEC_NAME = "HTML";
+    private GrailsApplication grailsApplication;
     private Encoder encoder;
     static final Encoder xml_encoder = new HTMLEncoder();
     static final Encoder html4_encoder = new HTML4Encoder() {
@@ -60,6 +63,10 @@ public final class HTMLCodec implements CodecFactory, GrailsApplicationAware {
     }
 
     public void setGrailsApplication(GrailsApplication grailsApplication) {
+        this.grailsApplication = grailsApplication;
+    }
+
+    public void afterPropertiesSet() {
         if (grailsApplication == null || grailsApplication.getFlatConfig() == null) {
             return;
         }

--- a/grails-plugin-codecs/src/test/groovy/org/codehaus/groovy/grails/web/codecs/HTMLCodecTests.groovy
+++ b/grails-plugin-codecs/src/test/groovy/org/codehaus/groovy/grails/web/codecs/HTMLCodecTests.groovy
@@ -1,19 +1,56 @@
 package org.codehaus.groovy.grails.web.codecs
 
+import org.codehaus.groovy.grails.commons.StandaloneGrailsApplication
 import org.codehaus.groovy.grails.plugins.codecs.HTMLCodec
 
 class HTMLCodecTests extends GroovyTestCase {
 
-    def encoder = new HTMLCodec().encoder
-    def decoder = new HTMLCodec().decoder
+    def getEncoderXml() {
+        def htmlCodec = new HTMLCodec()
+        def grailsApplication = new StandaloneGrailsApplication()
+        grailsApplication.config.grails.views.gsp.htmlcodec = 'xml'
+        grailsApplication.configChanged()
+        htmlCodec.setGrailsApplication(grailsApplication)
+        htmlCodec.afterPropertiesSet()
+        return htmlCodec.getEncoder()
+    }
 
-    void testEncode() {
+    def getEncoderHtml() {
+        def htmlCodec = new HTMLCodec()
+        def grailsApplication = new StandaloneGrailsApplication()
+        grailsApplication.config.grails.views.gsp.htmlcodec = 'html'
+        grailsApplication.configChanged()
+        htmlCodec.setGrailsApplication(grailsApplication)
+        htmlCodec.afterPropertiesSet()
+        return htmlCodec.getEncoder()
+    }
+
+    def getDecoder() {
+        def htmlCodec = new HTMLCodec()
+        def grailsApplication = new StandaloneGrailsApplication()
+        htmlCodec.setGrailsApplication(grailsApplication)
+        htmlCodec.afterPropertiesSet()
+        return htmlCodec.getDecoder()
+    }
+
+    void testEncodeXml() {
+        def encoder = getEncoderXml()
         assertEquals('&lt;tag&gt;', encoder.encode('<tag>'))
         assertEquals('&quot;quoted&quot;', encoder.encode('"quoted"'))
         assertEquals("Hitchiker&#39;s Guide", encoder.encode("Hitchiker's Guide"))
+        assertEquals("Vid\u00E9o", encoder.encode("Vid\u00E9o"))
+    }
+
+    void testEncodeHtml() {
+        def encoder = getEncoderHtml()
+        assertEquals('&lt;tag&gt;', encoder.encode('<tag>'))
+        assertEquals('&quot;quoted&quot;', encoder.encode('"quoted"'))
+        assertEquals("Hitchiker&#39;s Guide", encoder.encode("Hitchiker's Guide"))
+        assertEquals("Vid&eacute;o", encoder.encode("Vid\u00E9o"))
     }
 
     void testDecode() {
+        def decoder = getDecoder()
         assertEquals('<tag>', decoder.decode('&lt;tag&gt;'))
         assertEquals('"quoted"', decoder.decode('&quot;quoted&quot;'))
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsCodecClassTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/commons/DefaultGrailsCodecClassTests.groovy
@@ -16,12 +16,14 @@ class DefaultGrailsCodecClassTests extends GroovyTestCase {
 
     void testCodecWithClosures() {
         def codecClass = new DefaultGrailsCodecClass(CodecWithClosuresCodec)
+        codecClass.afterPropertiesSet();
         assertEquals "encoded", codecClass.encoder.encode("stuff")
         assertEquals "decoded", codecClass.decoder.decode("stuff")
     }
 
     void testCodecWithMethods() {
         def codecClass = new DefaultGrailsCodecClass(CodecWithMethodsCodec)
+        codecClass.afterPropertiesSet();
         assertEquals "encoded", codecClass.encoder.encode("stuff")
         assertEquals "decoded", codecClass.decoder.decode("stuff")
     }

--- a/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/util/CodecPrintWriterTest.java
+++ b/grails-test-suite-uber/src/test/groovy/org/codehaus/groovy/grails/web/util/CodecPrintWriterTest.java
@@ -148,8 +148,12 @@ class MockGrailsApplication implements GrailsApplication {
     private Map<String, DefaultGrailsCodecClass> mockCodecArtefacts = new HashMap<String, DefaultGrailsCodecClass>();
 
     MockGrailsApplication() {
-        mockCodecArtefacts.put(HTMLCodec.class.getName(), new DefaultGrailsCodecClass(HTMLCodec.class));
-        mockCodecArtefacts.put(CodecWithClosureProperties.class.getName(), new DefaultGrailsCodecClass(CodecWithClosureProperties.class));
+        DefaultGrailsCodecClass htmlCodec = new DefaultGrailsCodecClass(HTMLCodec.class);
+        htmlCodec.afterPropertiesSet();
+        mockCodecArtefacts.put(HTMLCodec.class.getName(), htmlCodec);
+        DefaultGrailsCodecClass codecWithClosureProperties = new DefaultGrailsCodecClass(CodecWithClosureProperties.class);
+        codecWithClosureProperties.afterPropertiesSet();
+        mockCodecArtefacts.put(CodecWithClosureProperties.class.getName(), codecWithClosureProperties);
     }
 
     public GrailsClass getArtefact(String artefactType, String name) {


### PR DESCRIPTION
Commit 5037e65a04e33d9b6cd9cf7be8ca5921c4816de4 intended for the grails.views.gsp.htmlcodec setting to take effect. This commit fixes the implementation so that setting is respected.

https://jira.grails.org/browse/GRAILS-8978
