### PR TITLE
Support command line arguments

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -75,9 +75,9 @@ class GrailsApp extends SpringApplication {
 
     @Override
     protected void configureEnvironment(ConfigurableEnvironment environment, String[] args) {
+        configurePropertySources(environment, args)
+
         def env = Environment.current
-
-
         environment.addActiveProfile(env.name)
     }
 


### PR DESCRIPTION
This PR adds support for external configuration from command line arguments ( e.g. `java -jar my-grails-app.war --server.port=9000`). 

see http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#boot-features-external-config
