### PR TITLE
Add value information to CodeGenConfig exception

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/config/CodeGenConfig.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/config/CodeGenConfig.groovy
@@ -198,7 +198,7 @@ class CodeGenConfig implements Cloneable, ConfigMap {
     }
     
     protected <T> T convertToOtherTypes(Object value, Class<T> requiredType) {
-        throw new RuntimeException("conversion to $requiredType.name not implemented")
+        throw new RuntimeException("conversion of $value to $requiredType.name not implemented")
     }
 
     public Object navigate(String... path) {


### PR DESCRIPTION
Experienced the exception message thrown from `convertToOtherTypes` from the CLI this week and had trouble discerning where it came from and why it was happening. In talking it over with James Kleeh, we figured that adding the value that caused the conversion to fail would at least aid others who make a similar mistake in the future. 

For reference, our particular error was declaring a datasource in `application.yml` without any properties. Obviously not something one should do, it was a mistaken commit.

```
datasource:
  development:
    # commented out by accident
```
