### PR TITLE
Switch oraclejdk7 to openjdk7 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: groovy
 sudo: false
 jdk:
-- oraclejdk7
+- openjdk7
 env:
   global:
   - TERM=dumb


### PR DESCRIPTION
Due to the issues with the latest Travis images.
https://github.com/travis-ci/travis-ci/issues/7884