### PR TITLE
(chore) Travis script refactoring part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install: /bin/true
 script:
 - ./travis-build.sh
 after_success:
+- ./travis-publish-archives.sh
 - ./trigger-dependent-build.sh
 after_failure:
 - ./travis-after-failure.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,13 @@ env:
   - secure: Frvf9gLJ/pfy3SWMm9LXdprO/snMFfDO9pTd1bl2GN3QBmkF40G20NzoFI6jbYeyg+gwJQmnC6NVi/KDAkJ/EBO05Xk/qMKwWWsASgdDzdnUNTynFPH0zcnv64d6qZAaLWeH/gWQPZ+99zmbVzFqSNDggEo+cPBm9QjqJ608Yx4=
   - secure: JM8mzEz6+UtRnG68vbitVoPzcrSHbEIa0z7Nfhu3RKMDOmQgfGNIF+ZDZPAa/tYpNBTJWKjeIJc8opCfd1p1+s6ISc7B29ymulQ3ztwFWcetunrSmxl8H96aqzjc+82DO6huj4Tzi0u2MADnh9wVm+A1+tcqLjpaLGmskMlvdbw=
   - secure: ICWgIGwHFH37nlY9k094qnnKy0tW2XDSOtGsvHb65AxsPsXB1zqj7Qd76Fboo1xFGQGpg+S6AHekY6Ch1prNOpkpPHw35UaQzaRqUxFUhfZYiD0rlmvzKrvKTesrFLy4LJwrTzGCQrViYgqfHvCeQ3r53wWff6nu8uFmMOPmGNY=
-script: ./travis-build.sh
 install: /bin/true
-after_failure: ./travis-after-failure.sh
+script:
+- ./travis-build.sh
+after_success:
+- ./trigger-dependent-build.sh
+after_failure:
+- ./travis-after-failure.sh
 deploy:
   provider: releases
   api_key:
@@ -41,8 +45,6 @@ deploy:
     all_branches: true
 after_deploy:
 - ./gradlew sdkMajorRelease
-after_success:
-- ./trigger-dependent-build.sh
 cache:
   directories:
   - $HOME/.gradle

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -34,100 +34,12 @@ else
     fi
 fi
 
-
-if [[ $TRAVIS_PULL_REQUEST == 'false' && $EXIT_STATUS -eq 0
-    && $TRAVIS_REPO_SLUG == grails/grails-core && ( $TRAVIS_TAG =~ ^v[[:digit:]] || $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ )  ]]; then
-    # files encrypted with 'openssl aes-256-cbc -in <INPUT FILE> -out <OUTPUT_FILE> -pass pass:$SIGNING_PASSPHRASE'
-    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in secring.gpg.enc -out secring.gpg -d
-    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in pubring.gpg.enc -out pubring.gpg -d
-    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in settings.xml.enc -out settings.xml -d
-    mkdir -p ~/.m2
-    cp settings.xml ~/.m2/settings.xml
-
-    mv ~/.gradle/gradle.properties{,.orig}
-    echo "org.gradle.jvmargs=-XX\:MaxPermSize\=1024m -Xmx1500m -Dfile.encoding\=UTF-8 -Duser.country\=US -Duser.language\=en -Duser.variant" >> ~/.gradle/gradle.properties
-    echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties
-    ./gradlew --stop
-    #./gradlew groovydoc
-    mv ~/.gradle/gradle.properties{.orig,}
-
-    echo "Publishing archives"
-
-    gpg --keyserver keyserver.ubuntu.com --recv-key $SIGNING_KEY
-
-    echo "Running Gradle publish for branch $TRAVIS_BRANCH"
-
-    if [[ $TRAVIS_TAG =~ ^v[[:digit:]] ]]; then
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" publish uploadArchives -x grails-bom:uploadArchives -x grails-dependencies:uploadArchives || EXIT_STATUS=$?
-        ./gradlew closeAndPromoteRepository
-
-        if [[ $EXIT_STATUS == 0 ]]; then
-            ./gradlew --stop
-            # wait 30 seconds to ensure the previous promotion completes
-            sleep 30
-            ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" grails-dependencies:uploadArchives grails-bom:uploadArchives || EXIT_STATUS=$?
-            ./gradlew closeAndPromoteRepository
-        fi
-
-        if [[ $EXIT_STATUS == 0 ]]; then
-            ./gradlew assemble || EXIT_STATUS=$?
-        fi
-
-        # Configure GIT
-        git config --global user.name "$GIT_NAME"
-        git config --global user.email "$GIT_EMAIL"
-        git config --global credential.helper "store --file=~/.git-credentials"
-
-        # Tag the Profile Repo
-        git clone https://${GH_TOKEN}@github.com/grails/grails-profile-repository.git
-        cd grails-profile-repository
-
-        git branch --track 3.1.x remotes/origin/3.1.x
-        git checkout 3.1.x
-
-        echo "grailsVersion=${TRAVIS_TAG:1}" > profiles/gradle.properties
-        git add profiles/gradle.properties
-        git commit -m "Release $TRAVIS_TAG profiles"
-
-        git tag $TRAVIS_TAG
-        git push --tags
-        git push
-
-        # Tag and release the docs
-        cd ..
-        git clone https://${GH_TOKEN}@github.com/grails/grails-doc.git grails-doc
-        cd grails-doc
-        git branch --track 3.1.x remotes/origin/3.1.x
-        git checkout 3.1.x
-        
-        echo "grails.version=${TRAVIS_TAG:1}" > gradle.properties
-        git add gradle.properties
-        git commit -m "Release $TRAVIS_TAG docs"
-        git tag $TRAVIS_TAG
-        git push --tags
-        git push
-        cd ..
-
-        # Update the website
-        git clone https://${GH_TOKEN}@github.com/grails/grails-static-website.git
-        cd grails-static-website
-        echo -e "${TRAVIS_TAG:1}" >> generator/src/main/resources/versions
-        git add generator/src/main/resources/versions
-        git commit -m "Release Grails $TRAVIS_TAG"
-        git push
-        cd ..
-
-        # Rebuild Artifactory index
-        curl -H "X-Api-Key:$ARTIFACTORY_API_KEY" -X POST "http://repo.grails.org/grails/api/maven?repos=libs-releases-local,plugins-releases-local,plugins3-releases-local,core&force=1"
-
-    elif [[ $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ ]]; then
-        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" publish || EXIT_STATUS=$?
-    fi
-
-fi
-
-#if [[ $EXIT_STATUS == 0 ]]; then
-#    ./gradlew travisciTrigger -i
-#fi
+export EXIT_STATUS
+export grailsVersion
+# done. after build, then after_success will run if EXIT_STATUS is 0
+#
+# This also means that the later modifications to EXIT_STATUS will not affect
+# the build status: Build could now be success, even though the later steps will
+# change EXIT_STATUS variable
 
 exit $EXIT_STATUS

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -11,9 +11,6 @@ grailsVersion="${grailsVersion//[[:blank:]\'\"]/}"
 
 echo "Project Version: '$grailsVersion'"
 
-git config --global credential.helper "store --file=~/.git-credentials"
-echo "https://$GH_TOKEN:@github.com" > ~/.git-credentials
-
 EXIT_STATUS=0
 ./gradlew --stop
 

--- a/travis-publish-archives.sh
+++ b/travis-publish-archives.sh
@@ -8,8 +8,9 @@
 echo "Project Version: '$grailsVersion'"
 echo "EXIT STATUS of build: '$EXIT_STATUS'"
 
-if [[ $TRAVIS_PULL_REQUEST == 'false' && $EXIT_STATUS -eq 0
-    && $TRAVIS_REPO_SLUG == grails/grails-core && ( $TRAVIS_TAG =~ ^v[[:digit:]] || $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ )  ]]; then
+if [[ $TRAVIS_PULL_REQUEST == 'false'
+    && $TRAVIS_REPO_SLUG == grails/grails-core
+    && ( $TRAVIS_TAG =~ ^v[[:digit:]] || $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ )  ]]; then
     # files encrypted with 'openssl aes-256-cbc -in <INPUT FILE> -out <OUTPUT_FILE> -pass pass:$SIGNING_PASSPHRASE'
     openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in secring.gpg.enc -out secring.gpg -d
     openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in pubring.gpg.enc -out pubring.gpg -d

--- a/travis-publish-archives.sh
+++ b/travis-publish-archives.sh
@@ -47,9 +47,11 @@ if [[ $TRAVIS_PULL_REQUEST == 'false' && $EXIT_STATUS -eq 0
         fi
 
         # Configure GIT
+        git config --global credential.helper "store --file=~/.git-credentials"
+        echo "https://$GH_TOKEN:@github.com" > ~/.git-credentials
+
         git config --global user.name "$GIT_NAME"
         git config --global user.email "$GIT_EMAIL"
-        git config --global credential.helper "store --file=~/.git-credentials"
 
         # Tag the Profile Repo
         git clone https://${GH_TOKEN}@github.com/grails/grails-profile-repository.git

--- a/travis-publish-archives.sh
+++ b/travis-publish-archives.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# This will run after a successful build
+#
+# This also means that the later modifications to EXIT_STATUS will not affect
+# the build status: Build could now be success, even though the later steps here will
+# change EXIT_STATUS variable
+
+echo "Project Version: '$grailsVersion'"
+echo "EXIT STATUS of build: '$EXIT_STATUS'"
+
+if [[ $TRAVIS_PULL_REQUEST == 'false' && $EXIT_STATUS -eq 0
+    && $TRAVIS_REPO_SLUG == grails/grails-core && ( $TRAVIS_TAG =~ ^v[[:digit:]] || $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ )  ]]; then
+    # files encrypted with 'openssl aes-256-cbc -in <INPUT FILE> -out <OUTPUT_FILE> -pass pass:$SIGNING_PASSPHRASE'
+    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in secring.gpg.enc -out secring.gpg -d
+    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in pubring.gpg.enc -out pubring.gpg -d
+    openssl aes-256-cbc -pass pass:$SIGNING_PASSPHRASE -in settings.xml.enc -out settings.xml -d
+    mkdir -p ~/.m2
+    cp settings.xml ~/.m2/settings.xml
+
+    mv ~/.gradle/gradle.properties{,.orig}
+    echo "org.gradle.jvmargs=-XX\:MaxPermSize\=1024m -Xmx1500m -Dfile.encoding\=UTF-8 -Duser.country\=US -Duser.language\=en -Duser.variant" >> ~/.gradle/gradle.properties
+    echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties
+    ./gradlew --stop
+    #./gradlew groovydoc
+    mv ~/.gradle/gradle.properties{.orig,}
+
+    echo "Publishing archives"
+
+    gpg --keyserver keyserver.ubuntu.com --recv-key $SIGNING_KEY
+
+    echo "Running Gradle publish for branch $TRAVIS_BRANCH"
+
+    if [[ $TRAVIS_TAG =~ ^v[[:digit:]] ]]; then
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" publish uploadArchives -x grails-bom:uploadArchives -x grails-dependencies:uploadArchives || EXIT_STATUS=$?
+        ./gradlew closeAndPromoteRepository
+
+        if [[ $EXIT_STATUS == 0 ]]; then
+            ./gradlew --stop
+            # wait 30 seconds to ensure the previous promotion completes
+            sleep 30
+            ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" grails-dependencies:uploadArchives grails-bom:uploadArchives || EXIT_STATUS=$?
+            ./gradlew closeAndPromoteRepository
+        fi
+
+        if [[ $EXIT_STATUS == 0 ]]; then
+            ./gradlew assemble || EXIT_STATUS=$?
+        fi
+
+        # Configure GIT
+        git config --global user.name "$GIT_NAME"
+        git config --global user.email "$GIT_EMAIL"
+        git config --global credential.helper "store --file=~/.git-credentials"
+
+        # Tag the Profile Repo
+        git clone https://${GH_TOKEN}@github.com/grails/grails-profile-repository.git
+        cd grails-profile-repository
+
+        git branch --track 3.1.x remotes/origin/3.1.x
+        git checkout 3.1.x
+
+        echo "grailsVersion=${TRAVIS_TAG:1}" > profiles/gradle.properties
+        git add profiles/gradle.properties
+        git commit -m "Release $TRAVIS_TAG profiles"
+
+        git tag $TRAVIS_TAG
+        git push --tags
+        git push
+
+        # Tag and release the docs
+        cd ..
+        git clone https://${GH_TOKEN}@github.com/grails/grails-doc.git grails-doc
+        cd grails-doc
+        git branch --track 3.1.x remotes/origin/3.1.x
+        git checkout 3.1.x
+
+        echo "grails.version=${TRAVIS_TAG:1}" > gradle.properties
+        git add gradle.properties
+        git commit -m "Release $TRAVIS_TAG docs"
+        git tag $TRAVIS_TAG
+        git push --tags
+        git push
+        cd ..
+
+        # Update the website
+        git clone https://${GH_TOKEN}@github.com/grails/grails-static-website.git
+        cd grails-static-website
+        echo -e "${TRAVIS_TAG:1}" >> generator/src/main/resources/versions
+        git add generator/src/main/resources/versions
+        git commit -m "Release Grails $TRAVIS_TAG"
+        git push
+        cd ..
+
+        # Rebuild Artifactory index
+        curl -H "X-Api-Key:$ARTIFACTORY_API_KEY" -X POST "http://repo.grails.org/grails/api/maven?repos=libs-releases-local,plugins-releases-local,plugins3-releases-local,core&force=1"
+
+    elif [[ $TRAVIS_BRANCH =~ ^master|[23]\..\.x$ ]]; then
+        ./gradlew -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" publish || EXIT_STATUS=$?
+    fi
+
+fi
+
+#if [[ $EXIT_STATUS == 0 ]]; then
+#    ./gradlew travisciTrigger -i
+#fi
+
+exit $EXIT_STATUS


### PR DESCRIPTION
After #9952, this PR actually extracts the publishing part into a separate script.

Grails publish part is up till this part both handled in the original build script (`travis-build.sh`) and later in the `deploy` phase and in `after_deploy`

This pull request extracts the part about publishing into a separate script, which is only running if build is successful. This mimicks the behaviour today, so there is no change in functionality. 

Well, ...

Actually, the old `EXIT_STATUS` variable would also be affected by errors when publishing artifacts.

This is no longer the case:

What will happen if a travis `after_success` returns a non-zero exit status? Will it run the second line in `after_success`?

According to [travis documentation](https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build): 

> The `after_success`, `after_failure`, `after_script` and subsequent stages do not affect the the build result.

Nevertheless, this should be the only change of the script behaviour added with this change.

See also #9946 for discussion
