### PR TITLE
Grails Inline Plugin Patching

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -141,11 +141,14 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
 
             def processResourcesDependencies = []
             if(grailsExtension.packageAssets) {
-                processResourcesDependencies << project.task(type: Copy, "copyAssets") {
-                    new File(project.projectDir,"grails-app/assets").eachDir { subDirectory ->
-                        from subDirectory.canonicalPath
+                def assetsDir = new File(project.projectDir,"grails-app/assets")
+                if(assetsDir.exists()) {
+                    processResourcesDependencies << project.task(type: Copy, "copyAssets") {
+                        assetsDir.eachDir { subDirectory ->
+                            from subDirectory.canonicalPath
+                        }
+                        into "${processResources.destinationDir}/META-INF/assets"
                     }
-                    into "${processResources.destinationDir}/META-INF/assets"
                 }
             }
 

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -142,9 +142,9 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             def processResourcesDependencies = []
             if(grailsExtension.packageAssets) {
                 processResourcesDependencies << project.task(type: Copy, "copyAssets") {
-                    from "${project.projectDir}/grails-app/assets/javascripts"
-                    from "${project.projectDir}/grails-app/assets/stylesheets"
-                    from "${project.projectDir}/grails-app/assets/images"
+                    new File(project.projectDir,"grails-app/assets").eachDir { subDirectory ->
+                        from subDirectory.canonicalPath
+                    }
                     into "${processResources.destinationDir}/META-INF/assets"
                 }
             }


### PR DESCRIPTION
We need to fix the grails plugin packaging to not hard code subfolders for organization in the `grails-app/assets` folder
