### PR TITLE
update definition of applicationContextCommand task to pass args to GrailsApplicationContextCommandRunner

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.testing.Test
 import org.gradle.process.JavaForkOptions
+import org.grails.build.parsing.CommandLineParser
 import org.grails.gradle.plugin.agent.AgentTasksEnhancer
 import org.grails.gradle.plugin.commands.ApplicationContextCommandTask
 import org.grails.gradle.plugin.run.FindMainClassTask
@@ -144,6 +145,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
             project.tasks.create(taskName, ApplicationContextCommandTask) {
                 classpath = project.sourceSets.main.runtimeClasspath + project.configurations.console
                 command = commandName
+                if (project.hasProperty('args')) {
+                    args(CommandLineParser.translateCommandline(project.args))
+                }
             }
         }
     }


### PR DESCRIPTION
pass arguments that are set at the https://github.com/grails/grails-core/blob/master/grails-shell/src/main/groovy/org/grails/cli/gradle/commands/GradleTaskCommandAdapter.groovy#L65 to GrailsApplicationContextCommandRunner
