### PR TITLE
Allow subclasses of RestfulController to override delete behaviour

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/RestfulController.groovy
@@ -189,7 +189,7 @@ class RestfulController<T> {
             return
         }
 
-        instance.delete flush:true
+        deleteResource instance
 
         request.withFormat {
             form multipartForm {
@@ -317,5 +317,14 @@ class RestfulController<T> {
      */
     protected T updateResource(T resource) {
         saveResource resource
+    }
+
+    /**
+     * Deletes a resource
+     * 
+     * @param resource The resource to be deleted
+     */
+    protected void deleteResource(T resource) {
+        resource.delete flush:true
     }
 }


### PR DESCRIPTION
- Added deleteResource method that is used from delete method
- deleteResource method has protected access modifier so sublasses can override it
- Changes made for #10054
- Following the same mechanism as with saveResource and updateResource
