### PR TITLE
Fix for issue when using plugin with dashes in name

### DIFF
--- a/grails-core/src/main/groovy/grails/plugins/GrailsPlugin.java
+++ b/grails-core/src/main/groovy/grails/plugins/GrailsPlugin.java
@@ -235,9 +235,16 @@ public interface GrailsPlugin extends ApplicationContextAware, Comparable, Grail
     /**
      * Returns the path of the plug-in
      *
-     * @return A String that makes up the path to the plug-in in the format /plugins/PLUGIN_NAME-PLUGIN_VERSION
+     * @return A String that makes up the path to the plug-in in the format /plugins/plugin-name-PLUGIN_VERSION
      */
     String getPluginPath();
+
+    /**
+     * Returns the path of the plug-in using camel case
+     *
+     * @return A String that makes up the path to the plug-in in the format /plugins/pluginName-PLUGIN_VERSION
+     */
+    String getPluginPathCamelCase();
 
     /**
      * @return The names of the plugins this plugin is dependant on

--- a/grails-core/src/main/groovy/grails/plugins/GrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/GrailsPluginManager.java
@@ -253,6 +253,17 @@ public interface GrailsPluginManager extends ApplicationContextAware {
     String getPluginPath(String name);
 
     /**
+     * Returns the pluginContextPath for the given plugin and will force name to camel case instead of '-' lower case
+     *
+     * my-plug-web would resolve to myPlugWeb if forceCamelCase is true.
+     *
+     * @param name The plugin name
+     * @param forceCamelCase Force camel case for name
+     * @return the context path
+     */
+    String getPluginPath(String name, boolean forceCamelCase);
+
+    /**
      * Looks up the plugin that defined the given instance. If no plugin
      * defined the instance then null is returned.
      *

--- a/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPlugin.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPlugin.java
@@ -175,6 +175,12 @@ public abstract class AbstractGrailsPlugin extends GroovyObjectSupport implement
         return PLUGINS_PATH + '/' + GrailsNameUtils.getScriptName(getName()) + '-' + getVersion();
     }
 
+    // https://github.com/grails/grails-core/issues/9406
+    // The name of the plugin for my-plug on the path is myPlugin the GrailsNameUtils.getScriptName(getName()) will always use my-plugin
+    public String getPluginPathCamelCase() {
+        return PLUGINS_PATH + '/' + GrailsNameUtils.getPropertyNameForLowerCaseHyphenSeparatedName(getName()) + '-' + getVersion();
+    }
+
     public GrailsPluginManager getManager() {
         return manager;
     }

--- a/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/org/grails/plugins/AbstractGrailsPluginManager.java
@@ -389,9 +389,17 @@ public abstract class AbstractGrailsPluginManager implements GrailsPluginManager
     }
 
     public String getPluginPath(String name) {
+        return getPluginPath(name, false);
+    }
+
+    public String getPluginPath(String name, boolean forceCamelCase) {
         GrailsPlugin plugin = getGrailsPlugin(name);
         if (plugin != null && !plugin.isBasePlugin()) {
-            return plugin.getPluginPath();
+            if(forceCamelCase){
+                return plugin.getPluginPathCamelCase();
+            } else {
+                return plugin.getPluginPath();
+            }
         }
         return BLANK;
     }

--- a/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
+++ b/grails-core/src/test/groovy/org/grails/plugins/GrailsPluginTests.groovy
@@ -15,6 +15,70 @@ import grails.plugins.DefaultGrailsPluginManager
  */
 class GrailsPluginTests extends GroovyTestCase {
 
+    void testPluginPath() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOneGrailsPlugin {
+    def version = 0.1
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "/plugins/test-one-0.1", plugin.pluginPath
+    }
+
+    void testPluginPathLongName() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOnetwoThreeFourfiveGrailsPlugin {
+    def version = 0.1
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "/plugins/test-onetwo-three-fourfive-0.1", plugin.pluginPath
+    }
+
+    void testPluginPathCamelCase() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOneGrailsPlugin {
+    def version = 0.1
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "/plugins/testOne-0.1", plugin.pluginPathCamelCase
+    }
+
+    void testPluginPathCamelCaseLongName() {
+
+        def gcl = new GroovyClassLoader()
+        def test1 = gcl.parseClass('''
+class TestOnetwoThreeFourfiveGrailsPlugin {
+    def version = 0.1
+    def scopes = 'test'
+}
+''')
+
+        DefaultGrailsApplication application = new DefaultGrailsApplication()
+        def plugin = new DefaultGrailsPlugin(test1, application)
+
+        assertEquals "/plugins/testOnetwoThreeFourfive-0.1", plugin.pluginPathCamelCase
+    }
+
     void testFileSystemName() {
 
         def gcl = new GroovyClassLoader()

--- a/grails-gsp/src/main/groovy/org/grails/gsp/io/DefaultGroovyPageLocator.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/io/DefaultGroovyPageLocator.java
@@ -20,7 +20,6 @@ import grails.plugins.GrailsPluginManager;
 import grails.plugins.PluginManagerAware;
 import grails.util.CollectionUtils;
 import grails.util.Environment;
-import grails.util.Metadata;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.grails.gsp.GroovyPage;
@@ -110,10 +109,21 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
         if (scriptSource == null) {
             scriptSource = findResourceScriptSource(uri);
         }
+
+        //last effort to resolve and force name of plugin to use camel case
+        if (scriptSource == null) {
+            contextPath = resolveContextPath(pluginName, uri, binding, true);
+            scriptSource = findPageInBinding(GrailsResourceUtils.appendPiecesForUri(contextPath, uri), binding);
+        }
+
         return scriptSource;
     }
 
     protected String resolveContextPath(String pluginName, String uri, TemplateVariableBinding binding) {
+        return resolveContextPath(pluginName, uri, binding, false);
+    }
+
+    protected String resolveContextPath(String pluginName, String uri, TemplateVariableBinding binding, boolean forceCamelCase) {
         String contextPath = null;
 
         if (uri.startsWith("/plugins/")) {
@@ -121,7 +131,7 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
         } else if (pluginName != null && pluginManager != null) {
             contextPath = pluginManager.getPluginPath(pluginName);
         } else if (binding instanceof GroovyPageBinding) {
-            String pluginContextPath = ((GroovyPageBinding)binding).getPluginContextPath();
+            String pluginContextPath = ((GroovyPageBinding) binding).getPluginContextPath();
             contextPath = pluginContextPath != null ? pluginContextPath : BLANK;
         } else {
             contextPath = BLANK;
@@ -138,15 +148,14 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
     }
 
     public GroovyPageScriptSource findPageInBinding(String uri, TemplateVariableBinding binding) {
-         GroovyPageScriptSource scriptSource = findResourceScriptSource(uri);
+        GroovyPageScriptSource scriptSource = findResourceScriptSource(uri);
 
         if (scriptSource == null) {
-            GrailsPlugin pagePlugin = binding instanceof GroovyPageBinding ? ((GroovyPageBinding)binding).getPagePlugin() : null;
+            GrailsPlugin pagePlugin = binding instanceof GroovyPageBinding ? ((GroovyPageBinding) binding).getPagePlugin() : null;
             if (pagePlugin instanceof BinaryGrailsPlugin) {
                 BinaryGrailsPlugin binaryPlugin = (BinaryGrailsPlugin) pagePlugin;
                 scriptSource = resolveViewInBinaryPlugin(binaryPlugin, uri);
-            }
-            else if (pagePlugin != null) {
+            } else if (pagePlugin != null) {
                 scriptSource = findResourceScriptSource(resolvePluginViewPath(uri, pagePlugin));
             }
         }
@@ -164,13 +173,13 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
         uri = GrailsResourceUtils.appendPiecesForUri(PATH_TO_WEB_INF_VIEWS, uri);
         Class<?> viewClass = binaryPlugin.resolveView(uri);
         if (viewClass != null && !reloadedPrecompiledGspClassNames.contains(viewClass.getName())) {
-             scriptSource = createGroovyPageCompiledScriptSource(uri, uri, viewClass);
+            scriptSource = createGroovyPageCompiledScriptSource(uri, uri, viewClass);
         }
         return scriptSource;
     }
 
     protected GroovyPageCompiledScriptSource createGroovyPageCompiledScriptSource(final String uri, String fullPath, Class<?> viewClass) {
-        GroovyPageCompiledScriptSource scriptSource = new GroovyPageCompiledScriptSource(uri, fullPath,viewClass);
+        GroovyPageCompiledScriptSource scriptSource = new GroovyPageCompiledScriptSource(uri, fullPath, viewClass);
         if (reloadEnabled) {
             scriptSource.setResourceCallable(new PrivilegedAction<Resource>() {
                 public Resource run() {
@@ -271,21 +280,19 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
                 PluginViewPathInfo pathInfo = getPluginViewPathInfo(uri);
 
                 searchPaths = CollectionUtils.newList(
-                    GrailsResourceUtils.appendPiecesForUri(GrailsResourceUtils.WEB_INF, PLUGINS_PATH, pathInfo.pluginName,GrailsResourceUtils.VIEWS_DIR_PATH, pathInfo.path),
-                    GrailsResourceUtils.appendPiecesForUri(GrailsResourceUtils.WEB_INF, uri),
-                    uri);
-            }
-            else {
+                        GrailsResourceUtils.appendPiecesForUri(GrailsResourceUtils.WEB_INF, PLUGINS_PATH, pathInfo.pluginName, GrailsResourceUtils.VIEWS_DIR_PATH, pathInfo.path),
+                        GrailsResourceUtils.appendPiecesForUri(GrailsResourceUtils.WEB_INF, uri),
+                        uri);
+            } else {
                 searchPaths = CollectionUtils.newList(
+                        GrailsResourceUtils.appendPiecesForUri(PATH_TO_WEB_INF_VIEWS, uri),
+                        uri);
+            }
+        } else {
+            searchPaths = CollectionUtils.newList(
+                    GrailsResourceUtils.appendPiecesForUri(SLASHED_VIEWS_DIR_PATH, uri),
                     GrailsResourceUtils.appendPiecesForUri(PATH_TO_WEB_INF_VIEWS, uri),
                     uri);
-            }
-        }
-        else {
-            searchPaths = CollectionUtils.newList(
-                GrailsResourceUtils.appendPiecesForUri(SLASHED_VIEWS_DIR_PATH, uri),
-                GrailsResourceUtils.appendPiecesForUri(PATH_TO_WEB_INF_VIEWS, uri),
-                uri);
         }
         return searchPaths;
     }
@@ -298,9 +305,8 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
                 if (gspClassName != null && !reloadedPrecompiledGspClassNames.contains(gspClassName)) {
                     Class<GroovyPage> gspClass = null;
                     try {
-                        gspClass = (Class<GroovyPage>)Class.forName(gspClassName, true, Thread.currentThread().getContextClassLoader());
-                    }
-                    catch (ClassNotFoundException e) {
+                        gspClass = (Class<GroovyPage>) Class.forName(gspClassName, true, Thread.currentThread().getContextClassLoader());
+                    } catch (ClassNotFoundException e) {
                         LOG.warn("Cannot load class " + gspClassName + ". Resuming on non-precompiled implementation.", e);
                     }
                     if (gspClass != null) {
@@ -311,7 +317,7 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
         }
 
         Resource foundResource = findResource(searchPaths);
-        return foundResource == null ? null : new GroovyPageResourceScriptSource(uri,foundResource);
+        return foundResource == null ? null : new GroovyPageResourceScriptSource(uri, foundResource);
     }
 
     protected Resource findResource(String uri) {
@@ -359,7 +365,7 @@ public class DefaultGroovyPageLocator implements GroovyPageLocator, ResourceLoad
             basePath = uri.substring(PLUGINS_PATH.length(), uri.length());
             int i = basePath.indexOf("/");
             if (i > -1) {
-                pluginName = basePath.substring(0,i);
+                pluginName = basePath.substring(0, i);
                 path = basePath.substring(i, basePath.length());
             }
         }

--- a/grails-plugin-testing/src/main/groovy/grails/test/runtime/NoOpGrailsPluginManager.java
+++ b/grails-plugin-testing/src/main/groovy/grails/test/runtime/NoOpGrailsPluginManager.java
@@ -157,6 +157,11 @@ final class NoOpGrailsPluginManager implements GrailsPluginManager {
     }
 
     @Override
+    public String getPluginPath(String name, boolean forceCamelCase) {
+        return null;
+    }
+
+    @Override
     public GrailsPlugin getPluginForInstance(Object instance) {
         return null;
     }


### PR DESCRIPTION
Reference to isse #9406 

There appears to be an assumption in loading the getPluginPath that all names go through a plugin="fooName" -> "Foo Name" -> "foo-name-version" transformation which appears to break loading items/templates/gsp/etc from inline/bundled plugins that are "fooName-version"

Not in love with the solution as it requires a new interface method to explicitly interrogate the name in camel case and there might be farther reaching implications on static assets that still do not resolve the correct path/name.
