### PR TITLE
Allow restful POST updates #9926

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
@@ -35,7 +35,7 @@ import org.springframework.http.HttpStatus
 @Artefact("Controller")
 @Transactional(readOnly = true)
 class RestfulController<T> {
-    static allowedMethods = [save: "POST", update: "PUT", patch: "PATCH", delete: "DELETE"]
+    static allowedMethods = [save: "POST", update: ["PUT", "POST"], patch: "PATCH", delete: "DELETE"]
 
     Class<T> resource
     String resourceName


### PR DESCRIPTION
RestfulController allowed methods is too restrictive and is not extensible at the controller level. It should be less restrictive by default or allow extensibility. There is no reason why not to allow POST updates.

https://github.com/grails/grails-core/issues/9926
https://github.com/grails/grails-core/pull/9928

Pull request for 3.1.x branch @graemerocher 
