### PR TITLE
Fixing squid:S128 - Switch cases should end with an unconditional "break" statement

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/json/parser/ParseException.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/parser/ParseException.java
@@ -159,31 +159,31 @@ public class ParseException extends Exception {
         switch (str.charAt(i))
         {
            case 0 :
-              continue;
+              break;
            case '\b':
               retval.append("\\b");
-              continue;
+               break;
            case '\t':
               retval.append("\\t");
-              continue;
+               break;
            case '\n':
               retval.append("\\n");
-              continue;
+               break;
            case '\f':
               retval.append("\\f");
-              continue;
+               break;
            case '\r':
               retval.append("\\r");
-              continue;
+               break;
            case '\"':
               retval.append("\\\"");
-              continue;
+               break;
            case '\'':
               retval.append("\\\'");
-              continue;
+               break;
            case '\\':
               retval.append("\\\\");
-              continue;
+               break;
            default:
               if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                  String s = "0000" + Integer.toString(ch, 16);
@@ -191,7 +191,7 @@ public class ParseException extends Exception {
               } else {
                  retval.append(ch);
               }
-              continue;
+               break;
         }
       }
       return retval.toString();

--- a/grails-web-common/src/main/groovy/org/grails/web/json/parser/TokenMgrError.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/parser/TokenMgrError.java
@@ -52,28 +52,28 @@ public class TokenMgrError extends Error {
                     continue;
                 case '\b':
                     retval.append("\\b");
-                    continue;
+                    break;
                 case '\t':
                     retval.append("\\t");
-                    continue;
+                    break;
                 case '\n':
                     retval.append("\\n");
-                    continue;
+                    break;
                 case '\f':
                     retval.append("\\f");
-                    continue;
+                    break;
                 case '\r':
                     retval.append("\\r");
-                    continue;
+                    break;
                 case '\"':
                     retval.append("\\\"");
-                    continue;
+                    break;
                 case '\'':
                     retval.append("\\\'");
-                    continue;
+                    break;
                 case '\\':
                     retval.append("\\\\");
-                    continue;
+                    break;
                 default:
                     if ((ch = str.charAt(i)) < 0x20 || ch > 0x7e) {
                         String s = "0000" + Integer.toString(ch, 16);
@@ -81,7 +81,7 @@ public class TokenMgrError extends Error {
                     } else {
                         retval.append(ch);
                     }
-                    continue;
+                    break;
             }
         }
         return retval.toString();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S128 - Switch cases should end with an unconditional "break" statement
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S128
Please let me know if you have any questions.
Kirill Vlasov
