### PR TITLE
Include request method in URL matching (Fixes #9065)

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
@@ -199,7 +199,7 @@ class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
             if (mapping) mappingInfos << mapping
         }
         else {
-            mappingInfos = mappingsHolder.matchAll(url)
+            mappingInfos = mappingsHolder.matchAll(url, request.method)
         }
 
         if (mappingInfos.size() == 0) throw new AssertionFailedError("url '$url' did not match any mappings")

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
@@ -1,6 +1,7 @@
 package grails.test.mixin
 
 import grails.artefact.Artefact
+import grails.rest.RestfulController
 import grails.test.mixin.web.UrlMappingsUnitTestMixin
 import grails.web.Action
 import junit.framework.AssertionFailedError
@@ -8,6 +9,7 @@ import junit.framework.ComparisonFailure
 
 import org.junit.Test
 import org.springframework.web.context.WebApplicationContext
+import spock.lang.Issue
 
 /**
  * Tests for the UrlMappingsTestMixin class
@@ -154,6 +156,42 @@ class UrlMappingsTestMixinTests {
             dateParam = new Date(1)
         }
     }
+
+    @Test
+    @Issue('https://github.com/grails/grails-core/issues/9065')
+    void testResourcesUrlMapping() {
+        mockController(PersonController)
+        mockUrlMappings(ResourceTestUrlMappings)
+
+        request.method = 'GET'
+        assertForwardUrlMapping('/person', controller: 'person', action: 'index')
+        assertForwardUrlMapping('/person/create', controller: 'person', action: 'create')
+        assertForwardUrlMapping('/person/personId', controller: 'person', action: 'show') {
+            id = 'personId'
+        }
+        assertForwardUrlMapping('/person/personId/edit', controller: 'person', action: 'edit') {
+            id = 'personId'
+        }
+
+        request.method = 'POST'
+        assertForwardUrlMapping('/person', controller: 'person', action: 'save')
+
+        request.method = 'PUT'
+        assertForwardUrlMapping('/person/personId', controller: 'person', action: 'update') {
+            id = 'personId'
+        }
+
+        request.method = 'PATCH'
+        assertForwardUrlMapping('/person/personId', controller: 'person', action: 'patch') {
+            id = 'personId'
+        }
+
+        request.method = 'DELETE'
+        assertForwardUrlMapping('/person/personId', controller: 'person', action: 'delete') {
+            id = 'personId'
+        }
+
+    }
 }
 
 class AnotherUrlMappings {
@@ -209,5 +247,18 @@ class GRAILS9110UrlMappings {
             objParam = [test:true]
             dateParam = new Date(1)
         }
+    }
+}
+
+@Artefact("Controller")
+class PersonController extends RestfulController<String> {
+    PersonController() {
+        super(''.class)
+    }
+}
+
+class ResourceTestUrlMappings {
+    static mappings = {
+        '/person'(resources: 'person')
     }
 }


### PR DESCRIPTION
Test included. Allows for unit testing of the 'resource(s)' style of url
mappings using assertForwardUrlMapping.

Fixes https://github.com/grails/grails-core/issues/9065
