### PR TITLE
Ignore migrations folder when getting project package names

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/io/ResourceUtils.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/io/ResourceUtils.groovy
@@ -47,7 +47,7 @@ class ResourceUtils extends GrailsResourceUtils {
             File[] allFiles = rootDir.listFiles()
             rootDir.eachDir { File dir ->
                 def dirName = dir.name
-                if (!dir.hidden && !dirName.startsWith('.') && !['conf', 'i18n', 'assets', 'views'].contains(dirName)) {
+                if (!dir.hidden && !dirName.startsWith('.') && !['conf', 'i18n', 'assets', 'views', 'migrations'].contains(dirName)) {
                     File[] files = dir.listFiles()
                     populatePackages(dir,files, packageNames, "")
                 }


### PR DESCRIPTION
If a project uses the grails [database-migration](https://github.com/grails-plugins/grails-database-migration) plugin, by default, the changelog and changesets are written to the grails-app/migrations/ folder. These files can be either xml or groovy scripts. If they're groovy scripts, they'll be picked up when scanning for packages. On app startup the following error will be logged by [ClassPathScanner](https://github.com/grails/grails-core/blob/master/grails-core/src/main/groovy/grails/boot/config/tools/ClassPathScanner.groovy#L141) because the scripts are interpreted to be in the default package:

> The application defines a Groovy source using the default package. Please move all Groovy sources into a package.

Since these migrations aren't application classes, they can be ignored from scanning.