### PR TITLE
Fixed a caching bug in GrailsMockHttpServletRequest

### DIFF
--- a/grails-plugin-converters/src/main/groovy/grails/converters/JSON.java
+++ b/grails-plugin-converters/src/main/groovy/grails/converters/JSON.java
@@ -62,7 +62,7 @@ import org.codehaus.groovy.runtime.IOGroovyMethods;
 public class JSON extends AbstractConverter<JSONWriter> implements IncludeExcludeConverter<JSONWriter> {
 
     private final static Log log = LogFactory.getLog(JSON.class);
-    private static final String CACHED_JSON = "org.codehaus.groovy.grails.CACHED_JSON_REQUEST_CONTENT";
+    public static final String CACHED_JSON = "org.codehaus.groovy.grails.CACHED_JSON_REQUEST_CONTENT";
 
     protected Object target;
     protected final ConverterConfiguration<JSON> config;

--- a/grails-plugin-converters/src/main/groovy/grails/converters/XML.java
+++ b/grails-plugin-converters/src/main/groovy/grails/converters/XML.java
@@ -62,7 +62,7 @@ public class XML extends AbstractConverter<XMLStreamWriter> implements IncludeEx
 
     public static final Log log = LogFactory.getLog(XML.class);
 
-    private static final String CACHED_XML = "org.codehaus.groovy.grails.CACHED_XML_REQUEST_CONTENT";
+    public static final String CACHED_XML = "org.codehaus.groovy.grails.CACHED_XML_REQUEST_CONTENT";
 
     private Object target;
     private StreamingMarkupWriter stream;

--- a/grails-test/src/main/groovy/org/codehaus/groovy/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/codehaus/groovy/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -65,8 +65,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
     private cachedJson
     private cachedXml
     DispatcherType dispatcherType
-    AsyncContext asyncContext
-    
+    AsyncContext asyncContext    
     
     public GrailsMockHttpServletRequest() {
         super();
@@ -117,6 +116,8 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
         else {
             setContent(new JSON(sourceJson).toString().getBytes("UTF-8"))
         }
+        cachedJson = null
+        setAttribute(JSON.CACHED_JSON, null)
         getAttribute("org.codehaus.groovy.grails.WEB_REQUEST")?.informParameterCreationListeners()
     }
 
@@ -141,7 +142,8 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
             }
             setContent(xml.toString().getBytes("UTF-8"))
         }
-
+        cachedXml = null
+        setAttribute(XML.CACHED_XML, null)
         getAttribute("org.codehaus.groovy.grails.WEB_REQUEST")?.informParameterCreationListeners()
     }
 


### PR DESCRIPTION
Fixed a problem in GrailsMockHttpServletRequest that prevented it from removing stale cached XML and JSON.
