### PR TITLE
Issue #9090 - Grails docs not building the source tags

### DIFF
--- a/grails-docs/src/main/groovy/grails/doc/macros/GspTagSourceMacro.groovy
+++ b/grails-docs/src/main/groovy/grails/doc/macros/GspTagSourceMacro.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2004-2015 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package grails.doc.macros
 
 import java.util.regex.Pattern
@@ -24,14 +39,12 @@ class GspTagSourceMacro extends BaseMacro {
         def i = source.indexOf('=')
         def type = source[0..i-1]
         def name = source[i+1..-1]
-        String code
 
         switch (type) {
             case "tag":
                 def j = name.indexOf('.')
                 def className = name[0..j-1]
                 def tagName = name[j+1..-1]
-                Pattern regex = ~/(?s)(\s*?def\s+?$tagName\s*?=\s*?\{\s*?attrs\s*?,{0,1}\s*?(body){0,1}\s*?->.+?)(\/\*\*|def\s*[a-zA-Z]+?\s*=\s*\{)/
 
                 // Recursively search for the tag library source file in the
                 // configured base directory.
@@ -42,13 +55,13 @@ class GspTagSourceMacro extends BaseMacro {
                 }
 
                 def text = tagLibFile?.getText("UTF-8") ?: ""
-                def matcher = regex.matcher(text)
-                if (matcher.find()) {
+                String closureSource = extractTagClosureSource(tagName, text)
+                if (closureSource) {
                     out << '<p><a href="#' + tagName +
                             '" onclick="document.getElementById(\'' + tagName +
                             '\').style.display=\'inline\'">Show Source</a></p>'
                     out << "<div id=\"$tagName\" style=\"display:none;\">"
-                    text = Encoder.escape(matcher.group(1))
+                    text = Encoder.escape(closureSource)
 
                     def macro = new CodeMacro()
                     macro.setInitialContext(initialContext)
@@ -60,5 +73,61 @@ class GspTagSourceMacro extends BaseMacro {
                 break
         }
     }
-}
 
+    /**
+     * Extracts the Closure source code for a given tag name.
+     *
+     * @param tagName name of the tag method to extract the source code for
+     * @param sourceText    the source code to search
+     * @return  source code for the tag Closure or an empty string if not found
+     */
+    String extractTagClosureSource(String tagName, String sourceText) {
+        if (!sourceText) return ''
+        String source = ''
+        Pattern regex = ~/(?s)(?:\s*\n)*(\s*?(?:Closure)\s+?${tagName}\s*?=\s*?\{.*?->.+?)(.*)/
+        def matcher = regex.matcher(sourceText)
+        if (matcher.find() && matcher.groupCount() == 2) {
+            String signature = matcher.group(1)
+            String remaining = matcher.group(2)
+            source = signature + substringToClosingBrace(remaining)
+        }
+        return source
+    }
+
+    //
+    // Returns a substring of the text up to and including the closing brace '}'.
+    // Assumes that opening brace count is 1 and counts '{' and '}' until the
+    // count is 0.  Be sure to NOT include the opening brace in the text.
+    //
+    // Given:
+    //          def foo = bar.find { it == 2 }
+    //      }
+    //      private void doSomething() { doSomethingElse() }
+    //
+    // Returns:
+    //          def foo = bar.find { it == 2 }
+    //      }
+    //
+    private String substringToClosingBrace(String text) {
+        StringBuilder sb = new StringBuilder()
+        int braceCount = 1
+        char[] chars = text.toCharArray()
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i]
+            switch (c) {
+                case '{':
+                    ++braceCount
+                    break
+                case '}':
+                    --braceCount
+                    break
+            }
+            sb.append(c)
+            if (braceCount == 0) {
+                break
+            }
+        }
+        return sb.toString()
+    }
+
+}

--- a/grails-docs/src/test/groovy/grails/doc/macros/GspTagSourceMacroTest.groovy
+++ b/grails-docs/src/test/groovy/grails/doc/macros/GspTagSourceMacroTest.groovy
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2015 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package grails.doc.macros
+
+import spock.lang.Specification
+
+/**
+ * Tests for the GspTagSourceMacro class file which is used by the grails-doc
+ * project to parse out TagLib closure methods and include the source in
+ * the documentation of each tag.
+ *
+ * @author John Wagenleitner
+ */
+class GspTagSourceMacroTest extends Specification {
+
+    void 'extracts tag closure source'() {
+        given:
+        GspTagSourceMacro macro = new GspTagSourceMacro([])
+        String closureSource = macro.extractTagClosureSource(tagName, testSource)
+
+        expect:
+        closureSource.split('\n').size() == linesOfSource
+
+        where:
+        tagName               | linesOfSource
+        'textField'           | 5
+        'field'               | 4
+        'checkBox'            | 60
+        'uploadForm'          | 3
+        'tagWithTypedAttrs'   | 3
+    }
+
+    void 'returns empty string if tag does not exist'() {
+        given:
+        GspTagSourceMacro macro = new GspTagSourceMacro([])
+
+        when:
+        String closureSource = macro.extractTagClosureSource('tagNotExists', testSource)
+
+        then:
+        '' == closureSource
+    }
+
+    void 'returns empty string if not source text'() {
+        given:
+        GspTagSourceMacro macro = new GspTagSourceMacro([])
+
+        when:
+        String closureSource = macro.extractTagClosureSource('someTag', '')
+
+        then:
+        '' == closureSource
+    }
+
+    static String testSource = '''
+@TagLib
+class TestTagLib implements TagLibrary {
+
+    Closure textField = { attrs ->
+        attrs.type = "text"
+        attrs.tagName = "textField"
+        fieldImpl(out, attrs)
+    }
+
+    def hiddenFieldImpl(out, attrs) {
+        attrs.type = "hidden"
+        attrs.tagName = "hiddenField"
+        fieldImpl(out, attrs)
+    }
+
+    Closure field = { attrs ->
+        attrs.tagName = "field"
+        fieldImpl(out, attrs)
+    }
+
+    @CompileStatic
+    private void outputNameAsIdIfIdDoesNotExist(Map attrs, GrailsPrintWriter out) {
+        if (!attrs.containsKey('id') && attrs.containsKey('name')) {
+            Encoder htmlEncoder = codecLookup?.lookupEncoder('HTML')
+            out << 'id="\'
+            out << (htmlEncoder != null ? htmlEncoder.encode(attrs.name) : attrs.name)
+            out << '" \'
+        }
+    }
+
+    Closure checkBox = { attrs ->
+        def value = attrs.remove('value')
+        def name = attrs.remove('name')
+        booleanToAttribute(attrs, 'disabled')
+        booleanToAttribute(attrs, 'readonly')
+
+        // Deal with the "checked" attribute. If it doesn't exist, we
+        // default to a value of "true", otherwise we use Groovy Truth
+        // to determine whether the HTML attribute should be displayed or not.
+        def checked = true
+        def checkedAttributeWasSpecified = false
+        if (attrs.containsKey('checked')) {
+            checkedAttributeWasSpecified = true
+            checked = attrs.remove('checked')
+        }
+
+        if (checked instanceof String) checked = Boolean.valueOf(checked)
+
+        if (value == null) value = false
+        def hiddenValue = ""
+
+        def unprocessed = value
+        value = processFormFieldValueIfNecessary(name, value,"checkbox")
+        hiddenValue = processFormFieldValueIfNecessary("_${name}", hiddenValue, "hidden")
+
+        def hiddenFieldName
+        if(name.indexOf('.') == -1) {
+            hiddenFieldName = "_${name}"
+        } else {
+            def lastDot = name.lastIndexOf('.')
+            hiddenFieldName = name[0..lastDot] + '_' + name[(lastDot+1)..-1]
+        }
+        out << "<input type=\\"hidden\\" name=\\"${hiddenFieldName}\\""
+        if (hiddenValue != "") {
+            out << " value=\\"${hiddenValue}\\""
+        }
+        out << " /><input type=\\"checkbox\\" name=\\"${name}\\" "
+        if (checkedAttributeWasSpecified) {
+            if (checked) {
+                out << 'checked="checked" \'
+            }
+        }
+        else if (unprocessed) {
+            out << 'checked="checked" \'
+        }
+
+        def outputValue = !(unprocessed instanceof Boolean || unprocessed?.getClass() == boolean)
+        if (outputValue) {
+            out << "value=\\"${value}\\" "
+        }
+        // process remaining attributes
+        outputAttributes(attrs, out)
+
+        if (!attrs.containsKey('id')) {
+            out << """id="${name}" """
+        }
+
+        // close the tag, with no body
+        out << ' />\'
+    }
+
+    private processFormFieldValueIfNecessary(name, value, type) {
+        if (requestDataValueProcessor != null) {
+            return requestDataValueProcessor.processFormFieldValue(request, name, "${value}", type)
+        }
+        return value
+    }
+
+    Closure uploadForm = { attrs, body ->
+        attrs.enctype = "multipart/form-data"; out << form(attrs, body)
+    }
+
+    Closure tagWithTypedAttrs = { Map attrs, body ->
+        out << 'some layout'
+    }
+
+}'''
+
+}


### PR DESCRIPTION
Regex was not picking up the new tag closure signature (def -> Closure).  Also it had issues identifying the end of the method, relying on either a javadoc comment or a `def method...`.  In looking at various taglibs there was a variety of things after the closure that would have been difficult to write a regex for so went with counting braces.

Also will submit a PR for the grails-docs repo.
