### PR TITLE
Add modelAndView object when render a template

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -339,6 +339,8 @@ trait ResponseRenderer extends WebAttributes {
 
                 Map binding = [:]
 
+                if (templateUri && hasModel && modelObject instanceof Map) ((GroovyObject)this).setProperty ControllerDynamicMethods.MODEL_AND_VIEW_PROPERTY, new ModelAndView(templateUri, modelObject)
+
                 if (argMap.containsKey(ARGUMENT_BEAN)) {
                     Object bean = argMap[ARGUMENT_BEAN]
                     if (hasModel) {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/RenderMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/RenderMethodTests.groovy
@@ -33,6 +33,7 @@ class RenderMethodTests {
 
     @Test
     void testRenderFile() {
+
         controller.render file:"hello".bytes, contentType:"text/plain"
 
         assert "hello" == response.contentAsString
@@ -172,6 +173,11 @@ class RenderMethodTests {
 
         assertEquals "text/html;charset=UTF-8", response.contentType
         assertEquals "hello world!", response.contentAsString
+
+        assert controller.modelAndView
+
+        assertEquals controller.modelAndView.viewName, "/render/_testTemplate"
+        assertEquals controller.modelAndView.model.hello, "world"
     }
 
     @Test


### PR DESCRIPTION
As part of the original problem shown in this [stackoverflow question](http://stackoverflow.com/questions/36006830/grails-3-1-testing-controllers-as-integration/36064649#36064649) the aim of this PR is add the possibility of use `modelAndView`object when a render template is done.

`modelAndView` object is added in the render template portion of code of the `ResponseRenderer`trait. Is added in the same way as int he render view portion of code.

Test `testRenderFile`of `RenderMethodTests`is modified to obtain modelAndView object, to test `viewName`, as the template's name, and `model`, as the model's parameters passed to the template.
