### PR TITLE
Travis: use a container and caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: groovy
+sudo: false
 jdk:
 - oraclejdk7
 env:
@@ -36,3 +37,6 @@ deploy:
     all_branches: true
 after_deploy:
   - ./gradlew sdkMajorRelease
+cache:
+  directories:
+    - $HOME/.gradle


### PR DESCRIPTION
Using a container can shorten a waiting time for starting a build. And using caches can skip over downloading dependencies.
