### PR TITLE
Ensured that only the unique repositories remain in the aetherDepende…

### DIFF
--- a/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/config/AetherDsl.groovy
+++ b/grails-aether/src/main/groovy/org/codehaus/groovy/grails/resolve/maven/aether/config/AetherDsl.groovy
@@ -196,6 +196,7 @@ class AetherDsl {
         callable.call()
 
         this.aetherDependencyManager.repositories.addAll(rc.repositories)
+        this.aetherDependencyManager.repositories.unique()
     }
 
     /**

--- a/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
+++ b/grails-aether/src/test/groovy/org/codehaus/groovy/grails/resolve/maven/AetherDependencyManagerSpec.groovy
@@ -618,4 +618,30 @@ class AetherDependencyManagerSpec extends Specification {
             report != null
             !report.hasError()
     }
+
+    void "Test duplicated repositories"() {
+        given: "A dependency manager instance"
+            def dependencyManager = new AetherDependencyManager()
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                    mavenRepo "https://repo.grails.org/grails/core"
+                }
+            }
+
+        when: "Another set of dependencies are parsed (like an inline plugin)"
+            dependencyManager.parseDependencies {
+                repositories {
+                    mavenCentral()
+                    mavenRepo "https://repo.grails.org/grails/core"
+                }
+            }
+
+        then: "only the unique set of repositories remain"
+            dependencyManager.repositories.size == 2
+
+        and: "the declaration order is retained"
+            dependencyManager.repositories[0].id == "mavenCentral"
+            dependencyManager.repositories[1].url == "https://repo.grails.org/grails/core"
+    }
 }


### PR DESCRIPTION
Ensured that only the unique repositories remain in the aetherDependencyManager after the repositories closure is called resolving issue #9437 
