### PR TITLE
Fix for #9229

### DIFF
--- a/grails-async/src/main/groovy/org/grails/async/factory/SynchronousPromiseFactory.groovy
+++ b/grails-async/src/main/groovy/org/grails/async/factory/SynchronousPromiseFactory.groovy
@@ -32,15 +32,24 @@ import java.util.concurrent.TimeUnit
 class SynchronousPromiseFactory extends AbstractPromiseFactory {
     @Override
     def <T> Promise<T> createPromise(Closure<T>... closures) {
+        Promise<T> promise
         if (closures.length == 1) {
-            return new SynchronousPromise<T>(closures[0])
+            promise = new SynchronousPromise<T>(closures[0])
+        } else {
+            def promiseList = new PromiseList()
+            for(p in closures) {
+                promiseList << p
+            }
+            promise = promiseList
         }
 
-        def promiseList = new PromiseList()
-        for(p in closures) {
-            promiseList << p
+        try {
+            promise.get()
+        } catch (e) {
+            // ignore
         }
-        return promiseList
+
+        return promise
     }
 
     @Override

--- a/grails-async/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
+++ b/grails-async/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
@@ -18,6 +18,7 @@ package grails.async
 import org.grails.async.decorator.PromiseDecorator
 import org.grails.async.factory.SynchronousPromiseFactory
 import org.grails.async.factory.gpars.GparsPromiseFactory
+import spock.lang.Issue
 import spock.lang.Specification
 
 import java.util.concurrent.TimeUnit
@@ -139,12 +140,24 @@ class SynchronousPromiseFactorySpec extends Specification {
 
     void "Test promise chaining with exception"() {
         when:"A promise is chained"
-            def promise = Promises.createPromise { 1 + 1 }
-            promise = promise.then { it * 2 } then { throw new RuntimeException("bad")} then { it + 6 }
-            def val = promise.get()
+        def promise = Promises.createPromise { 1 + 1 }
+        promise = promise.then { it * 2 } then { throw new RuntimeException("bad")} then { it + 6 }
+        def val = promise.get()
 
         then:'the chain is executed'
-            thrown RuntimeException
-            val == null
+        thrown RuntimeException
+        val == null
+    }
+
+    @Issue("GRAILS-9229")
+    void "Test promise is executed without calling get"() {
+        given:
+        Closure callable = Mock(Closure)
+
+        when:"A promise is created"
+        Promises.createPromise(callable)
+
+        then:'the closure is executed'
+        1 * callable.call()
     }
 }


### PR DESCRIPTION
Execute promise closure without having to call `get`, `onComplete`, etc
