### PR TITLE
Added check to prevent empty names from being added to the baseNames collection

### DIFF
--- a/grails-core/src/main/groovy/org/grails/spring/context/support/PluginAwareResourceBundleMessageSource.java
+++ b/grails-core/src/main/groovy/org/grails/spring/context/support/PluginAwareResourceBundleMessageSource.java
@@ -122,7 +122,7 @@ public class PluginAwareResourceBundleMessageSource extends ReloadableResourceBu
             if(i > -1) {
                 baseName = baseName.substring(0, i);
             }
-            if(!basenames.contains(baseName))
+            if(!basenames.contains(baseName) && !baseName.equals(""))
                 basenames.add(baseName);
         }
 


### PR DESCRIPTION
This will ultimately prevent a Spring BeanCreationException from being thrown due to the empty baseName.
