### PR TITLE
Excluding a URI from an interceptor

### DIFF
--- a/grails-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grails-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -33,9 +33,9 @@ import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
 import org.grails.web.servlet.mvc.exceptions.ControllerExecutionException
 import org.grails.web.servlet.view.CompositeViewResolver
 import org.grails.web.util.GrailsApplicationAttributes
-import org.grails.web.util.WebUtils
 import org.springframework.core.Ordered
 import org.springframework.web.servlet.ModelAndView
+
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -90,9 +90,15 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
 
         UrlMappingInfo grailsMappingInfo = (UrlMappingInfo)matchedInfo
 
-        for(Matcher matcher in allMatchers) {
-            if(matcher.doesMatch(uri, grailsMappingInfo, req.method) ||
-               (checkNoCtxUri && matcher.doesMatch(noCtxUri, grailsMappingInfo, req.method))) {
+        for (Matcher matcher in allMatchers) {
+            boolean matchUri = matcher.doesMatch(uri, grailsMappingInfo, req.method)
+            boolean matchNoCtxUri = matcher.doesMatch(noCtxUri, grailsMappingInfo, req.method)
+
+            if (matcher.isExclude()) {
+                // Exclude interceptors are special because with only one of the conditions being false the interceptor
+                // won't be applied to the request
+                return matchUri && matchNoCtxUri
+            } else if (matchUri || (checkNoCtxUri && matchNoCtxUri)) {
                 return true
             }
         }

--- a/grails-plugin-interceptors/src/main/groovy/grails/interceptors/Matcher.groovy
+++ b/grails-plugin-interceptors/src/main/groovy/grails/interceptors/Matcher.groovy
@@ -84,4 +84,9 @@ interface Matcher {
      * @return This matcher
      */
     Matcher excludes(@DelegatesTo(Interceptor) Closure<Boolean> condition)
+
+    /**
+     * Checks whether the current matcher is a exclude matcher or not
+     */
+    boolean isExclude()
 }

--- a/grails-plugin-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
+++ b/grails-plugin-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
@@ -17,16 +17,12 @@ package org.grails.plugins.web.interceptors
 
 import grails.artefact.Interceptor
 import grails.interceptors.Matcher
-import grails.util.Environment
 import grails.web.mapping.UrlMappingInfo
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.util.HashCodeHelper
 import org.springframework.util.AntPathMatcher
 
-import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
-
-
 
 /**
  * Used to match {@link UrlMappingInfo} instance by {@link grails.artefact.Interceptor} instances
@@ -151,6 +147,11 @@ class UrlMappingMatcher implements Matcher {
     Matcher excludes(Closure<Boolean> condition) {
         excludes << new ClosureExclude(interceptor, condition)
         return this
+    }
+
+    @Override
+    boolean isExclude() {
+        return excludes || uriExcludePatterns
     }
 
     private Pattern regexMatch(Map arguments, String type, Pattern defaultPattern = WILD_CARD_PATTERN) {

--- a/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -25,11 +25,10 @@ import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.request.RequestContextHolder
+import spock.lang.Issue
 import spock.lang.Specification
 
 import javax.servlet.http.HttpServletRequest
-
-
 /**
  * @author graemerocher
  */
@@ -253,6 +252,46 @@ class InterceptorSpec extends Specification {
     void clearMatch(i, HttpServletRequest request) {
         request.removeAttribute(i.getClass().name + InterceptorArtefactHandler.MATCH_SUFFIX)
     }
+
+    @Issue('10857')
+    void "Test match excluding uri and with context path and interceptor without context path"() {
+        given: "A test interceptor"
+        def i = new TestExcludeUriWithoutContextPathInterceptor()
+        def mockRequest = new MockHttpServletRequest("", requestUri)
+        mockRequest.setContextPath('/grails')
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
+        def request = webRequest.request
+
+        expect: "We match: ${shouldMatch}"
+        i.doesMatch() == shouldMatch
+
+        where:
+        requestUri            | shouldMatch
+        '/grails/mgmt/health' | false
+        '/grails'             | true
+        '/grails/foo'         | true
+        '/grails/foo/x'       | true
+    }
+
+    @Issue('10857')
+    void "Test match excluding uri and with context path and interceptor with context path"() {
+        given: "A test interceptor"
+        def i = new TestExcludeUriWithContextPathInterceptor()
+        def mockRequest = new MockHttpServletRequest("", requestUri)
+        mockRequest.setContextPath('/grails')
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
+        def request = webRequest.request
+
+        expect: "We match: ${shouldMatch}"
+        i.doesMatch() == shouldMatch
+
+        where:
+        requestUri            | shouldMatch
+        '/grails/mgmt/health' | false
+        '/grails'             | true
+        '/grails/foo'         | true
+        '/grails/foo/x'       | true
+    }
 }
 
 class TestInterceptor implements Interceptor {
@@ -312,5 +351,17 @@ class TestContextUriInterceptor implements Interceptor {
         match(uri: '/grails/bar/**')
         match(uri: '/grails/foo')
         match(uri: '/grails/foo/bar')
+    }
+}
+
+class TestExcludeUriWithoutContextPathInterceptor implements Interceptor {
+    TestExcludeUriWithoutContextPathInterceptor() {
+        matchAll().excludes(uri: "/mgmt/*")
+    }
+}
+
+class TestExcludeUriWithContextPathInterceptor implements Interceptor {
+    TestExcludeUriWithContextPathInterceptor() {
+        matchAll().excludes(uri: "/grails/mgmt/*")
     }
 }

--- a/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -17,10 +17,8 @@ package grails.artefact
 
 import grails.util.GrailsWebMockUtil
 import org.grails.plugins.web.interceptors.InterceptorArtefactHandler
-import org.grails.web.mapping.DefaultUrlMappingInfo
 import org.grails.web.mapping.ForwardUrlMappingInfo
 import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
-import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
@@ -247,6 +245,46 @@ class InterceptorSpec extends Specification {
         '/grails/foo'     | true
         '/grails/foo/x'   | false
         '/grails/foo/bar' | true
+    }
+
+    @Issue('10857')
+    void "Test match excluding uri and with context path and interceptor without context path"() {
+        given: "A test interceptor"
+        def i = new TestExcludeUriWithoutContextPathInterceptor()
+        def mockRequest = new MockHttpServletRequest("", requestUri)
+        mockRequest.setContextPath('/grails')
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
+        def request = webRequest.request
+
+        expect: "We match: ${shouldMatch}"
+        i.doesMatch() == shouldMatch
+
+        where:
+        requestUri            | shouldMatch
+        '/grails/mgmt/health' | false
+        '/grails'             | true
+        '/grails/foo'         | true
+        '/grails/foo/x'       | true
+    }
+
+    @Issue('10857')
+    void "Test match excluding uri and with context path and interceptor with context path"() {
+        given: "A test interceptor"
+        def i = new TestExcludeUriWithContextPathInterceptor()
+        def mockRequest = new MockHttpServletRequest("", requestUri)
+        mockRequest.setContextPath('/grails')
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
+        def request = webRequest.request
+
+        expect: "We match: ${shouldMatch}"
+        i.doesMatch() == shouldMatch
+
+        where:
+        requestUri            | shouldMatch
+        '/grails/mgmt/health' | false
+        '/grails'             | true
+        '/grails/foo'         | true
+        '/grails/foo/x'       | true
     }
 
     void clearMatch(i, HttpServletRequest request) {

--- a/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -290,46 +290,6 @@ class InterceptorSpec extends Specification {
     void clearMatch(i, HttpServletRequest request) {
         request.removeAttribute(i.getClass().name + InterceptorArtefactHandler.MATCH_SUFFIX)
     }
-
-    @Issue('10857')
-    void "Test match excluding uri and with context path and interceptor without context path"() {
-        given: "A test interceptor"
-        def i = new TestExcludeUriWithoutContextPathInterceptor()
-        def mockRequest = new MockHttpServletRequest("", requestUri)
-        mockRequest.setContextPath('/grails')
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
-        def request = webRequest.request
-
-        expect: "We match: ${shouldMatch}"
-        i.doesMatch() == shouldMatch
-
-        where:
-        requestUri            | shouldMatch
-        '/grails/mgmt/health' | false
-        '/grails'             | true
-        '/grails/foo'         | true
-        '/grails/foo/x'       | true
-    }
-
-    @Issue('10857')
-    void "Test match excluding uri and with context path and interceptor with context path"() {
-        given: "A test interceptor"
-        def i = new TestExcludeUriWithContextPathInterceptor()
-        def mockRequest = new MockHttpServletRequest("", requestUri)
-        mockRequest.setContextPath('/grails')
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
-        def request = webRequest.request
-
-        expect: "We match: ${shouldMatch}"
-        i.doesMatch() == shouldMatch
-
-        where:
-        requestUri            | shouldMatch
-        '/grails/mgmt/health' | false
-        '/grails'             | true
-        '/grails/foo'         | true
-        '/grails/foo/x'       | true
-    }
 }
 
 class TestInterceptor implements Interceptor {


### PR DESCRIPTION
This is still a work in progress but it pretends to fix #10857. I've added two new test cases that are failing.

I've been trying to modify https://github.com/grails/grails-core/blob/3.3.x/grails-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy#L94-L95 without luck. Once I fix these new tests other existing test start failing.
The main issue is that the actual code checks for both the pattern and the URI with and without the application context, so at least one of those checks makes the interceptor not being excluded for this particular new test case.

@jameskleeh I would really appreciate if you have some time to guide me here.