### PR TITLE
Plugin environment block support

### DIFF
--- a/grails-core/src/main/groovy/org/grails/config/yaml/YamlPropertySourceLoader.groovy
+++ b/grails-core/src/main/groovy/org/grails/config/yaml/YamlPropertySourceLoader.groovy
@@ -37,89 +37,81 @@ import org.springframework.util.ClassUtils
 @CompileStatic
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class YamlPropertySourceLoader extends YamlProcessor implements PropertySourceLoader {
-    @Override
-    String[] getFileExtensions() {
-        ['yml', 'yaml'] as String[]
-    }
+	@Override
+	String[] getFileExtensions() {
+		['yml', 'yaml'] as String[]
+	}
 
-    @Override
-    PropertySource<?> load(String name, Resource resource, String profile) throws IOException {
-        return load(name, resource, profile, true, Collections.<String> emptyList())
-    }
+	@Override
+	PropertySource<?> load(String name, Resource resource, String profile) throws IOException {
+		return load(name, resource, profile, true, Collections.<String> emptyList())
+	}
 
-    PropertySource<?> load(String name, Resource resource, String profile, boolean parseFlatKeys) throws IOException {
-        return load(name, resource, profile, true, Collections.<String> emptyList())
-    }
+	PropertySource<?> load(String name, Resource resource, String profile, boolean parseFlatKeys) throws IOException {
+		return load(name, resource, profile, true, Collections.<String> emptyList())
+	}
 
-    PropertySource<?> load(String name, Resource resource, String profile, boolean parseFlatKeys, List<String> filteredKeys) throws IOException {
-        if (ClassUtils.isPresent("org.yaml.snakeyaml.Yaml", null)) {
-            boolean matchDefault
-            if (profile == null) {
-                matchDefault = true
-                setMatchDefault(matchDefault)
-                setDocumentMatchers(new SpringProfileDocumentMatcher())
-            } else {
-                matchDefault = false;
-                setMatchDefault(matchDefault)
-                setDocumentMatchers(new SpringProfileDocumentMatcher(profile))
-            }
-            resources = [resource] as Resource[]
-            def propertySource = new NavigableMap()
-            if (matchDefault && resource.filename == Metadata.FILE) {
-                def metadata = Metadata.getCurrent()
-                def metadataSource = metadata.getSource()
-                def metadataFile = metadata.getMetadataFile()
-                if (metadataSource != null && metadataFile != null && metadataFile.getURL().equals(resource.getURL())) {
-                    for (o in metadataSource) {
-                        if (o instanceof Map) {
-                            propertySource.merge((Map) o, false)
-                        }
-                    }
-                } else {
-                    process { Properties properties, Map<String, Object> map ->
-                        propertySource.merge(map, parseFlatKeys)
-                    }
-                }
-            } else {
-                process { Properties properties, Map<String, Object> map ->
-                    if (!filteredKeys.isEmpty()) {
-                        def env = map.get(GrailsPlugin.ENVIRONMENTS)
-                        for (key in filteredKeys) {
-                            map.remove(key)
-                            if (env instanceof Map) {
-                                Map envMap = (Map) env
-                                for (envSpecific in envMap.values()) {
-                                    if (envSpecific instanceof Map) {
-                                        ((Map) envSpecific).remove(key)
-                                    }
-                                }
-                            }
-                        }
-                    }
+	PropertySource<?> load(String name, Resource resource, String profile, boolean parseFlatKeys, List<String> filteredKeys) throws IOException {
+		if (ClassUtils.isPresent("org.yaml.snakeyaml.Yaml", null)) {
+			boolean matchDefault
+			if (profile == null) {
+				matchDefault = true
+				setMatchDefault(matchDefault)
+				setDocumentMatchers(new SpringProfileDocumentMatcher())
+			} else {
+				matchDefault = false;
+				setMatchDefault(matchDefault)
+				setDocumentMatchers(new SpringProfileDocumentMatcher(profile))
+			}
+			resources = [resource] as Resource[]
+			def propertySource = new NavigableMap()
+			if (matchDefault && resource.filename == Metadata.FILE) {
+				def metadata = Metadata.getCurrent()
+				def metadataSource = metadata.getSource()
+				def metadataFile = metadata.getMetadataFile()
+				if (metadataSource != null && metadataFile != null && metadataFile.getURL().equals(resource.getURL())) {
+					for (o in metadataSource) {
+						if (o instanceof Map) {
+							propertySource.merge((Map) o, false)
+						}
+					}
+				} else {
+					process { Properties properties, Map<String, Object> map ->
+						propertySource.merge(map, parseFlatKeys)
+					}
+				}
+			} else {
+				process { Properties properties, Map<String, Object> map ->
+					//Now merge the environment config over the top of the normal stuff
+					def environments = map.get(GrailsPlugin.ENVIRONMENTS)
+					if (environments instanceof Map) {
+						Map envMap = (Map) environments
+						for (envSpecific in envMap) {
+							if (envSpecific instanceof Map || envSpecific instanceof Map.Entry) {
+								def environmentEntries = environments.get(envSpecific.key)
+								if (environmentEntries instanceof Map) {
+									if (envSpecific?.key?.toString()?.equalsIgnoreCase(Environment.getCurrentEnvironment()?.name)) {
+										map.putAll(environmentEntries)
+									}
+								}
+							}
+						}
+					}
 
-                    //Now merge the environment config over the top of the normal stuff
-                    def environments = map.get(GrailsPlugin.ENVIRONMENTS)
-                    if (environments instanceof Map) {
-                        Map envMap = (Map) environments
-                        for (envSpecific in envMap) {
-                            if (envSpecific instanceof Map.Entry) {
-                                if (envSpecific?.key?.toString()?.equalsIgnoreCase(Environment.getCurrentEnvironment()?.name)) {
-                                    map << (environments.get(envSpecific.key) as LinkedHashMap)
-                                }
-                            }
-                        }
-                    }
+					filteredKeys?.each { key ->
+						map.remove(key)
+					}
 
-                    propertySource.merge(map, parseFlatKeys)
-                }
-            }
+					propertySource.merge(map, parseFlatKeys)
+				}
+			}
 
-            if (!propertySource.isEmpty()) {
-                return new NavigableMapPropertySource(name, propertySource)
-            }
-        }
-        return null
-    }
+			if (!propertySource.isEmpty()) {
+				return new NavigableMapPropertySource(name, propertySource)
+			}
+		}
+		return null
+	}
 
 
 }

--- a/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPlugin.java
@@ -87,7 +87,7 @@ public abstract class AbstractGrailsPlugin extends GroovyObjectSupport implement
         if(resource != null && resource.exists()) {
             YamlPropertySourceLoader propertySourceLoader = new YamlPropertySourceLoader();
             try {
-                this.propertySource = propertySourceLoader.load(GrailsNameUtils.getLogicalPropertyName(pluginClass.getSimpleName(), "GrailsPlugin") + "-plugin.yml", resource, null, false, DEFAULT_CONFIG_IGNORE_LIST);
+                this.propertySource = propertySourceLoader.load(GrailsNameUtils.getLogicalPropertyName(pluginClass.getSimpleName(), "GrailsPlugin") + "-plugin.yml", resource, null, true, DEFAULT_CONFIG_IGNORE_LIST);
             } catch (IOException e) {
                 LOG.warn("Error loading plugin.yml for plugin: " + pluginClass.getName() +": " + e.getMessage(), e);
             }

--- a/grails-core/src/test/groovy/org/grails/config/YamlPropertySourceLoaderSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/config/YamlPropertySourceLoaderSpec.groovy
@@ -1,0 +1,85 @@
+package org.grails.config
+
+import grails.core.DefaultGrailsApplication
+import grails.core.GrailsApplication
+import org.grails.config.yaml.YamlPropertySourceLoader
+import org.springframework.core.env.Environment
+import org.springframework.core.io.FileSystemResource
+import org.springframework.core.io.Resource
+import spock.lang.Specification
+
+class YamlPropertySourceLoaderSpec extends Specification {
+
+    def "ensure the config for environment is merged with single environment block"() {
+        given: "A PropertySourcesConfig instance"
+        def propertySource = new YamlPropertySourceLoader()
+        Resource resource = new FileSystemResource(getClass().getClassLoader().getResource("foo-plugin-environments.yml").getFile())
+
+        when:
+        def yamlPropertiesSource = propertySource.load('foo-plugin-environments.yml', resource, null, true, Arrays.asList("dataSource", "hibernate"))
+        def config = new PropertySourcesConfig(yamlPropertiesSource)
+
+        then: "The config to be accessible with the merged env values"
+        config.one == 2
+        config.two == 3
+        config.three.four == 45
+        !config.four.five
+        config.getProperty('one', String) == '2'
+        config.getProperty('three.four', String) == '45'
+        config.getProperty('three', String) == null
+        config.get('three.four') == 45
+        config.getProperty('three.four') == '45'
+        config.getProperty('three.four', Date) == null
+        config.empty.value == 'development'
+    }
+
+    def "ensure the config for environment is merged with single environment block with parseFlatMap false"() {
+        given: "A PropertySourcesConfig instance"
+        def propertySource = new YamlPropertySourceLoader()
+        Resource resource = new FileSystemResource(getClass().getClassLoader().getResource("foo-plugin-environments.yml").getFile())
+
+        when:
+        def yamlPropertiesSource = propertySource.load('foo-plugin-environments.yml', resource, null, false, Arrays.asList("dataSource", "hibernate"))
+        def config = new PropertySourcesConfig(yamlPropertiesSource)
+
+        then: "These will not be navigable due to false parseFlatKeys"
+        !config.three.four
+        !config.empty.value
+
+        and: "The config to be accessible with the merged env values"
+        config.one == 2
+        config.two == 3
+        !config.four.five
+        config.getProperty('one', String) == '2'
+        config.getProperty('three.four', String) == '45'
+        config.getProperty('three', String) == null
+        config.get('three.four') == 45
+        config.getProperty('three.four') == '45'
+        config.getProperty('three.four', Date) == null
+    }
+
+    def "ensure the config for environment is merged with multiple environment block"() {
+        given: "A PropertySourcesConfig instance"
+        def propertySource = new YamlPropertySourceLoader()
+        Resource resource = new FileSystemResource(getClass().getClassLoader().getResource("foo-plugin-multiple-environments.yml").getFile())
+
+        when:
+        def yamlPropertiesSource = propertySource.load('foo-plugin-multiple-environments.yml', resource, null, true, Arrays.asList("dataSource", "hibernate"))
+        def config = new PropertySourcesConfig(yamlPropertiesSource)
+
+        then: "The config to be accessible with the merged env values"
+        config.one == -2
+        config.two == 3
+        config.three.four == 45
+        config.four.five == 45
+        config.getProperty('one', String) == '-2'
+        config.getProperty('three.four', String) == '45'
+        config.getProperty('three', String) == null
+        config.get('three.four') == 45
+        config.get('four.five') == 45
+        config.getProperty('three.four') == '45'
+        config.getProperty('three.four', Date) == null
+        config.getProperty('four.five') == '45'
+        config.empty.value == 'development'
+    }
+}

--- a/grails-core/src/test/groovy/org/grails/config/YamlPropertySourceLoaderSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/config/YamlPropertySourceLoaderSpec.groovy
@@ -31,6 +31,9 @@ class YamlPropertySourceLoaderSpec extends Specification {
         config.getProperty('three.four') == '45'
         config.getProperty('three.four', Date) == null
         config.empty.value == 'development'
+        !config.dataSource
+        !config.getProperty('dataSource')
+        !config.get('dataSource')
     }
 
     def "ensure the config for environment is merged with single environment block with parseFlatMap false"() {
@@ -56,6 +59,9 @@ class YamlPropertySourceLoaderSpec extends Specification {
         config.get('three.four') == 45
         config.getProperty('three.four') == '45'
         config.getProperty('three.four', Date) == null
+        !config.dataSource
+        !config.getProperty('dataSource')
+        !config.get('dataSource')
     }
 
     def "ensure the config for environment is merged with multiple environment block"() {
@@ -81,5 +87,8 @@ class YamlPropertySourceLoaderSpec extends Specification {
         config.getProperty('three.four', Date) == null
         config.getProperty('four.five') == '45'
         config.empty.value == 'development'
+        !config.dataSource
+        !config.getProperty('dataSource')
+        !config.get('dataSource')
     }
 }

--- a/grails-core/src/test/resources/foo-plugin-environments.yml
+++ b/grails-core/src/test/resources/foo-plugin-environments.yml
@@ -1,0 +1,17 @@
+one: 1
+two: 2
+three.four: 34
+empty.value:
+
+---
+environments:
+  development:
+    one: 2
+    two: 3
+    three.four: 45
+    empty.value: development
+  test:
+    one: 3
+    two: 4
+    three.four: 56
+    empty.value: test

--- a/grails-core/src/test/resources/foo-plugin-environments.yml
+++ b/grails-core/src/test/resources/foo-plugin-environments.yml
@@ -2,6 +2,7 @@ one: 1
 two: 2
 three.four: 34
 empty.value:
+dataSource: dataSource
 
 ---
 environments:
@@ -10,8 +11,14 @@ environments:
     two: 3
     three.four: 45
     empty.value: development
+    dataSource: dataSource
   test:
     one: 3
     two: 4
     three.four: 56
     empty.value: test
+    dataSource: dataSource
+
+---
+environments:
+    development: bad

--- a/grails-core/src/test/resources/foo-plugin-multiple-environments.yml
+++ b/grails-core/src/test/resources/foo-plugin-multiple-environments.yml
@@ -1,0 +1,25 @@
+one: 1
+two: 2
+three.four: 34
+empty.value:
+
+---
+environments:
+  development:
+    one: 2
+    two: 3
+    three.four: 45
+    empty.value: development
+  test:
+    one: 3
+    two: 4
+    three.four: 56
+    empty.value: test
+
+---
+environments:
+  development:
+    one: -2
+    four.five: 45
+  test:
+    four.five: 56

--- a/grails-core/src/test/resources/foo-plugin-multiple-environments.yml
+++ b/grails-core/src/test/resources/foo-plugin-multiple-environments.yml
@@ -2,6 +2,7 @@ one: 1
 two: 2
 three.four: 34
 empty.value:
+dataSource: dataSource
 
 ---
 environments:
@@ -10,16 +11,20 @@ environments:
     two: 3
     three.four: 45
     empty.value: development
+    dataSource: dataSource
   test:
     one: 3
     two: 4
     three.four: 56
     empty.value: test
+    dataSource: dataSource
 
 ---
 environments:
   development:
     one: -2
     four.five: 45
+    dataSource: dataSource
   test:
     four.five: 56
+    dataSource: dataSource


### PR DESCRIPTION
Adding code and tests for doing plugin environment block stuffs.  Also set parseFlatMap to true to allow config navigation via dot notation. It was unclear why this was false.  Please review and revert that if required.
