### PR TITLE
Fix for issue #10737: Error in maven-clean-plugin version

### DIFF
--- a/grails-resources/src/grails/templates/maven/binary-plugin.pom
+++ b/grails-resources/src/grails/templates/maven/binary-plugin.pom
@@ -85,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.2</version>
                 <configuration>
                     <filesets>
                         <fileset>

--- a/grails-resources/src/grails/templates/maven/project.pom
+++ b/grails-resources/src/grails/templates/maven/project.pom
@@ -137,7 +137,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
-                <version>2.4.0</version>
+                <version>2.4.2</version>
                 <configuration>
                     <filesets>
                         <fileset>


### PR DESCRIPTION
The version for the maven-clean-plugin in the files binary-plugin.pom and project.pom was unexistent so I upgraded them to a existing version.