### PR TITLE
Upgrade React profile, added React-Webpack profile

### DIFF
--- a/grails-bom/profiles.properties
+++ b/grails-bom/profiles.properties
@@ -8,5 +8,6 @@ web-jboss7=1.0.0.RC2
 web=3.3.0
 profile=3.3.0
 angular=4.0.1
-react=2.0.3
+react=2.1.0
+react-webpack=1.0.0
 webpack=1.1.2


### PR DESCRIPTION
React-Webpack was formerly the "1.x" branch of the React profile. This change is to allow users to specify either version of the profile by name when creating a project (rather than having to include the full artifact group/name/version). In addition both profiles have been upgraded to React 16.x.