### PR TITLE
Add WebApplicationInitializer interface to generated ApplicationLoader

### DIFF
--- a/grails-web-boot/src/main/groovy/org/grails/compiler/boot/BootInitializerClassInjector.groovy
+++ b/grails-web-boot/src/main/groovy/org/grails/compiler/boot/BootInitializerClassInjector.groovy
@@ -22,6 +22,7 @@ import org.grails.boot.context.web.GrailsAppServletInitializer
 import org.grails.compiler.injection.GrailsASTUtils
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.web.SpringBootServletInitializer
+import org.springframework.web.WebApplicationInitializer
 
 import java.lang.reflect.Modifier
 
@@ -61,6 +62,7 @@ class BootInitializerClassInjector extends GlobalClassInjectorAdapter {
                 if(Modifier.isStatic(mn.modifiers) && Modifier.isPublic(mn.modifiers)) {
                     def loaderClassNode = new ClassNode("${classNode.name}Loader", Modifier.PUBLIC, ClassHelper.make(GrailsAppServletInitializer))
 
+                    loaderClassNode.addInterface(ClassHelper.make(WebApplicationInitializer))
 
                     def springApplicationBuilder = ClassHelper.make(SpringApplicationBuilder)
 


### PR DESCRIPTION
Here is the PR for 3.0.x; Feel free to close the PR #9607 created for master

---

This makes the ApplicationLoader discoverable for older versions of
the weblogic application server.

See also: https://github.com/spring-projects/spring-boot/issues/2078
