### PR TITLE
Adds integrationTest task to verification group

### DIFF
--- a/gradle/integration-test.gradle
+++ b/gradle/integration-test.gradle
@@ -24,6 +24,10 @@ task integrationTest(type: Test) {
   reports.html.enabled = false
 }
 
+configure(integrationTest) {
+    group =  JavaBasePlugin.VERIFICATION_GROUP
+}
+
 // Make sure 'check' task calls integration test
 check.dependsOn integrationTest
 


### PR DESCRIPTION
It makes sense to show the integrationTest task in the same group as the _test_ or _check_ gradle tasks.
