### PR TITLE
(chore) Travis script refactoring part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,13 @@ env:
   - secure: Frvf9gLJ/pfy3SWMm9LXdprO/snMFfDO9pTd1bl2GN3QBmkF40G20NzoFI6jbYeyg+gwJQmnC6NVi/KDAkJ/EBO05Xk/qMKwWWsASgdDzdnUNTynFPH0zcnv64d6qZAaLWeH/gWQPZ+99zmbVzFqSNDggEo+cPBm9QjqJ608Yx4=
   - secure: JM8mzEz6+UtRnG68vbitVoPzcrSHbEIa0z7Nfhu3RKMDOmQgfGNIF+ZDZPAa/tYpNBTJWKjeIJc8opCfd1p1+s6ISc7B29ymulQ3ztwFWcetunrSmxl8H96aqzjc+82DO6huj4Tzi0u2MADnh9wVm+A1+tcqLjpaLGmskMlvdbw=
   - secure: ICWgIGwHFH37nlY9k094qnnKy0tW2XDSOtGsvHb65AxsPsXB1zqj7Qd76Fboo1xFGQGpg+S6AHekY6Ch1prNOpkpPHw35UaQzaRqUxFUhfZYiD0rlmvzKrvKTesrFLy4LJwrTzGCQrViYgqfHvCeQ3r53wWff6nu8uFmMOPmGNY=
-script: ./travis-build.sh
 install: /bin/true
-after_failure: ./travis-after-failure.sh
+script:
+- ./travis-build.sh
+after_success:
+- ./trigger-dependent-build.sh
+after_failure:
+- ./travis-after-failure.sh
 deploy:
   provider: releases
   api_key:
@@ -41,8 +45,6 @@ deploy:
     all_branches: true
 after_deploy:
 - ./gradlew sdkMajorRelease
-after_success:
-- ./trigger-dependent-build.sh
 cache:
   directories:
   - $HOME/.gradle


### PR DESCRIPTION
Reorder scripts in .travis file to make it easier to see relations.

Scripts still run in the same order but are now grouped in the file.

Also put script triggers consistently in the yaml syntax

Reason for doing this is to prepare for running the build job faster (where we can move some of the releasing stuff to `on_success`

See #9946 for discussion
