### PR TITLE
Update ant to 1.9.4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -231,7 +231,7 @@ SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
 
 SECTION 2: Apache License, V2.0
 
-   >>> ant-1.8.4
+   >>> ant-1.9.4
    >>> commons-codec.commons-codec-1.6
    >>> commons-collections-3.2.1
    >>> commons-fileupload-1.3.1
@@ -475,7 +475,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Apache License, V2.0 is applicable to the following component(s).
 
 
->>> ant-1.8.4
+>>> ant-1.9.4
 
 Apache License
                            Version 2.0, January 2004

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ ext {
     isTravisBuild = System.getenv().get("TRAVIS") == 'true'
 
     antTraxVersion = "1.7.1"
-    antVersion = "1.8.4"
+    antVersion = "1.9.4"
     aspectjVersion = "1.8.5"  // use same version as org.springframework:spring-aspects uses
     commonsCliVersion = "1.2"
     commonsCollectionsVersion = "3.2.1"


### PR DESCRIPTION
Ant 1.8.x is incompatible with Java 8. Since Java 7 is EOL this month it's likely a good idea to update this dependency. 

Also fixes https://jira.grails.org/browse/GPSTANDALONE-18
