### PR TITLE
Issue #636: Fixes for auto-reloading in development mode

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/io/watch/AbstractDirectoryWatcher.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/io/watch/AbstractDirectoryWatcher.java
@@ -47,6 +47,15 @@ abstract class AbstractDirectoryWatcher implements Runnable {
     }
 
     /**
+     * Removes a file listener from the current list
+     *
+     * @param listener The file listener
+     */
+    public void removeListener(DirectoryWatcher.FileChangeListener listener) {
+        listeners.remove(listener);
+    }
+
+    /**
      * Adds a file to the watch list
      *
      * @param fileToWatch The file to watch

--- a/grails-bootstrap/src/main/groovy/org/grails/io/watch/DirectoryWatcher.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/io/watch/DirectoryWatcher.java
@@ -80,6 +80,15 @@ public class DirectoryWatcher extends Thread {
     }
 
     /**
+     * Removes a file listener from the current list
+     *
+     * @param listener The file listener
+     */
+    public void removeListener(FileChangeListener listener) {
+        directoryWatcherDelegate.removeListener(listener);
+    }
+
+    /**
      * Adds a file to the watch list
      *
      * @param fileToWatch The file to watch


### PR DESCRIPTION
Hi there

I made some changes to address the auto-reloading issues mentioned in #636, there are actually two separate ones. The first only happens on IDEA / Windows 7 that I know of, IDEA on OS X seems ok.
- Some IDE / OS combos mean we get both a NEW and CHANGE notification for the same file, leading to a full reload. Added some de-duping so that every time we check, a file will come up at most once.
  - During a reload the applicationContext was being lost meaning that the 2nd reload would fail since it couldn't be shut down properly. Also had to add a removeListener() method to the DirectoryWatcher to allow us to remove and re-add the listener for the new plugin manager since that was also different.

Note: there is still a lingering issue around the hibernate plugin and the auto-reload which I haven't figured out yet. Every second reload it throws a bunch of exceptions, but the app appears to be functioning.
