### PR TITLE
Add LinkedHashSet to default collections for binding

### DIFF
--- a/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -447,6 +447,8 @@ class SimpleDataBinder implements DataBinder {
             val = []
         } else if (SortedSet.isAssignableFrom(type)) {
             val = new TreeSet()
+        } else if (LinkedHashSet.isAssignableFrom(type)) {
+            val = new LinkedHashSet()
         } else if (Collection.isAssignableFrom(type)) {
             val = new HashSet()
         }


### PR DESCRIPTION
This prevents non-existent LinkedHashSet collections from being instantiated as HashSets during data binding.