### PR TITLE
Introduced EmailValidator and replaced common-validator on EmailConstraint

### DIFF
--- a/grails-validation/src/main/groovy/org/grails/validation/EmailConstraint.java
+++ b/grails-validation/src/main/groovy/org/grails/validation/EmailConstraint.java
@@ -19,7 +19,7 @@ import grails.util.GrailsStringUtils;
 import grails.validation.AbstractConstraint;
 import grails.validation.ConstrainedProperty;
 
-import org.apache.commons.validator.routines.EmailValidator;
+import org.grails.validation.routines.EmailValidator;
 import org.springframework.validation.Errors;
 
 /**

--- a/grails-validation/src/main/groovy/org/grails/validation/routines/EmailValidator.java
+++ b/grails-validation/src/main/groovy/org/grails/validation/routines/EmailValidator.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.validation.routines;
+
+import java.io.Serializable;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * <p>Perform email validations.</p>
+ * <p>
+ * Based on a script by <a href="mailto:stamhankar@hotmail.com">Sandeep V. Tamhankar</a>
+ * http://javascript.internet.com
+ * </p>
+ * <p>
+ * This implementation is not guaranteed to catch all possible errors in an email address.
+ * </p>.
+ *
+ * @version $Revision: 1723573 $
+ * @since Validator 1.4
+ */
+public class EmailValidator implements Serializable {
+
+    private static final long serialVersionUID = 1705927040799295880L;
+
+    private static final String SPECIAL_CHARS = "\\p{Cntrl}\\(\\)<>@,;:'\\\\\\\"\\.\\[\\]";
+    private static final String VALID_CHARS = "(\\\\.)|[^\\s" + SPECIAL_CHARS + "]";
+    private static final String QUOTED_USER = "(\"(\\\\\"|[^\"])*\")";
+    private static final String WORD = "((" + VALID_CHARS + "|')+|" + QUOTED_USER + ")";
+
+    private static final String EMAIL_REGEX = "^\\s*?(.+)@(.+?)\\s*$";
+    private static final String IP_DOMAIN_REGEX = "^\\[(.*)\\]$";
+    private static final String USER_REGEX = "^\\s*" + WORD + "(\\." + WORD + ")*$";
+
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
+    private static final Pattern IP_DOMAIN_PATTERN = Pattern.compile(IP_DOMAIN_REGEX);
+    private static final Pattern USER_PATTERN = Pattern.compile(USER_REGEX);
+
+    private static final int MAX_USERNAME_LEN = 64;
+
+    private final boolean allowTld;
+
+    /**
+     * Singleton instance of this class
+     */
+    private static final EmailValidator EMAIL_VALIDATOR = new EmailValidator(false);
+
+    /**
+     * Singleton instance of this class
+     */
+    private static final EmailValidator EMAIL_VALIDATOR_WITH_TLD = new EmailValidator( true);
+
+    /**
+     * Returns the Singleton instance of this validator.
+     *
+     * @return singleton instance of this validator.
+     */
+    public static EmailValidator getInstance() {
+        return EMAIL_VALIDATOR;
+    }
+
+    /**
+     * Returns the Singleton instance of this validator
+     *
+     * @param allowTld Should TLDs be allowed?
+     * @return singleton instance of this validator
+     */
+    public static EmailValidator getInstance(boolean allowTld) {
+        if (allowTld) {
+            return EMAIL_VALIDATOR_WITH_TLD;
+        } else {
+            return EMAIL_VALIDATOR;
+        }
+    }
+
+    /**
+     * Protected constructor for subclasses to use.
+     *
+     * @param allowTld Should TLDs be allowed?
+     */
+    protected EmailValidator(boolean allowTld) {
+        super();
+        this.allowTld = allowTld;
+    }
+
+    /**
+     * <p>Checks if a field has a valid e-mail address.</p>
+     *
+     * @param email The value validation is being performed on.  A <code>null</code> value is considered invalid.
+     * @return true if the email address is valid.
+     */
+    public boolean isValid(String email) {
+        if (email == null) {
+            return false;
+        }
+
+        if (email.endsWith(".")) { // check this first - it's cheap!
+            return false;
+        }
+
+        // Check the whole email address structure
+        Matcher emailMatcher = EMAIL_PATTERN.matcher(email);
+        if (!emailMatcher.matches()) {
+            return false;
+        }
+
+        if (!isValidUser(emailMatcher.group(1))) {
+            return false;
+        }
+
+        if (!isValidDomain(emailMatcher.group(2))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the domain component of an email address is valid.
+     *
+     * @param domain being validated, may be in IDN format
+     * @return true if the email address's domain is valid.
+     */
+    protected boolean isValidDomain(String domain) {
+        // see if domain is an IP address in brackets
+        Matcher ipDomainMatcher = IP_DOMAIN_PATTERN.matcher(domain);
+
+        if (ipDomainMatcher.matches()) {
+            InetAddressValidator inetAddressValidator =
+                    InetAddressValidator.getInstance();
+            return inetAddressValidator.isValid(ipDomainMatcher.group(1));
+        }
+        // Domain is symbolic name
+        DomainValidator domainValidator = DomainValidator.getInstance();
+        if (allowTld) {
+            return domainValidator.isValid(domain) || (!domain.startsWith(".") && domainValidator.isValidTld(domain));
+        } else {
+            return domainValidator.isValid(domain);
+        }
+    }
+
+    /**
+     * Returns true if the user component of an email address is valid.
+     *
+     * @param user being validated
+     * @return true if the user name is valid.
+     */
+    protected boolean isValidUser(String user) {
+
+        if (user == null || user.length() > MAX_USERNAME_LEN) {
+            return false;
+        }
+
+        return USER_PATTERN.matcher(user).matches();
+    }
+
+}

--- a/grails-validation/src/test/groovy/org/grails/validation/routines/EmailValidatorTests.java
+++ b/grails-validation/src/test/groovy/org/grails/validation/routines/EmailValidatorTests.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.validation.routines;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for the EmailValidator.
+ */
+public class EmailValidatorTests extends TestCase {
+
+    private EmailValidator validator = EmailValidator.getInstance();
+
+    public void testEmail() {
+        assertTrue(validator.isValid("jsmith@apache.org"));
+    }
+
+    public void testEmailWithNumericAddress() {
+        assertTrue(validator.isValid("someone@[216.109.118.76]"));
+        assertTrue(validator.isValid("someone@yahoo.com"));
+    }
+
+    public void testEmailExtension() {
+        assertTrue(validator.isValid("jsmith@apache.org"));
+        assertTrue(validator.isValid("jsmith@apache.com"));
+        assertTrue(validator.isValid("jsmith@apache.net"));
+        assertTrue(validator.isValid("jsmith@apache.info"));
+        assertFalse(validator.isValid("jsmith@apache."));
+        assertFalse(validator.isValid("jsmith@apache.c"));
+        assertTrue(validator.isValid("someone@yahoo.museum"));
+        assertFalse(validator.isValid("someone@yahoo.mu-seum"));
+    }
+
+    /**
+     * <p>Tests the e-mail validation with a dash in
+     * the address.</p>
+     */
+    public void testEmailWithDash() {
+        assertTrue(validator.isValid("andy.noble@data-workshop.com"));
+        assertFalse(validator.isValid("andy-noble@data-workshop.-com"));
+        assertFalse(validator.isValid("andy-noble@data-workshop.c-om"));
+        assertFalse(validator.isValid("andy-noble@data-workshop.co-m"));
+    }
+
+    /**
+     * Tests the e-mail validation with a dot at the end of
+     * the address.
+     */
+    public void testEmailWithDotEnd()  {
+        assertFalse(validator.isValid("andy.noble@data-workshop.com."));
+    }
+
+    /**
+     * Tests the e-mail validation with an RCS-noncompliant character in
+     * the address.
+     */
+    public void testEmailWithBogusCharacter()  {
+
+        assertFalse(validator.isValid("andy.noble@\u008fdata-workshop.com"));
+
+        // The ' character is valid in an email username.
+        assertTrue(validator.isValid("andy.o'reilly@data-workshop.com"));
+
+        // But not in the domain name.
+        assertFalse(validator.isValid("andy@o'reilly.data-workshop.com"));
+
+        // The + character is valid in an email username.
+        assertTrue(validator.isValid("foo+bar@i.am.not.in.us.example.com"));
+
+        // But not in the domain name
+        assertFalse(validator.isValid("foo+bar@example+3.com"));
+
+        // Domains with only special characters aren't allowed (VALIDATOR-286)
+        assertFalse(validator.isValid("test@%*.com"));
+        assertFalse(validator.isValid("test@^&#.com"));
+
+    }
+
+    /**
+     * Tests the email validation with commas.
+     */
+    public void testEmailWithCommas()  {
+        assertFalse(validator.isValid("joeblow@apa,che.org"));
+
+        assertFalse(validator.isValid("joeblow@apache.o,rg"));
+
+        assertFalse(validator.isValid("joeblow@apache,org"));
+
+    }
+
+    /**
+     * Tests the email validation with spaces.
+     */
+    public void testEmailWithSpaces()  {
+        assertFalse(validator.isValid("joeblow @apache.org")); // TODO - this should be valid?
+
+        assertFalse(validator.isValid("joeblow@ apache.org"));
+
+        assertTrue(validator.isValid(" joeblow@apache.org")); // TODO - this should be valid?
+
+        assertTrue(validator.isValid("joeblow@apache.org "));
+
+        assertFalse(validator.isValid("joe blow@apache.org "));
+
+        assertFalse(validator.isValid("joeblow@apa che.org "));
+
+    }
+
+    /**
+     * Tests the email validation with ascii control characters.
+     * (i.e. Ascii chars 0 - 31 and 127)
+     */
+    public void testEmailWithControlChars()  {
+        for (char c = 0; c < 32; c++) {
+            assertFalse("Test control char " + ((int)c), validator.isValid("foo" + c + "bar@domain.com"));
+        }
+        assertFalse("Test control char 127", validator.isValid("foo" + ((char)127) + "bar@domain.com"));
+    }
+
+    /**
+     * VALIDATOR-296 - A / or a ! is valid in the user part,
+     *  but not in the domain part
+     */
+    public void testEmailWithSlashes() {
+        assertTrue(
+                "/ and ! valid in username",
+                validator.isValid("joe!/blow@apache.org")
+        );
+        assertFalse(
+                "/ not valid in domain",
+                validator.isValid("joe@ap/ache.org")
+        );
+        assertFalse(
+                "! not valid in domain",
+                validator.isValid("joe@apac!he.org")
+        );
+    }
+
+    /**
+     * Write this test according to parts of RFC, as opposed to the type of character
+     * that is being tested.
+     */
+    public void testEmailUserName()  {
+
+        assertTrue(validator.isValid("joe1blow@apache.org"));
+
+        assertTrue(validator.isValid("joe$blow@apache.org"));
+
+        assertTrue(validator.isValid("joe-@apache.org"));
+
+        assertTrue(validator.isValid("joe_@apache.org"));
+
+        assertTrue(validator.isValid("joe+@apache.org")); // + is valid unquoted
+
+        assertTrue(validator.isValid("joe!@apache.org")); // ! is valid unquoted
+
+        assertTrue(validator.isValid("joe*@apache.org")); // * is valid unquoted
+
+        assertTrue(validator.isValid("joe'@apache.org")); // ' is valid unquoted
+
+        assertTrue(validator.isValid("joe%45@apache.org")); // % is valid unquoted
+
+        assertTrue(validator.isValid("joe?@apache.org")); // ? is valid unquoted
+
+        assertTrue(validator.isValid("joe&@apache.org")); // & ditto
+
+        assertTrue(validator.isValid("joe=@apache.org")); // = ditto
+
+        assertTrue(validator.isValid("+joe@apache.org")); // + is valid unquoted
+
+        assertTrue(validator.isValid("!joe@apache.org")); // ! is valid unquoted
+
+        assertTrue(validator.isValid("*joe@apache.org")); // * is valid unquoted
+
+        assertTrue(validator.isValid("'joe@apache.org")); // ' is valid unquoted
+
+        assertTrue(validator.isValid("%joe45@apache.org")); // % is valid unquoted
+
+        assertTrue(validator.isValid("?joe@apache.org")); // ? is valid unquoted
+
+        assertTrue(validator.isValid("&joe@apache.org")); // & ditto
+
+        assertTrue(validator.isValid("=joe@apache.org")); // = ditto
+
+        assertTrue(validator.isValid("+@apache.org")); // + is valid unquoted
+
+        assertTrue(validator.isValid("!@apache.org")); // ! is valid unquoted
+
+        assertTrue(validator.isValid("*@apache.org")); // * is valid unquoted
+
+        assertTrue(validator.isValid("'@apache.org")); // ' is valid unquoted
+
+        assertTrue(validator.isValid("%@apache.org")); // % is valid unquoted
+
+        assertTrue(validator.isValid("?@apache.org")); // ? is valid unquoted
+
+        assertTrue(validator.isValid("&@apache.org")); // & ditto
+
+        assertTrue(validator.isValid("=@apache.org")); // = ditto
+
+
+        //UnQuoted Special characters are invalid
+
+        assertFalse(validator.isValid("joe.@apache.org")); // . not allowed at end of local part
+
+        assertFalse(validator.isValid(".joe@apache.org")); // . not allowed at start of local part
+
+        assertFalse(validator.isValid(".@apache.org")); // . not allowed alone
+
+        assertTrue(validator.isValid("joe.ok@apache.org")); // . allowed embedded
+
+        assertFalse(validator.isValid("joe..ok@apache.org")); // .. not allowed embedded
+
+        assertFalse(validator.isValid("..@apache.org")); // .. not allowed alone
+
+        assertFalse(validator.isValid("joe(@apache.org"));
+
+        assertFalse(validator.isValid("joe)@apache.org"));
+
+        assertFalse(validator.isValid("joe,@apache.org"));
+
+        assertFalse(validator.isValid("joe;@apache.org"));
+
+
+        //Quoted Special characters are valid
+        assertTrue(validator.isValid("\"joe.\"@apache.org"));
+
+        assertTrue(validator.isValid("\".joe\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe+\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe!\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe*\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe'\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe(\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe)\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe,\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe%45\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe;\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe?\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe&\"@apache.org"));
+
+        assertTrue(validator.isValid("\"joe=\"@apache.org"));
+
+        assertTrue(validator.isValid("\"..\"@apache.org"));
+
+        // escaped quote character valid in quoted string
+        assertTrue(validator.isValid("\"john\\\"doe\"@apache.org"));
+
+        assertTrue(validator.isValid("john56789.john56789.john56789.john56789.john56789.john56789.john@example.com"));
+
+        assertFalse(validator.isValid("john56789.john56789.john56789.john56789.john56789.john56789.john5@example.com"));
+
+        assertTrue(validator.isValid("\\>escape\\\\special\\^characters\\<@example.com"));
+
+        assertTrue(validator.isValid("Abc\\@def@example.com"));
+
+        assertFalse(validator.isValid("Abc@def@example.com"));
+
+        assertTrue(validator.isValid("space\\ monkey@example.com"));
+    }
+
+    /**
+     * Tests the e-mail validation with a user at a TLD
+     *
+     * http://tools.ietf.org/html/rfc5321#section-2.3.5
+     * (In the case of a top-level domain used by itself in an
+     * email address, a single string is used without any dots)
+     */
+    public void testEmailAtTLD() {
+        EmailValidator val = EmailValidator.getInstance(true);
+        assertTrue(val.isValid("test@com"));
+    }
+}


### PR DESCRIPTION
As described in https://github.com/grails/grails-core/issues/10254

This introduces `org.grails.validation.routines.EmailValidator` which relies on `org.grails.validation.routines.DomainValidator` during the validation.

Also replaced `EmailValidator` in `EmailConstraint` to use the new one.

NOTE: I noticed that `org.grails.validation.routines.DomainValidator` doesn't support `allowLocal` so I applied the same approach for the `EmailValidator`.

Tests Results:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.grails.validation.EmailConstraintTests" tests="4" skipped="0" failures="0" errors="0" timestamp="2016-10-20T18:08:55" hostname="Roberto-MacBook-Pro.local" time="0.006">
  <properties/>
  <testcase name="testCreation" classname="org.grails.validation.EmailConstraintTests" time="0.0"/>
  <testcase name="testValidation" classname="org.grails.validation.EmailConstraintTests" time="0.004"/>
  <testcase name="testNullValue" classname="org.grails.validation.EmailConstraintTests" time="0.0"/>
  <testcase name="testBlankString" classname="org.grails.validation.EmailConstraintTests" time="0.0"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[]]></system-err>
</testsuite>

<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="org.grails.validation.routines.EmailValidatorTests" tests="12" skipped="0" failures="0" errors="0" timestamp="2016-10-20T18:08:55" hostname="Roberto-MacBook-Pro.local" time="0.006">
  <properties/>
  <testcase name="testEmailWithControlChars" classname="org.grails.validation.routines.EmailValidatorTests" time="0.001"/>
  <testcase name="testEmail" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailWithSlashes" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailExtension" classname="org.grails.validation.routines.EmailValidatorTests" time="0.001"/>
  <testcase name="testEmailWithDash" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailWithCommas" classname="org.grails.validation.routines.EmailValidatorTests" time="0.001"/>
  <testcase name="testEmailWithDotEnd" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailWithSpaces" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailUserName" classname="org.grails.validation.routines.EmailValidatorTests" time="0.002"/>
  <testcase name="testEmailWithBogusCharacter" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailAtTLD" classname="org.grails.validation.routines.EmailValidatorTests" time="0.0"/>
  <testcase name="testEmailWithNumericAddress" classname="org.grails.validation.routines.EmailValidatorTests" time="0.001"/>
  <system-out><![CDATA[]]></system-out>
  <system-err><![CDATA[]]></system-err>
</testsuite>

```
