### PR TITLE
Resolving issue where warDeployed in embedded container is not detected as true

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
@@ -238,8 +238,8 @@ public class Metadata extends CodeGenConfig  {
      * @return true if this application is deployed as a WAR
      */
     public boolean isWarDeployed() {
-        def loadedLocation = getClass().getClassLoader().getResource("");
-        if(loadedLocation && loadedLocation.path.contains('/WEB-INF/classes/')) {
+        def loadedLocation = getClass().getClassLoader().getResource(FILE);
+        if(loadedLocation && loadedLocation.path.contains('/WEB-INF/classes')) {
             return true
         }
         return false


### PR DESCRIPTION
This changes the warDeployed check to accept embedded containers due to `!` being added to resource location path. It also needs to point to a file that is in that folder so we point to the application.yml file or static `FILE` definition. This resolves part of #583 which still cannot resolve views. and fully resolves #584 
