### PR TITLE
watchedResources does not work in Plugin

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -223,8 +223,8 @@ class GrailsApp extends SpringApplication {
                                 recompile(f, compilerConfig, location)
                                 if(newFiles.contains(f)) {
                                     newFiles.remove(f)
-                                    pluginManager.informOfFileChange(f)
                                 }
+                                pluginManager.informOfFileChange(f)
                                 sleep 1000
                             }
                         }
@@ -241,8 +241,8 @@ class GrailsApp extends SpringApplication {
                                 recompile(changedFile, compilerConfig, location)
                                 if(newFiles.contains(changedFile)) {
                                     newFiles.remove(changedFile)
-                                    pluginManager.informOfFileChange(changedFile)
                                 }
+                                pluginManager.informOfFileChange(changedFile)
                             }
                         }
 


### PR DESCRIPTION
 change events were not propagated to the Plugin.

This was because changes were not picked up by the change watcher thread.