### PR TITLE
Update Tomcat to 8.5.23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ ext {
     cglibVersion = "2.2.2"
     objenesisVersion = "1.4"
     tomcatVersion = "8.5.23"
+    tomcatLog4jVersion = "8.5.2"
     servletApiVersion = "3.0.1"
 
     isJava8Compatible = org.gradle.api.JavaVersion.current().isJava8Compatible()

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     concurrentlinkedhashmapVersion = "1.4.2"
     cglibVersion = "2.2.2"
     objenesisVersion = "1.4"
-    tomcatVersion = "8.5.2"
+    tomcatVersion = "8.5.23"
     servletApiVersion = "3.0.1"
 
     isJava8Compatible = org.gradle.api.JavaVersion.current().isJava8Compatible()

--- a/grails-plugin-datasource/build.gradle
+++ b/grails-plugin-datasource/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     }
 
     compile "org.apache.tomcat:tomcat-jdbc:$tomcatVersion"
-    runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatVersion"
+    runtime "org.apache.tomcat.embed:tomcat-embed-logging-log4j:$tomcatLog4jVersion"
 
     compile project(":grails-core")
 }


### PR DESCRIPTION
Update to the latest 8.5 version of tomcat.

RCE was reported in older versions of tomcat:
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-12617

If you want to update your app without waiting for the next release of Grails you can add this to your `build.gradle` file:
`ext['tomcat.version']='8.5.23' `