### PR TITLE
Fixed content dispostion HTTP header renderer.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Aug 23 09:20:31 CEST 2016
+#Tue Dec 06 11:22:33 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -391,7 +391,7 @@ trait ResponseRenderer extends WebAttributes {
                         hasContentType = detectContentTypeFromFileName(webRequest, response, argMap, fileName)
                     }
                     if (fnO) {
-                        response.setHeader HttpHeaders.CONTENT_DISPOSITION, DISPOSITION_HEADER_PREFIX + fileName
+                        response.setHeader HttpHeaders.CONTENT_DISPOSITION, DISPOSITION_HEADER_PREFIX + "\"" + fileName + "\""
                     }
                 }
                 if (!hasContentType) {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/mvc/RenderDynamicMethodTests.groovy
@@ -12,6 +12,19 @@ import org.junit.Test
 class RenderDynamicMethodTests  {
 
     @Test
+    void testCanaryTest() {
+        assert true == true
+    }
+
+    @Test
+    void testRenderContentDispositionWithArgsMap() {
+        controller.renderArgsMap()
+        assertEquals 'theFile', response.contentAsString
+        assertEquals 'text/plain;charset=utf-8', response.contentType
+        assertEquals "\"File Space Name.txt\"", response.getHeaders("Content-Disposition").toString().split("filename=")[1].replace("]", "")
+    }
+
+    @Test
     void testRenderTextWithLayout() {
         controller.renderTextWithLayout()
         assertEquals "text/html;charset=utf-8", response.contentType
@@ -107,6 +120,11 @@ class RenderDynamicMethodTests  {
 
 @Artefact('Controller')
 class RenderDynamicMethodTestController {
+
+    def renderArgsMap = {
+        render contentType:"text/plain;charset=utf-8", file:"theFile".bytes, fileName:"File Space Name.txt"
+    }
+
     def renderText = {
         render "text"
     }


### PR DESCRIPTION
Content-Disposition header can now include spaces as per issue# 10312.