### PR TITLE
Issue #685 - Second format in DateConversionHelper should also use HH

### DIFF
--- a/grails-databinding/src/main/groovy/org/grails/databinding/converters/DateConversionHelper.groovy
+++ b/grails-databinding/src/main/groovy/org/grails/databinding/converters/DateConversionHelper.groovy
@@ -32,7 +32,7 @@ class DateConversionHelper implements ValueConverter {
      * This converter attempts to convert a String to a Date, these formats will be tried in
      * the order in which they appear in the List.
      */
-    List<String> formatStrings = ['yyyy-MM-dd HH:mm:ss.S',"yyyy-MM-dd'T'hh:mm:ss'Z'","yyyy-MM-dd HH:mm:ss.S z"]
+    List<String> formatStrings = ['yyyy-MM-dd HH:mm:ss.S',"yyyy-MM-dd'T'HH:mm:ss'Z'","yyyy-MM-dd HH:mm:ss.S z"]
 
     Object convert(value) {
         Date dateValue


### PR DESCRIPTION
Lenient Calendars will correctly parse hours 13-23 using either 'hh' or
'HH' and lenient is the default.  Since the formats are used to parse date
strings and not format dates, this change should not be a breaking change
or have any noticeable impact.  However, for consistency it make sense to
change to match the other hour formats.
