### PR TITLE
Add check for groovy ToString annotation before applying toString met…

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
@@ -188,8 +188,9 @@ public class DefaultGrailsDomainClassInjector implements GrailsDomainClassInject
     private void injectToStringMethod(ClassNode classNode) {
         final boolean hasToString = GrailsASTUtils.implementsOrInheritsZeroArgMethod(
                 classNode, "toString", classesWithInjectedToString);
+        final boolean hasToStringAnnotation = GrailsASTUtils.hasAnnotation(classNode, groovy.transform.ToString.class);
 
-        if (!hasToString && !isEnum(classNode)) {
+        if (!hasToString && !isEnum(classNode) && !hasToStringAnnotation) {
             GStringExpression ge = new GStringExpression(classNode.getName() + " : ${id ? id : '(unsaved)'}");
             ge.addString(new ConstantExpression(classNode.getName() + " : "));
             VariableExpression idVariable = new VariableExpression("id");

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/DefaultDomainClassInjectorSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/DefaultDomainClassInjectorSpec.groovy
@@ -1,0 +1,35 @@
+package org.grails.compiler.injection
+
+import grails.persistence.Entity
+import groovy.transform.ToString
+
+/**
+ * @author James Kleeh
+ */
+class DefaultDomainClassInjectorSpec extends GroovyTestCase {
+
+    void "test default toString"() {
+        Test test = new Test()
+        test.id = 1
+        assert test.toString().endsWith("Test : 1")
+    }
+
+    void "test domain with groovy.transform.ToString"() {
+        TestWithGroovy test = new TestWithGroovy()
+        test.id = 1
+        assert test.toString().endsWith("TestWithGroovy(1)")
+    }
+
+
+    @Entity
+    class Test {
+    }
+
+    @Entity
+    @ToString(includes = ["id"])
+    class TestWithGroovy {
+    }
+
+
+
+}


### PR DESCRIPTION
…hod in domain classes. The ToString annotation is getting applied after the domain class injector runs, so it is not finding a toString method, therefore it adds the default. The ToString annotation cannot be applied before the domain class injector because if it included the id property, it would not exist.

See issue https://github.com/grails/grails-core/issues/9317
