### PR TITLE
Handling constraints block underneath group. Fixes #9426

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -219,7 +219,7 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
 
 
         private boolean urlDefiningMode = true;
-        private boolean inGroupConstratins = false;
+        private boolean inGroupConstraints = false;
         private List<ConstrainedProperty> previousConstraints = new ArrayList<ConstrainedProperty>();
         private List<UrlMapping> urlMappings = new ArrayList<UrlMapping>();
         private Map<String, Object> parameterValues = new HashMap<String, Object>();
@@ -557,17 +557,17 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
         }
 
         private String establishFullURI(String uri, List<ConstrainedProperty> constrainedList) {
-            if (parentResources.isEmpty() || inGroupConstratins) {
+            if (parentResources.isEmpty() || inGroupConstraints) {
                 return uri;
             }
 
             ParentResource parentResource = parentResources.peek();
             if (CONSTRAINTS.equals(uri) && parentResource.isGroup) {
-                inGroupConstratins = true;
+                inGroupConstraints = true;
                 return uri;
             }
 
-            inGroupConstratins = false;
+            inGroupConstraints = false;
 
             StringBuilder uriBuilder = new StringBuilder();
 

--- a/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/GroupedUrlMappingSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/GroupedUrlMappingSpec.groovy
@@ -25,16 +25,43 @@ class GroupedUrlMappingSpec extends AbstractUrlMappingsSpec {
 
     @Issue('#9138')
     void "Test that group parameters are included in generated links"() {
-        given:"A link generator with a dynamic URL mapping"
+        given: "A link generator with a dynamic URL mapping"
         def linkGenerator = getLinkGenerator {
             group "/events/$alias", {
-                "/" (controller: 'test', action: 'index')
-                "/orders/$id" (controller: 'test', action: 'show')
+                "/"(controller: 'test', action: 'index')
+                "/orders/$id"(controller: 'test', action: 'show')
             }
         }
 
         expect:
-        linkGenerator.link(controller:"test", action: 'index', params:[alias:'foo']) == 'http://localhost/events/foo'
-        linkGenerator.link(controller:"test", action: 'show', id:1, params:[alias:'foo']) == 'http://localhost/events/foo/orders/1'
+        linkGenerator.link(controller: "test", action: 'index', params: [alias: 'foo']) == 'http://localhost/events/foo'
+        linkGenerator.link(controller: "test", action: 'show', id: 1, params: [alias: 'foo']) == 'http://localhost/events/foo/orders/1'
+    }
+
+    @Issue('#9426')
+    void "Test that constraints embedded within groups are properly respected"() {
+        given: "A group with a child URL that contains a constraint"
+        def urlMappingsHolder = getUrlMappingsHolder {
+            group "/group", {
+                "/$id/$page?" {
+                    controller = "test"
+                    action = "index"
+                    constraints {
+                        id(matches: /\d+/)
+                        page(matches: /\d+/)
+                    }
+                }
+            }
+        }
+
+        when: 'Attempting to match some urls to this group'
+        def goodMatch_full = urlMappingsHolder.matchAll("/group/1/2")
+        def goodMatch_optional = urlMappingsHolder.matchAll("/group/1")
+        def badMatch = urlMappingsHolder.matchAll("/group/1/char")
+
+        then: 'Should succeed'
+        goodMatch_full
+        goodMatch_optional
+        !badMatch
     }
 }


### PR DESCRIPTION
Added attribution to reflect when `ParentResource` is a group. This allows checking to make sure the `constraints` block is not re-written when a child of a url in a group.
