### PR TITLE
Default to null namespace

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -257,7 +257,7 @@ class UrlMappingTagLib implements TagLibrary{
 
         def property = attrs.remove("property")
         def action = attrs.action ? attrs.remove("action") : (actionName ?: "list")
-        def namespace = attrs.namespace ? attrs.remove("namespace") : ""
+        def namespace = attrs.remove("namespace")
 
         def defaultOrder = attrs.remove("defaultOrder")
         if (defaultOrder != "desc") defaultOrder = "asc"


### PR DESCRIPTION
Fixes https://github.com/grails/grails-core/issues/10819

The `DefaultLinkGenerator` does not check for groovy truth but for a namespace with null value: 

https://github.com/grails/grails-core/blob/master/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultLinkGenerator.groovy#L249