### PR TITLE
GRAILS-11796: Add decorators to the GSP source

### DIFF
--- a/grails-web-gsp/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPageSourceDecorator.java
+++ b/grails-web-gsp/src/main/groovy/org/codehaus/groovy/grails/web/pages/GroovyPageSourceDecorator.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2004-2005 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.grails.web.pages;
+
+import java.lang.StringBuilder;
+
+public interface GroovyPageSourceDecorator {
+	StringBuilder decorate(StringBuilder source);
+}


### PR DESCRIPTION
https://jira.grails.org/browse/GRAILS-11796

Adds a new `GroovyPagesTemplateEngine.setGroovyPageSourceDecorators(List<GroovyPageSourceDecorator>)` method that allows for the decoration of the source of the GSP.

To use this functionality, I imagine plugins or applications (via BootStrap.groovy or some equivalent mechanism) can call:

```
groovyPagesTemplateEngine.getGroovyPageSourceDecorators().add(myDecorator)
```

or, in a plugin's "doWithSpring", they could do:

```
def groovyPagesTemplateEngine = delegate.getBeanDefinition("groovyPagesTemplateEngine")
groovyPagesTemplateEngine.getPropertyValue("groovyPageSourceDecorators").add(myDecorator)
```
