### PR TITLE
Using multiple datasources the default dataSource is not handled by the DataSourceGrailsPlugin

### DIFF
--- a/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
+++ b/grails-plugin-datasource/src/main/groovy/org/grails/plugins/datasource/DataSourceGrailsPlugin.groovy
@@ -64,12 +64,10 @@ class DataSourceGrailsPlugin extends Plugin {
         }
         transactionManagerPostProcessor(TransactionManagerPostProcessor)
 
+        def defaultDataSource = config.getProperty('dataSource', Map)
         def dataSources = config.getProperty('dataSources', Map, [:])
-        if(!dataSources) {
-            def defaultDataSource = config.getProperty('dataSource', Map)
-            if(defaultDataSource) {
-                dataSources['dataSource'] = defaultDataSource
-            }
+        if(defaultDataSource) {
+            dataSources['dataSource'] = defaultDataSource
         }
 
         for(Map.Entry<String, Object> entry in dataSources.entrySet()) {

--- a/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/DataSourcesGrailsPluginTests.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/org/grails/plugins/services/DataSourcesGrailsPluginTests.groovy
@@ -1,0 +1,61 @@
+package org.grails.plugins.services
+
+import org.grails.commons.test.AbstractGrailsMockTests
+import org.grails.plugins.DefaultGrailsPlugin
+import org.grails.web.servlet.context.support.WebRuntimeSpringConfiguration
+import org.springframework.context.ApplicationContext
+
+class DataSourcesGrailsPluginTests  extends AbstractGrailsMockTests {
+
+    void testSingleDataSource() {
+        def appCtx = initializeContext([
+                dataSource: [
+                        pooled :true,
+                        driverClassName:"org.h2.Driver",
+                        username :"sa",
+                        password :"",
+                        dbCreate :"create-drop"
+                ]
+        ])
+        assertTrue appCtx.containsBean("dataSource")
+    }
+    void testMultipleDataSources() {
+        def appCtx = initializeContext([
+                dataSource: [
+                        pooled :true,
+                        driverClassName:"org.h2.Driver",
+                        username :"sa",
+                        password :"",
+                        dbCreate :"create-drop"
+                ],
+                dataSources: [
+                        second:[
+                                pooled :true,
+                                driverClassName:"org.h2.Driver",
+                                username :"sa",
+                                password :"",
+                                dbCreate :"create-drop"
+                        ]
+                ]
+        ])
+        assertTrue appCtx.containsBean("dataSource")
+        assertTrue appCtx.containsBean("dataSource_second")
+    }
+
+
+    private ApplicationContext initializeContext(Map dataSources) {
+        ga.getConfig().putAll(dataSources)
+        def corePluginClass = gcl.loadClass("org.grails.plugins.CoreGrailsPlugin")
+        def corePlugin = new DefaultGrailsPlugin(corePluginClass, ga)
+        def dataSourcePluginClass = gcl.loadClass("org.grails.plugins.datasource.DataSourceGrailsPlugin")
+
+        def dataSourcePlugin = new DefaultGrailsPlugin(dataSourcePluginClass, ga)
+        def springConfig = new WebRuntimeSpringConfiguration(ctx)
+        springConfig.servletContext = createMockServletContext()
+
+        corePlugin.doWithRuntimeConfiguration(springConfig)
+        dataSourcePlugin.doWithRuntimeConfiguration(springConfig)
+
+        springConfig.getApplicationContext()
+    }
+}


### PR DESCRIPTION
Using multiple datasources the default dataSource is not handled by the DataSourceGrailsPlugin.
Added a test as well. 

I think this has to do with the old vs new method of defining multiple datasources. Currently the default dataSource should always be defined separately. 