### PR TITLE
Added details for grails logging plugin

### DIFF
--- a/grails-logging/README.md
+++ b/grails-logging/README.md
@@ -1,2 +1,3 @@
 ## grails-logging
 
+This subproject adds a log property to all artefacts. Refer to http://grails.github.io/grails-doc/latest/ref/Plug-ins/logging.html

--- a/grails-logging/src/main/groovy/org/grails/compiler/logging/LoggingTransformer.java
+++ b/grails-logging/src/main/groovy/org/grails/compiler/logging/LoggingTransformer.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Modifier;
 import java.net.URL;
 
 /**
- * Adds a log method to all artifacts.
+ * Adds a log field to all artifacts.
  *
  * @author Graeme Rocher
  * @since 2.0


### PR DESCRIPTION
- Added details for grails logging plugin
- Fix doc comment

Related to https://github.com/grails/grails-core/issues/9088

@graemerocher 

A question. The code has

```
String logName = artefactType == null ? classNode.getName() : "grails.app." + artefactType + "." + classNode.getName();
```

When can the artefactType by null? Can probably add this to docs and close https://github.com/grails/grails-doc/issues/274 .

Also the logging plugin supports logback because the library is in the Grails' default dependencies. Correct?
