### PR TITLE
Issue #9308

### DIFF
--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -337,7 +337,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
                     }
                 }
             } else if(grailsApplication != null) { // Fixes bidirectional oneToOne binding issue #9308
-                def domainClass = (GrailsDomainClass) grailsApplication.getArtefact('Domain', obj.getClass().name)
+                def domainClass = (GrailsDomainClass) grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, obj.getClass().name)
                 if (domainClass != null) {
                     def property = domainClass.getPersistentProperty metaProperty.name
                     if (property != null && property.isBidirectional()) {
@@ -485,7 +485,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
             return
         }
 
-        def domainClass = (GrailsDomainClass)grailsApplication.getArtefact('Domain', obj.getClass().name)
+        def domainClass = (GrailsDomainClass)grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, obj.getClass().name)
         if (domainClass != null) {
             def property = domainClass.getPersistentProperty propertyName
             if (property != null && property.isBidirectional()) {
@@ -579,7 +579,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
 
         // Fix for issue #9308 sets propertyValue's otherside value to the owning object for bidirectional manyToOne relationships
         if (grailsApplication != null) {
-            def domainClass = (GrailsDomainClass) grailsApplication.getArtefact('Domain', obj.getClass().name)
+            def domainClass = (GrailsDomainClass) grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, obj.getClass().name)
             if (domainClass != null) {
                 def property = domainClass.getPersistentProperty propName
                 if (property != null && property.isBidirectional()) {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -336,6 +336,17 @@ class GrailsWebDataBinder extends SimpleDataBinder {
                         }
                     }
                 }
+            } else if(grailsApplication != null) { // Fixes bidirectional oneToOne binding issue #9308
+                def domainClass = (GrailsDomainClass) grailsApplication.getArtefact('Domain', obj.getClass().name)
+                if (domainClass != null) {
+                    def property = domainClass.getPersistentProperty metaProperty.name
+                    if (property != null && property.isBidirectional()) {
+                        def otherSide = property.otherSide
+                        if (otherSide.isOneToOne()) {
+                            val[otherSide.name] = obj
+                        }
+                    }
+                }
             }
         }
         if (needsBinding) {
@@ -566,7 +577,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
     @Override
     protected addElementToCollection(obj, String propName, Class propertyType, propertyValue, boolean clearCollection) {
 
-        // Fix for issue #9308 sets propertyValue's otherside value to the owning object
+        // Fix for issue #9308 sets propertyValue's otherside value to the owning object for bidirectional manyToOne relationships
         if (grailsApplication != null) {
             def domainClass = (GrailsDomainClass) grailsApplication.getArtefact('Domain', obj.getClass().name)
             if (domainClass != null) {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -565,6 +565,21 @@ class GrailsWebDataBinder extends SimpleDataBinder {
     
     @Override
     protected addElementToCollection(obj, String propName, Class propertyType, propertyValue, boolean clearCollection) {
+
+        // Fix for issue #9308 sets propertyValue's otherside value to the owning object
+        if (grailsApplication != null) {
+            def domainClass = (GrailsDomainClass) grailsApplication.getArtefact('Domain', obj.getClass().name)
+            if (domainClass != null) {
+                def property = domainClass.getPersistentProperty propName
+                if (property != null && property.isBidirectional()) {
+                    def otherSide = property.otherSide
+                    if (otherSide.isManyToOne()) {
+                        propertyValue[otherSide.name] = obj
+                    }
+                }
+            }
+        }
+
         def elementToAdd = propertyValue
         def referencedType = getReferencedTypeForCollection propName, obj
         if (referencedType != null) {


### PR DESCRIPTION
These 2 fixes set the property value's otherside entry to the object, 
therefore fixing the binding issue.

The addToCollection fix corrects the oneToMany relationship
The processProperty fix corrects the oneToOne relationship (I couldn't find a more appropriate place to put this fix than in this method)

Has had changes as recommended in #9312 and as requested being submitted to the 3.0.x branch
