### PR TITLE
Fix travis config to use the previous version of Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: groovy
+dist: precise
 jdk:
 - oraclejdk7
 env:


### PR DESCRIPTION
Due to an upgrade on the Travis CI environment the builds where broken because the JDK used was non exitent.
I've updated the config in travis.yml to use the previous version of the Travis image.