### PR TITLE
Make AbstractConverter implement Writable for grails-plugins/grails-r…

### DIFF
--- a/grails-plugin-converters/src/main/groovy/org/grails/web/converters/AbstractConverter.java
+++ b/grails-plugin-converters/src/main/groovy/org/grails/web/converters/AbstractConverter.java
@@ -15,10 +15,13 @@
  */
 package org.grails.web.converters;
 
+import groovy.lang.Writable;
 import org.grails.buffer.FastStringWriter;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 
+import java.io.IOException;
+import java.io.Writer;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +32,7 @@ import java.util.Map;
  * @author Siegfried Puchbauer
  * @author Graeme Rocher
  */
-public abstract class AbstractConverter<W> implements ConfigurableConverter<W> {
+public abstract class AbstractConverter<W> implements ConfigurableConverter<W>, Writable {
 
     protected String contentType;
     protected String encoding = "UTF-8";
@@ -100,6 +103,12 @@ public abstract class AbstractConverter<W> implements ConfigurableConverter<W> {
     @Override
     public List<String> getIncludes(Class type) {
         return includes.get(type);
+    }
+
+    @Override
+    public Writer writeTo(Writer out) throws IOException {
+        render(out);
+        return out;
     }
 
     @Override


### PR DESCRIPTION
This is the same change that is in #10462, but targets the `3.2.x` branch instead of `master`.