### PR TITLE
Add a default typeMismatch message which is used for Boolean and primitive types

### DIFF
--- a/grails-resources/src/grails/grails-app/i18n/messages.properties
+++ b/grails-resources/src/grails/grails-app/i18n/messages.properties
@@ -53,3 +53,4 @@ typeMismatch.java.lang.Long=Property {0} must be a valid number
 typeMismatch.java.lang.Short=Property {0} must be a valid number
 typeMismatch.java.math.BigDecimal=Property {0} must be a valid number
 typeMismatch.java.math.BigInteger=Property {0} must be a valid number
+typeMismatch=Property {0} is type-mismatched


### PR DESCRIPTION
It's very important as insurance when using `java.lang.Boolean` or primitive types in the domain class. It's enough to be written at the default `messages.properties`.
