### PR TITLE
Fix for https://github.com/grails/grails-core/issues/9245

### DIFF
--- a/grails-plugin-domain-class/src/main/groovy/grails/artefact/DomainClass.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/grails/artefact/DomainClass.groovy
@@ -36,7 +36,7 @@ trait DomainClass {
 
 
     static Map<String, Constrained> getConstrainedProperties() {
-        GrailsDomainClass domainClass = (GrailsDomainClass)Holders?.grailsApplication?.getArtefact(DomainClassArtefactHandler.TYPE, this.getClass().name)
+        GrailsDomainClass domainClass = (GrailsDomainClass)Holders?.grailsApplication?.getArtefact(DomainClassArtefactHandler.TYPE, this.name)
         return (Map<String, Constrained>)domainClass?.getConstrainedProperties() ?: Collections.emptyMap()
     }
 }

--- a/grails-plugin-domain-class/src/test/groovy/org/codehaus/groovy/grails/domain/DomainClassTraitSpec.groovy
+++ b/grails-plugin-domain-class/src/test/groovy/org/codehaus/groovy/grails/domain/DomainClassTraitSpec.groovy
@@ -3,6 +3,7 @@ package org.codehaus.groovy.grails.domain
 import grails.core.DefaultGrailsApplication
 import grails.persistence.Entity
 import grails.util.Holders
+import spock.lang.Issue
 import spock.lang.Specification
 
 /**
@@ -10,6 +11,7 @@ import spock.lang.Specification
  */
 class DomainClassTraitSpec extends Specification {
 
+    @Issue("GRAILS-9245")
     void "test getConstrainedProperties"() {
         given:
         def application = new DefaultGrailsApplication([Person] as Class[], getClass().classLoader)

--- a/grails-plugin-domain-class/src/test/groovy/org/codehaus/groovy/grails/domain/DomainClassTraitSpec.groovy
+++ b/grails-plugin-domain-class/src/test/groovy/org/codehaus/groovy/grails/domain/DomainClassTraitSpec.groovy
@@ -1,0 +1,32 @@
+package org.codehaus.groovy.grails.domain
+
+import grails.core.DefaultGrailsApplication
+import grails.persistence.Entity
+import grails.util.Holders
+import spock.lang.Specification
+
+/**
+ * @author James Kleeh
+ */
+class DomainClassTraitSpec extends Specification {
+
+    void "test getConstrainedProperties"() {
+        given:
+        def application = new DefaultGrailsApplication([Person] as Class[], getClass().classLoader)
+        application.initialise()
+        Holders.grailsApplication = application
+
+        expect:
+        !Person.constrainedProperties.name.blank
+    }
+
+    @Entity
+    class Person {
+        String name
+
+        static constraints = {
+            name blank: false
+        }
+    }
+}
+


### PR DESCRIPTION
Calling `this.getClass().name` is for use in non static methods. Since the method is static it was returning `java.lang.Class`
