### PR TITLE
Fix for https://github.com/grails/grails-core/issues/10293

### DIFF
--- a/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/rest/render/util/AbstractLinkingRenderer.groovy
@@ -182,7 +182,7 @@ abstract class AbstractLinkingRenderer<T> extends AbstractIncludeExcludeRenderer
 
             } else if ((a instanceof ToOne) && (proxyHandler instanceof EntityProxyHandler)) {
                 if (associatedEntity) {
-                    final proxy = mappingContext.getEntityReflector(associatedEntity).getProperty(object, propertyName)
+                    final proxy = mappingContext.getEntityReflector(a.owner).getProperty(object, propertyName)
                     final id = proxyHandler.getProxyIdentifier(proxy)
                     final href = linkGenerator.link(resource: associatedEntity.decapitalizedName, id: id, method: HttpMethod.GET, absolute: absoluteLinks)
                     final associationTitle = getLinkTitle(associatedEntity, locale)


### PR DESCRIPTION
Fix `AbstractLinkingRenderer` so that it renders many-to-one associations using the HAL format with out throwing an exception (see https://github.com/grails/grails-core/issues/10293).