### PR TITLE
Fix get multipartFiles from parts of GrailsMockHttpServletRequest

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequestSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequestSpec.groovy
@@ -1,13 +1,12 @@
 package org.grails.plugins.testing
 
 import grails.converters.XML
-
 import grails.core.DefaultGrailsApplication
-import org.grails.plugins.testing.GrailsMockHttpServletRequest
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
-
 import spock.lang.Issue
 import spock.lang.Specification
+
+import javax.servlet.http.Part
 
 class GrailsMockHttpServletRequestSpec extends Specification {
     @Issue("GRAILS-11493")
@@ -40,5 +39,21 @@ class GrailsMockHttpServletRequestSpec extends Specification {
 
         then: 'the content is no longer available'
         null == result
+    }
+
+    def 'gets multipartFiles from parts of request'() {
+        given:
+        GrailsMockMultipartFile aFile = new GrailsMockMultipartFile('aFile', 'content of a file'.bytes)
+        GrailsMockMultipartFile anotherFile = new GrailsMockMultipartFile('anotherFile', 'content of another file'.bytes)
+
+        GrailsMockHttpServletRequest request = new GrailsMockHttpServletRequest()
+        request.addFile(aFile)
+        request.addFile(anotherFile)
+
+        when:
+        List<Part> parts = request.parts
+
+        then:
+        parts.file == [aFile, anotherFile]
     }
 }

--- a/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -409,7 +409,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
     }
 
     Collection<Part> getParts() {
-        getFileMap().values().collect {new MockPart(it)}
+        getFileMap().values().flatten().collect {new MockPart(it)}
     }
 
     Part getPart(String name) {


### PR DESCRIPTION
Fix get parts from GrailsMockHttpServletRequest.

Reproduce:
Add the next test to `grails-test-suite-uber/src/test/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequestSpec.groovyGrailsMockHttpServletRequestSpec`:
```
def 'gets multipartFiles from parts of request'() {
        given:
        GrailsMockMultipartFile aFile = new GrailsMockMultipartFile('aFile', 'content of a file'.bytes)
        GrailsMockMultipartFile anotherFile = new GrailsMockMultipartFile('anotherFile', 'content of another file'.bytes)

        GrailsMockHttpServletRequest request = new GrailsMockHttpServletRequest()
        request.addFile(aFile)
        request.addFile(anotherFile)

        when:
        List<Part> parts = request.parts

        then:
        parts.file == [aFile, anotherFile]
    }
```
Run tests and obtain GroovyRuntimeException:
```
groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.grails.plugins.testing.MockPart(java.util.LinkedList)
	at org.grails.plugins.testing.GrailsMockHttpServletRequest.getParts_closure2(GrailsMockHttpServletRequest.groovy:412)
	at groovy.lang.Closure.call(Closure.java:414)
	at groovy.lang.Closure.call(Closure.java:430)
	at org.grails.plugins.testing.GrailsMockHttpServletRequest.getParts(GrailsMockHttpServletRequest.groovy:412)
	at groovy.lang.MetaBeanProperty.getProperty(MetaBeanProperty.java:59)
	at org.grails.plugins.testing.GrailsMockHttpServletRequest.getProperty(GrailsMockHttpServletRequest.groovy:207)
	at org.grails.plugins.testing.GrailsMockHttpServletRequestSpec.gets multipartFiles from parts of request(GrailsMockHttpServletRequestSpec.groovy:54)
```