### PR TITLE
Add Mac OS X Native File Watcher Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ ext {
     spockVersion = '1.0-groovy-2.4'
     springBootVersion = "1.4.6.RELEASE"
     springLoadedVersion = "1.2.8.RELEASE"
+    directoryWatcherVersion = "0.3.0"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
     springVersion = "4.3.9.RELEASE"
     ehcacheVersion = "2.4.6"

--- a/grails-bom/build.gradle
+++ b/grails-bom/build.gradle
@@ -158,6 +158,12 @@ publishing {
                             }
 
                             mkp.dependency {
+                                mkp.groupId 'io.methvin'
+                                mkp.artifactId "directory-watcher"
+                                mkp.version(directoryWatcherVersion) //0.3.0
+                            }
+
+                            mkp.dependency {
                                 mkp.groupId 'org.springframework'
                                 mkp.artifactId "springloaded"
                                 mkp.version( springLoadedVersion )

--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     compile ( "org.codehaus.groovy:groovy-xml:$groovyVersion" )
     compile ( "org.codehaus.groovy:groovy-templates:$groovyVersion" )
     compile "org.yaml:snakeyaml:1.14"
-    compile "io.methvin:directory-watcher:0.3.0" //TODO: Needs JNA to run
-
+    
+    compileOnly("io.methvin:directory-watcher:0.3.0")
     compileOnly("org.fusesource.jansi:jansi:$jansiVersion")
     compileOnly("jline:jline:$jlineVersion")
     compileOnly("net.java.dev.jna:jna:$jnaVersion")

--- a/grails-bootstrap/build.gradle
+++ b/grails-bootstrap/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     compile ( "org.codehaus.groovy:groovy-xml:$groovyVersion" )
     compile ( "org.codehaus.groovy:groovy-templates:$groovyVersion" )
     compile "org.yaml:snakeyaml:1.14"
+    compile "io.methvin:directory-watcher:0.3.0" //TODO: Needs JNA to run
 
     compileOnly("org.fusesource.jansi:jansi:$jansiVersion")
     compileOnly("jline:jline:$jlineVersion")

--- a/grails-bootstrap/src/main/groovy/org/grails/io/watch/DirectoryWatcher.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/io/watch/DirectoryWatcher.java
@@ -44,7 +44,22 @@ public class DirectoryWatcher extends Thread {
         setDaemon(true);
         AbstractDirectoryWatcher directoryWatcherDelegate;
         try {
-			directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.grails.io.watch.WatchServiceDirectoryWatcher").newInstance();
+            if(System.getProperty("os.name").equals("Mac OS X")) {
+                Boolean jnaAvailable = false;
+                try {
+                    Class.forName( "com.sun.jna.Pointer" );
+                    jnaAvailable = true;
+                } catch( ClassNotFoundException e ) {
+                    LOG.error("Error Initializing Native OS X File Event Watcher. Add JNA to classpath for Faster File Watching performance.");
+                }
+                if(jnaAvailable) {
+                    directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.grails.io.watch.MacOsWatchServiceDirectoryWatcher").newInstance();
+                } else {
+                    directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.grails.io.watch.WatchServiceDirectoryWatcher").newInstance();                    
+                }
+            } else {
+                directoryWatcherDelegate = (AbstractDirectoryWatcher) Class.forName("org.grails.io.watch.WatchServiceDirectoryWatcher").newInstance();                
+            }
 		} catch (Throwable e) {
 			LOG.info("Exception while trying to load WatchServiceDirectoryWatcher (this is probably Java 6 and WatchService isn't available). Falling back to PollingDirectoryWatcher.", e);
 	        directoryWatcherDelegate = new PollingDirectoryWatcher();

--- a/grails-bootstrap/src/main/groovy/org/grails/io/watch/MacOsWatchServiceDirectoryWatcher.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/io/watch/MacOsWatchServiceDirectoryWatcher.java
@@ -1,0 +1,180 @@
+package org.grails.io.watch;
+
+import java.nio.file.WatchEvent.Kind;
+import io.methvin.watchservice.MacOSXListeningWatchService;
+import io.methvin.watchservice.WatchablePath;
+import static io.methvin.watcher.DirectoryChangeEvent.EventType.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of a {@link AbstractDirectoryWatcher} that uses {@link java.nio.WatchService}.
+ * This implementation is used for Java 7 and later.
+ * @author Eric Helgeson
+ * @author David Estes
+ * @since 3.2
+ * @see DirectoryWatcher
+ */
+class MacOsWatchServiceDirectoryWatcher extends AbstractDirectoryWatcher {
+
+	private static final Logger LOG = LoggerFactory.getLogger(MacOsWatchServiceDirectoryWatcher.class);
+    private Map<WatchKey, List<String>> watchKeyToExtensionsMap = new ConcurrentHashMap<WatchKey, List<String>>();
+    private Set<Path> individualWatchedFiles = new HashSet<Path>();
+
+	private final WatchService watchService;
+
+    @SuppressWarnings("unchecked")
+    private static <T> WatchEvent<T> cast(WatchEvent<?> event) {
+        return (WatchEvent<T>)event;
+    }
+
+	public MacOsWatchServiceDirectoryWatcher(){
+		try {
+			watchService = new MacOSXListeningWatchService();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void run() {
+        while (active) {
+			try {
+                WatchKey watchKey;
+                try {
+                    watchKey = watchService.take();
+                } catch (InterruptedException x) {
+                    return;
+                }
+                for (WatchEvent<?> watchEvent : watchKey.pollEvents()) {
+                    WatchEvent.Kind<?> kind = watchEvent.kind();
+                    if (kind == StandardWatchEventKinds.OVERFLOW) {
+                        // TODO how is this supposed to be handled? I think the best thing to do is ignore it, but I'm not positive
+                        LOG.warn("WatchService Overflow occurred");
+                        continue;
+                    }
+                    WatchEvent<Path> pathWatchEvent = cast(watchEvent);
+                    Path child = pathWatchEvent.context();
+                    File childFile = child.toFile();
+                    if(individualWatchedFiles.contains(child) || individualWatchedFiles.contains(child.normalize())){
+                        if(kind == StandardWatchEventKinds.ENTRY_CREATE){
+                            fireOnNew(childFile);
+                        }else if(kind == StandardWatchEventKinds.ENTRY_MODIFY){
+                            fireOnChange(childFile);
+                        }else if(kind == StandardWatchEventKinds.ENTRY_DELETE){
+                            // do nothing... there's no way to communicate deletions
+                        }
+                    }else{
+                        List<String> fileExtensions = watchKeyToExtensionsMap.get(watchKey);
+                        if(fileExtensions==null){
+                            // this event didn't match a file in individualWatchedFiles so it's a not an individual file we're interested in
+                            // this event also didn't match a directory that we're interested in (if it did, fileExtentions wouldn't be null)
+                            // so it must be event for a file we're not interested in. An example of how this can happen is:
+                            // there's a directory with files in it like this:
+                            // /images/a.png
+                            // /images/b.png
+                            // by using the addWatchFile method, /images/a.png is watched.
+                            // Now, /images/b.png is changed. Because java.nio.file.WatchService watches directories, it gets a WatchEvent
+                            // for /images/b.png. But we aren't interested in that.
+                            LOG.debug("WatchService received an event for a file/directory that it's not interested in.");
+                        }else{
+                            if(kind==StandardWatchEventKinds.ENTRY_CREATE){
+                                // new directory created, so watch its contents
+                                addWatchDirectory(child,fileExtensions);
+                                if(childFile.isDirectory() && childFile.exists()) {
+                                    final File[] files = childFile.listFiles();
+                                    if(files != null) {
+                                        for (File newFile : files) {
+                                            if(isValidFileToMonitor(newFile, fileExtensions)) {
+                                                fireOnNew(newFile);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if(isValidFileToMonitor(childFile,fileExtensions)){
+                                if(kind == StandardWatchEventKinds.ENTRY_CREATE){
+                                    fireOnNew(childFile);
+                                }else if(kind == StandardWatchEventKinds.ENTRY_MODIFY){
+                                    fireOnChange(childFile);
+                                }else if(kind == StandardWatchEventKinds.ENTRY_DELETE){
+                                    // do nothing... there's no way to communicate deletions
+                                }
+                            }
+                        }
+                    }
+                }
+                watchKey.reset();
+			} catch (Exception e) {
+                LOG.error(e.toString());
+                // ignore
+			}
+        }
+        try {
+			watchService.close();
+		} catch (IOException e) {
+			LOG.debug("Exception while closing watchService", e);
+		}
+	}
+
+	@Override
+	public void addWatchFile(File fileToWatch) {
+		if(!isValidFileToMonitor(fileToWatch, Arrays.asList("*"))) return;
+		try {
+            if(!fileToWatch.exists()) return;
+			Path pathToWatch = fileToWatch.toPath().toAbsolutePath();
+			individualWatchedFiles.add(pathToWatch);
+            WatchablePath watchPath = new WatchablePath(pathToWatch);
+			Kind[] events = new Kind[] { StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY };
+			watchPath.register(watchService, events);
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void addWatchDirectory(File dir, final List<String> fileExtensions) {
+		Path dirPath = dir.toPath();
+		addWatchDirectory(dirPath, fileExtensions);
+	}
+
+	private void addWatchDirectory(Path dir, final List<String> fileExtensions) {
+		if(!isValidDirectoryToMonitor(dir.toFile())){
+			return;
+		}
+		try {
+			//add the subdirectories too
+			Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+	            @Override
+	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+	                throws IOException
+	            {
+	            	if(!isValidDirectoryToMonitor(dir.toFile())){
+	            		return FileVisitResult.SKIP_SUBTREE;
+	            	}
+                    WatchablePath watchPath = new WatchablePath(dir);
+	            	Kind[] events = new Kind[] { StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY };
+					WatchKey watchKey = watchPath.register(watchService, events);
+	    			final List<String> originalFileExtensions = watchKeyToExtensionsMap.get(watchKey);
+	    			if(originalFileExtensions==null){
+	    				watchKeyToExtensionsMap.put(watchKey, fileExtensions);
+	    			}else{
+	    				final HashSet<String> newFileExtensions = new HashSet<String>(originalFileExtensions);
+	    				newFileExtensions.addAll(fileExtensions);
+	    				watchKeyToExtensionsMap.put(watchKey, Collections.unmodifiableList(new ArrayList(newFileExtensions)));
+	    			}
+	                return FileVisitResult.CONTINUE;
+	            }
+	        });
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -474,7 +474,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
             project.dependencies {
                 agent "org.springframework:springloaded"
-                runtime "io.methvin:directory-watcher"
+                agent "io.methvin:directory-watcher"
             }
             project.afterEvaluate(new AgentTasksEnhancer())
         }

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -474,6 +474,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
             project.dependencies {
                 agent "org.springframework:springloaded"
+                runtime "io.methvin:directory-watcher"
             }
             project.afterEvaluate(new AgentTasksEnhancer())
         }


### PR DESCRIPTION
Implements a new Native OS X File Watcher using JNA via a plugin called `directory-watcher` to listen to Carbon API File Events instead of polling for file modified information. This improves file watching performance on large projects when developing in OS X Signficantly..

@erichelgeson did most of the grunt work getting this tested out and digging into it.

**Sources:**
(https://github.com/gmethvin/directory-watcher)[https://github.com/gmethvin/directory-watcher]

**Requirements:**
Currently this library (directory-watcher) does require jna to be in the runtime classpath and not build time only for use of the `jna.Pointer` classes among other things. These are explicitly excluded in the grails core gradle dependencies so do not propagate forward. This PR will gracefully degrade if jna is not on the classpath.


