### PR TITLE
ReadOnly datasources should be left out of chained transaction manager

### DIFF
--- a/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
+++ b/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
@@ -185,7 +185,7 @@ public class ChainedTransactionManagerPostProcessor implements BeanDefinitionReg
         if(transactional == null) {
             Boolean isReadOnly =  config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + READONLY, Boolean.class, null);
             if (isReadOnly != null && isReadOnly == true) {
-                transactional = false
+                transactional = false;
             }
         }
         if(transactional != null){

--- a/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
+++ b/grails-core/src/main/groovy/org/grails/transaction/ChainedTransactionManagerPostProcessor.java
@@ -183,7 +183,10 @@ public class ChainedTransactionManagerPostProcessor implements BeanDefinitionReg
         }
         Boolean transactional = config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + TRANSACTIONAL, Boolean.class, null);
         if(transactional == null) {
-            transactional =  config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + READONLY, Boolean.class, null);
+            Boolean isReadOnly =  config.getProperty(DATA_SOURCES_PREFIX + suffix + "." + READONLY, Boolean.class, null);
+            if (isReadOnly != null && isReadOnly == true) {
+                transactional = false
+            }
         }
         if(transactional != null){
             return !transactional;


### PR DESCRIPTION
Grails user guide said that 

> Datasources with readOnly = true will also be left out of the chained transaction manager 

http://docs.grails.org/latest/guide/conf.html#multipleDatasources

The logic in isNotTransactional() is not correct for readOnly datasources.

