### PR TITLE
Fix for issue 9513 - validate() mades private and protected getter methods nullable: false

### DIFF
--- a/grails-plugin-validation/src/main/groovy/grails/validation/Validateable.groovy
+++ b/grails-plugin-validation/src/main/groovy/grails/validation/Validateable.groovy
@@ -116,11 +116,12 @@ trait Validateable {
     boolean validate(List fieldsToValidate) {
         beforeValidateHelper.invokeBeforeValidate(this, fieldsToValidate)
 
-        def constraints = getConstraintsMap()
+        //initialize errors before constraints block, because this block may be empty
+        def localErrors = new ValidationErrors(this, this.class.name)
 
+        def constraints = getConstraintsMap()
         if (constraints) {
             Object messageSource = findMessageSource()
-            def localErrors = new ValidationErrors(this, this.class.name)
             def originalErrors = getErrors()
             for (originalError in originalErrors.allErrors) {
                 if (originalError instanceof FieldError) {
@@ -142,9 +143,11 @@ trait Validateable {
                     }
                 }
             }
-            errors = localErrors
         }
 
+        //set errors instance even if constraints were not verified
+        //object should must have it initialized after validate()
+        errors = localErrors
         return !errors.hasErrors()
     }
 

--- a/grails-test-suite-uber/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
@@ -134,6 +134,15 @@ class ValidateableTraitSpec extends Specification {
         expect: 'property accessors are not invoked for properties which are not explicitly constrained (getName() would throw an exception)'
         obj.validate()
     }
+
+    void 'ensure class without any constraints can be validated'(){
+        NoConstraintsValidateable obj = new NoConstraintsValidateable()
+
+        expect:
+        obj.validate() == true
+        !obj.hasErrors()
+        obj.errors != null
+    }
 }
 
 class MyValidateable implements Validateable {
@@ -179,5 +188,11 @@ class MyNullableValidateable implements Validateable {
     
     static boolean defaultNullable() {
         true
+    }
+}
+
+class NoConstraintsValidateable implements Validateable {
+    static constraints = {
+
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
@@ -143,6 +143,45 @@ class ValidateableTraitSpec extends Specification {
         !obj.hasErrors()
         obj.errors != null
     }
+
+    void 'ensure only getters are considered as validateable properties'(){
+
+        expect:
+        propertyGetter == ValidatableGetters.isPropertyGetter(ValidatableGetters.getDeclaredMethod(methodName))
+
+        where:
+        propertyGetter  |   methodName
+        true            |   'getTown'
+        true            |   'getName'
+        false           |   'getSurname'
+        false           |   'getEmail'
+        false           |   'getDay'
+        false           |   'getEaster'
+        false           |   'getChristmas'
+        false           |   'getNewYear'
+    }
+
+    @Issue('9513')
+    void 'ensure validation may be done for classes with private and protected getters'(){
+        ValidatableGetters obj = new ValidatableGetters()
+
+        expect: 'validation is executed and public properties/getters are marked nullable in errors'
+        obj.validate() == false
+        obj.errors['name'].code == 'nullable'
+        !obj.errors['surname']
+        !obj.errors['email']
+    }
+
+    void 'ensure private and protected getter is not handled as not-nullable property by default'(){
+        when:
+        Map constraints = new ValidatableGetters().getConstraintsMap()
+
+        then: 'only public properties and public getters should be considered validateable properties by default'
+        constraints
+        constraints.size() == 2
+        constraints.name
+        constraints.town
+    }
 }
 
 class MyValidateable implements Validateable {
@@ -195,4 +234,22 @@ class NoConstraintsValidateable implements Validateable {
     static constraints = {
 
     }
+}
+
+class ValidatableGetters implements Validateable {
+    //standard properties - private/protected will not have getter
+    String town
+
+    //properties from getters
+    String getName(){}
+    protected String getSurname(){}
+    private String getEmail(){}
+
+    //static properties
+    static Integer day
+
+    //static properties from getters
+    static Date getEaster() {}
+    protected static Date getChristmas() {}
+    private static Date getNewYear() {}
 }


### PR DESCRIPTION
For simple class

```
class NoConstraintsValidateable implements Validateable {
    static constraints = {

    }
}
```

NullPointerException is thrown in validate() method. Provided pull request initializes errors even if constraintsMap is empty + spec
