### PR TITLE
propName parameter is not used in AbstractGrailsClass.getPropertyValue(...)

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/AbstractGrailsClass.java
+++ b/grails-core/src/main/groovy/org/grails/core/AbstractGrailsClass.java
@@ -247,7 +247,7 @@ public abstract class AbstractGrailsClass implements GrailsClass {
      * @return The property value or null
      */
     public <T> T getPropertyValue(String propName, Class<T> type) {
-        return ClassPropertyFetcher.getStaticPropertyValue(getClazz(), name, type);
+        return ClassPropertyFetcher.getStaticPropertyValue(getClazz(), propName, type);
     }
 
 


### PR DESCRIPTION
**propName** parameter is not used in **AbstractGrailsClass.getPropertyValue(String propName, Class type)**