### PR TITLE
put assets into META-INF/assets for jar builds

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -77,7 +77,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
             else {
                 project.processResources {
-                    from "${project.buildDir}/assetCompile"
+                    from("${project.buildDir}/assetCompile") {
+                        into "META-INF"
+                    }
                 }
             }
         }


### PR DESCRIPTION
the new asset-pipeline `SpringResourceAssetResolver` will be registered to look under classpath:META-INF/assets. hence, for jar builds we should use that dir.
will require bumps to `asset-pipeline:3.0.0.BUILD-SNAPSHOT` / `asset-pipeline-core-2.1.1`.
