### PR TITLE
GRAILS-11946 - update the existing profile repository

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/profile/git/GitProfileRepository.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/git/GitProfileRepository.groovy
@@ -137,8 +137,7 @@ class GitProfileRepository implements ProfileRepository{
         if(forceUpdate || !fetchHead.exists() || fetchHead.lastModified() < System.currentTimeMillis() - updateInterval) {
             try {
                 Git git = Git.open(profilesDirectory)
-                git.fetch()
-                git.rebase()
+                git.fetch().call()
             } catch (Exception e) {
                 GrailsConsole.getInstance().error("Problem updating profiles from origin git repository", e)
             }


### PR DESCRIPTION
JGit uses the Builder Pattern. So, `call()` is required. Besides, for this purpose, `rebase()` is unnecessary.
