### PR TITLE
Grails core 9340

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
+++ b/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
@@ -15,6 +15,8 @@
  */
 package org.grails.core;
 
+import grails.config.Settings;
+import grails.core.GrailsApplication;
 import grails.core.GrailsControllerClass;
 import grails.util.GrailsClassUtils;
 import grails.web.Action;
@@ -45,7 +47,7 @@ public class DefaultGrailsControllerClass extends AbstractInjectableGrailsClass 
     public static final Object[] EMPTY_ARGS = new Object[0];
     public static final String SCOPE = "scope";
     public static final String SCOPE_SINGLETON = "singleton";
-    private final String scope;
+    private String scope;
     private Map<String, FastMethod> actions = new HashMap<String, FastMethod>();
     private String defaultActionName;
     private String namespace;
@@ -57,13 +59,20 @@ public class DefaultGrailsControllerClass extends AbstractInjectableGrailsClass 
         if (defaultActionName == null) {
             defaultActionName = INDEX_ACTION;
         }
-        final String t = getStaticPropertyValue(SCOPE, String.class);
-        this.scope = t != null ? t : SCOPE_SINGLETON;
         methodStrategy(actions);
+        this.scope = getStaticPropertyValue(SCOPE, String.class);
     }
 
     public void initialize() {
         // no-op
+    }
+
+    @Override
+    public void setGrailsApplication(GrailsApplication grailsApplication) {
+        this.grailsApplication = grailsApplication;
+        if (this.scope == null) {
+            this.scope = grailsApplication.getConfig().getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, "prototype");
+        }
     }
 
     @Override

--- a/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
@@ -12,7 +12,7 @@ class DefaultGrailsControllerClassSpec extends Specification {
     static final String SINGLETON = "singleton"
     static final String PROTOTYPE = "prototype"
 
-    void "test getScope & isSingleton when scope is not specified on the controller, but it specified in config"() {
+    void "test getScope when scope is not specified on the controller, but it specified in config"() {
         given:
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         def grailsApplication = new DefaultGrailsApplication()
@@ -24,7 +24,7 @@ class DefaultGrailsControllerClassSpec extends Specification {
         controllerClass.isSingleton()
     }
 
-    void "test getScope & isSingleton when scope is not specified on the controller, and not specified in config"() {
+    void "test getScope when scope is not specified on the controller, and not specified in config"() {
         given:
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         controllerClass.setGrailsApplication(new DefaultGrailsApplication())

--- a/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
@@ -1,0 +1,64 @@
+package org.grails.core
+
+import grails.config.Settings
+import grails.core.DefaultGrailsApplication
+import spock.lang.Specification
+
+/**
+ * @author James Kleeh
+ */
+class DefaultGrailsControllerClassSpec extends Specification {
+
+    static final String SINGLETON = "singleton"
+    static final String PROTOTYPE = "prototype"
+
+    void "test getScope & isSingleton when scope is not specified on the controller, but it specified in config"() {
+        given:
+        def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
+        def grailsApplication = new DefaultGrailsApplication()
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
+        controllerClass.setGrailsApplication(grailsApplication)
+
+        expect: "the configuration value is used"
+        controllerClass.getScope() == SINGLETON
+        controllerClass.isSingleton()
+    }
+
+    void "test getScope & isSingleton when scope is not specified on the controller, and not specified in config"() {
+        given:
+        def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
+        controllerClass.setGrailsApplication(new DefaultGrailsApplication())
+
+        expect: "the default scope is prototype"
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
+    }
+
+    void "test getScope when scope is specified on the controller, and not specified in config"() {
+        given:
+        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+
+        expect:
+        controllerClass.getScope() == SINGLETON
+        controllerClass.isSingleton()
+    }
+
+    void "test getScope when scope is specified both in the controller and config"() {
+        given:
+        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+        def grailsApplication = new DefaultGrailsApplication()
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
+        controllerClass.setGrailsApplication(grailsApplication)
+
+        expect: "controller's setting to have priority"
+        controllerClass.getScope() == SINGLETON
+        controllerClass.isSingleton()
+    }
+
+    class NotSpecifiedController {
+    }
+
+    class SingletonController {
+        static scope = "singleton"
+    }
+}

--- a/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersGrailsPlugin.groovy
@@ -68,7 +68,6 @@ class ControllersGrailsPlugin extends Plugin {
         def application = grailsApplication
         def config = application.config
 
-        String defaultScope = config.getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, 'prototype')
         boolean useJsessionId = config.getProperty(Settings.GRAILS_VIEWS_ENABLE_JSESSIONID, Boolean, false)
         String uploadTmpDir = config.getProperty(Settings.CONTROLLERS_UPLOAD_LOCATION, System.getProperty("java.io.tmpdir"))
         long maxFileSize = config.getProperty(Settings.CONTROLLERS_UPLOAD_MAX_FILE_SIZE, Long, 128000L)
@@ -152,7 +151,7 @@ class ControllersGrailsPlugin extends Plugin {
             log.debug "Configuring controller $controller.fullName"
             if (controller.available) {
                 "${controller.fullName}"(controller.clazz) { bean ->
-                    def beanScope = controller.getPropertyValue("scope") ?: defaultScope
+                    def beanScope = controller.getScope()
                     bean.scope = beanScope
                     bean.autowire =  "byName"
                     if (beanScope == 'prototype') {
@@ -181,12 +180,11 @@ class ControllersGrailsPlugin extends Plugin {
                 return
             }
 
-            def defaultScope = application.config.getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, 'prototype')
 
             GrailsControllerClass controllerClass = (GrailsControllerClass)application.addArtefact(ControllerArtefactHandler.TYPE, (Class)event.source)
             beans {
                 "${controllerClass.fullName}"(controllerClass.clazz) { bean ->
-                    def beanScope = controllerClass.getPropertyValue("scope") ?: defaultScope
+                    def beanScope = controllerClass.getScope()
                     bean.scope = beanScope
                     bean.autowire = "byName"
                     if (beanScope == 'prototype') {


### PR DESCRIPTION
Move use of default scope inside of `DefaultGrailsControllerClass` in order to correctly determine whether or not the bean is a singleton
