### PR TITLE
Grails 9744 DataSources plugin revamp

### DIFF
--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -9,8 +9,8 @@ dependencies {
         exclude group: 'commons-logging', module:'commons-logging'
     }
 
-    compileOnly "org.grails:grails.datastore.gorm:$datastoreVersion"
-    compileOnly "org.grails:grails.datastore.core:$datastoreVersion"
+    compileOnly "org.grails:grails-datastore-gorm:$datastoreVersion"
+    compileOnly "org.grails:grails-datastore-core:$datastoreVersion"
 
     compileOnly "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
     runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"

--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -9,8 +9,8 @@ dependencies {
         exclude group: 'commons-logging', module:'commons-logging'
     }
 
-    compileOnly "org.grails:grails-datastore-gorm:$datastoreVersion"
-    compileOnly "org.grails:grails-datastore-core:$datastoreVersion"
+    compile "org.grails:grails-datastore-gorm:$datastoreVersion"
+    compile "org.grails:grails-datastore-core:$datastoreVersion"
 
     compileOnly "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
     runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"

--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -9,7 +9,7 @@ dependencies {
         exclude group: 'commons-logging', module:'commons-logging'
     }
 
-    compile "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
+    compileOnly "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
     runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"
 
     compile project(":grails-core")

--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -9,6 +9,9 @@ dependencies {
         exclude group: 'commons-logging', module:'commons-logging'
     }
 
+    compileOnly "org.grails:grails.datastore.gorm:$datastoreVersion"
+    compileOnly "org.grails:grails.datastore.core:$datastoreVersion"
+
     compileOnly "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
     runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"
 

--- a/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceConnectionSourcesFactoryBean.groovy
+++ b/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceConnectionSourcesFactoryBean.groovy
@@ -1,0 +1,84 @@
+package org.grails.plugins.datasource
+
+import groovy.transform.CompileStatic
+import org.grails.datastore.gorm.jdbc.connections.DataSourceConnectionSourceFactory
+import org.grails.datastore.gorm.jdbc.connections.DataSourceSettings
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.core.connections.ConnectionSourceSettings
+import org.grails.datastore.mapping.core.connections.ConnectionSources
+import org.grails.datastore.mapping.core.connections.ConnectionSourcesInitializer
+import org.grails.datastore.mapping.core.connections.DefaultConnectionSource
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.PropertyResolver
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+
+import javax.sql.DataSource
+
+/**
+ * A factory bean for creating the data sources
+ *
+ * @author Graeme Rocher
+ * @since 3.3
+ */
+@CompileStatic
+class DataSourceConnectionSourcesFactoryBean implements InitializingBean, FactoryBean<ConnectionSources<DataSource, DataSourceSettings>>, ApplicationContextAware {
+
+    final PropertyResolver configuration
+    ApplicationContext applicationContext
+    private ConnectionSources<DataSource, DataSourceSettings> connectionSources
+
+    DataSourceConnectionSourcesFactoryBean(PropertyResolver configuration) {
+        this.configuration = configuration
+    }
+
+    @Override
+    ConnectionSources<DataSource, DataSourceSettings> getObject() throws Exception {
+        return connectionSources
+    }
+
+    @Override
+    Class<?> getObjectType() {
+        return ConnectionSources
+    }
+
+    @Override
+    boolean isSingleton() {
+        return true
+    }
+
+    @Override
+    void afterPropertiesSet() throws Exception {
+        DataSourceConnectionSourceFactory factory = new DataSourceConnectionSourceFactory()
+        this.connectionSources = ConnectionSourcesInitializer.create(factory, configuration)
+        if(applicationContext instanceof ConfigurableApplicationContext) {
+            ConfigurableApplicationContext configurableApplicationContext = (ConfigurableApplicationContext)applicationContext
+            for(ConnectionSource<DataSource, ConnectionSourceSettings> connectionSource in connectionSources.allConnectionSources) {
+                if (connectionSource.name != ConnectionSource.DEFAULT) {
+                    String suffix = "_${connectionSource.name}"
+                    String dsName = "dataSource${suffix}"
+                    String tmName = "transactionManager${suffix}"
+                    if(!applicationContext.containsBean(dsName)) {
+                        DataSource dataSource = connectionSource.source
+                        configurableApplicationContext.beanFactory.registerSingleton(
+                                dsName,
+                                dataSource
+                        )
+                    }
+                    if(!applicationContext.containsBean(tmName)) {
+                        DataSource dataSource = connectionSource.source
+                        configurableApplicationContext.beanFactory.registerSingleton(
+                                tmName,
+                                new DataSourceTransactionManager(dataSource)
+                        )
+                    }
+                }
+
+            }
+        }
+    }
+
+}

--- a/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
+++ b/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
@@ -73,14 +73,15 @@ class DataSourceGrailsPlugin extends Plugin {
             ConnectionSources sources = ConnectionSourcesInitializer.create(factory, config)
 
             for (ConnectionSource source: sources.allConnectionSources) {
-                if (source.name == ConnectionSource.DEFAULT) {
-                    dataSource(InstanceFactoryBean, source.source)
-                    transactionManager(DataSourceTransactionManager, ref("dataSource"))
-                } else {
+                String dsName = "dataSource"
+                String tmName = "transactionManager"
+                if (source.name != ConnectionSource.DEFAULT) {
                     String suffix = "_${source.name}"
-                    "dataSource$suffix"(InstanceFactoryBean, source.source)
-                    "transactionManager$suffix"(DataSourceTransactionManager, ref("dataSource$suffix"))
+                    dsName = "${dsName}${suffix}"
+                    tmName = "${tmName}${suffix}"
                 }
+                "$dsName"(InstanceFactoryBean, source.source)
+                "$tmName"(DataSourceTransactionManager, ref(dsName))
             }
 
         }

--- a/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
+++ b/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
@@ -21,18 +21,15 @@ import grails.util.Environment
 import grails.util.GrailsUtil
 import org.apache.commons.logging.Log
 import org.apache.commons.logging.LogFactory
-import org.apache.tomcat.jdbc.pool.DataSource as TomcatDataSource
-import org.grails.core.exceptions.GrailsConfigurationException
+import org.grails.datastore.gorm.jdbc.connections.DataSourceConnectionSourceFactory
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.spring.beans.factory.InstanceFactoryBean
 import org.grails.transaction.ChainedTransactionManagerPostProcessor
 import org.springframework.jdbc.datasource.DataSourceTransactionManager
-import org.springframework.jdbc.datasource.DriverManagerDataSource
-import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy
-import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy
 import org.springframework.jmx.support.JmxUtils
-import org.springframework.jndi.JndiObjectFactoryBean
 import org.springframework.util.ClassUtils
 
-import javax.sql.DataSource
 
 /**
  * Handles the configuration of a DataSource within Grails.
@@ -48,8 +45,6 @@ class DataSourceGrailsPlugin extends Plugin {
     public static final String TRANSACTION_MANAGER_ENABLED = 'grails.transaction.chainedTransactionManagerPostProcessor.enabled'
     def version = GrailsUtil.getGrailsVersion()
     def dependsOn = [core: version]
-
-    def watchedResources = "file:./grails-app/conf/DataSource.groovy"
 
     @Override
     Closure doWithSpring() {{->
@@ -78,18 +73,17 @@ class DataSourceGrailsPlugin extends Plugin {
                     dataSources['dataSource'] = defaultDataSource
                 }
             }
+            DataSourceConnectionSourceFactory factory = new DataSourceConnectionSourceFactory()
 
             for(Map.Entry<String, Object> entry in dataSources.entrySet()) {
                 def name = entry.key
                 def value = entry.value
 
                 if(value instanceof Map) {
-                    createDatasource delegate, name, (Map)value
+                    createDatasource delegate, name, (Map)value, factory
                 }
             }
         }
-
-
 
         if(config.getProperty('dataSource.jmxExport', Boolean, false) && ClassUtils.isPresent('org.apache.tomcat.jdbc.pool.DataSource')) {
             try {
@@ -108,161 +102,25 @@ class DataSourceGrailsPlugin extends Plugin {
         }
     }}
 
-    protected void createDatasource(beanBuilder, String dataSourceName, Map dataSourceData ) {
+    protected void createDatasource(beanBuilder, String dataSourceName, Map dataSourceData, DataSourceConnectionSourceFactory factory) {
         boolean isDefault = dataSourceName == 'dataSource'
         String suffix = isDefault ? '' : "_$dataSourceName"
-        String unproxiedName = "dataSourceUnproxied$suffix"
-        String lazyName = "dataSourceLazy$suffix"
-        String beanName = isDefault ? 'dataSource' : "dataSource_$dataSourceName"
+        String beanName = isDefault ? 'dataSource' : "dataSource$suffix"
 
         if (applicationContext?.containsBean(dataSourceName)) {
             return
         }
 
-        if (dataSourceData?.jndiName) {
-            beanBuilder."$unproxiedName"(JndiObjectFactoryBean) {
-                jndiName = dataSourceData.jndiName
-                expectedType = DataSource
-            }
-            beanBuilder."$lazyName"(LazyConnectionDataSourceProxy, beanBuilder.ref(unproxiedName))
-            beanBuilder."$beanName"(TransactionAwareDataSourceProxy, beanBuilder.ref(lazyName))
-            return
-        }
+        ConnectionSource source = factory.create(isDefault ? "DEFAULT" : dataSourceName, DatastoreUtils.createPropertyResolver(dataSourceData))
 
-        boolean readOnly = Boolean.TRUE.equals(dataSourceData.readOnly)
-        boolean pooled = !Boolean.FALSE.equals(dataSourceData.pooled)
+        beanBuilder."$beanName"(InstanceFactoryBean, source.source)
 
-        if (pooled && !ClassUtils.isPresent('org.apache.tomcat.jdbc.pool.TomcatDataSource', this.class.classLoader)) {
-            throw new GrailsConfigurationException("The datasource [$dataSourceName] specifies a pooled connection but org.apache.tomcat:tomcat-jdbc is not on the classpath")
-        }
-
-        String driver = dataSourceData?.driverClassName ?: "org.h2.Driver"
-
-        final String hsqldbDriver = "org.hsqldb.jdbcDriver"
-        if (hsqldbDriver.equals(driver) && !ClassUtils.isPresent(hsqldbDriver, getClass().classLoader)) {
-            throw new GrailsConfigurationException("Database driver [" + hsqldbDriver +
-                "] for HSQLDB not found. Since Grails 2.0 H2 is now the default database. You need to either " +
-                "add the 'org.h2.Driver' class as your database driver and change the connect URL format " +
-                "(for example 'jdbc:h2:mem:devDb') in DataSource.groovy or add HSQLDB as a dependency of your application.")
-        }
-
-        boolean defaultDriver = (driver == "org.h2.Driver")
-
-        String pwd
-        boolean passwordSet = false
-        if (dataSourceData.password) {
-            pwd = resolvePassword(dataSourceData, grailsApplication)
-            passwordSet = true
-        }
-        else if (defaultDriver) {
-            pwd = ''
-            passwordSet = true
-        }
-
-        beanBuilder."abstractGrailsDataSourceBean$suffix" {
-            driverClassName = driver
-
-            if (pooled) {
-                defaultReadOnly = readOnly
-            }
-
-            url = dataSourceData.url ?: "jdbc:h2:mem:grailsDB;MVCC=TRUE;LOCK_TIMEOUT=10000"
-
-            String theUsername = dataSourceData.username ?: (defaultDriver ? "sa" : null)
-            if (theUsername != null) {
-                username = theUsername
-            }
-
-            if (passwordSet) password = pwd
-
-            // support for setting custom properties (for example maxActive) on the dataSource bean
-            def dataSourceProperties = dataSourceData.properties
-            if (dataSourceProperties) {
-                if (dataSourceProperties instanceof Map) {
-                    for (entry in dataSourceProperties) {
-                        log.debug("Setting property on dataSource bean $entry.key -> $entry.value")
-                        delegate."${entry.key}" = entry.value
-                    }
-                }
-                else {
-                    log.warn("dataSource.properties is not an instanceof java.util.Map, ignoring")
-                }
-            }
-        }
-
-        def parentConfig = { dsBean ->
-            dsBean.parent = 'abstractGrailsDataSourceBean' + suffix
-        }
-
-        String desc = isDefault ? 'data source' : "data source '$dataSourceName'"
-        log.info "[RuntimeConfiguration] Configuring $desc for environment: $Environment.current"
-
-        Class dsClass = pooled ? TomcatDataSource : readOnly ? ReadOnlyDriverManagerDataSource : DriverManagerDataSource
-
-        def bean = beanBuilder."$unproxiedName"(dsClass, parentConfig)
-        if (pooled) {
-            bean.destroyMethod = "close"
-        }
-
-        beanBuilder."$lazyName"(LazyConnectionDataSourceProxy, beanBuilder.ref(unproxiedName))
-        beanBuilder."$beanName"(TransactionAwareDataSourceProxy, beanBuilder.ref(lazyName))
-        
         // transactionManager beans will get overridden in Hibernate plugin
-        beanBuilder."transactionManager$suffix"(DataSourceTransactionManager, beanBuilder.ref(lazyName))
-    }
-
-    String resolvePassword(ds, GrailsApplication application) {
-
-        if (!ds.passwordEncryptionCodec) {
-            return ds.password
-        }
-
-        def encryptionCodec = ds.passwordEncryptionCodec
-        if (encryptionCodec instanceof Class) {
-            try {
-                return encryptionCodec.decode(ds.password)
-            }
-            catch (e) {
-                throw new GrailsConfigurationException(
-                    "Error decoding dataSource password with codec [$encryptionCodec.name]: $e.message", e)
-            }
-        }
-
-        encryptionCodec = encryptionCodec.toString()
-        def codecClass = application.getArtefacts("Codec").find {
-            it.name.equalsIgnoreCase(encryptionCodec) || it.fullName == encryptionCodec
-        }?.clazz
-
-        try {
-            if (!codecClass) {
-                codecClass = Class.forName(encryptionCodec, true, application.classLoader)
-            }
-            if (codecClass) {
-                return codecClass.decode(ds.password)
-            }
-            else {
-                throw new GrailsConfigurationException(
-                    "Error decoding dataSource password. Codec class not found for name [$encryptionCodec]")
-            }
-        }
-        catch (ClassNotFoundException e) {
-            throw new GrailsConfigurationException(
-                "Error decoding dataSource password. Codec class not found for name [$encryptionCodec]: $e.message", e)
-        }
-        catch (e) {
-            throw new GrailsConfigurationException(
-                "Error decoding dataSource password with codec [$encryptionCodec]: $e.message", e)
-        }
+        beanBuilder."transactionManager$suffix"(DataSourceTransactionManager, beanBuilder.ref(beanName))
     }
 
     @Override
     void onShutdown(Map<String, Object> event) {
-        if (Environment.current.isWarDeployed() || Environment.isFork()) {
-            deregisterJDBCDrivers()
-        }
-    }
-
-    private void deregisterJDBCDrivers() {
         try {
             DataSourceUtils.clearJdbcDriverRegistrations()
         }
@@ -270,4 +128,5 @@ class DataSourceGrailsPlugin extends Plugin {
             log.debug "Error deregistering JDBC drivers: $e.message", e
         }
     }
+
 }

--- a/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
+++ b/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
@@ -132,6 +132,10 @@ class DataSourceGrailsPlugin extends Plugin {
         boolean readOnly = Boolean.TRUE.equals(dataSourceData.readOnly)
         boolean pooled = !Boolean.FALSE.equals(dataSourceData.pooled)
 
+        if (pooled && !ClassUtils.isPresent('org.apache.tomcat.jdbc.pool.TomcatDataSource', this.class.classLoader)) {
+            throw new GrailsConfigurationException("The datasource [$dataSourceName] specifies a pooled connection but org.apache.tomcat:tomcat-jdbc is not on the classpath")
+        }
+
         String driver = dataSourceData?.driverClassName ?: "org.h2.Driver"
 
         final String hsqldbDriver = "org.hsqldb.jdbcDriver"

--- a/grails-plugin-datasource/src/test/groovy/org/grails/plugins/datasource/DataSourceGrailsPluginSpec.groovy
+++ b/grails-plugin-datasource/src/test/groovy/org/grails/plugins/datasource/DataSourceGrailsPluginSpec.groovy
@@ -1,0 +1,54 @@
+package org.grails.plugins.datasource
+
+import grails.core.GrailsApplication
+import grails.plugins.GrailsPluginManager
+import grails.spring.BeanBuilder
+import groovy.sql.Sql
+import org.grails.config.PropertySourcesConfig
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.springframework.context.ApplicationContext
+import spock.lang.Specification
+
+import javax.sql.DataSource
+
+/**
+ * Created by graemerocher on 19/01/2017.
+ */
+class DataSourceGrailsPluginSpec extends Specification {
+
+    void "test data sources Grails plugin Spring configuration"() {
+        when:
+        DataSourceGrailsPlugin plugin = new DataSourceGrailsPlugin()
+        plugin.setPluginManager(Mock(GrailsPluginManager))
+        GrailsApplication application = Mock(GrailsApplication)
+        application.getConfig() >> new PropertySourcesConfig('dataSource.pooled':true,'dataSource.url':'jdbc:h2:mem:devDb;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE')
+
+        plugin.setGrailsApplication(application)
+
+        BeanBuilder beanBuilder = new BeanBuilder()
+        beanBuilder.beans plugin.doWithSpring()
+
+        ApplicationContext ctx = beanBuilder.createApplicationContext()
+
+        then:
+        ctx.containsBean('dataSource')
+        ctx.getBean('dataSource', DataSource)
+
+
+        when:"A query is executed"
+        DataSource ds = ctx.getBean('dataSource', DataSource)
+        Sql sql = new Sql(ds)
+        int result = sql.call('''
+CREATE TABLE user (
+    username VARCHAR(50),
+    password VARCHAR(50));
+
+
+select * from user''')
+
+        then:""
+        result == 0
+
+
+    }
+ }

--- a/grails-test-suite-base/src/main/groovy/org/grails/commons/test/AbstractGrailsMockTests.java
+++ b/grails-test-suite-base/src/main/groovy/org/grails/commons/test/AbstractGrailsMockTests.java
@@ -18,18 +18,22 @@ package org.grails.commons.test;
 import grails.util.Metadata;
 import groovy.lang.ExpandoMetaClass;
 import groovy.lang.GroovyClassLoader;
+import groovy.util.ConfigObject;
+import groovy.util.ConfigSlurper;
 import groovy.util.GroovyTestCase;
 
 import java.io.IOException;
 
 import grails.core.DefaultGrailsApplication;
 import grails.core.GrailsApplication;
+import org.grails.config.PropertySourcesConfig;
 import org.grails.support.MockApplicationContext;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.StaticMessageSource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.mock.web.MockServletContext;
+import org.springframework.util.ClassUtils;
 
 /**
  * Abstract simple test harness for testing Grails Applications that just loads
@@ -59,8 +63,11 @@ public abstract class AbstractGrailsMockTests extends GroovyTestCase {
         ctx.registerMockBean(GrailsApplication.CLASS_LOADER_BEAN, gcl);
         onSetUp();
         ga = new DefaultGrailsApplication(gcl.getLoadedClasses(),gcl);
+        if(ClassUtils.isPresent("Config", gcl)) {
+            ConfigObject config = new ConfigSlurper().parse(gcl.loadClass("Config"));
+            ga.setConfig(new PropertySourcesConfig(config));
+        }
         ga.getMetadata().put(Metadata.APPLICATION_NAME, getClass().getName());
-
         ga.setApplicationContext(ctx);
         ga.initialise();
         ctx.registerMockBean(GrailsApplication.APPLICATION_ID, ga);

--- a/grails-test-suite-persistence/build.gradle
+++ b/grails-test-suite-persistence/build.gradle
@@ -38,6 +38,8 @@ dependencies {
         exclude group: 'javassist', module: 'javassist'
     }
 
+    compile "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
+
     testRuntime 'com.h2database:h2:1.3.176'
 }
 

--- a/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
@@ -21,7 +21,7 @@ class ServicesGrailsPluginTests extends AbstractGrailsMockTests {
     void onSetUp() {
         gcl.parseClass('''
             dataSource {
-                pooled = true
+                pooled = false
                 driverClassName = "org.h2.Driver"
                 username = "sa"
                 password = ""
@@ -206,7 +206,7 @@ class TransactionalAbsentService {
     private ApplicationContext initializeContext(boolean transactionManagement = true) {
 
         ga.getConfig().put(Settings.SPRING_TRANSACTION_MANAGEMENT, transactionManagement)
-        ga.getConfig().put("dataSources", [dataSource: [:]])
+        ga.getConfig().put("dataSources", [dataSource: [pooled: false]])
         def corePluginClass = gcl.loadClass("org.grails.plugins.CoreGrailsPlugin")
         def corePlugin = new DefaultGrailsPlugin(corePluginClass, ga)
         def dataSourcePluginClass = gcl.loadClass("org.grails.plugins.datasource.DataSourceGrailsPlugin")

--- a/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
@@ -1,11 +1,20 @@
 package org.grails.plugins.services
 
 import grails.config.Settings
+import grails.core.GrailsApplication
+import grails.plugins.GrailsPlugin
+import grails.plugins.GrailsPluginManager
+import grails.plugins.PluginFilter
+import grails.plugins.exceptions.PluginException
+import grails.web.servlet.plugins.GrailsWebPluginManager
 import org.grails.commons.test.AbstractGrailsMockTests
 import org.grails.plugins.DefaultGrailsPlugin
 import org.grails.plugins.MockHibernateGrailsPlugin
+import org.grails.spring.RuntimeSpringConfiguration
 import org.grails.web.servlet.context.support.WebRuntimeSpringConfiguration
+import org.springframework.beans.BeansException
 import org.springframework.context.ApplicationContext
+import org.springframework.core.type.filter.TypeFilter
 
 class ServicesGrailsPluginTests extends AbstractGrailsMockTests {
 
@@ -206,7 +215,7 @@ class TransactionalAbsentService {
         def dataSourcePlugin = new DefaultGrailsPlugin(dataSourcePluginClass, ga)
         def hibernatePlugin = new DefaultGrailsPlugin(MockHibernateGrailsPlugin, ga)
         def domainPlugin = new DefaultGrailsPlugin(domainPluginClass, ga)
-
+        dataSourcePlugin.manager = new GrailsWebPluginManager([dataSourcePluginClass, MockHibernateGrailsPlugin, domainPluginClass] as Class[], ga)
         def springConfig = new WebRuntimeSpringConfiguration(ctx)
         springConfig.servletContext = createMockServletContext()
 

--- a/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/ServicesGrailsPluginTests.groovy
@@ -18,6 +18,7 @@ import org.springframework.core.type.filter.TypeFilter
 
 class ServicesGrailsPluginTests extends AbstractGrailsMockTests {
 
+
     void onSetUp() {
         gcl.parseClass('''
             dataSource {

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -6,6 +6,8 @@ dependencies {
             project(':grails-plugin-controllers'),
             project(':grails-plugin-testing')
 
+    compile "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
+
     testRuntime 'javax.servlet.jsp:jsp-api:2.1'
     testRuntime 'jstl:jstl:1.1.2'
     testRuntime 'javax.el:el-api:1.0'

--- a/grails-test-suite-uber/src/test/groovy/org/grails/plugins/CoreGrailsPluginTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/plugins/CoreGrailsPluginTests.groovy
@@ -2,6 +2,7 @@ package org.grails.plugins
 
 import grails.plugins.GrailsPlugin
 import grails.plugins.GrailsPluginManager
+import grails.web.servlet.plugins.GrailsWebPluginManager
 import org.grails.config.PropertySourcesConfig
 import org.grails.plugins.DefaultGrailsPlugin
 import org.grails.plugins.MockGrailsPluginManager
@@ -88,7 +89,7 @@ class CoreGrailsPluginTests extends AbstractGrailsMockTests {
     void testBeanPropertyOverride() {
         def co = new ConfigSlurper().parse('''
             dataSource {
-                pooled = true
+                pooled = false
                 driverClassName = "org.h2.Driver"
                 username = "sa"
                 password = ""
@@ -117,6 +118,7 @@ class CoreGrailsPluginTests extends AbstractGrailsMockTests {
         springConfig.servletContext = createMockServletContext()
 
         corePlugin.doWithRuntimeConfiguration(springConfig)
+        dataSourcePlugin.manager = new GrailsWebPluginManager([corePluginClass] as Class[], ga)
         dataSourcePlugin.doWithRuntimeConfiguration(springConfig)
 
         def pluginClass = gcl.loadClass("org.grails.plugins.services.ServicesGrailsPlugin")


### PR DESCRIPTION
Tomcat JDBC is now compileOnly.
ChainedTransactionManagerPostProcessor now only gets defined if hibernate 4 or 5 is a plugin in the application and it has been specifically enabled.
EmbeddedDatabaseShutdownHook is only defined if hibernate 4 or 5 is a plugin in the application.
tomcatJDBCPoolMBeanExporter is only created if Tomcat JDBC is on the classpath.
dataSources are not created if hibernate 4 or 5 is in the application.
Throw an error if Tomcat JDBC is not on the classpath and the datasource is pooled.


Issue #9744 