### PR TITLE
Issue #10820: Use environment variable GRAILS_ENV when system property not set

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -63,6 +63,11 @@ public enum Environment {
      * Constant used to resolve the environment via System.getProperty(Environment.KEY)
      */
     public static String KEY = "grails.env";
+    
+    /**
+     * Constant used to resolve the environment via System.getenv(Environment.ENV_KEY).
+     */
+    public static final String ENV_KEY = "GRAILS_ENV";
 
     /**
      * The name of the GRAILS_HOME environment variable
@@ -260,7 +265,8 @@ public enum Environment {
      * @return The current environment.
      */
     public static Environment getCurrent() {
-        String envName = System.getProperty(Environment.KEY);
+        String envName = getEnvironment();
+
         Environment env;
         if(!isBlank(envName)) {
             env = getEnvironment(envName);
@@ -278,7 +284,7 @@ public enum Environment {
     }
 
     private static Environment resolveCurrentEnvironment() {
-        String envName = System.getProperty(Environment.KEY);
+        String envName = getEnvironment();
 
         if (isBlank(envName)) {
             Metadata metadata = Metadata.getCurrent();
@@ -417,7 +423,7 @@ public enum Environment {
      * @return Return true if the environment has been set as a System property
      */
     public static boolean isSystemSet() {
-        return System.getProperty(KEY) != null;
+        return getEnvironment() != null;
     }
 
     /**
@@ -708,5 +714,10 @@ public enum Environment {
         return location;
     }
 
+    private static String getEnvironment() {
+        String envName = System.getProperty(Environment.KEY);
+        
+        return isBlank(envName) ? System.getenv(Environment.ENV_KEY) : envName;
+    }
 
 }

--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -716,7 +716,6 @@ public enum Environment {
 
     private static String getEnvironment() {
         String envName = System.getProperty(Environment.KEY);
-        
         return isBlank(envName) ? System.getenv(Environment.ENV_KEY) : envName;
     }
 


### PR DESCRIPTION
Updated Environment to check System.getenv("GRAILS_ENV") if System.getProperty("grails.env") returns null.