### PR TITLE
Added/exposed controllerNamespace on the RenderContext

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/RenderContext.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/RenderContext.groovy
@@ -108,6 +108,11 @@ public interface RenderContext {
     String getControllerName()
 
     /**
+     * @return The current controller name
+     */
+    String getControllerNamespace()
+
+    /**
      * Returns true if the getWriter() method was called
      */
     boolean wasWrittenTo()

--- a/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/render/ServletRenderContext.groovy
+++ b/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/render/ServletRenderContext.groovy
@@ -161,6 +161,11 @@ class ServletRenderContext extends AbstractRenderContext {
     }
 
     @Override
+    String getControllerNamespace() {
+        return webRequest.controllerNamespace
+    }
+
+    @Override
     boolean wasWrittenTo() {
         return writerObtained
     }


### PR DESCRIPTION
The controllerName was exposed, but we should expose the controllerNamespace as well
