### PR TITLE
Fixed non domain classes being identified as a domain class (base branch: 3.1.x).

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/artefact/DomainClassArtefactHandler.java
+++ b/grails-core/src/main/groovy/org/grails/core/artefact/DomainClassArtefactHandler.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.net.URL;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.TreeSet;
 
 /**
  * Evaluates the conventions that define a domain class in Grails.
@@ -115,7 +115,8 @@ public class DomainClassArtefactHandler extends ArtefactHandlerAdapter implement
         return isDomainClass(clazz);
     }
 
-    static final Map<Integer, Boolean> DOMAIN_CLASS_CHECK_CACHE = new ConcurrentHashMap<Integer, Boolean>();
+    static final TreeSet<String> DOMAIN_CLASS_CACHE = new TreeSet<String>();
+    static final TreeSet<String> NOT_DOMAIN_CLASS_CACHE = new TreeSet<String>();
 
     public static boolean isDomainClass(Class<?> clazz, boolean allowProxyClass) {
         boolean retval = isDomainClass(clazz);
@@ -128,17 +129,22 @@ public class DomainClassArtefactHandler extends ArtefactHandlerAdapter implement
     public static boolean isDomainClass(Class<?> clazz) {
         if (clazz == null) return false;
 
-        Integer cacheKey = System.identityHashCode(clazz);
+        String cacheKey = clazz.getName();
 
-        Boolean retval = DOMAIN_CLASS_CHECK_CACHE.get(cacheKey);
-        if (retval != null) {
-            return retval;
+        if (DOMAIN_CLASS_CACHE.contains(cacheKey)) {
+            return true;
+        } else if (NOT_DOMAIN_CLASS_CACHE.contains(cacheKey)) {
+            return false;
         }
 
-        retval = doIsDomainClassCheck(clazz);
-        
+        boolean retval = doIsDomainClassCheck(clazz);
+
         if (!developmentMode) {
-            DOMAIN_CLASS_CHECK_CACHE.put(cacheKey, retval);
+            if (retval) {
+                DOMAIN_CLASS_CACHE.add(cacheKey);
+            } else {
+                NOT_DOMAIN_CLASS_CACHE.add(cacheKey);
+            }
         }
         return retval;
     }


### PR DESCRIPTION
_This fix achieves the same as #10453 but for grails-core 3.1.x. It is worth noting that in this branch the modified file is located in a different directory._

The use of HashMap eventually had inappropriate cache hits, which caused non domain classes being identified as domain. As a consequence, when starting up the application server, sometimes the following error occurred:

`Identity property not found, but required in domain class`

...followed by the name of a non domain class such as `org.codehaus.groovy.grails.plugins.codecs.SHA1BytesCodec`

http://stackoverflow.com/questions/41616489/grailsdomainexception-identity-property-not-found-but-required-in-domain-clas?noredirect=1#comment70442945_41616489