### PR TITLE
render() should not set a default text/html content-type

### DIFF
--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -275,7 +275,7 @@ trait ResponseRenderer extends WebAttributes {
                 if (isPromise) return
             }
 
-            applyContentType webRequest.currentResponse, argMap, null
+            applyContentType webRequest.currentResponse, argMap, null, false
 
             Map model
             if (modelObject instanceof Map) {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
@@ -24,7 +24,6 @@ class RenderDynamicMethodTests  {
         controller.renderView()
 
         assertEquals '/renderDynamicMethodTest/foo', controller.modelAndView.viewName
-        assertEquals 'text/html;charset=utf-8', response.contentType
     }
 
     @Test


### PR DESCRIPTION
This should be applied to the 3.1.x branch too. #10337 