### PR TITLE
Fix for writing templates in wrong charset

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/profile/commands/templates/TemplateRendererImpl.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/commands/templates/TemplateRendererImpl.groovy
@@ -266,7 +266,7 @@ class TemplateRendererImpl implements TemplateRenderer, ProfileRepositoryAware {
 
     private static void writeTemplateToDestination(Template template, Map model, File destination) {
         destination.parentFile.mkdirs()
-        destination.withWriter { Writer w ->
+        destination.withWriter("UTF-8") { Writer w ->
             template.make(model).writeTo(w)
             w.flush()
         }


### PR DESCRIPTION
Template renderer reads templates using UTF-8 but writes the processed output in the default charset (which on some systems might not be UTF-8). This small fix addresses that by forcing the output also be written in UTF-8.
