### PR TITLE
Created BindInitializer annotation 

### DIFF
--- a/grails-databinding/src/main/groovy/grails/databinding/BindInitializer.java
+++ b/grails-databinding/src/main/groovy/grails/databinding/BindInitializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package grails.databinding;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * This annotation may be applied to a a field to
+ * customize initialization of object properties in the data binding process.
+ *
+ * When the annotation is applied to a field, the value assigned to the
+ * annotation should be a Closure which accepts 1 parameter.  The 
+ * parameter is the object that data binding is being applied to.  
+ * The value returned by the Closure will be bound to the field.  The
+ * following code demonstrates using this technique to bind a contact
+ * to user with the same account as the user.
+ *
+<pre>
+class Contact{
+  Account account
+  String firstName
+} 
+class User {
+    &#064;BindInitializer({
+        obj -> new Contact(account:obj.account)
+    })
+    Contact contact
+    Account account
+}
+</pre>
+ 
+ *
+ * @since 3.2.11
+ * @see BindingHelper
+ * @see DataBindingSource
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BindInitializer {
+    Class<?> value();
+}

--- a/grails-databinding/src/main/groovy/grails/databinding/initializers/ValueInitializer.java
+++ b/grails-databinding/src/main/groovy/grails/databinding/initializers/ValueInitializer.java
@@ -1,0 +1,7 @@
+package grails.databinding.initializers;
+
+
+public interface ValueInitializer {
+    Object initialize();
+    Class<?> getTargetType();
+}

--- a/grails-databinding/src/main/groovy/org/grails/databinding/ClosureValueInitializer.groovy
+++ b/grails-databinding/src/main/groovy/org/grails/databinding/ClosureValueInitializer.groovy
@@ -1,0 +1,17 @@
+package org.grails.databinding
+
+import grails.databinding.initializers.ValueInitializer
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class ClosureValueInitializer implements ValueInitializer {
+
+    Closure initializerClosure
+    Class targetType
+    
+
+    @Override
+    Object initialize() {
+        initializerClosure.call()
+    }
+}

--- a/grails-databinding/src/test/groovy/grails/databinding/BindInitializerSpec.groovy
+++ b/grails-databinding/src/test/groovy/grails/databinding/BindInitializerSpec.groovy
@@ -1,0 +1,32 @@
+package grails.databinding
+
+import spock.lang.Specification
+
+
+class BindInitializerSpec extends Specification {
+    
+    void 'Test BindInitializer for specific property'() {
+        given:
+            def binder = new SimpleDataBinder()
+            def obj = new ClassWithBindInitializerOnProperty()
+        when:
+            binder.bind(obj, new SimpleMapDataBindingSource(['association': [valueBound:'valueBound']]))
+
+        then:
+            obj.association.valueBound == 'valueBound'
+            obj.association.valueInitialized == 'valueInitialized'
+    }
+
+
+    static class ReferencedClass{
+        String valueInitialized
+        String valueBound
+    }
+    class ClassWithBindInitializerOnProperty {
+        @BindInitializer({
+            obj -> 
+                new ReferencedClass(valueInitialized:'valueInitialized')
+        })
+        ReferencedClass association
+    }
+}


### PR DESCRIPTION
Created @BindInitializer annotation for better control of initializing binding associations. 
After the bindInitializer finishes, the normal binding process continues (unlike @BindUsing)

Use case: 
```
class Account{}
class User{
  Account account

  @BindInitializer({obj->  new Contact(account:obj.account) })
  Contact contact
}
class Contact{
  Account account
  String firstName
}
```
You can bind using:
```
bindData(user,['contact':['fistName':'Dennie']])
```
And if contact is null, it will be initialized with firstName Dennie and the account of the User