### PR TITLE
Add the ability to pass GRAILS_OPTS or GRAILS_FORK_OPTS to forked JVM processes

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -331,6 +331,12 @@ class GrailsGradlePlugin extends GroovyPlugin {
                 task.jvmArgs "-XX:PermSize=96m", "-XX:MaxPermSize=256m"
             }
             task.jvmArgs "-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1", "-XX:CICompilerCount=3"
+
+            // Copy GRAILS_FORK_OPTS into the fork. Or use GRAILS_OPTS if no fork options provided
+            // This allows run-app etc. to run using appropriate settings and allows users to provided
+            // different FORK JVM options to the build options.
+            String opts = System.env.GRAILS_FORK_OPTS ?: System.env.GRAILS_OPTS
+            if(opts) task.jvmArgs opts.split(' ')
         }
 
         def tasks = project.tasks


### PR DESCRIPTION
The JVM args are hardcoded which makes run-app and test-app difficult to do when an
application needs more than 768mb of RAM and better GC.

Using `GRAILS_OPTS` will pass the options through to the forked process,
alternatively to provide different options to forked processes the user can
set `GRAILS_FORK_OPTS` which will be chosen in preference.
