### PR TITLE
Fixing squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/grails-async/src/main/groovy/grails/async/Promises.java
+++ b/grails-async/src/main/groovy/grails/async/Promises.java
@@ -46,6 +46,9 @@ public class Promises {
         }
     }
 
+    private Promises() {
+    }
+
     public static PromiseFactory getPromiseFactory() {
         if (promiseFactory == null) {
             if (GparsPromiseFactory.isGparsAvailable()) {

--- a/grails-bootstrap/src/main/groovy/grails/util/GrailsNameUtils.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/GrailsNameUtils.java
@@ -27,6 +27,9 @@ public class GrailsNameUtils {
     private static final String PROPERTY_SET_PREFIX = "set";
     private static final String PROPERTY_GET_PREFIX = "get";
 
+    private GrailsNameUtils() {
+    }
+
     /**
      * Retrieves the name of a setter for the specified property name
      * @param propertyName The property name

--- a/grails-core/src/main/groovy/grails/util/GrailsUtil.java
+++ b/grails-core/src/main/groovy/grails/util/GrailsUtil.java
@@ -94,6 +94,8 @@ public class GrailsUtil {
         GRAILS_VERSION = version;
     }
 
+    private GrailsUtil() {
+    }
 
 
     /**

--- a/grails-core/src/main/groovy/grails/validation/DeferredBindingActions.java
+++ b/grails-core/src/main/groovy/grails/validation/DeferredBindingActions.java
@@ -41,6 +41,9 @@ public class DeferredBindingActions {
         }, true);
     }
 
+    private DeferredBindingActions() {
+    }
+
     public static void addBindingAction(Runnable runnable) {
         List<Runnable> bindingActions = getDeferredBindingActions();
         bindingActions.add(runnable);

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/TraitInjectionUtils.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/TraitInjectionUtils.java
@@ -37,6 +37,9 @@ public class TraitInjectionUtils {
 
     private static List<TraitInjector> traitInjectors;
 
+    private TraitInjectionUtils() {
+    }
+
     private static void doInjectionInternal(CompilationUnit unit, SourceUnit source, ClassNode classNode,
             List<TraitInjector> injectorsToUse) {
         boolean traitsAdded = false;

--- a/grails-core/src/main/groovy/org/grails/spring/RuntimeSpringConfigUtilities.java
+++ b/grails-core/src/main/groovy/org/grails/spring/RuntimeSpringConfigUtilities.java
@@ -45,6 +45,9 @@ public class RuntimeSpringConfigUtilities {
 
     private static volatile BeanBuilder springGroovyResourcesBeanBuilder = null;
 
+    private RuntimeSpringConfigUtilities() {
+    }
+
     /**
      * Attempt to load the beans defined by a BeanBuilder DSL closure in "resources.groovy".
      *

--- a/grails-docs/src/main/groovy/grails/doc/internal/StringEscapeCategory.java
+++ b/grails-docs/src/main/groovy/grails/doc/internal/StringEscapeCategory.java
@@ -6,6 +6,9 @@ import java.net.URISyntaxException;
 import org.apache.commons.lang.StringEscapeUtils;
 
 public class StringEscapeCategory {
+    private StringEscapeCategory() {
+    }
+
     public static String encodeAsUrlPath(String str) {
         try {
             String uri = new URI("http", "localhost", '/' + str, "").toASCIIString();

--- a/grails-encoder/src/main/groovy/org/grails/buffer/StringCharArrayAccessor.java
+++ b/grails-encoder/src/main/groovy/org/grails/buffer/StringCharArrayAccessor.java
@@ -73,6 +73,9 @@ public class StringCharArrayAccessor {
         }
     }
 
+    private StringCharArrayAccessor() {
+    }
+
     /**
      * Writes a portion of a string to a target java.io.Writer with direct access to the char[] of the java.lang.String
      *

--- a/grails-encoder/src/main/groovy/org/grails/charsequences/CharSequences.java
+++ b/grails-encoder/src/main/groovy/org/grails/charsequences/CharSequences.java
@@ -27,6 +27,9 @@ import java.io.Writer;
  *
  */
 public class CharSequences {
+    private CharSequences() {
+    }
+
     public static CharSequence createCharSequence(char[] chars) {
         return new CharArrayCharSequence(chars, 0, chars.length);
     }

--- a/grails-encoder/src/main/groovy/org/grails/encoder/ChainedEncoders.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/ChainedEncoders.java
@@ -24,6 +24,9 @@ import org.grails.buffer.StreamCharBuffer;
 
 public class ChainedEncoders {
 
+    private ChainedEncoders() {
+    }
+
     public static List<StreamingEncoder> toStreamingEncoders(List<Encoder> encoders) {
         if(encoders == null || encoders.isEmpty()) {
             return null;

--- a/grails-encoder/src/main/groovy/org/grails/encoder/CodecLookupHelper.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/CodecLookupHelper.java
@@ -23,7 +23,10 @@ import org.springframework.context.ApplicationContext;
 
 public class CodecLookupHelper {
     private static final Logger log = LoggerFactory.getLogger(CodecLookupHelper.class);
-    
+
+    private CodecLookupHelper() {
+    }
+
     /**
      * Lookup encoder.
      *

--- a/grails-encoder/src/main/groovy/org/grails/encoder/EncodingStateRegistryLookupHolder.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/EncodingStateRegistryLookupHolder.java
@@ -20,6 +20,9 @@ import grails.util.Holder;
 public class EncodingStateRegistryLookupHolder {
     private static Holder<EncodingStateRegistryLookup> holder = new Holder<EncodingStateRegistryLookup>("encodingStateRegistryLookup");
 
+    private EncodingStateRegistryLookupHolder() {
+    }
+
     public static void setEncodingStateRegistryLookup(EncodingStateRegistryLookup lookup) {
         holder.set(lookup);
     }

--- a/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
+++ b/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
@@ -21,6 +21,9 @@ public class TagOutput {
     public static final Closure<?> EMPTY_BODY_CLOSURE = new ConstantClosure("");
     public static final String DEFAULT_NAMESPACE = "g";
 
+    private TagOutput() {
+    }
+
     @SuppressWarnings("rawtypes")
     public final static Object captureTagOutput(TagLibraryLookup gspTagLibraryLookup, String namespace,
                                                 String tagName, Map attrs, Object body, OutputContext outputContext) {

--- a/grails-taglib/src/main/groovy/org/grails/taglib/encoder/OutputContextLookupHelper.java
+++ b/grails-taglib/src/main/groovy/org/grails/taglib/encoder/OutputContextLookupHelper.java
@@ -24,6 +24,9 @@ import org.grails.core.io.support.GrailsFactoriesLoader;
 public class OutputContextLookupHelper {
     private static OutputContextLookup outputContextLookup = GrailsFactoriesLoader.loadFactory(OutputContextLookup.class, OutputContextLookupHelper.class.getClassLoader());
 
+    private OutputContextLookupHelper() {
+    }
+
     public static OutputContext lookupOutputContext() {
         return outputContextLookup.lookupOutputContext();
     }

--- a/grails-test/src/main/groovy/org/grails/test/support/TestStacktraceSanitizer.java
+++ b/grails-test/src/main/groovy/org/grails/test/support/TestStacktraceSanitizer.java
@@ -24,6 +24,9 @@ public class TestStacktraceSanitizer {
 
     private static final String TEST_RUNNING_CLASS = "_GrailsTest";
 
+    private TestStacktraceSanitizer() {
+    }
+
     public static Throwable sanitize(Throwable t) {
         new DefaultStackTraceFilterer().filter(t, true);
         StackTraceElement[] trace = t.getStackTrace();

--- a/grails-web-common/src/main/groovy/grails/util/GrailsWebUtil.java
+++ b/grails-web-common/src/main/groovy/grails/util/GrailsWebUtil.java
@@ -47,6 +47,9 @@ public class GrailsWebUtil {
     private static final String CHARSET_ATTRIBUTE = ";charset=";
     private static final Pattern CHARSET_IN_CONTENT_TYPE_REGEXP = Pattern.compile(";\\s*charset\\s*=", Pattern.CASE_INSENSITIVE);
 
+    private GrailsWebUtil() {
+    }
+
     /**
      * Looks up a GrailsApplication instance from the ServletContext.
      *

--- a/grails-web-common/src/main/groovy/org/grails/web/json/parser/StringUnmarshaller.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/parser/StringUnmarshaller.java
@@ -22,6 +22,9 @@ package org.grails.web.json.parser;
  */
 final class StringUnmarshaller {
 
+    private StringUnmarshaller() {
+    }
+
     static String unmarshall(String str) {
         str = str.substring(1, str.length() - 1);
 

--- a/grails-web-gsp/src/main/groovy/org/grails/web/pages/GroovyPageUtils.java
+++ b/grails-web-gsp/src/main/groovy/org/grails/web/pages/GroovyPageUtils.java
@@ -37,6 +37,9 @@ public class GroovyPageUtils {
 
     public static final String PATH_TO_VIEWS = GroovyPagesUriSupport.PATH_TO_VIEWS;
 
+    private GroovyPageUtils() {
+    }
+
     private static GroovyPagesUriSupport getInstance() {
         try {
             GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes();

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
@@ -56,6 +56,9 @@ import java.util.Map;
  * @since 2.4
  */
 public class UrlMappingUtils {
+    private UrlMappingUtils() {
+    }
+
     /**
      * Looks up the UrlMappingsHolder instance
      *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118
Please let me know if you have any questions.
Kirill Vlasov
