### PR TITLE
Issue #10150 Views without <html> or <body> should still be rendered

### DIFF
--- a/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GrailsContentBufferingResponse.java
+++ b/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GrailsContentBufferingResponse.java
@@ -85,8 +85,14 @@ public class GrailsContentBufferingResponse extends HttpServletResponseWrapper {
         }
 
         char[] data = pageResponseWrapper.getContents();
-        if (data != null && webAppContext.getContentType() != null) {
-            return contentProcessor.build(data, webAppContext);
+        if (data != null) {
+            if (webAppContext.getContentType() == null && pageResponseWrapper.getContentType() != null
+                    && pageResponseWrapper.getContentType().contains("html")) {
+                webAppContext.setContentType(pageResponseWrapper.getContentType());
+            }
+            if (webAppContext.getContentType() != null) {
+                return contentProcessor.build(data, webAppContext);
+            }
         }
 
         return null;


### PR DESCRIPTION
See #10150 contentType was not copied over to the webAppContext thus the non-sitemesh html views won't be rendered.
