### PR TITLE
Do not rollback transaction in jUnit @Before and @After methods

### DIFF
--- a/grails-core/src/test/groovy/grails/transaction/TransactionalTransformSpec.groovy
+++ b/grails-core/src/test/groovy/grails/transaction/TransactionalTransformSpec.groovy
@@ -94,6 +94,46 @@ class TransactionalTransformSpec extends Specification {
 
     }
 
+  void "Test @Rollback when applied to JUnit specifications"() {
+    when:
+    Class mySpec = new GroovyShell().evaluate('''
+    import grails.transaction.*
+    import org.junit.Test
+    import org.junit.Before
+    import org.junit.After
+
+    @Rollback
+    class MyJunitTest {
+        @Before
+        def junitSetup() {
+
+        }
+
+        @After
+        def junitCleanup() {
+
+        }
+
+        @Test
+        void junitTest() {
+            expect:
+                1 == 1
+        }
+    }
+    MyJunitTest
+    ''')
+
+    then: "It implements TransactionManagerAware"
+    TransactionManagerAware.isAssignableFrom(mySpec)
+    mySpec.getDeclaredMethod('junitSetup')
+    mySpec.getDeclaredMethod('$tt__junitSetup', TransactionStatus)
+    mySpec.getDeclaredMethod('junitCleanup')
+    mySpec.getDeclaredMethod('$tt__junitCleanup', TransactionStatus)
+
+    mySpec.getDeclaredMethod('junitTest')
+    mySpec.getDeclaredMethod('$tt__junitTest', TransactionStatus)
+  }
+
     void "Test @Rollback when applied to Spock specifications"() {
         when: "A new instance of a class with a @Transactional method is created that subclasses another transactional class"
         Class mySpec = new GroovyShell().evaluate('''


### PR DESCRIPTION
The TransactionalTransform has special cases for Spock's setup method but doesn't support jUnit @Before. If a test class is annotated with @Rollback, the transaction in @Before method will be rolled back before the test case is run. In this pull request I add the same handling for jUnit methods as for the ones from Spock.
