### PR TITLE
improve arguments for ApplicationContextCommand

### DIFF
--- a/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
+++ b/grails-console/src/main/groovy/grails/ui/command/GrailsApplicationContextCommandRunner.groovy
@@ -49,7 +49,7 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
             }
 
             try {
-                def result = command.handle(ctx)
+                def result = command.handle(ctx, args)
                 result ? System.exit(0) : System.exit(1)
             } catch (Throwable e) {
                 System.err.println("Command execution error: $e.message")
@@ -73,20 +73,20 @@ class GrailsApplicationContextCommandRunner extends DevelopmentGrailsApplication
     /**
      * Main method to run an existing Application class
      *
-     * @param args The first argument is the Application class name
+     * @param args The first argument is the Command name, the last argument is the Application class name
      */
     public static void main(String[] args) {
         if(args.size() > 1) {
             Class applicationClass
             try {
-                applicationClass = Thread.currentThread().contextClassLoader.loadClass(args[1])
+                applicationClass = Thread.currentThread().contextClassLoader.loadClass(args.last())
             } catch (Throwable e) {
                 System.err.println("Application class not found")
                 System.exit(1)
             }
 
             def runner = new GrailsApplicationContextCommandRunner(args[0], applicationClass)
-            runner.run(args[1..-1] as String[])
+            runner.run((args.size() > 2 ? args[1..-2] : []) as String[])
         }
         else {
             System.err.println("Missing application class name and script name arguments")

--- a/grails-core/src/main/groovy/grails/dev/commands/ApplicationContextCommand.groovy
+++ b/grails-core/src/main/groovy/grails/dev/commands/ApplicationContextCommand.groovy
@@ -32,8 +32,9 @@ interface ApplicationContextCommand extends Named {
      * Handles the command
      *
      * @param applicationContext The {@link org.springframework.context.ApplicationContext} instance
+     * @param args the command arguments
      * @return True if the command was successful
      */
-    boolean handle(ConfigurableApplicationContext applicationContext)
+    boolean handle(ConfigurableApplicationContext applicationContext, Object... args)
 
 }

--- a/grails-core/src/main/groovy/grails/dev/commands/ApplicationContextCommand.groovy
+++ b/grails-core/src/main/groovy/grails/dev/commands/ApplicationContextCommand.groovy
@@ -35,6 +35,6 @@ interface ApplicationContextCommand extends Named {
      * @param args the command arguments
      * @return True if the command was successful
      */
-    boolean handle(ConfigurableApplicationContext applicationContext, Object... args)
+    boolean handle(ConfigurableApplicationContext applicationContext, String... args)
 
 }

--- a/grails-shell/src/main/groovy/org/grails/cli/gradle/GradleInvoker.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/gradle/GradleInvoker.groovy
@@ -58,9 +58,6 @@ class GradleInvoker {
                 arguments << '--stacktrace'
                 arguments << '-Dgrails.full.stacktrace=true'
             }
-            if (commandLine.remainingArgs || commandLine.undeclaredOptions) {
-                arguments << "-Pargs=${commandLine.remainingArgsWithOptionsString}".toString()
-            }
 
             arguments.addAll argArray.collect() { it.toString() }
             buildLauncher.withArguments( arguments as String[])

--- a/grails-shell/src/main/groovy/org/grails/cli/gradle/GradleInvoker.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/gradle/GradleInvoker.groovy
@@ -58,6 +58,9 @@ class GradleInvoker {
                 arguments << '--stacktrace'
                 arguments << '-Dgrails.full.stacktrace=true'
             }
+            if (commandLine.remainingArgs || commandLine.undeclaredOptions) {
+                arguments << "-Pargs=${commandLine.remainingArgsWithOptionsString}".toString()
+            }
 
             arguments.addAll argArray.collect() { it.toString() }
             buildLauncher.withArguments( arguments as String[])

--- a/grails-shell/src/main/groovy/org/grails/cli/gradle/commands/GradleTaskCommandAdapter.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/gradle/commands/GradleTaskCommandAdapter.groovy
@@ -52,7 +52,13 @@ class GradleTaskCommandAdapter implements ProfileCommand {
     boolean handle(ExecutionContext executionContext) {
         GradleInvoker invoker = new GradleInvoker(executionContext)
 
-        invoker."${GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(adapted.name)}"()
+        def commandLine = executionContext.commandLine
+        if (commandLine.remainingArgs || commandLine.undeclaredOptions) {
+            invoker."${GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(adapted.name)}"("-Pargs=${commandLine.remainingArgsWithOptionsString}")
+        } else {
+            invoker."${GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(adapted.name)}"()
+        }
+
         return true
     }
 

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
@@ -39,7 +39,7 @@ class UrlMappingsReportCommand implements ApplicationContextCommand {
     final String name = "url-mappings-report"
 
     @Override
-    boolean handle(ConfigurableApplicationContext applicationContext) {
+    boolean handle(ConfigurableApplicationContext applicationContext, Object... args) {
         try {
             def urlMappings = applicationContext.getBean("grailsUrlMappingsHolder", UrlMappings)
 

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/reporting/UrlMappingsReportCommand.groovy
@@ -39,7 +39,7 @@ class UrlMappingsReportCommand implements ApplicationContextCommand {
     final String name = "url-mappings-report"
 
     @Override
-    boolean handle(ConfigurableApplicationContext applicationContext, Object... args) {
+    boolean handle(ConfigurableApplicationContext applicationContext, String... args) {
         try {
             def urlMappings = applicationContext.getBean("grailsUrlMappingsHolder", UrlMappings)
 


### PR DESCRIPTION
This makes it possible to pass command line arguments to `ApplicationContextCommand`.

If there is a Gradle task as following:

```
project.tasks.create("myTask", ApplicationContextCommandTask) {
    classpath = project.sourceSets.main.runtimeClasspath + project.configurations.console
    command = 'my-task'
    if (project.hasProperty('args')) {
        args(project.args.split(' '))
    }
}
```

and execute the task with arguments:

```
grails my-task args1 args2
```

The above will pass `['args1', 'args2']` to the implementation of `ApplicationContextCommand`.
