### PR TITLE
Narrow event types AbstractGrailsApplication supports

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
+++ b/grails-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
@@ -29,13 +29,15 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.*;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.SmartApplicationListener;
+import org.springframework.core.Ordered;
 import org.springframework.util.ClassUtils;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public abstract class AbstractGrailsApplication extends GroovyObjectSupport implements GrailsApplication, ApplicationContextAware, BeanClassLoaderAware, ApplicationListener<ApplicationEvent> {
+public abstract class AbstractGrailsApplication extends GroovyObjectSupport implements GrailsApplication, ApplicationContextAware, BeanClassLoaderAware, SmartApplicationListener {
     protected ClassLoader classLoader;
     protected Config config;
     @SuppressWarnings("rawtypes")
@@ -140,5 +142,20 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
         if (event instanceof ContextRefreshedEvent) {
             this.contextInitialized = true;
         }
+    }
+
+    @Override
+    public boolean supportsEventType(Class<? extends ApplicationEvent> eventType) {
+        return ContextRefreshedEvent.class.isAssignableFrom(eventType);
+    }
+
+    @Override
+    public boolean supportsSourceType(Class<?> sourceType) {
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 }

--- a/grails-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
+++ b/grails-core/src/main/groovy/org/grails/core/AbstractGrailsApplication.java
@@ -25,7 +25,6 @@ import groovy.lang.GroovyObjectSupport;
 import groovy.util.ConfigObject;
 import org.grails.config.FlatConfig;
 import org.grails.config.PropertySourcesConfig;
-import org.grails.datastore.mapping.model.MappingContext;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.context.*;
@@ -48,8 +47,8 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         this.parentContext = applicationContext;
-        if(applicationContext instanceof ConfigurableApplicationContext) {
-            ((ConfigurableApplicationContext)applicationContext).addApplicationListener(this);
+        if (applicationContext instanceof ConfigurableApplicationContext) {
+            ((ConfigurableApplicationContext) applicationContext).addApplicationListener(this);
         }
     }
 
@@ -62,7 +61,7 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
     public boolean isWarDeployed() {
         return Environment.isWarDeployed();
     }
-    
+
     public Config getConfig() {
         return config;
     }
@@ -99,20 +98,20 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
     public void configChanged() {
         updateFlatConfig();
         final ArtefactHandler[] handlers = getArtefactHandlers();
-        if(handlers != null) {
+        if (handlers != null) {
             for (ArtefactHandler handler : handlers) {
                 if (handler instanceof GrailsConfigurationAware) {
-                    ((GrailsConfigurationAware)handler).setConfiguration(config);
+                    ((GrailsConfigurationAware) handler).setConfiguration(config);
                 }
             }
         }
     }
-    
+
     @Override
     public void setBeanClassLoader(ClassLoader classLoader) {
         this.classLoader = classLoader;
     }
-    
+
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;
@@ -122,8 +121,8 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
     @Override
     public Class getClassForName(String className) {
         return ClassUtils.resolveClassName(className, getClassLoader());
-    }    
-    
+    }
+
     public ApplicationContext getMainContext() {
         return parentContext;
     }
@@ -138,7 +137,7 @@ public abstract class AbstractGrailsApplication extends GroovyObjectSupport impl
 
     @Override
     public void onApplicationEvent(ApplicationEvent event) {
-        if(event instanceof ContextRefreshedEvent) {
+        if (event instanceof ContextRefreshedEvent) {
             this.contextInitialized = true;
         }
     }


### PR DESCRIPTION
Why this is important in some cases:
I'm using grails and I have one kind of requests which performance is really important for my application. During processing of such requests there are a lot of Hibernate entities that are deserialized from cache. Each deserialization rises a bunch of event like preLoad, postLoad e.t.c. and as it happens handling of this events takes much more time than deserialization itself. 
![pasted image at 2017_06_28 07_41 pm](https://user-images.githubusercontent.com/5521317/27678286-5c11c790-5cbd-11e7-9797-f0b2b93062db.png)
When I found this I took a look on a list of registered listeners and found that the couple of them are handling all events when it seems that there is absolutely no need in it.

Proposed solution is one of two possible solutions. Other one is to implement `ApplicationListener<ContextRefreshedEvent>` instead of `ApplicationListener<ApplicationEvent>`, but in this case subclasses of  `AbstractGrailsApplication` won't be able to handle other events.
In my solution there is no such problem because all methods can be overridden.

Proposed order is same to [default order](https://github.com/spring-projects/spring-framework/blob/master/spring-core/src/main/java/org/springframework/core/OrderComparator.java#L124) that is currently used for AbstractGrailsApplication.