### PR TITLE
GRAILS-11954 Fix for content negotiation response content type.

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -16,6 +16,7 @@
 package grails.artefact.controller.support
 
 import groovy.transform.CompileStatic
+import org.grails.web.converters.Converter
 
 /**
  * 
@@ -50,5 +51,9 @@ trait ResponseRenderer {
 
     void render(Map args, CharSequence body) {
         helper.invokeRender this, args, body
+    }
+
+    void render(Converter<?> converter) {
+        helper.invokeRender this, converter
     }
 }


### PR DESCRIPTION
Instead of modifying 

``` groovy
//ResponseRenderer.groovy
void render(o) {
    helper.invokeRender this, o.inspect()
}
```

added a new render method with `Converters` as argument for better IDE support.
