### PR TITLE
Removed extra Whitespace in UrlMappingUtils

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
@@ -314,9 +314,4 @@ public class UrlMappingUtils {
             WebUtils.cleanupIncludeRequestAttributes(request, toRestore);
         }
     }
-
-
-
-
-
 }


### PR DESCRIPTION
I ran across these extra empty lines today and cleaned them up
