### PR TITLE
Erase unnecessary grails.util.Environment imports

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -39,7 +39,7 @@ class GrailsApp extends SpringApplication {
         System.setProperty(BuildSettings.RUN_EXECUTED, "true")
         def applicationContext = super.run(args)
 
-        grails.util.Environment environment = grails.util.Environment.getCurrent()
+        Environment environment = Environment.getCurrent()
         if(environment.isReloadEnabled()) {
             enableDevelopmentModeWatch(environment, applicationContext)
         }


### PR DESCRIPTION
Do I really need to import grails.util.Environment at the top and inside the run method?
