### PR TITLE
Test changes so that 'gradlew test' will work on the Windows platform

### DIFF
--- a/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
+++ b/grails-bootstrap/src/test/groovy/grails/build/logging/GrailsConsoleSpec.groovy
@@ -38,7 +38,10 @@ import java.util.regex.Pattern
  * @author Tom Bujok
  * @since 2.3
  */
-@IgnoreIf({ System.getenv("TRAVIS") != null })
+@IgnoreIf({
+    System.getenv("TRAVIS") != null ||
+            !GrailsConsole.instance.isAnsiEnabled()
+})
 class GrailsConsoleSpec extends Specification {
 
     static final String RESET = Pattern.quote(Ansi.ansi().reset().toString())

--- a/grails-test-suite-uber/src/test/groovy/org/grails/io/support/GrailsResourceUtilsTests.java
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/io/support/GrailsResourceUtilsTests.java
@@ -8,6 +8,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 
 import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 
 public class GrailsResourceUtilsTests extends TestCase {
@@ -92,18 +93,18 @@ public class GrailsResourceUtilsTests extends TestCase {
 
     public void testGetViewsDirForURL() throws Exception {
         Resource viewsDir = GrailsResourceUtils.getViewsDir(new UrlResource(TEST_CONTROLLER_URL));
-        assertEquals("file:/test/grails/app/grails-app/views", viewsDir.getURL().toString());
+        assertEquals(toFileUrl("/test/grails/app/grails-app/views"), viewsDir.getURL().toString());
 
         viewsDir = GrailsResourceUtils.getViewsDir(new UrlResource(TEST_URL));
-        assertEquals("file:/test/grails/app/grails-app/views", viewsDir.getURL().toString());
+        assertEquals(toFileUrl("/test/grails/app/grails-app/views"), viewsDir.getURL().toString());
     }
 
     public void testGetAppDir() throws Exception {
         Resource appDir = GrailsResourceUtils.getAppDir(new UrlResource(TEST_CONTROLLER_URL));
-        assertEquals("file:/test/grails/app/grails-app", appDir.getURL().toString());
+        assertEquals(toFileUrl("/test/grails/app/grails-app"), appDir.getURL().toString());
 
         appDir = GrailsResourceUtils.getAppDir(new UrlResource(TEST_URL));
-        assertEquals("file:/test/grails/app/grails-app", appDir.getURL().toString());
+        assertEquals(toFileUrl("/test/grails/app/grails-app"), appDir.getURL().toString());
     }
 
     public void testGetDirWithinWebInf() throws Exception {
@@ -113,12 +114,12 @@ public class GrailsResourceUtilsTests extends TestCase {
         Resource webInfViews = GrailsResourceUtils.getViewsDir(new UrlResource(WEBINF_CONTROLLER));
         Resource webInfPluginViews = GrailsResourceUtils.getViewsDir(new UrlResource(WEBINF_PLUGIN_CTRL));
 
-        assertEquals("file:/test/grails/app/grails-app/views", viewsDir.getURL().toString());
-        assertEquals("file:/test/grails/app/plugins/myplugin/grails-app/views",
+        assertEquals(toFileUrl("/test/grails/app/grails-app/views"), viewsDir.getURL().toString());
+        assertEquals(toFileUrl("/test/grails/app/plugins/myplugin/grails-app/views"),
                 pluginViews.getURL().toString());
-        assertEquals("file:/test/grails/app/WEB-INF/grails-app/views",
+        assertEquals(toFileUrl("/test/grails/app/WEB-INF/grails-app/views"),
                 webInfViews.getURL().toString());
-        assertEquals("file:/test/grails/app/WEB-INF/plugins/myplugin/grails-app/views",
+        assertEquals(toFileUrl("/test/grails/app/WEB-INF/plugins/myplugin/grails-app/views"),
                 webInfPluginViews.getURL().toString());
 
         assertEquals("/WEB-INF/grails-app/views", GrailsResourceUtils.getRelativeInsideWebInf(webInfViews));
@@ -153,5 +154,16 @@ public class GrailsResourceUtilsTests extends TestCase {
         assertEquals("/alpha/beta/gamma", GrailsResourceUtils.appendPiecesForUri("/alpha/", "/beta/", "/gamma"));
         assertEquals("/alpha/beta/gamma/", GrailsResourceUtils.appendPiecesForUri("/alpha/", "/beta/", "/gamma/"));
         assertEquals("alpha/beta/gamma", GrailsResourceUtils.appendPiecesForUri("alpha", "beta", "gamma"));
+    }
+
+    private String toFileUrl(String path) {
+        if (path == null) return path;
+        String url = null;
+        try {
+            url = new File(path).toURI().toURL().toString();
+        } catch (MalformedURLException e) {
+            url = path;
+        }
+        return url;
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/org/grails/plugins/web/ControllersGrailsPluginTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/plugins/web/ControllersGrailsPluginTests.groovy
@@ -126,7 +126,7 @@ class FormTagLib {
             assertEquals "org.grails.gsp.GroovyPageResourceLoader", beanDef.beanClassName
             assertNotNull beanDef.getPropertyValues().getPropertyValue('baseResource')
 
-            assertEquals "file:${new File(".").absolutePath}/".toString(), beanDef.getPropertyValues().getPropertyValue('baseResource').getValue()
+            assertEquals "file:${new File(".").absolutePath}${File.separatorChar}".toString(), beanDef.getPropertyValues().getPropertyValue('baseResource').getValue()
 
             beanDef = bb.getBeanDefinition("groovyPagesTemplateEngine")
             assertEquals "groovyPageLocator", beanDef.getPropertyValues().getPropertyValue("groovyPageLocator").getValue()?.beanName


### PR DESCRIPTION
Running `gradlew test` on the grails-core source currently fails on the Windows os.

The `GrailsConsoleSpec` tests for the ansi reset code but the WindowsTerminal doesn't support ansi so the reset code is never written.  Changed so that the tests only run if ansi is supported.

A few other tests just needed minor path fixes in order to have the correct file separator or to build a file URL that includes the root directory (i.e., file://C:/path/.../).
