### PR TITLE
Configuring system properties in ApplicationContextCommandTask 

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/commands/ApplicationContextCommandTask.groovy
@@ -30,6 +30,7 @@ class ApplicationContextCommandTask extends JavaExec {
     ApplicationContextCommandTask() {
         setMain("grails.ui.command.GrailsApplicationContextCommandRunner")
         dependsOn("classes", "findMainClass")
+        systemProperties(System.properties.findAll { it.key.toString().startsWith('grails.') } as Map<String, Object>)
     }
 
     void setCommand(String commandName) {


### PR DESCRIPTION
This makes configuring system properties in ApplicationContextCommandTask to pass grails system properties , e.g. `grails.env`, `grails.full.stacktrace`.
