### PR TITLE
Fix XXE vulnerabilities

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/io/support/IOUtils.java
+++ b/grails-bootstrap/src/main/groovy/org/codehaus/groovy/grails/io/support/IOUtils.java
@@ -367,7 +367,7 @@ public class IOUtils {
             saxParserFactory.setValidating(false);
 
             try {
-                saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+                saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             } catch (Exception pce) {
                 // ignore, parser doesn't support
             }


### PR DESCRIPTION
To effectively protect internal grails parsing against XXE vulnerabilities it is necessary to set the disallow-doctype-decl feature to true and not false. See https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing.
