### PR TITLE
Asset Packaging In the Plugin Gradle task should not hardcode organizational folders

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -152,11 +152,14 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
 
             def processResourcesDependencies = []
             if(grailsExtension.packageAssets) {
-                processResourcesDependencies << project.task(type: Copy, "copyAssets") {
-                    new File(project.projectDir,"grails-app/assets").eachDir { subDirectory ->
-                        from subDirectory.canonicalPath
+                def assetsDir = new File(project.projectDir,"grails-app/assets")
+                if(assetsDir.exists()) {
+                    processResourcesDependencies << project.task(type: Copy, "copyAssets") {
+                        assetsDir.eachDir { subDirectory ->
+                            from subDirectory.canonicalPath
+                        }
+                        into "${processResources.destinationDir}/META-INF/assets"
                     }
-                    into "${processResources.destinationDir}/META-INF/assets"
                 }
             }
 

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -153,9 +153,9 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             def processResourcesDependencies = []
             if(grailsExtension.packageAssets) {
                 processResourcesDependencies << project.task(type: Copy, "copyAssets") {
-                    from "${project.projectDir}/grails-app/assets/javascripts"
-                    from "${project.projectDir}/grails-app/assets/stylesheets"
-                    from "${project.projectDir}/grails-app/assets/images"
+                    new File(project.projectDir,"grails-app/assets").eachDir { subDirectory ->
+                        from subDirectory.canonicalPath
+                    }
                     into "${processResources.destinationDir}/META-INF/assets"
                 }
             }


### PR DESCRIPTION
This fix resolves an issue where inline plugin asset packaging had to be within `assets/javascripts` `assets/stylesheets` or `assets/images`. These should not be hardcoded and should be any folder underneath `assets``.
