### PR TITLE
method called from constructor should be static

### DIFF
--- a/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/boot/GrailsDependencyVersions.groovy
@@ -58,7 +58,7 @@ class GrailsDependencyVersions implements DependencyManagement {
         }
     }
 
-    GrapeEngine getDefaultEngine() {
+    static GrapeEngine getDefaultEngine() {
         def grape = Grape.getInstance()
         grape.addResolver((Map<String,Object>)[name:"grailsCentral", root:"https://repo.grails.org/grails/core"])
         grape


### PR DESCRIPTION
I suspect this path isn't currently exercised by the test suite. In any case, Groovy 2.5+ has stricter checks for this case and it won't compile in that version.