### PR TITLE
Support plugin.yml and plugin-[environment].yml in grails plugins

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
@@ -132,13 +132,15 @@ class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProces
             def plugins = pluginManager.allPlugins
             if(plugins) {
                 for(GrailsPlugin plugin in plugins.reverse()) {
-                    def pluginPropertySource = plugin.propertySource
-                    if(pluginPropertySource) {
-                        if(pluginPropertySource instanceof EnumerablePropertySource) {
-                            propertySources.addLast( new PrefixedMapPropertySource( "grails.plugins.$plugin.name", (EnumerablePropertySource)pluginPropertySource ) )
-                        }
-                        propertySources.addLast pluginPropertySource
-                    }
+                    def pluginPropertySources = plugin.propertySources
+					pluginPropertySources.each { pluginPropertySource ->
+						if (pluginPropertySource) {
+							if (pluginPropertySource instanceof EnumerablePropertySource) {
+								propertySources.addLast(new PrefixedMapPropertySource("grails.plugins.$plugin.name", (EnumerablePropertySource) pluginPropertySource))
+							}
+							propertySources.addLast pluginPropertySource
+						}
+					}
                 }
             }
             ((DefaultGrailsApplication)grailsApplication).config = new PropertySourcesConfig(propertySources)

--- a/grails-core/src/main/groovy/grails/plugins/GrailsPlugin.java
+++ b/grails-core/src/main/groovy/grails/plugins/GrailsPlugin.java
@@ -275,7 +275,7 @@ public interface GrailsPlugin extends ApplicationContextAware, Comparable, Grail
     String getDependentVersion(String name);
 
 
-    PropertySource<?> getPropertySource();
+    List<PropertySource<?>> getPropertySources();
 
     /**
      * Refreshes this Grails plugin reloading any watched resources as necessary


### PR DESCRIPTION
This feature will attempt to load an environment and general plugin config such as:

plugin-[environment].yml
plugin.xml

The order at which they are processed as resources should be environment first then generic so that environment wins out over general.
