### PR TITLE
Remove delay in releasing from Travis

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -44,8 +44,6 @@ if [[ $EXIT_STATUS -eq 0 ]]; then
 
 	    if [[ $EXIT_STATUS == 0 ]]; then
 	        ./gradlew --stop
-	        # wait 30 seconds to ensure the previous promotion completes
-	        sleep 30
 	        ./gradlew --no-daemon -Psigning.keyId="$SIGNING_KEY" -Psigning.password="$SIGNING_PASSPHRASE" -Psigning.secretKeyRingFile="${TRAVIS_BUILD_DIR}/secring.gpg" grails-dependencies:uploadArchives grails-bom:uploadArchives || EXIT_STATUS=$?
 	        ./gradlew closeAndReleaseRepository
 	    fi


### PR DESCRIPTION
It should not be needed any longer after upgrade to gradle-nexus-staging-plugin 0.8.0
which waits for the close/release operations to effectively finish.