### PR TITLE
Fix spring boot config not loading from environment first

### DIFF
--- a/grails-core/src/main/groovy/org/grails/config/PropertySourcesConfig.java
+++ b/grails-core/src/main/groovy/org/grails/config/PropertySourcesConfig.java
@@ -86,7 +86,12 @@ public class PropertySourcesConfig extends NavigableMapConfig {
         EnvironmentAwarePropertySource environmentAwarePropertySource = new EnvironmentAwarePropertySource(propertySources);
         mergeEnumerablePropertySource(environmentAwarePropertySource);
         if(propertySources instanceof MutablePropertySources) {
-            ((MutablePropertySources)propertySources).addLast(environmentAwarePropertySource);
+            final String applicationConfig = "applicationConfigurationProperties";
+            if (propertySources.contains(applicationConfig)) {
+                ((MutablePropertySources)propertySources).addBefore(applicationConfig, environmentAwarePropertySource);
+            } else {
+                ((MutablePropertySources)propertySources).addLast(environmentAwarePropertySource);
+            }
         }
     }
 


### PR DESCRIPTION
Issue #9916 

The property sources are read in order in org.springframework.boot.bind.PropertySourcesPropertyValues so the environment property source needs to be before the application config property source.
