### PR TITLE
PropertySourcesConfig implements Cloneable

### DIFF
--- a/grails-core/src/main/groovy/org/grails/config/PropertySourcesConfig.java
+++ b/grails-core/src/main/groovy/org/grails/config/PropertySourcesConfig.java
@@ -31,7 +31,7 @@ import java.util.Map;
  * @author Graeme Rocher
  * @since 3.0
  */
-public class PropertySourcesConfig extends NavigableMapConfig {
+public class PropertySourcesConfig extends NavigableMapConfig implements Cloneable {
 
     protected PropertySources propertySources;
     protected PropertySourcesPropertyResolver propertySourcesPropertyResolver;


### PR DESCRIPTION
I am in the process of attempting to port the Grails Platform Core plugin to a 3.x plugin.  When it merges the configuration of all of the plugins it controls with the main application configuration, it wants to clone the main configuration.  The comment in the code states the reason for the clone:

> Deep clone app config to avoid side effects of querying existing config values

The current grails-core (without this change) throws the following exception when `run-app`ing platform-core:

``` java
java.lang.CloneNotSupportedException: org.grails.config.PropertySourcesConfig
    at java.lang.Object.clone(Native Method) ~[na:1.8.0_60]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_60]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_60]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_60]
    at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_60]
    at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426) ~[springloaded-1.2.5.RELEASE.jar:1.2.5.RELEASE]
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoCachedMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:233) ~[groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56) ~[groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48) [groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113) [groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:117) [groovy-2.4.5.jar:2.4.5]
    at org.grails.plugin.platform.config.PluginConfigurationImpl$_mergeDoWithConfig_closure5.doCall(PluginConfigurationImpl.groovy:261) ~[main/:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_60]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_60]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_60]
    at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_60]
    at org.springsource.loaded.ri.ReflectiveInterceptor.jlrMethodInvoke(ReflectiveInterceptor.java:1426) ~[springloaded-1.2.5.RELEASE.jar:1.2.5.RELEASE]
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93) ~[groo5.jar:2.4.5]
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325) ~[groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294) ~[groovy-2.4.5.jar:2.4.5]
Exception in thread "main"  at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1019) ~[groovy-2.4.5.jar:2.4.5]
    at groovy.lang.Closure.call(Closure.java:426) ~[groovy-2.4.5.jar:2.4.5]
java.lang.reflect.UndeclaredThrowableException  at org.grails.plugin.platform.config.PluginConfigurationImpl$_mergeDoWithConfig_closure5.call(PluginConfigurationImpl.groovy) ~[main/:na]

    at groovy.lang.Closure.call(Closure.java:442) ~[groovy-2.4.5.jar:2.4.5]
    at org.springframework.util.ReflectionUtils.rethrowRuntimeException(ReflectionUtils.java:303)
    at org.grails.plugin.platform.config.PluginConfigurationImpl$_mergeDoWithConfig_closure5.call(PluginConfigurationImpl.groovy) ~[main/:na]
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:346)
    at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:2030) ~[groovy-2.4.5.jar:2.4.5]
    at grails.boot.GrailsApp.run(GrailsApp.groovy:54)
    at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1890) ~[groovy-2.4.5.jar:2.4.5]
    at grails.boot.GrailsApp.run(GrailsApp.groovy:346)
    at org.codehaus.groovy.runtime.dgm$159.invoke(Unknown Source) ~[groovy-2.4.5.jar:2.4.5]
    at grails.boot.GrailsApp.run(GrailsApp.groovy:335)
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:274) ~[groovy-2.4.5.jar:2.4.5]
    at grails.boot.GrailsApp$run.call(Unknown Source)
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:56) ~[groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48) [groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113) [groovy-2.4.5.jar:2.4.5]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:133)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125) [groovy-2.4.5.jar:2.4.5]
    at grails.platform.core3.Application.main(Application.groovy:8)
    at org.grails.plugin.platform.config.PluginConfigurationImpl.mergeDoWithConfig(PluginConfigurationImpl.groovy:250) ~[main/:na]
Caused by: java.lang.CloneNotSupportedException: org.grails.config.PropertySourcesConfig
    at org.grails.plugin.platform.config.PluginConfigurationImpl.applyConfig(PluginConfigurationImpl.groovy:174) ~[main/:na]
    at java.lang.Object.clone(Native Method)
    at org.grails.plugin.platform.config.PluginConfigurationImpl$applyConfig.call(Unknown Source) ~[na:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48) [groovy-2.4.5.jar:2.4.5]
```
