### PR TITLE
contentType needs to be kept in sync with the sitmesh webAppContext

### DIFF
--- a/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GrailsContentBufferingResponse.java
+++ b/grails-web-sitemesh/src/main/groovy/org/grails/web/sitemesh/GrailsContentBufferingResponse.java
@@ -56,6 +56,9 @@ public class GrailsContentBufferingResponse extends HttpServletResponseWrapper {
         this.contentProcessor = contentProcessor;
         this.webAppContext = webAppContext;
         pageResponseWrapper = (GrailsPageResponseWrapper) getResponse();
+        if (response.getContentType() != null) {
+            webAppContext.setContentType(response.getContentType());
+        }
     }
 
     public HttpServletResponse getTargetResponse() {


### PR DESCRIPTION
#10150 If the contentType is set on the response the sitemesh WebAppContext needs to be kept in sync

Note the `setContentType()` method is doing this but on creation they could be out of sync
