### PR TITLE
adjust aspectj version to fit to the used spring version (issue 9450)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 buildscript {
     repositories {
         maven { url "https://repo.grails.org/grails/core" }
@@ -27,7 +25,7 @@ ext {
 
     antTraxVersion = "1.7.1"
     antVersion = "1.9.4"
-    aspectjVersion = "1.8.5"  // use same version as org.springframework:spring-aspects uses
+    aspectjVersion = "1.8.7"  // use same version as org.springframework:spring-aspects uses
     commonsCliVersion = "1.2"
     commonsCollectionsVersion = "3.2.1"
     commonsIOVersion = "2.2"
@@ -47,7 +45,7 @@ ext {
     springLoadedVersion = "1.2.5.RELEASE"
     springBootVersion = "1.2.7.RELEASE"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
-    springVersion = "4.1.8.RELEASE"
+    springVersion = "4.1.8.RELEASE" // ensure to sync "aspectjVersion" (see commend above)
     ehcacheVersion = "2.4.6"
     junitVersion = "4.12"
     concurrentlinkedhashmapVersion = "1.4.2"


### PR DESCRIPTION
for issue #9450 I created PR #9563 for 2.5.x. As the comment in build.gradle still exists that advises to use the same aspectj version, here also the PR for 3.0.x
