### PR TITLE
removing plugin packaging logic from grails plugin gradle plugin as i…

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -184,18 +184,6 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
             GrailsExtension grailsExtension = project.extensions.findByType(GrailsExtension)
 
             def processResourcesDependencies = []
-            if(grailsExtension.packageAssets) {
-                def assetsDir = new File(project.projectDir,"grails-app/assets")
-                if(assetsDir.exists()) {
-                    processResourcesDependencies << project.task(type: Copy, "copyAssets") {
-                        assetsDir.eachDir { subDirectory ->
-                            from subDirectory.canonicalPath
-                        }
-                        into "${processResources.destinationDir}/META-INF/assets"
-                    }
-                }
-            }
-
 
             processResourcesDependencies << project.task(type: Copy, "copyCommands") {
                 from "${project.projectDir}/src/main/scripts"


### PR DESCRIPTION
Plugin packaging is now built into asset-pipeline-gradle. It also correclty creates an `assets.list` file which allows recursive scanning on the classpath from binary plugin packaging. The profile for a plugin also needs modded to include 

```
assets {
    packagePlugin=true
}
```

Expect a follow up profile PR for htis
