### PR TITLE
Allow status to be set in argMap when rendering a closure

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -139,6 +139,8 @@ trait ResponseRenderer extends WebAttributes {
         String explicitSiteMeshLayout = argMap[ARGUMENT_LAYOUT]?.toString() ?: null
 
         applyContentType response, argMap, closure
+        handleStatusArgument argMap, webRequest, response
+
         if (BUILDER_TYPE_JSON.equals(argMap.get(ARGUMENT_BUILDER)) || isJSONResponse(response)) {
             renderJsonInternal(response, closure)
             webRequest.renderView = false

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/RenderMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/RenderMethodTests.groovy
@@ -82,6 +82,14 @@ class RenderMethodTests {
     }
 
     @Test
+    void testRenderClosureWithStatus() {
+        controller.renderClosureWithStatus()
+
+        def response = controller.response
+        assertEquals 500, response.status
+    }
+
+    @Test
     void testRenderList() {
         controller.renderList()
 
@@ -205,6 +213,10 @@ class RenderController {
     }
     def renderObject() {
         render new RenderTest(foo:"bar")
+    }
+    def renderClosureWithStatus() {
+        render(status: 500) {
+        }
     }
     def renderMessageWithStatus() {
         render text:"test", status:500


### PR DESCRIPTION
This fixes a small issue I discovered while upgrading from Grails 2.x to 3.x. 

Given a controller action like this: 

``` groovy
def doIt() {
     render(status: 404, ... ) {
          [foo: 'bar']
     }
}
```

The status of the response would always be 200. The workaround without this change is to explicitly set the status on the `response` object:

``` groovy
def doIt() {
     response.status = 404
     render(...) {
          [foo: 'bar']
     }
}
```
