### PR TITLE
2.4.x

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -63,16 +63,11 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
 
     boolean useJsessionId = false
     boolean hasResourceProcessor = false
-    boolean flowExecutionParamInd = true
 
     void afterPropertiesSet() {
         def config = grailsApplication.config
         if (config.grails.views.enable.jsessionid instanceof Boolean) {
             useJsessionId = config.grails.views.enable.jsessionid
-        }
-
-        if (config.grails.views.enable.flowExecutionKey.param instanceof Boolean) {
-            flowExecutionParamInd = config.grails.views.enable.flowExecutionKey.param
         }
 
         hasResourceProcessor = applicationContext.containsBean('grailsResourceProcessor')
@@ -364,11 +359,9 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         }
         def params = urlAttrs.params && urlAttrs.params instanceof Map ? urlAttrs.params : [:]
         if (request.flowExecutionKey) {
-            params.execution = request.flowExecutionKey           
-            //externalization of flow execution param
-            if(flowExecutionParamInd){                
-                urlAttrs.params = params
-            }           
+            params.execution = request.flowExecutionKey
+            //Commenting code for resolving Grails GRAILS-11583
+            //urlAttrs.params = params
             if (attrs.controller == null && attrs.action == null && attrs.url == null && attrs.uri == null) {
                 urlAttrs[LinkGenerator.ATTRIBUTE_ACTION] = GrailsWebRequest.lookup().actionName
             }
@@ -379,7 +372,6 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         }
 
         String generatedLink = linkGenerator.link(urlAttrs, request.characterEncoding)
-
         generatedLink = processedUrl(generatedLink, request)
 
         return useJsessionId ? response.encodeURL(generatedLink) : generatedLink

--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -359,8 +359,6 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         }
         def params = urlAttrs.params && urlAttrs.params instanceof Map ? urlAttrs.params : [:]
         if (request.flowExecutionKey) {
-            params.execution = request.flowExecutionKey
-            urlAttrs.params = params
             if (attrs.controller == null && attrs.action == null && attrs.url == null && attrs.uri == null) {
                 urlAttrs[LinkGenerator.ATTRIBUTE_ACTION] = GrailsWebRequest.lookup().actionName
             }

--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -360,8 +360,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         def params = urlAttrs.params && urlAttrs.params instanceof Map ? urlAttrs.params : [:]
         if (request.flowExecutionKey) {
             params.execution = request.flowExecutionKey
-            //Commenting code for resolving Grails GRAILS-11583
-            //urlAttrs.params = params
+            urlAttrs.params = params
             if (attrs.controller == null && attrs.action == null && attrs.url == null && attrs.uri == null) {
                 urlAttrs[LinkGenerator.ATTRIBUTE_ACTION] = GrailsWebRequest.lookup().actionName
             }

--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -63,11 +63,16 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
 
     boolean useJsessionId = false
     boolean hasResourceProcessor = false
+    boolean flowExecutionParamInd = true
 
     void afterPropertiesSet() {
         def config = grailsApplication.config
         if (config.grails.views.enable.jsessionid instanceof Boolean) {
             useJsessionId = config.grails.views.enable.jsessionid
+        }
+
+        if (config.grails.views.enable.flowExecutionKey.param instanceof Boolean) {
+            flowExecutionParamInd = config.grails.views.enable.flowExecutionKey.param
         }
 
         hasResourceProcessor = applicationContext.containsBean('grailsResourceProcessor')
@@ -359,9 +364,11 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         }
         def params = urlAttrs.params && urlAttrs.params instanceof Map ? urlAttrs.params : [:]
         if (request.flowExecutionKey) {
-            params.execution = request.flowExecutionKey
-            //Commenting code for resolving Grails GRAILS-11583
-            //urlAttrs.params = params
+            params.execution = request.flowExecutionKey           
+            //externalization of flow execution param
+            if(flowExecutionParamInd){                
+                urlAttrs.params = params
+            }           
             if (attrs.controller == null && attrs.action == null && attrs.url == null && attrs.uri == null) {
                 urlAttrs[LinkGenerator.ATTRIBUTE_ACTION] = GrailsWebRequest.lookup().actionName
             }
@@ -372,6 +379,7 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         }
 
         String generatedLink = linkGenerator.link(urlAttrs, request.characterEncoding)
+
         generatedLink = processedUrl(generatedLink, request)
 
         return useJsessionId ? response.encodeURL(generatedLink) : generatedLink

--- a/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy
@@ -360,7 +360,8 @@ class ApplicationTagLib implements ApplicationContextAware, InitializingBean, Gr
         def params = urlAttrs.params && urlAttrs.params instanceof Map ? urlAttrs.params : [:]
         if (request.flowExecutionKey) {
             params.execution = request.flowExecutionKey
-            urlAttrs.params = params
+            //Commenting code for resolving Grails GRAILS-11583
+            //urlAttrs.params = params
             if (attrs.controller == null && attrs.action == null && attrs.url == null && attrs.uri == null) {
                 urlAttrs[LinkGenerator.ATTRIBUTE_ACTION] = GrailsWebRequest.lookup().actionName
             }

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -291,32 +291,27 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
 
     void testCreateLinkWithFlowExecutionKeyAndEvent() {
         unRegisterRequestDataValueProcessor()
-        request.flowExecutionKey = '12345'
-
+      
         def template = '<g:createLink controller="foo" action="bar" event="boo" />'
-        assertOutputEquals('/foo/bar?execution=12345&_eventId=boo', template)
+        assertOutputEquals('/foo/bar?_eventId=boo', template)
     }
 
     void testCreateLinkWithFlowExecutionKeyAndEventAndRequestDataValueProcessor() {
-        request.flowExecutionKey = '12345'
 
         def template = '<g:createLink controller="foo" action="bar" event="boo" />'
-        assertOutputEquals('/foo/bar?execution=12345&_eventId=boo&requestDataValueProcessorParamName=paramValue', template)
+        assertOutputEquals('/foo/bar?_eventId=boo&requestDataValueProcessorParamName=paramValue', template)
     }
 
     void testLinkWithFlowExecutionKeyAndEvent() {
         unRegisterRequestDataValueProcessor()
-        request.flowExecutionKey = '12345'
 
         def template = '<g:link controller="foo" action="bar" event="boo" >link</g:link>'
-        assertOutputEquals('<a href="/foo/bar?execution=12345&amp;_eventId=boo">link</a>', template)
+        assertOutputEquals('<a href="/foo/bar?_eventId=boo">link</a>', template)
     }
 
     void testLinkWithFlowExecutionKeyAndEventAndRequestDataValueProcessor() {
-        request.flowExecutionKey = '12345'
-
         def template = '<g:link controller="foo" action="bar" event="boo" >link</g:link>'
-        assertOutputEquals('<a href="/foo/bar?execution=12345&amp;_eventId=boo&amp;requestDataValueProcessorParamName=paramValue">link</a>', template)
+        assertOutputEquals('<a href="/foo/bar?_eventId=boo&amp;requestDataValueProcessorParamName=paramValue">link</a>', template)
     }
 
     void testSetTag() {

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -289,6 +289,28 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         }
     }
 
+    void testGCreateLinkWithFlowExecutionParamConfigIndOff() {
+        unRegisterRequestDataValueProcessor()
+        request.flowExecutionKey = '12345'
+        def tagLibBean = appCtx.getBean(ApplicationTagLib.name)
+        ga.config.grails.views.enable.flowExecutionKey.param=false
+        tagLibBean.afterPropertiesSet()
+        def template = '<g:createLink controller="foo" action="bar" />'
+
+        assertOutputEquals('/foo/bar', template)
+    }
+
+    void testGCreateLinkWithFlowExecutionParamConfigIndOn() {
+        unRegisterRequestDataValueProcessor()
+        request.flowExecutionKey = '12345'
+        def tagLibBean = appCtx.getBean(ApplicationTagLib.name)
+        ga.config.grails.views.enable.flowExecutionKey.param=true
+        tagLibBean.afterPropertiesSet()
+        
+        def template = '<g:createLink controller="foo" action="bar" />'
+        assertOutputEquals('/foo/bar?execution=12345', template)
+    }
+
     void testCreateLinkWithFlowExecutionKeyAndEvent() {
         unRegisterRequestDataValueProcessor()
         request.flowExecutionKey = '12345'

--- a/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/codehaus/groovy/grails/web/taglib/ApplicationTagLibTests.groovy
@@ -289,28 +289,6 @@ class ApplicationTagLibTests extends AbstractGrailsTagTests {
         }
     }
 
-    void testGCreateLinkWithFlowExecutionParamConfigIndOff() {
-        unRegisterRequestDataValueProcessor()
-        request.flowExecutionKey = '12345'
-        def tagLibBean = appCtx.getBean(ApplicationTagLib.name)
-        ga.config.grails.views.enable.flowExecutionKey.param=false
-        tagLibBean.afterPropertiesSet()
-        def template = '<g:createLink controller="foo" action="bar" />'
-
-        assertOutputEquals('/foo/bar', template)
-    }
-
-    void testGCreateLinkWithFlowExecutionParamConfigIndOn() {
-        unRegisterRequestDataValueProcessor()
-        request.flowExecutionKey = '12345'
-        def tagLibBean = appCtx.getBean(ApplicationTagLib.name)
-        ga.config.grails.views.enable.flowExecutionKey.param=true
-        tagLibBean.afterPropertiesSet()
-        
-        def template = '<g:createLink controller="foo" action="bar" />'
-        assertOutputEquals('/foo/bar?execution=12345', template)
-    }
-
     void testCreateLinkWithFlowExecutionKeyAndEvent() {
         unRegisterRequestDataValueProcessor()
         request.flowExecutionKey = '12345'


### PR DESCRIPTION
Resolution of GRAILS-11583,
Prob - While using grails webflow, it's adding additional "execution=e1s1"  query string to URL, 

Current Solution - provides configurable parameter to users "grails.views.enable.flowExecutionKey.param" to append query string to url.

Recommended Solution -  remove "urlAttrs.params = params" mapping ( https://github.com/grails/grails-core/blob/v2.4.4/grails-plugin-gsp/src/main/groovy/org/codehaus/groovy/grails/plugins/web/taglib/ApplicationTagLib.groovy#L363) line as it's duplicate place.
grails-web-flow-plugin 2.1.0 - has code to handle execution=e1s1, parameter if you need to bookmark or share the pages.

Thank You,
Vinod
