### PR TITLE
tests for #9754 and #9749

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/grails/validation/CommandObjectConstraintGettersSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/validation/CommandObjectConstraintGettersSpec.groovy
@@ -1,0 +1,457 @@
+package grails.validation
+
+import spock.lang.Issue
+import spock.lang.Specification
+import grails.validation.Validateable
+
+/**
+ * This is a test suite which should prevent issues from grails/grails-core#9749 and 
+ * grails/grails-core#9754 to happen again
+ *
+ * It verifies all different scenarios of getter/setter methods in command object
+ * and Grails making them constrained properties in valid cases only
+ *
+ * Main assumptions are:
+ * * public properties are by default constrained
+ * * properties from methods are only constrained if are public, non static and have both getter and setter
+ * * properties and methods inherited from super class or trait behave in the same way
+ *
+ * Analogous test case is created for Domain classes
+ * 
+ * @see grails.validation.DomainConstraintGettersSpec
+ */
+@Issue(['grails/grails-core#9749', 'grails/grails-core#9754'])
+class CommandObjectConstraintGettersSpec extends Specification {
+
+	// STANDARD COMMAND OBJECT
+
+	void 'ensure all public properties are by default constraint properties'(){
+		SimplePropertiesCommand command = new SimplePropertiesCommand()
+
+		when: 'empty command with simple properties is validated'
+		command.validate()
+
+		then: 'only public should fail on nullable constraint'
+		command.hasErrors()
+		command.errors['list']?.code == 'nullable'
+		command.errors['map']?.code == 'nullable'
+		command.errors['string']?.code == 'nullable'
+		command.errors['book']?.code == 'nullable'
+		command.errors.getErrorCount() == 4
+	}
+
+	void 'ensure constrained properties are only public ones'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = SimplePropertiesCommand.getConstraintsMap()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 4
+		constrainedProperties.containsKey('list')
+		constrainedProperties.containsKey('map')
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('book')
+	}
+
+	void 'ensure only public non-static properties with getter and setter are constrained properties'(){
+		MethodPropertiesCommand command = new MethodPropertiesCommand()
+		when: 'empty command with method properties is validated'
+		command.validate()
+
+		then: 'only public with getter and setter should fail'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = MethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only public property with getter and setter should fail'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// COMMAND OBJECT WITH SUPER CLASS
+
+	void 'ensure all inherited public properties are by default constraint properties'(){
+		InheritedPropertiesCommand command = new InheritedPropertiesCommand()
+
+		when: 'empty command with simple properties from parent class inheriteds validated'
+		command.validate()
+
+		then: 'all public should fail on nullable constraint'
+		command.hasErrors()
+		command.errors['list']?.code == 'nullable'
+		command.errors['map']?.code == 'nullable'
+		command.errors['string']?.code == 'nullable'
+		command.errors['book']?.code == 'nullable'
+		command.errors.getErrorCount() == 4
+	}
+
+	void 'ensure inherited constrained properties are only public ones'(){
+		when: 'constrained properties map is get on child class'
+		Map constrainedProperties = InheritedPropertiesCommand.getConstraintsMap()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 4
+		constrainedProperties.containsKey('list')
+		constrainedProperties.containsKey('map')
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('book')
+	}
+
+	void 'ensure only public non-static inherited properties with getter and setter are constrained properties'(){
+		InheritedMethodPropertiesCommand command = new InheritedMethodPropertiesCommand()
+		when: 'empty command with method properties is validated'
+		command.validate()
+
+		then: 'only public with getter and setter should fail'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained inherited method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get from child class'
+		Map constrainedProperties = InheritedMethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only public with getter and setter should be there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// COMMAND OBJECT WITH TRAIT
+
+	void 'ensure all trait public properties are by default constraint properties'(){
+		TraitPropertiesCommand command = new TraitPropertiesCommand()
+
+		when: 'empty command with trait properties is validated'
+		command.validate()
+
+		then: 'only public should fail on nullable constraint'
+		command.hasErrors()
+		command.errors['list']?.code == 'nullable'
+		command.errors['map']?.code == 'nullable'
+		command.errors['string']?.code == 'nullable'
+		command.errors['book']?.code == 'nullable'
+		command.errors.getErrorCount() == 4
+	}
+
+	void 'ensure constrained properties are only traits public ones'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitPropertiesCommand.getConstraintsMap()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 4
+		constrainedProperties.containsKey('list')
+		constrainedProperties.containsKey('map')
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('book')
+	}
+
+	void 'ensure only public non-static properties from trait with getter and setter are constrained properties'(){
+		TraitMethodPropertiesCommand command = new TraitMethodPropertiesCommand()
+		when: 'empty command with simple properties is validated'
+		command.validate()
+
+		then: 'all should fail on nullable constraint'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained method properties from trait are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitMethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL METHODS COMMAND OBJECT
+
+	void 'ensure only public non-static bool properties with getter and setter are constrained properties'(){
+		BoolMethodPropertiesCommand command = new BoolMethodPropertiesCommand()
+		when: 'empty command with method properties is validated'
+		command.validate()
+
+		then: 'only public with getter and setter should fail'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained bool method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = BoolMethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only public property with getter and setter should fail'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL COMMAND OBJECT WITH SUPER CLASS
+
+	void 'ensure only public non-static inherited bool properties with getter and setter are constrained properties'(){
+		InheritedBoolMethodPropertiesCommand command = new InheritedBoolMethodPropertiesCommand()
+		when: 'empty command with method properties is validated'
+		command.validate()
+
+		then: 'only public with getter and setter should fail'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained inherited bool method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get from child class'
+		Map constrainedProperties = InheritedBoolMethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only public with getter and setter should be there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL COMMAND OBJECT WITH TRAIT
+
+	void 'ensure only public non-static bool properties from trait with getter and setter are constrained properties'(){
+		TraitBoolMethodPropertiesCommand command = new TraitBoolMethodPropertiesCommand()
+		when: 'empty command with simple properties is validated'
+		command.validate()
+
+		then: 'all should fail on nullable constraint'
+		command.hasErrors()
+		command.errors['publicProperty']?.code == 'nullable'
+		command.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained bool method properties from trait are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitBoolMethodPropertiesCommand.getConstraintsMap()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+}
+
+/**
+ * Command with properties only
+ */
+class SimplePropertiesCommand implements Validateable {
+	List list
+	Map map
+	String string
+	Book book
+
+	private String fisrtName
+	protected String secondName
+	static String finalName
+	private static String foo
+	protected static String bar
+}
+
+/**
+ * Command with properties from super class only
+ */
+class InheritedPropertiesCommand extends SimplePropertiesCommand implements Validateable {}
+
+/**
+ * Command with getter/setter methods
+ */
+class MethodPropertiesCommand implements Validateable {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	String getPublicProperty() {}
+	void setPublicProperty(String value) {}
+
+	protected String getProtectedProperty() {}
+	protected void setProtectedProperty(String value) {}
+
+	private String getPrivateProperty() {}
+	private void setPrivateProperty(String value) {}	
+
+	static String getStaticPublicProperty() {}
+	static void setStaticPublicProperty(String value) {}
+
+	static protected String getStaticProtectedProperty() {}
+	static protected void setStaticProtectedProperty(String value) {}
+
+	static private String getStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(String value) {}	
+
+	String getGetterOnly() {}
+	protected String getProtectedGetterOnly() {}
+	private String getPrivateGetterOnly() {}
+
+	static String getStaticGetterOnly() {}
+	static protected String getStaticProtectedGetterOnly() {}
+	static private String getStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(String value) {}
+	protected void setProtectedSetterOnly(String value) {}
+	private void setPrivateSetterOnly(String value) {}
+
+	static void setStaticSetterOnly(String value) {}
+	static protected void setStaticProtectedSetterOnly(String value) {}
+	static private void setStaticPrivateSetterOnly(String value) {}
+}
+
+/**
+ * Command with method properties from super class
+ */
+class InheritedMethodPropertiesCommand extends MethodPropertiesCommand implements Validateable {}
+
+/**
+ * Trait with properties only
+ */
+trait SimplePropertiesTrait implements Validateable {
+	List list
+	Map map
+	String string
+	Book book
+
+	private String fisrtName
+	static String finalName
+	private static String foo
+}
+
+/**
+ * Trait with getter/setter methods
+ */
+trait MethodPropertiesTrait {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	String getPublicProperty() {}
+	void setPublicProperty(String value) {}
+
+	private String getPrivateProperty() {}
+	private void setPrivateProperty(String value) {}	
+
+	static String getStaticPublicProperty() {}
+	static void setStaticPublicProperty(String value) {}
+
+	static private String getStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(String value) {}	
+
+	String getGetterOnly() {}
+	private String getPrivateGetterOnly() {}
+
+	static String getStaticGetterOnly() {}
+	static private String getStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(String value) {}
+	private void setPrivateSetterOnly(String value) {}
+
+	static void setStaticSetterOnly(String value) {}
+	static private void setStaticPrivateSetterOnly(String value) {}
+}
+
+/**
+ * Domain with properties from trait
+ */
+class TraitPropertiesCommand implements SimplePropertiesTrait, Validateable {}
+
+/**
+ * Command with method properties from trait
+ */
+class TraitMethodPropertiesCommand implements MethodPropertiesTrait, Validateable {}
+
+/**
+ * Command with bool methods - `is` instead of `get`
+ */
+class BoolMethodPropertiesCommand implements Validateable {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	Boolean isPublicProperty() {}
+	void setPublicProperty(Boolean value) {}
+
+	protected Boolean isProtectedProperty() {}
+	protected void setProtectedProperty(Boolean value) {}
+
+	private Boolean isPrivateProperty() {}
+	private void setPrivateProperty(Boolean value) {}	
+
+	static Boolean isStaticPublicProperty() {}
+	static void setStaticPublicProperty(Boolean value) {}
+
+	static protected Boolean isStaticProtectedProperty() {}
+	static protected void setStaticProtectedProperty(Boolean value) {}
+
+	static private Boolean isStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(Boolean value) {}	
+
+	Boolean isGetterOnly() {}
+	protected Boolean isProtectedGetterOnly() {}
+	private Boolean isPrivateGetterOnly() {}
+
+	static Boolean isStaticGetterOnly() {}
+	static protected Boolean isStaticProtectedGetterOnly() {}
+	static private Boolean isStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(Boolean value) {}
+	protected void setProtectedSetterOnly(Boolean value) {}
+	private void setPrivateSetterOnly(Boolean value) {}
+
+	static void setStaticSetterOnly(Boolean value) {}
+	static protected void setStaticProtectedSetterOnly(Boolean value) {}
+	static private void setStaticPrivateSetterOnly(Boolean value) {}
+}
+
+/**
+ * Trait with getter/setter methods
+ */
+trait BoolMethodPropertiesTrait {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	Boolean isPublicProperty() {}
+	void setPublicProperty(Boolean value) {}
+
+	private Boolean isPrivateProperty() {}
+	private void setPrivateProperty(Boolean value) {}	
+
+	static Boolean isStaticPublicProperty() {}
+	static void setStaticPublicProperty(Boolean value) {}
+
+	static private Boolean isStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(Boolean value) {}	
+
+	Boolean isGetterOnly() {}
+	private Boolean isPrivateGetterOnly() {}
+
+	static Boolean isStaticGetterOnly() {}
+	static private Boolean isStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(Boolean value) {}
+	private void setPrivateSetterOnly(Boolean value) {}
+
+	static void setStaticSetterOnly(Boolean value) {}
+	static private void setStaticPrivateSetterOnly(Boolean value) {}
+}
+
+/**
+ * Command with inherited bool method properties from super class
+ */
+class InheritedBoolMethodPropertiesCommand extends BoolMethodPropertiesCommand implements Validateable {}
+
+/**
+ * Command with inherited bool method properties from trait
+ */
+class TraitBoolMethodPropertiesCommand implements BoolMethodPropertiesTrait, Validateable {}
+
+/** 
+ * Helper class
+ */
+class Book {}
+
+

--- a/grails-test-suite-uber/src/test/groovy/grails/validation/DomainConstraintGettersSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/validation/DomainConstraintGettersSpec.groovy
@@ -1,0 +1,538 @@
+package grails.validation
+
+import spock.lang.Issue
+import spock.lang.Specification
+import grails.persistence.Entity
+import grails.test.mixin.TestFor
+import grails.test.mixin.Mock
+
+/**
+ * Test is similar to CommandObjectConstraintGettersSpec but for domain classes.
+ * Check more detailed description in CommandObjectConstraintGettersSpec
+ * 
+ * @see grails.validation.CommandObjectConstraintGettersSpec
+ */
+@Issue(['grails/grails-core#9749', 'grails/grails-core#9754'])
+@TestFor(SimplePropertiesDomain)
+@Mock([SimplePropertiesDomain, MethodPropertiesDomain, InheritedPropertiesDomain, 
+	InheritedMethodPropertiesDomain, TraitPropertiesDomain, TraitMethodPropertiesDomain, 
+	BoolMethodPropertiesDomain, InheritedBoolMethodPropertiesDomain, TraitBoolMethodPropertiesDomain,
+	DomainWithTransients, InheritedDomainWithTransients, TraitDomainWithTransients])
+class DomainConstraintGettersSpec extends Specification {
+
+	// STANDARD DOMAIN
+	void 'ensure all public properties are by default constraint properties'(){
+		SimplePropertiesDomain domain = new SimplePropertiesDomain()
+
+		when: 'empty domain with simple properties is validated'
+		domain.validate()
+
+		then: 'only public should fail on nullable constraint'
+		domain.hasErrors()
+		domain.errors['string']?.code == 'nullable'
+		domain.errors['pages']?.code == 'nullable'
+		domain.errors.getErrorCount() == 2
+	}
+
+	void 'ensure constrained properties are only public ones'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = SimplePropertiesDomain.getConstrainedProperties()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 2
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('pages')
+	}
+
+	void 'ensure only public non-static properties with getter and setter are constrained properties'(){
+		MethodPropertiesDomain domain = new MethodPropertiesDomain()
+		when: 'empty domain with method properties is validated'
+		domain.validate()
+
+		then: 'only public with getter and setter should fail'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = MethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only public property with getter and setter should fail'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// DOMAIN WITH SUPER CLASS
+
+	void 'ensure all inherited public properties are by default constraint properties'(){
+		InheritedPropertiesDomain domain = new InheritedPropertiesDomain()
+
+		when: 'empty domain with simple properties from parent class inheriteds validated'
+		domain.validate()
+
+		then: 'all public should fail on nullable constraint'
+		domain.hasErrors()
+		domain.errors['string']?.code == 'nullable'
+		domain.errors['pages']?.code == 'nullable'
+		domain.errors.getErrorCount() == 2
+	}
+
+	void 'ensure inherited constrained properties are only public ones'(){
+		when: 'constrained properties map is get on child class'
+		Map constrainedProperties = InheritedPropertiesDomain.getConstrainedProperties()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 2
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('pages')
+	}
+
+	void 'ensure only public non-static inherited properties with getter and setter are constrained properties'(){
+		InheritedMethodPropertiesDomain domain = new InheritedMethodPropertiesDomain()
+		when: 'empty domain with method properties is validated'
+		domain.validate()
+
+		then: 'only public with getter and setter should fail'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained inherited method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get from child class'
+		Map constrainedProperties = InheritedMethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only public with getter and setter should be there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// DOMAIN WITH TRAIT
+
+	void 'ensure all trait public properties are by default constraint properties'(){
+		TraitPropertiesDomain domain = new TraitPropertiesDomain()
+
+		when: 'empty domain with trait properties is validated'
+		domain.validate()
+
+		then: 'only public should fail on nullable constraint'
+		domain.hasErrors()
+		domain.errors['string']?.code == 'nullable'
+		domain.errors['pages']?.code == 'nullable'
+		domain.errors.getErrorCount() == 2
+	}
+
+	void 'ensure constrained properties are only traits public ones'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitPropertiesDomain.getConstrainedProperties()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 2
+		constrainedProperties.containsKey('string')
+		constrainedProperties.containsKey('pages')
+	}
+
+	void 'ensure only public non-static properties from trait with getter and setter are constrained properties'(){
+		TraitMethodPropertiesDomain domain = new TraitMethodPropertiesDomain()
+		when: 'empty domain with simple properties is validated'
+		domain.validate()
+
+		then: 'all should fail on nullable constraint'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained method properties from trait are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitMethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL METHODS DOMAIN OBJECT
+
+	void 'ensure only public non-static bool properties with getter and setter are constrained properties'(){
+		BoolMethodPropertiesDomain domain = new BoolMethodPropertiesDomain()
+		when: 'empty domain with method properties is validated'
+		domain.validate()
+
+		then: 'only public with getter and setter should fail'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained bool method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = BoolMethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only public property with getter and setter should fail'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL DOMAIN OBJECT WITH SUPER CLASS
+
+	void 'ensure only public non-static inherited bool properties with getter and setter are constrained properties'(){
+		InheritedBoolMethodPropertiesDomain domain = new InheritedBoolMethodPropertiesDomain()
+		when: 'empty domain with method properties is validated'
+		domain.validate()
+
+		then: 'only public with getter and setter should fail'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained inherited bool method properties are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get from child class'
+		Map constrainedProperties = InheritedBoolMethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only public with getter and setter should be there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// BOOL DOMAIN OBJECT WITH TRAIT
+
+	void 'ensure only public non-static bool properties from trait with getter and setter are constrained properties'(){
+		TraitBoolMethodPropertiesDomain domain = new TraitBoolMethodPropertiesDomain()
+		when: 'empty domain with simple properties is validated'
+		domain.validate()
+
+		then: 'all should fail on nullable constraint'
+		domain.hasErrors()
+		domain.errors['publicProperty']?.code == 'nullable'
+		domain.errors.getErrorCount() == 1
+	}
+
+	void 'ensure constrained bool method properties from trait are only public ones with both getter and setter'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitBoolMethodPropertiesDomain.getConstrainedProperties()
+
+		then: 'only 4 defined public properties are there'
+		constrainedProperties.size() == 1
+		constrainedProperties.containsKey('publicProperty')
+	}
+
+	// DOMAIN WITH TRANSIENTS
+
+	void 'ensure transient properties and methods are not validated'(){
+		DomainWithTransients domain = new DomainWithTransients()
+		when: 'domain with transient methods and properties is validated'
+		domain.validate()
+
+		then: 'nothing should fail'
+		domain.errors.getErrorCount() == 0
+	}
+
+	void 'ensure transient methods and properties are not constrained'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = DomainWithTransients.getConstrainedProperties()
+
+		then: 'nothing is constrained'
+		constrainedProperties.size() == 0
+	}
+
+	// DOMAIN WITH SUPER CLASS WITH TRANSIENTS
+
+	void 'ensure inherited transient properties and methods are not validated'(){
+		DomainWithTransients domain = new DomainWithTransients()
+		when: 'domain with superclass properties and methods is validated'
+		domain.validate()
+
+		then: 'nothing should fail'
+		domain.errors.getErrorCount() == 0
+	}
+
+	void 'ensure inherited transient methods and properties are not constrained'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = DomainWithTransients.getConstrainedProperties()
+
+		then: 'nothing is constrained'
+		constrainedProperties.size() == 0
+	}
+
+	// DOMAIN WITH TRAIT WITH TRANSIENTS
+
+	void 'ensure trait transient properties and methods are not validated'(){
+		TraitDomainWithTransients domain = new TraitDomainWithTransients()
+		when: 'domain with trait transient properties and methods'
+		domain.validate()
+
+		then: 'nothing should fail'
+		domain.errors.getErrorCount() == 0
+	}
+
+	void 'ensure trait transient methods and properties are not constrained'(){
+		when: 'constrained properties map is get'
+		Map constrainedProperties = TraitDomainWithTransients.getConstrainedProperties()
+
+		then: 'nothing is constrained'
+		constrainedProperties.size() == 0
+	}
+}
+
+/**
+ * Domain with properties only
+ */
+@Entity
+class SimplePropertiesDomain {
+	String string
+	Integer pages
+
+	private String firstName
+	protected String secondName
+	static String finalName
+	private static String foo
+	protected static String bar
+}
+
+/**
+ * Domain with properties from super class only
+ */
+@Entity
+class InheritedPropertiesDomain extends SimplePropertiesDomain {}
+
+
+/**
+ * Domain with getter/setter methods
+ */
+@Entity
+class MethodPropertiesDomain {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	String getPublicProperty() {}
+	void setPublicProperty(String value) {}
+
+	protected String getProtectedProperty() {}
+	protected void setProtectedProperty(String value) {}
+
+	private String getPrivateProperty() {}
+	private void setPrivateProperty(String value) {}	
+
+	static String getStaticPublicProperty() {}
+	static void setStaticPublicProperty(String value) {}
+
+	static protected String getStaticProtectedProperty() {}
+	static protected void setStaticProtectedProperty(String value) {}
+
+	static private String getStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(String value) {}	
+
+	String getGetterOnly() {}
+	protected String getProtectedGetterOnly() {}
+	private String getPrivateGetterOnly() {}
+
+	static String getStaticGetterOnly() {}
+	static protected String getStaticProtectedGetterOnly() {}
+	static private String getStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(String value) {}
+	protected void setProtectedSetterOnly(String value) {}
+	private void setPrivateSetterOnly(String value) {}
+
+	static void setStaticSetterOnly(String value) {}
+	static protected void setStaticProtectedSetterOnly(String value) {}
+	static private void setStaticPrivateSetterOnly(String value) {}
+}
+
+/**
+ * Domain with method properties from super class
+ */
+@Entity
+class InheritedMethodPropertiesDomain extends MethodPropertiesDomain {}
+
+/**
+ * Trait with properties only
+ */
+trait SimpleDomainPropertiesTrait {
+	String string
+	Integer pages
+
+	private String firstName
+	static String finalName
+	private static String foo
+}
+
+/**
+ * Trait with getter/setter methods
+ */
+trait MethodPropertiesDomainTrait {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	String getPublicProperty() {}
+	void setPublicProperty(String value) {}
+
+	private String getPrivateProperty() {}
+	private void setPrivateProperty(String value) {}	
+
+	static String getStaticPublicProperty() {}
+	static void setStaticPublicProperty(String value) {}
+
+	static private String getStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(String value) {}	
+
+	String getGetterOnly() {}
+	private String getPrivateGetterOnly() {}
+
+	static String getStaticGetterOnly() {}
+	static private String getStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(String value) {}
+	private void setPrivateSetterOnly(String value) {}
+
+	static void setStaticSetterOnly(String value) {}
+	static private void setStaticPrivateSetterOnly(String value) {}
+}
+
+/**
+ * Domain with properties from trait
+ */
+@Entity
+class TraitPropertiesDomain implements SimpleDomainPropertiesTrait {}
+
+/**
+ * Domain with method properties from trait
+ */
+@Entity
+class TraitMethodPropertiesDomain implements MethodPropertiesDomainTrait {}
+
+/**
+ * Domain with bool methods - `is` instead of `get`
+ */
+@Entity
+class BoolMethodPropertiesDomain {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	Boolean isPublicProperty() {}
+	void setPublicProperty(Boolean value) {}
+
+	protected Boolean isProtectedProperty() {}
+	protected void setProtectedProperty(Boolean value) {}
+
+	private Boolean isPrivateProperty() {}
+	private void setPrivateProperty(Boolean value) {}	
+
+	static Boolean isStaticPublicProperty() {}
+	static void setStaticPublicProperty(Boolean value) {}
+
+	static protected Boolean isStaticProtectedProperty() {}
+	static protected void setStaticProtectedProperty(Boolean value) {}
+
+	static private Boolean isStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(Boolean value) {}	
+
+	Boolean isGetterOnly() {}
+	protected Boolean isProtectedGetterOnly() {}
+	private Boolean isPrivateGetterOnly() {}
+
+	static Boolean isStaticGetterOnly() {}
+	static protected Boolean isStaticProtectedGetterOnly() {}
+	static private Boolean isStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(Boolean value) {}
+	protected void setProtectedSetterOnly(Boolean value) {}
+	private void setPrivateSetterOnly(Boolean value) {}
+
+	static void setStaticSetterOnly(Boolean value) {}
+	static protected void setStaticProtectedSetterOnly(Boolean value) {}
+	static private void setStaticPrivateSetterOnly(Boolean value) {}
+}
+
+/**
+ * Trait with getter/setter methods
+ */
+trait BoolMethodPropertiesDomainTrait {
+	
+	/**
+	 * publicProperty should be constrained because those getter and setter
+	 */
+	Boolean isPublicProperty() {}
+	void setPublicProperty(Boolean value) {}
+
+	private Boolean isPrivateProperty() {}
+	private void setPrivateProperty(Boolean value) {}	
+
+	static Boolean isStaticPublicProperty() {}
+	static void setStaticPublicProperty(Boolean value) {}
+
+	static private Boolean isStaticPrivateProperty() {}
+	static private void setStaticPrivateProperty(Boolean value) {}	
+
+	Boolean isGetterOnly() {}
+	private Boolean isPrivateGetterOnly() {}
+
+	static Boolean isStaticGetterOnly() {}
+	static private Boolean isStaticPrivateGetterOnly() {}
+
+	void setSetterOnly(Boolean value) {}
+	private void setPrivateSetterOnly(Boolean value) {}
+
+	static void setStaticSetterOnly(Boolean value) {}
+	static private void setStaticPrivateSetterOnly(Boolean value) {}
+}
+
+/**
+ * Domain with inherited bool method properties from super class
+ */
+@Entity
+class InheritedBoolMethodPropertiesDomain extends BoolMethodPropertiesDomain {}
+
+/**
+ * Domain with inherited bool method properties from trait
+ */
+@Entity
+class TraitBoolMethodPropertiesDomain implements BoolMethodPropertiesDomainTrait {}
+
+@Entity
+class DomainWithTransients {
+	static transients = ['simpleProperty', 'methodProperty', 'boolMethodProperty']
+
+	String simpleProperty
+	String getMethodProperty(){}
+	void setMethodProperty(String value){}
+
+	transient String getTransientMethodProperty(){}
+	transient void setTransientMethodProperty(String value){}
+
+	Boolean isBoolMethodProperty(){}
+	void setBoolMethodProperty(Boolean value){}
+
+	transient Boolean isTransientBoolMethodProperty(){}
+	transient void setTransientBoolMethodProperty(Boolean value){}
+}
+
+trait TraitWithTransients {
+	static transients = ['simpleProperty', 'methodProperty', 'boolMethodProperty']
+
+	String simpleProperty
+	String getMethodProperty(){}
+	void setMethodProperty(String value){}
+
+	transient String getTransientMethodProperty(){}
+	transient void setTransientMethodProperty(String value){}
+
+	Boolean isBoolMethodProperty(){}
+	void setBoolMethodProperty(Boolean value){}
+
+	transient Boolean isTransientBoolMethodProperty(){}
+	transient void setTransientBoolMethodProperty(Boolean value){}
+}
+
+@Entity
+class InheritedDomainWithTransients extends DomainWithTransients {}
+
+@Entity
+class TraitDomainWithTransients implements TraitWithTransients {}


### PR DESCRIPTION
Attached are tests related to #9754 and #9749. The problem is a lot of them fails. Different fail on 3.0.x then on 3.1.x and master. Maybe because of newest commit @graemerocher did, it will be the same now.

Summary of issues on 3.0.x:
DOMAIN:
- having `isProperty()` + `setProperty()` is not consired property in Domain class
- `transient getProperty()` + `transient setProperty()` is not transient in domain class

COMMAND:
- inherited properties/methods are not constrained
- having just `getProperty()` without `setProperty()` creates constraint on property
- boolean `isProperty()` causes exception on validation even if setter is available

```
NotReadablePropertyException: Invalid property 'publicProperty' of bean class [grails.validation.TraitBoolMethodPropertiesCommand]: Bean property 'publicProperty' is not readable or has an invalid getter method: Does the return type of the getter match the parameter type of the setter?
```

If some of the tests should be disabled for now I can remove them or we could add `@Ignore`. If anything is incorrect in your opinion please let me know and I will work on it further.
