### PR TITLE
GRAILS-11696 g:sortableColumn does not allow namespace for link creation

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -50,10 +50,10 @@ class UrlMappingTagLib {
 
         if (attrs.controller || attrs.view) {
             def mapping = new ForwardUrlMappingInfo(controller: attrs.controller as String,
-                    action: attrs.action as String,
-                    view: attrs.view as String,
-                    id: attrs.id as String,
-                    params: attrs.params as Map)
+                action: attrs.action as String,
+                view: attrs.view as String,
+                id: attrs.id as String,
+                params: attrs.params as Map)
 
             if (attrs.namespace != null) {
                 mapping.namespace = attrs.namespace as String
@@ -242,6 +242,7 @@ class UrlMappingTagLib {
      * @attr titleKey title key to use for the column, resolved against the message source
      * @attr params a map containing request parameters
      * @attr action the name of the action to use in the link, if not specified the list action will be linked
+     * @attr namespace controller namespace (optional)
      * @attr params A map containing URL query parameters
      * @attr class CSS class name
      */
@@ -257,6 +258,7 @@ class UrlMappingTagLib {
 
         def property = attrs.remove("property")
         def action = attrs.action ? attrs.remove("action") : (actionName ?: "list")
+        def namespace = attrs.namespace ? attrs.remove("namespace") : ""
 
         def defaultOrder = attrs.remove("defaultOrder")
         if (defaultOrder != "desc") defaultOrder = "asc"
@@ -319,6 +321,7 @@ class UrlMappingTagLib {
         }
 
         linkAttrs.action = action
+        linkAttrs.namespace = namespace
 
         writer << callLink((Map)linkAttrs) {
             title

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/ReverseUrlMappingTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/mapping/ReverseUrlMappingTests.groovy
@@ -50,6 +50,10 @@ name showBooksWithAction: "/showSomeOtherBooks/$action" {
 
 "/$namespace/$controller/$action?"()
 
+"/grails/$controller/$action?" {
+    namespace = "grails"
+}
+
 "/invokePrimaryController" {
     controller = 'namespaced'
     namespace = 'primary'
@@ -109,7 +113,7 @@ class ProductController {
     void testPaginateWithNamedUrlMapping() {
         def template = '<g:paginate mapping="showBooks" total="15" max="5" />'
         assertOutputEquals '<span class="currentStep">1</span><a href="/showSomeBooks?offset=5&amp;max=5" class="step">2</a><a href="/showSomeBooks?offset=10&amp;max=5" class="step">3</a><a href="/showSomeBooks?offset=5&amp;max=5" class="nextLink">Next</a>', template
-   }
+    }
 
     void testSortableColumnWithNamedUrlMapping() {
         webRequest.controllerName = 'book'
@@ -119,5 +123,12 @@ class ProductController {
 
         def template2 = '<g:sortableColumn property="releaseDate" title="Release Date" mapping="showBooksWithAction" action="action_name"/>'
         assertOutputEquals '<th class="sortable" ><a href="/showSomeOtherBooks/action_name?sort=releaseDate&amp;order=asc">Release Date</a></th>', template2
-   }
+    }
+
+    void testSortableColumnWithNamespaceAttribute() {
+        webRequest.controllerName = 'book'
+
+        def template = '<g:sortableColumn property="id" title="ID" action="index" namespace="grails" />'
+        assertOutputEquals '<th class="sortable" ><a href="/grails/book/index?sort=id&amp;order=asc">ID</a></th>', template
+    }
 }


### PR DESCRIPTION
This PR fixes an issue reported here on JIRA https://jira.grails.org/browse/GRAILS-11696
