### PR TITLE
Issue #10062

### DIFF
--- a/grails-test-suite-web/src/test/groovy/org/grails/web/mapping/UrlMappingsHolderTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/mapping/UrlMappingsHolderTests.groovy
@@ -58,6 +58,28 @@ mappings {
 }
 '''
 
+    def mappingWithNamespace = '''
+mappings {
+    "/$namespace/$controller/$action?/$id?" ()
+}
+'''
+
+    @Test
+    void testGetReverseMappingWithNamespace() {
+        def res = new ByteArrayResource(mappingWithNamespace.bytes)
+
+        def evaluator = new DefaultUrlMappingEvaluator(mainContext)
+        def mappings = evaluator.evaluateMappings(res)
+
+        def holder = new DefaultUrlMappingsHolder(mappings)
+
+        def m = holder.getReverseMapping("product", "show", "foo", null, [:])
+        assertNotNull "getReverseMapping returned null", m
+
+        assertEquals "/foo/product/show", m.createURL("product", "show", "foo", null, [:], "utf-8")
+    }
+
+
     @Test
     void testGetReverseMappingWithNamedArgsAndClosure() {
         def res = new ByteArrayResource(mappingWithNamedArgsAndClosure.bytes)

--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/DefaultRequestStateLookupStrategy.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/DefaultRequestStateLookupStrategy.java
@@ -83,6 +83,14 @@ public class DefaultRequestStateLookupStrategy implements GrailsRequestStateLook
         return null;
     }
 
+    public String getControllerNamespace() {
+        final GrailsWebRequest req = getWebRequest();
+        if (req != null) {
+            return req.getControllerNamespace();
+        }
+        return null;
+    }
+
     public String getActionName() {
         final GrailsWebRequest req = getWebRequest();
         if (req != null) {

--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsRequestStateLookupStrategy.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsRequestStateLookupStrategy.java
@@ -44,6 +44,13 @@ public interface GrailsRequestStateLookupStrategy {
     public String getControllerName();
 
     /**
+     * The controller namespace
+     *
+     * @return The controller namespace or null if not known
+     */
+    public String getControllerNamespace();
+
+    /**
      * The action name for the given controller name
      *
      * @param controllerName The controller name

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/CachingLinkGenerator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/CachingLinkGenerator.java
@@ -17,6 +17,7 @@ package org.grails.web.mapping;
 
 import java.util.Map;
 
+import grails.util.GrailsStringUtils;
 import grails.web.mapping.LinkGenerator;
 import grails.web.mapping.UrlMapping;
 import grails.util.GrailsMetaClassUtils;
@@ -119,6 +120,13 @@ public class CachingLinkGenerator extends DefaultLinkGenerator {
                 value = getCacheKeyValueForResource(value);
             }
             appendKeyValue(buffer, map, key, value);
+        }
+        if (map.get(UrlMapping.NAMESPACE) == null) {
+            String namespace = getRequestStateLookupStrategy().getControllerNamespace();
+            if (GrailsStringUtils.isNotEmpty(namespace)) {
+                appendCommaIfNotFirst(buffer, first);
+                appendKeyValue(buffer, map, UrlMapping.NAMESPACE, namespace);
+            }
         }
         buffer.append(CLOSING_BRACKET);
     }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy
@@ -243,19 +243,19 @@ class DefaultLinkGenerator implements LinkGenerator, org.codehaus.groovy.grails.
                     params.put(ATTRIBUTE_ID, id)
                 }
                 def pluginName = attrs.get(UrlMapping.PLUGIN)?.toString()
-                def namespace = attrs.get(UrlMapping.NAMESPACE)?.toString()
+                def namespace = attrs.get(UrlMapping.NAMESPACE)?.toString() ?: requestStateLookupStrategy.controllerNamespace
                 UrlCreator mapping = urlMappingsHolder.getReverseMappingNoDefault(controller,action,namespace,pluginName,httpMethod,params)
                 if (mapping == null && isDefaultAction) {
                     mapping = urlMappingsHolder.getReverseMappingNoDefault(controller,null,namespace,pluginName,httpMethod,params)
                 }
                 if (mapping == null) {
-                    mapping = urlMappingsHolder.getReverseMapping(controller,action,pluginName,httpMethod,params)
+                    mapping = urlMappingsHolder.getReverseMapping(controller,action,namespace,pluginName,httpMethod,params)
                 }
 
                 boolean absolute = isAbsolute(attrs)
 
                 if (!absolute) {
-                    url = mapping.createRelativeURL(convertedControllerName, convertedActionName, params, encoding, frag)
+                    url = mapping.createRelativeURL(convertedControllerName, convertedActionName, namespace, pluginName, params, encoding, frag)
                     final contextPathAttribute = attrs.get(ATTRIBUTE_CONTEXT_PATH)
                     final cp = contextPathAttribute == null ? getContextPath() : contextPathAttribute
                     if (attrs.get(ATTRIBUTE_BASE) || cp == null) {
@@ -268,7 +268,7 @@ class DefaultLinkGenerator implements LinkGenerator, org.codehaus.groovy.grails.
                     writer.append url
                 }
                 else {
-                    url = mapping.createRelativeURL(convertedControllerName, convertedActionName, params, encoding, frag)
+                    url = mapping.createRelativeURL(convertedControllerName, convertedActionName, namespace, pluginName, params, encoding, frag)
                     writer.append handleAbsolute(attrs)
                     writer.append url
                 }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingsHolder.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingsHolder.java
@@ -85,6 +85,8 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
     private Map<UrlMappingKey, UrlMapping> mappingsLookup = new HashMap<UrlMappingKey, UrlMapping>();
     private Map<String, UrlMapping> namedMappings = new HashMap<String, UrlMapping>();
     private UrlMappingsList mappingsListLookup = new UrlMappingsList();
+    private Set<String> DEFAULT_NAMESPACE_PARAMS = CollectionUtils.newSet(
+            UrlMapping.NAMESPACE, UrlMapping.CONTROLLER, UrlMapping.ACTION);
     private Set<String> DEFAULT_CONTROLLER_PARAMS = CollectionUtils.newSet(
           UrlMapping.CONTROLLER, UrlMapping.ACTION);
     private Set<String> DEFAULT_ACTION_PARAMS = CollectionUtils.newSet(UrlMapping.ACTION);
@@ -349,6 +351,27 @@ public class DefaultUrlMappingsHolder implements UrlMappings, org.codehaus.groov
             if (mapping == null) {
                 lookupParams.removeAll(paramKeys);
                 UrlMappingKey lookupKeyModifiedParams = new UrlMappingKey(null, null, namespace, pluginName, httpMethod, version,lookupParams);
+                mapping = mappingsLookup.get(lookupKeyModifiedParams);
+                if (mapping == null) {
+                    lookupKeyModifiedParams.httpMethod = UrlMapping.ANY_HTTP_METHOD;
+                    mapping = mappingsLookup.get(lookupKeyModifiedParams);
+                }
+            }
+        }
+        if (mapping == null || (mapping instanceof ResponseCodeUrlMapping)) {
+            Set<String> lookupParams = new HashSet<String>(DEFAULT_NAMESPACE_PARAMS);
+            Set<String> paramKeys = new HashSet<String>(params.keySet());
+            paramKeys.removeAll(lookupParams);
+            lookupParams.addAll(paramKeys);
+            UrlMappingKey lookupKey = new UrlMappingKey(null, null, null, pluginName, httpMethod, version,lookupParams);
+            mapping = mappingsLookup.get(lookupKey);
+            if (mapping == null) {
+                lookupKey.httpMethod = UrlMapping.ANY_HTTP_METHOD;
+                mapping = mappingsLookup.get(lookupKey);
+            }
+            if (mapping == null) {
+                lookupParams.removeAll(paramKeys);
+                UrlMappingKey lookupKeyModifiedParams = new UrlMappingKey(null, null, null, pluginName, httpMethod, version,lookupParams);
                 mapping = mappingsLookup.get(lookupKeyModifiedParams);
                 if (mapping == null) {
                     lookupKeyModifiedParams.httpMethod = UrlMapping.ANY_HTTP_METHOD;

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -558,6 +558,7 @@ public class RegexUrlMapping extends AbstractUrlMapping {
         usedParams.add("controller");
         usedParams.add("action");
         usedParams.add("namespace");
+        usedParams.add("plugin");
 
         // A 'null' encoding will cause an exception, so default to 'UTF-8'.
         if (encoding == null) {

--- a/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/CachingLinkGeneratorSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/codehaus/groovy/grails/web/mapping/CachingLinkGeneratorSpec.groovy
@@ -1,0 +1,73 @@
+package org.codehaus.groovy.grails.web.mapping
+
+import grails.util.GrailsWebMockUtil
+import org.grails.web.mapping.CachingLinkGenerator
+import org.grails.web.servlet.mvc.DefaultRequestStateLookupStrategy
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.springframework.web.context.request.RequestContextHolder
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Tests for the {@link org.grails.web.mapping.CachingLinkGenerator} class
+ */
+class CachingLinkGeneratorSpec extends Specification {
+
+    @Shared
+    MyCachingLinkGenerator linkGenerator
+
+    @Shared
+    GrailsWebRequest request
+
+    void setup() {
+        linkGenerator = new MyCachingLinkGenerator("http://grails.org/")
+        request = GrailsWebMockUtil.bindMockWebRequest()
+        linkGenerator.requestStateLookupStrategy = new DefaultRequestStateLookupStrategy(request)
+    }
+
+    void cleanup() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    void "test namespace"() {
+        given:
+        String key
+
+        when: "not in the request or params"
+        key = linkGenerator.makeKey([controller: "foo", action: "bar"])
+
+        then: "its not in the key"
+        key == "link[controller:foo, action:bar]"
+
+        when: "its in the params"
+        key = linkGenerator.makeKey([controller: "foo", action: "bar", namespace: "foo"])
+
+        then: "its in the key"
+        key == "link[controller:foo, action:bar, namespace:foo]"
+
+        when: "its in the request"
+        request.setControllerNamespace("fooReq")
+        key = linkGenerator.makeKey([controller: "foo", action: "bar"])
+
+        then: "its in the key"
+        key == "link[controller:foo, action:bar, namespace:fooReq]"
+
+        when: "its in the request and the params"
+        request.setControllerNamespace("fooReq")
+        key = linkGenerator.makeKey([controller: "foo", action: "bar", namespace: "fooParam"])
+
+        then: "params wins"
+        key == "link[controller:foo, action:bar, namespace:fooParam]"
+    }
+
+
+    class MyCachingLinkGenerator extends CachingLinkGenerator {
+        public MyCachingLinkGenerator(String serverBaseURL) {
+            super(serverBaseURL)
+        }
+
+        String makeKey(Map attrs) {
+            super.makeKey(LINK_PREFIX, attrs)
+        }
+    }
+}

--- a/trigger-dependent-build.sh
+++ b/trigger-dependent-build.sh
@@ -34,6 +34,11 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
+# Only run for master branch
+if [ "${$TRAVIS_BRANCH}" != "master" ]; then
+  exit 0
+fi
+
 # Don't run for tagged releases
 if [[ $TRAVIS_TAG =~ ^v[[:digit:]] ]]; then
   exit 0

--- a/trigger-dependent-build.sh
+++ b/trigger-dependent-build.sh
@@ -35,7 +35,7 @@ if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
 fi
 
 # Only run for master branch
-if [ "${$TRAVIS_BRANCH}" != "master" ]; then
+if [ "${TRAVIS_BRANCH}" != "master" ]; then
   exit 0
 fi
 


### PR DESCRIPTION
Improving the link generator to use the namespace in the request uncovered 2 additional bugs. 
1. The url mappings for `/$namespace/$controler...` would never be found to generate correct URLS
2. The link generator was previously passing `pluginName` to the `namespace` variable when creating URLs. That prevented a bug with the plugin name getting appended as URL parameter from showing. After passing all arguments to the `createRelativeURL` method, URLs like `?pluginName=foo` were being created. I had to add `usedParams.add("plugin");` to `RegexUrlMappings.java`.
