### PR TITLE
Fix #10226

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
@@ -39,6 +39,7 @@ import org.grails.gsp.GroovyPagesTemplateEngine
  */
 class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
 
+    public static final String KEY_EXCEPTION = 'exception'
     private assertionKeys = ["controller", "action", "view"]
 
     /**
@@ -193,7 +194,12 @@ class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
         def mappingInfos
         if (url instanceof Integer) {
             mappingInfos = []
-            def mapping = mappingsHolder.matchStatusCode(url)
+            def mapping
+            if (assertions."$KEY_EXCEPTION") {
+                mapping = mappingsHolder.matchStatusCode(url, assertions."$KEY_EXCEPTION" as Throwable)
+            } else {
+                mapping = mappingsHolder.matchStatusCode(url)
+            }
             if (mapping) mappingInfos << mapping
         }
         else {

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/UrlMappingsTestMixinTests.groovy
@@ -167,6 +167,17 @@ class UrlMappingsTestMixinTests {
     }
 
     @Test
+    @Issue('https://github.com/grails/grails-core/issues/10226')
+    void testExceptionUrlMapping() {
+        mockController(ExceptionTestErrorsController)
+        mockUrlMappings(ExceptionTestUrlMappings)
+
+        assertForwardUrlMapping(500, controller: 'exceptionTestErrors', action: 'handleNullPointer', exception: new NullPointerException())
+        assertForwardUrlMapping(500, controller: 'exceptionTestErrors', action: 'handleIllegalArgument', exception: new IllegalArgumentException())
+        assertForwardUrlMapping(500, controller: 'exceptionTestErrors', action: 'handleDefault')
+    }
+
+    @Test
     @Issue('https://github.com/grails/grails-core/issues/9065')
     void testResourcesUrlMapping() {
         mockController(PersonController)
@@ -280,5 +291,20 @@ class PersonController extends RestfulController<String> {
 class ResourceTestUrlMappings {
     static mappings = {
         '/person'(resources: 'person')
+    }
+}
+
+@Artefact("Controller")
+class ExceptionTestErrorsController {
+    def handleNullPointer() {}
+    def handleIllegalArgument() {}
+    def handleDefault() {}
+}
+
+class ExceptionTestUrlMappings {
+    static mappings = {
+        '500'(controller: 'exceptionTestErrors', action: 'handleNullPointer', exception: NullPointerException)
+        '500'(controller: 'exceptionTestErrors', action: 'handleIllegalArgument', exception: IllegalArgumentException)
+        '500'(controller: 'exceptionTestErrors', action: 'handleDefault')
     }
 }


### PR DESCRIPTION
Include the "exception" property when checking url mappings in UrlMappingsUnitTestMixin.

This points to the 3.1.x branch so it can be included in 3.1.x and beyond.

Fixes
https://github.com/grails/grails-core/issues/10226
