### PR TITLE
Fixed a caching bug in GrailsMockHttpServletRequest

### DIFF
--- a/grails-test/src/main/groovy/org/codehaus/groovy/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/codehaus/groovy/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -65,8 +65,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
     private cachedJson
     private cachedXml
     DispatcherType dispatcherType
-    AsyncContext asyncContext
-    
+    AsyncContext asyncContext    
     
     public GrailsMockHttpServletRequest() {
         super();
@@ -117,6 +116,8 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
         else {
             setContent(new JSON(sourceJson).toString().getBytes("UTF-8"))
         }
+        cachedJson = null
+        setAttribute("org.codehaus.groovy.grails.CACHED_JSON_REQUEST_CONTENT", null)
         getAttribute("org.codehaus.groovy.grails.WEB_REQUEST")?.informParameterCreationListeners()
     }
 
@@ -141,7 +142,8 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
             }
             setContent(xml.toString().getBytes("UTF-8"))
         }
-
+        cachedXml = null
+        setAttribute("org.codehaus.groovy.grails.CACHED_XML_REQUEST_CONTENT", null)
         getAttribute("org.codehaus.groovy.grails.WEB_REQUEST")?.informParameterCreationListeners()
     }
 


### PR DESCRIPTION
Fixed a problem in GrailsMockHttpServletRequest that prevented it from removing stale cached XML and JSON.
