### PR TITLE
Support nested RESTful resources in form tag lib

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -404,7 +404,12 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
 
         // default to post
-        def method = linkAttrs[LinkGenerator.ATTRIBUTE_METHOD]?.toUpperCase() ?: 'POST'
+        def method
+        if (linkAttrs[LinkGenerator.ATTRIBUTE_RESOURCE] && linkAttrs[LinkGenerator.ATTRIBUTE_ACTION]) {
+            method = LinkGenerator.REST_RESOURCE_ACTION_TO_HTTP_METHOD_MAP.get(linkAttrs[LinkGenerator.ATTRIBUTE_ACTION].toString())
+        } else {
+            method = linkAttrs[LinkGenerator.ATTRIBUTE_METHOD]?.toUpperCase() ?: 'POST'
+        }
         def httpMethod = HttpMethod.valueOf(method)
         boolean notGet = httpMethod != HttpMethod.GET
 

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibResourceTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibResourceTests.groovy
@@ -1,0 +1,89 @@
+package org.grails.web.taglib
+
+import org.grails.core.artefact.UrlMappingsArtefactHandler
+
+class FormTagLibResourceTests extends AbstractGrailsTagTests {
+
+    protected void onInit() {
+        def mappingClass = gcl.parseClass('''
+class TestUrlMappings {
+    static mappings = {
+        "/books"(resources:"book") {
+            "/authors"(resources:"author")
+        }
+    }
+}
+        ''')
+
+        grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, mappingClass)
+    }
+
+    void testResourceSave() {
+        def template = '<g:form resource="book" action="save"/>'
+        assertOutputEquals('<form action="/books" method="post" ></form>', template)
+    }
+
+    void testResourceUpdate() {
+        def template = '<g:form resource="book" action="update" id="1"/>'
+        assertOutputEquals('<form action="/books/1" method="post" ><input type="hidden" name="_method" value="PUT" id="_method" /></form>', template)
+    }
+
+    void testResourceUpdateIdInParams() {
+        def template = '<g:form resource="book" action="update" params="[id:1]"/>'
+        assertOutputEquals('<form action="/books/1" method="post" ><input type="hidden" name="_method" value="PUT" id="_method" /></form>', template)
+    }
+
+    void testResourcePatch() {
+        def template = '<g:form resource="book" action="patch" id="1"/>'
+        assertOutputEquals('<form action="/books/1" method="post" ><input type="hidden" name="_method" value="PATCH" id="_method" /></form>', template)
+    }
+
+    void testResourcePatchIdInParams() {
+        def template = '<g:form resource="book" action="patch" params="[id:1]"/>'
+        assertOutputEquals('<form action="/books/1" method="post" ><input type="hidden" name="_method" value="PATCH" id="_method" /></form>', template)
+    }
+
+    void testResourceNestedSave() {
+        def template = '<g:form resource="book/author" action="save" params="[bookId:1]"/>'
+        assertOutputEquals('<form action="/books/1/authors" method="post" ></form>', template)
+    }
+
+    void testResourceNestedUpdate() {
+        // We'd really like to suppoer this format <g:form resource="book/author" action="update" id="2" bookId="1"/>
+        // but the form tag limits the set of attributes it hands to the linkGenerator and the dynamic parameters like 'bookId' get filtered out
+        // instead we make do with putting bookId in the params attribute
+        def template = '<g:form resource="book/author" action="update" id="2" params="[bookId:1]"/>'
+        assertOutputEquals('<form action="/books/1/authors/2" method="post" ><input type="hidden" name="_method" value="PUT" id="_method" /></form>', template)
+    }
+
+    void testResourceNestedUpdateIdInParams() {
+        def template = '<g:form resource="book/author" action="update" params="[bookId:1, id:2]"/>'
+        assertOutputEquals('<form action="/books/1/authors/2" method="post" ><input type="hidden" name="_method" value="PUT" id="_method" /></form>', template)
+    }
+
+    void testResourceNestedPatch() {
+        def template = '<g:form resource="book/author" action="patch" id="2" params="[bookId:1]"/>'
+        assertOutputEquals('<form action="/books/1/authors/2" method="post" ><input type="hidden" name="_method" value="PATCH" id="_method" /></form>', template)
+    }
+
+    void testResourceNestedPatchIdInParams() {
+        def template = '<g:form resource="book/author" action="patch" params="[bookId:1, id:2]"/>'
+        assertOutputEquals('<form action="/books/1/authors/2" method="post" ><input type="hidden" name="_method" value="PATCH" id="_method" /></form>', template)
+    }
+
+    void assertOutputEquals(expected, template, params = [:]) {
+        def engine = appCtx.groovyPagesTemplateEngine
+
+        assert engine
+        def t = engine.createTemplate(template, "test_"+ System.currentTimeMillis())
+
+        def w = t.make(params)
+
+        def sw = new StringWriter()
+        def out = new PrintWriter(sw)
+        webRequest.out = out
+        w.writeTo(out)
+
+        assertEquals expected, sw.toString()
+    }
+}

--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/LinkGenerator.java
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/LinkGenerator.java
@@ -70,6 +70,27 @@ public interface LinkGenerator {
        ATTRIBUTE_NAMESPACE
        );
 
+    Map<String, String> REST_RESOURCE_ACTION_TO_HTTP_METHOD_MAP = CollectionUtils.<String, String>newMap(
+        "create", "GET",
+        "save",   "POST",
+        "show",   "GET",
+        "index",  "GET",
+        "edit",   "GET",
+        "update", "PUT",
+        "patch",  "PATCH",
+        "delete", "DELETE"
+    );
+
+    Map<String, String> REST_RESOURCE_HTTP_METHOD_TO_ACTION_MAP = CollectionUtils.<String, String>newMap(
+        "GET_ID", "show",
+        "GET",    "index",
+        "POST",   "save",
+        "DELETE", "delete",
+        "PUT",    "update",
+        "PATCH",  "patch"
+    );
+
+
     /**
      * Generates a link to a static resource for the given named parameters.
      *

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -58,25 +58,6 @@ class DefaultLinkGenerator implements LinkGenerator, org.codehaus.groovy.grails.
 
     private static final Pattern absoluteUrlPattern = Pattern.compile('^[A-Za-z][A-Za-z0-9+\\-.]*:.*$')
 
-    private static final Map<String, String> REST_RESOURCE_ACTION_TO_HTTP_METHOD_MAP = [
-        create:"GET",
-        save:"POST",
-        show:"GET",
-        index:"GET",
-        edit:"GET",
-        update:"PUT",
-        patch:"PATCH",
-        delete:"DELETE"
-    ]
-
-    private static final Map<String, String> REST_RESOURCE_HTTP_METHOD_TO_ACTION_MAP = [
-        GET_ID:"show",
-        GET:"index",
-        POST:"save",
-        DELETE:"delete",
-        PUT:"update",
-        PATCH:"patch"
-    ]
     String configuredServerBaseURL
     String contextPath
     String resourcePath
@@ -207,7 +188,12 @@ class DefaultLinkGenerator implements LinkGenerator, org.codehaus.groovy.grails.
                     if (tokens.size()>1) {
                         for(t in tokens[0..-2]) {
                             final key = "${t}Id".toString()
-                            params[key] = urlAttrs.remove(key)
+                            final attr = urlAttrs.remove(key)
+                            // the params value might not be null
+                            // only overwrite if urlAttrs actually had the key
+                            if (attr) {
+                                params[key] = attr
+                            }
                         }
                     }
                     if (!methodAttribute && action) {


### PR DESCRIPTION
Allow the form tag lib to generate form elements that point to urls for nested restful resources.
