### PR TITLE
Fix an execution order of interceptors

### DIFF
--- a/grails-plugin-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/GrailsInterceptorHandlerInterceptorAdapter.groovy
+++ b/grails-plugin-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/GrailsInterceptorHandlerInterceptorAdapter.groovy
@@ -78,7 +78,7 @@ class GrailsInterceptorHandlerInterceptorAdapter implements HandlerInterceptor {
             if(modelAndView != null) {
                 request.setAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, modelAndView)
             }
-            for(i in interceptors) {
+            for(i in interceptors.reverse()) {
                 if(i.doesMatch()) {
                     if( !i.after() ) {
                         modelAndView.setView(null)
@@ -94,7 +94,7 @@ class GrailsInterceptorHandlerInterceptorAdapter implements HandlerInterceptor {
     void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
         request.setAttribute(Matcher.THROWABLE, ex)
         if(interceptors) {
-            for(i in interceptors) {
+            for(i in interceptors.reverse()) {
                 if(i.doesMatch(request)) {
                     i.afterView()
                 }


### PR DESCRIPTION
The 'after' and 'afterView' method should be executed in inverse order of the execution chain.
