### PR TITLE
Update LoggingTransformer AST to use SLF4J

### DIFF
--- a/grails-logging/src/main/groovy/org/grails/compiler/logging/LoggingTransformer.java
+++ b/grails-logging/src/main/groovy/org/grails/compiler/logging/LoggingTransformer.java
@@ -15,8 +15,8 @@
  */
 package org.grails.compiler.logging;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
@@ -65,9 +65,9 @@ public class LoggingTransformer implements AllArtefactClassInjector{
     public static void addLogField(ClassNode classNode, String logName) {
         FieldNode logVariable = new FieldNode(LOG_PROPERTY,
                                               Modifier.STATIC | Modifier.PRIVATE,
-                                              new ClassNode(Log.class),
+                                              new ClassNode(Logger.class),
                                               classNode,
-                                              new MethodCallExpression(new ClassExpression(new ClassNode(LogFactory.class)), "getLog", new ArgumentListExpression(new ConstantExpression(logName))));
+                                              new MethodCallExpression(new ClassExpression(new ClassNode(LoggerFactory.class)), "getLogger", new ArgumentListExpression(new ConstantExpression(logName))));
 
         classNode.addField(logVariable);
     }

--- a/grails-logging/src/test/groovy/org/grails/compiler/logging/LoggingTransformerSpec.groovy
+++ b/grails-logging/src/test/groovy/org/grails/compiler/logging/LoggingTransformerSpec.groovy
@@ -1,6 +1,6 @@
 package org.grails.compiler.logging
 
-import org.apache.commons.logging.Log
+import org.slf4j.Logger
 import grails.compiler.ast.ClassInjector
 import org.grails.compiler.injection.GrailsAwareClassLoader
 import spock.lang.Specification
@@ -27,10 +27,10 @@ class LoggingController extends BaseController{
 }
 ''', "foo/grails-app/controllers/LoggingController.groovy")
             def controller = cls.newInstance()
-            Log log = controller.index()
+            Logger log = controller.index()
 
         then:
-            log instanceof Log
+            log instanceof Logger
     }
     def "Test added log field"() {
         given:
@@ -48,10 +48,10 @@ class LoggingController {
 }
 ''', "foo/grails-app/controllers/LoggingController.groovy")
             def controller = cls.newInstance()
-            Log log = controller.index()
+            Logger log = controller.index()
 
         then:
-            log instanceof Log
+            log instanceof Logger
 
     }
 
@@ -69,10 +69,10 @@ class LoggingController {
 }
 ''', "foo/grails-app/controllers/LoggingController.groovy")
             def controller = cls.newInstance()
-            Log log = controller.index()
+            Logger log = controller.index()
 
         then:
-            log instanceof Log
+            log instanceof Logger
 
     }
 }

--- a/grails-plugin-testing/src/test/groovy/grails/test/mixin/TestForSpec.groovy
+++ b/grails-plugin-testing/src/test/groovy/grails/test/mixin/TestForSpec.groovy
@@ -1,6 +1,6 @@
 package grails.test.mixin
 
-import org.apache.commons.logging.Log
+import org.slf4j.Logger
 import org.junit.Test
 
 import spock.lang.Specification
@@ -14,7 +14,7 @@ class TestForSpec extends Specification{
         then:
             test != null
             test.getClass().getDeclaredMethod("testIndex", null).getAnnotation(Test.class) != null
-            test.retrieveLog() instanceof Log
+            test.retrieveLog() instanceof Logger
     }
 
     void "Test junit 3 test doesn't get annotation"() {
@@ -24,7 +24,7 @@ class TestForSpec extends Specification{
         then:
             test != null
             test.getClass().getDeclaredMethod("testIndex", null).getAnnotation(Test.class) == null
-            test.retrieveLog() instanceof Log
+            test.retrieveLog() instanceof Logger
     }
 
     void "Test spock test doesn't get annotation"() {
@@ -33,7 +33,7 @@ class TestForSpec extends Specification{
 
         then:
             test != null
-            test.retrieveLog() instanceof Log
+            test.retrieveLog() instanceof Logger
     }
 
     def getSpockTest() {


### PR DESCRIPTION
Is there any specific reason why the LoggingTransformer AST injects a commons-logging logger instead of SLF4J? It would be great to be able to utilize SLF4J directly instead of going through the jcl-over-slf4j bridge.
