### PR TITLE
Added method to retrieve the codes of a specific bundle.

### DIFF
--- a/grails-core/src/main/groovy/org/grails/spring/context/support/ReloadableResourceBundleMessageSource.java
+++ b/grails-core/src/main/groovy/org/grails/spring/context/support/ReloadableResourceBundleMessageSource.java
@@ -156,10 +156,10 @@ public class ReloadableResourceBundleMessageSource extends AbstractMessageSource
 	 * @param basenames the basenames of the bundle
 	 * @return a list with all codes from valid registered bundles
 	 */
-	public List<String> getBundleCodes(Locale locale,String...basenames){
+	public Set<String> getBundleCodes(Locale locale,String...basenames){
 		List<String> validBaseNames = getValidBasenames(basenames);
 		
-		List<String> codes = new ArrayList<>();
+		Set<String> codes = new HashSet<>();
 		for(String basename: validBaseNames){
 			List<Pair<String, Resource>> filenamesAndResources = calculateAllFilenames(basename,locale);
 			for (Pair<String, Resource> filenameAndResource : filenamesAndResources) {

--- a/grails-core/src/main/groovy/org/grails/spring/context/support/ReloadableResourceBundleMessageSource.java
+++ b/grails-core/src/main/groovy/org/grails/spring/context/support/ReloadableResourceBundleMessageSource.java
@@ -23,10 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -153,6 +150,41 @@ public class ReloadableResourceBundleMessageSource extends AbstractMessageSource
 		setBasenames(basename);
 	}
 
+	/**
+	 * Retrieves all codes from one or multiple basenames
+	 * @param locale the locale
+	 * @param basenames the basenames of the bundle
+	 * @return a list with all codes from valid registered bundles
+	 */
+	public List<String> getBundleCodes(Locale locale,String...basenames){
+		List<String> validBaseNames = getValidBasenames(basenames);
+		
+		List<String> codes = new ArrayList<>();
+		for(String basename: validBaseNames){
+			List<Pair<String, Resource>> filenamesAndResources = calculateAllFilenames(basename,locale);
+			for (Pair<String, Resource> filenameAndResource : filenamesAndResources) {
+				if(filenameAndResource.getbValue() != null) {
+					PropertiesHolder propHolder = getProperties(filenameAndResource.getaValue(), filenameAndResource.getbValue());
+					codes.addAll(propHolder.getProperties().stringPropertyNames());					
+				}
+			}
+		}
+		return codes;
+	}
+	
+	protected List<String> getValidBasenames(String[] basenames){
+		List<String> validBaseNames = new LinkedList<>();
+		for(String basename:basenames){
+			for(int i=0;i<this.basenames.length;i++){
+				if(basenames[i].equals(basename)){
+					validBaseNames.add(basename);
+					break;
+				}
+			}
+		}
+		return validBaseNames;
+	}
+	
 	/**
 	 * Set an array of basenames, each following the basic ResourceBundle convention
 	 * of not specifying file extension or language codes, but in contrast to

--- a/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
@@ -9,7 +9,9 @@ class ResourceBundleMessageSourceSpec extends Specification {
     File resourceFolder
     
     void setup(){
-        resourceFolder = File.createTempDir()
+        resourceFolder = new File(System.getProperty('user.home'),'.grails/test-resources')
+        if(!resourceFolder.exists()) resourceFolder.mkdirs()
+        
         def messages = new File(resourceFolder,'messages.properties')
         messages.text = '''\
             foo=bar
@@ -33,9 +35,9 @@ class ResourceBundleMessageSourceSpec extends Specification {
             messageSource.setBasenames('messages','other')
             def locale = Locale.default
         expect:
-            messageSource.getBundleCodes(locale,'messages') == ['foo']
-            messageSource.getBundleCodes(locale,'other') == ['bar']
-            messageSource.getBundleCodes(locale,'messages','other') == ['foo','bar']
+            messageSource.getBundleCodes(locale,'messages') == (['foo'] as Set)
+            messageSource.getBundleCodes(locale,'other') == (['bar'] as Set)
+            messageSource.getBundleCodes(locale,'messages','other') == (['foo','bar'] as Set)
     }
     
 }

--- a/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
@@ -1,0 +1,53 @@
+package org.grails.spring.context
+
+import org.grails.spring.context.support.ReloadableResourceBundleMessageSource
+import org.springframework.core.io.FileSystemResourceLoader
+import org.springframework.core.io.Resource
+import spock.lang.Specification
+
+class ResourceBundleMessageSourceSpec extends Specification {
+    File resourceFolder
+    
+    void setup(){
+        resourceFolder = new File(System.getProperty('java.io.tmpdir'),'resources')
+        resourceFolder.mkdirs()
+        def messages = new File(resourceFolder,'messages.properties')
+        messages.text = '''\
+            foo=bar
+        '''.stripIndent()
+        def other = new File(resourceFolder,'other.properties')
+        other.text = '''\
+            bar=foo
+        '''.stripIndent()
+    }
+    
+    void cleanup(){
+        resourceFolder.deleteDir()
+    }
+    
+    
+    void 'Check method to retrieve bundle codes per messagebundle'(){
+        given:
+            def messageSource = new ReloadableResourceBundleMessageSource(
+                resourceLoader: new TempResourceLoader(resourceFolder:resourceFolder)
+            )
+            messageSource.setBasenames('messages','other')
+            def locale = Locale.default
+        expect:
+            messageSource.getBundleCodes(locale,'messages') == ['foo']
+            messageSource.getBundleCodes(locale,'other') == ['bar']
+            messageSource.getBundleCodes(locale,'messages','other') == ['foo','bar']
+    }
+    
+}
+
+class TempResourceLoader extends FileSystemResourceLoader{
+    File resourceFolder
+    
+    @Override
+    protected Resource getResourceByPath(String path) {
+        path = new File(resourceFolder,path).absolutePath
+        return super.getResourceByPath(path)
+    }
+}
+

--- a/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/spring/context/ResourceBundleMessageSourceSpec.groovy
@@ -9,8 +9,7 @@ class ResourceBundleMessageSourceSpec extends Specification {
     File resourceFolder
     
     void setup(){
-        resourceFolder = new File(System.getProperty('java.io.tmpdir'),'resources')
-        resourceFolder.mkdirs()
+        resourceFolder = File.createTempDir()
         def messages = new File(resourceFolder,'messages.properties')
         messages.text = '''\
             foo=bar


### PR DESCRIPTION
For example if you want to send all client messages contained in
messagesclient bundle to the browser using i18next, you can now
retrieve all codes contained in the messagesclient bundle.