### PR TITLE
Fixing copy path for assets for the jar container

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -176,9 +176,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 tasks.withType(Jar) { Jar bundleTask ->
                     bundleTask.dependsOn assetCompile
                     bundleTask.from "${project.buildDir}/assetCompile", {
-                        if(!(bundleTask instanceof War)) {
-                            into "META-INF"
-                        }
+                        // if(!(bundleTask instanceof War)) {
+                        //     into "META-INF"
+                        // }
                     }
                 }
             }


### PR DESCRIPTION
Resolves issue #587 along with needing a new build of the grails3 branch of the asset-pipeline plugin which no longer depends on the warDeployed property.
