### PR TITLE
Update DomainClass plugin to register a constraint evaluator bean that takes into account the default constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,7 @@ cache:
 notifications:
   slack:
     secure: WAto/v/ZBvlXxWTHUH6hONQ1uJZxVnUts1V7379hCViN5+DOfIbxzQAq+10SAgD6pa2BcQftpKIWr1/9RUZyK3oxE2mHbVUulkaVHNJJfz6oPD5pnCVMxE+ZuhkRuhkddGDBHpYaVw37QBkalLB0rE0h7Ddvo/gk9ICSQQLTlvE=
+addons:
+  hosts:
+    - grails
+  hostname: grails

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/DomainClassGrailsPlugin.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/DomainClassGrailsPlugin.groovy
@@ -19,9 +19,9 @@ import grails.core.GrailsApplication
 import grails.plugins.Plugin
 import grails.util.GrailsUtil
 import grails.validation.ConstraintsEvaluator
+import org.grails.plugins.domain.support.DefaultConstraintEvaluatorFactoryBean
 import org.grails.plugins.domain.support.DefaultMappingContextFactoryBean
 import org.grails.plugins.domain.support.ValidatorRegistryFactoryBean
-import org.grails.validation.DefaultConstraintEvaluator
 
 /**
  * Configures the domain classes in the spring context.
@@ -40,7 +40,7 @@ class DomainClassGrailsPlugin extends Plugin {
 
     Closure doWithSpring() {{->
         GrailsApplication application = grailsApplication
-        "${ConstraintsEvaluator.BEAN_NAME}"(DefaultConstraintEvaluator)
+        "${ConstraintsEvaluator.BEAN_NAME}"(DefaultConstraintEvaluatorFactoryBean)
         grailsDomainClassMappingContext(DefaultMappingContextFactoryBean, application, applicationContext)
         gormValidatorRegistry(ValidatorRegistryFactoryBean)
     }}

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/DomainClassGrailsPlugin.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/DomainClassGrailsPlugin.groovy
@@ -22,6 +22,7 @@ import grails.validation.ConstraintsEvaluator
 import org.grails.plugins.domain.support.DefaultConstraintEvaluatorFactoryBean
 import org.grails.plugins.domain.support.DefaultMappingContextFactoryBean
 import org.grails.plugins.domain.support.ValidatorRegistryFactoryBean
+import org.grails.validation.DefaultConstraintEvaluator
 
 /**
  * Configures the domain classes in the spring context.
@@ -40,7 +41,8 @@ class DomainClassGrailsPlugin extends Plugin {
 
     Closure doWithSpring() {{->
         GrailsApplication application = grailsApplication
-        "${ConstraintsEvaluator.BEAN_NAME}"(DefaultConstraintEvaluatorFactoryBean)
+        "${ConstraintsEvaluator.BEAN_NAME}"(DefaultConstraintEvaluator)
+        validateableConstraintsEvaluator(DefaultConstraintEvaluatorFactoryBean)
         grailsDomainClassMappingContext(DefaultMappingContextFactoryBean, application, applicationContext)
         gormValidatorRegistry(ValidatorRegistryFactoryBean)
     }}

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -33,7 +33,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
 
     @Override
     Class<?> getObjectType() {
-        DefaultConstraintEvaluator
+        ConstraintsEvaluator
     }
 
     @Override

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -1,0 +1,43 @@
+package org.grails.plugins.domain.support
+
+import grails.core.GrailsApplication
+import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
+import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
+import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
+import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.validation.ConstraintEvalUtils
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.MessageSource
+
+class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEvaluator> {
+
+    @Autowired
+    MessageSource messageSource
+
+    @Autowired
+    @Qualifier('grailsDomainClassMappingContext')
+    MappingContext grailsDomainClassMappingContext
+
+    @Autowired
+    GrailsApplication grailsApplication
+
+    @Override
+    ConstraintsEvaluator getObject() throws Exception {
+        ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
+
+        new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config))
+    }
+
+    @Override
+    Class<?> getObjectType() {
+        DefaultConstraintEvaluator
+    }
+
+    @Override
+    boolean isSingleton() {
+        true
+    }
+}

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -1,8 +1,8 @@
 package org.grails.plugins.domain.support
 
 import grails.core.GrailsApplication
-import grails.validation.ConstraintsEvaluator
-import org.grails.validation.DefaultConstraintEvaluator
+import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
+import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
 import org.grails.datastore.mapping.model.MappingContext
@@ -28,7 +28,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
     ConstraintsEvaluator getObject() throws Exception {
         ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
 
-        new DefaultConstraintEvaluator(new org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config)))
+        new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config))
     }
 
     @Override

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -1,8 +1,7 @@
 package org.grails.plugins.domain.support
 
 import grails.core.GrailsApplication
-import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator
-import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
+import grails.validation.ConstraintsEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
 import org.grails.datastore.mapping.model.MappingContext
@@ -28,7 +27,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
     ConstraintsEvaluator getObject() throws Exception {
         ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
 
-        new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config))
+        new org.grails.validation.DefaultConstraintEvaluator(new org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config)))
     }
 
     @Override

--- a/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -2,6 +2,7 @@ package org.grails.plugins.domain.support
 
 import grails.core.GrailsApplication
 import grails.validation.ConstraintsEvaluator
+import org.grails.validation.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
 import org.grails.datastore.mapping.model.MappingContext
@@ -27,7 +28,7 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
     ConstraintsEvaluator getObject() throws Exception {
         ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
 
-        new org.grails.validation.DefaultConstraintEvaluator(new org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config)))
+        new DefaultConstraintEvaluator(new org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config)))
     }
 
     @Override


### PR DESCRIPTION
Note the actual implementation changed from `org.grails.validation.DefaultConstraintEvaluator` to `org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator`, which may be considered a breaking change.