### PR TITLE
New feature: Boolean attributes can be configured.

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -16,6 +16,8 @@
 package org.grails.plugins.web.taglib
 
 import grails.artefact.TagLibrary
+import grails.config.Config
+import grails.core.support.GrailsConfigurationAware
 import grails.gsp.TagLib
 import groovy.transform.CompileStatic
 import org.grails.plugins.web.GrailsTagDateHelper
@@ -45,7 +47,7 @@ import org.springframework.web.servlet.support.RequestDataValueProcessor
  * @author Graeme Rocher
  */
 @TagLib
-class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrary {
+class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrary, GrailsConfigurationAware {
 
     private static final DEFAULT_CURRENCY_CODES = ['EUR', 'XCD', 'USD', 'XOF', 'NOK', 'AUD',
                                                    'XAF', 'NZD', 'MAD', 'DKK', 'GBP', 'CHF',
@@ -57,7 +59,9 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     GrailsTagDateHelper grailsTagDateHelper
     
     CodecLookup codecLookup
-    
+
+    private List<String> booleanAttributes = ['disabled', 'checked', 'readonly']
+
     void afterPropertiesSet() {
         if (applicationContext.containsBean('requestDataValueProcessor')) {
             requestDataValueProcessor = applicationContext.getBean('requestDataValueProcessor', RequestDataValueProcessor)
@@ -314,10 +318,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
         attrs.value = attrs.value != null ? attrs.value : "" // can't use ?: since 0 is groovy false
 
-        // Some attributes can be treated as boolean, but must be converted to the
-        // expected value.
-        def makeBooleanAttributes = grailsApplication.config.grails.tags.booleanToAttributes ?: ['disabled', 'checked', 'readonly']
-        makeBooleanAttributes.each {
+        booleanAttributes.each {
             booleanToAttribute(attrs, it)
         }
     }
@@ -1194,5 +1195,13 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
 
         return requestDataValueProcessor.processUrl(request, link)
+    }
+
+    @Override
+    void setConfiguration(Config co) {
+        // Some attributes can be treated as boolean, but must be converted to the
+        // expected value.
+        booleanAttributes = co.grails.tags.booleanToAttributes ?: ['disabled', 'checked', 'readonly']
+
     }
 }

--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -316,9 +316,10 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
 
         // Some attributes can be treated as boolean, but must be converted to the
         // expected value.
-        booleanToAttribute(attrs, 'disabled')
-        booleanToAttribute(attrs, 'checked')
-        booleanToAttribute(attrs, 'readonly')
+        def makeBooleanAttributes = grailsApplication.config.grails.tags.booleanToAttributes ?: ['disabled', 'checked', 'readonly']
+        makeBooleanAttributes.each {
+            booleanToAttribute(attrs, it)
+        }
     }
 
     /**

--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -1201,7 +1201,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     void setConfiguration(Config co) {
         // Some attributes can be treated as boolean, but must be converted to the
         // expected value.
-        booleanAttributes = co.grails.tags.booleanToAttributes ?: ['disabled', 'checked', 'readonly']
-
+        booleanAttributes = co.getProperty('grails.tags.booleanToAttributes', List, ['disabled', 'checked', 'readonly'])
     }
 }

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -151,6 +151,23 @@ class FormTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals('<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;_PROCESSED_" id="testField" />', template, [value:/foo > " & < '/])
     }
 
+    void testTextFieldTagWithNonBooleanAttributes() {
+        unRegisterRequestDataValueProcessor()
+        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
+        assertOutputEquals('<input type="text" name="testField" value="1" required="false" id="testField" />', template)
+
+        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
+        assertOutputEquals('<input type="text" name="testField" value="1" required="true" disabled="disabled" checked="checked" readonly="readonly" id="testField" />', template)
+
+        grailsApplication.config.grails.tags.booleanToAttributes = ['disabled', 'checked', 'readonly', 'required']
+
+        template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
+        assertOutputEquals('<input type="text" name="testField" value="1" id="testField" />', template)
+
+        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
+        assertOutputEquals('<input type="text" name="testField" value="1" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />', template)
+    }
+
     void testTextAreaWithBody() {
         unRegisterRequestDataValueProcessor()
         def template = '<g:textArea name="test">This is content</g:textArea>'

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -2,7 +2,6 @@ package org.grails.web.taglib
 
 import grails.core.GrailsUrlMappingsClass
 import grails.util.MockRequestDataValueProcessor
-
 import org.grails.core.AbstractGrailsClass
 import org.grails.core.artefact.UrlMappingsArtefactHandler
 import org.grails.plugins.web.taglib.FormTagLib
@@ -28,7 +27,7 @@ class FormTagLibTests extends AbstractGrailsTagTests {
             "/admin/books"(controller:'books', namespace:'admin')
             "/books"(controller:'books')
         }
-        grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, new MockGrailsUrlMappingsClass(mappingsClosure));
+        grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, new MockGrailsUrlMappingsClass(mappingsClosure))
     }
     
 //    void testFormNamespace() {
@@ -42,19 +41,19 @@ class FormTagLibTests extends AbstractGrailsTagTests {
     }
     
     private static final class MockGrailsUrlMappingsClass extends AbstractGrailsClass implements GrailsUrlMappingsClass {
-        Closure mappingClosure;
+        Closure mappingClosure
         public MockGrailsUrlMappingsClass(Closure mappingClosure) {
-            super(this.getClass(), "UrlMappings");
-            this.mappingClosure = mappingClosure;
+            super(this.getClass(), "UrlMappings")
+            this.mappingClosure = mappingClosure
         }
         @Override
         public Closure getMappingsClosure() {
-            return mappingClosure;
+            return mappingClosure
         }
 
         @Override
         public List getExcludePatterns() {
-            return null;
+            return null
         }
     }
 
@@ -151,21 +150,31 @@ class FormTagLibTests extends AbstractGrailsTagTests {
         assertOutputEquals('<input type="text" name="testField" value="foo &gt; &quot; &amp; &lt; &#39;_PROCESSED_" id="testField" />', template, [value:/foo > " & < '/])
     }
 
-    void testTextFieldTagWithNonBooleanAttributes() {
+    void testTextFieldTagWithNonBooleanAttributesAndNoConfig() {
         unRegisterRequestDataValueProcessor()
         def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
         assertOutputEquals('<input type="text" name="testField" value="1" required="false" id="testField" />', template)
 
         template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
         assertOutputEquals('<input type="text" name="testField" value="1" required="true" disabled="disabled" checked="checked" readonly="readonly" id="testField" />', template)
+    }
 
-        grailsApplication.config.grails.tags.booleanToAttributes = ['disabled', 'checked', 'readonly', 'required']
+    void testTextFieldTagWithNonBooleanAttributesAndConfig() {
+        unRegisterRequestDataValueProcessor()
+        withConfig('''
+                grails {
+                    tags {
+                        booleanToAttributes = ['disabled', 'checked', 'readonly', 'required']
+                    }
+                }
+                ''') {
+            appCtx.getBean(FormTagLib.name).setConfiguration(grailsApplication.config)
+            def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
+            assertOutputEquals('<input type="text" name="testField" value="1" id="testField" />', template)
 
-        template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
-        assertOutputEquals('<input type="text" name="testField" value="1" id="testField" />', template)
-
-        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
-        assertOutputEquals('<input type="text" name="testField" value="1" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />', template)
+            template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
+            assertOutputEquals('<input type="text" name="testField" value="1" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />', template)
+        }
     }
 
     void testTextAreaWithBody() {


### PR DESCRIPTION
In the current implementation the three attributes `disabled`, `checked` and `readonly` will, when used with boolean value, turn into `attribute="attribute"`. It is desired to be able to configure this for additional attributes like `required` (HTML5).