### PR TITLE
Allow id attribute in <g:form>

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -418,6 +418,11 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         attrs.remove('method')
         // process remaining attributes
         if (attrs.id == null) attrs.remove('id')
+        
+        def elementId = attrs.remove('elementId')
+        if (elementId) {
+            attrs.id = elementId
+        }
 
         outputAttributes(attrs, writer, true)
 


### PR DESCRIPTION
Currently, attribute id is not supported in <g:form>. I wrote a patch to fix it.
