### PR TITLE
Keep the 'dot' properties when using urlConverter

### DIFF
--- a/grails-core/src/main/groovy/grails/web/CamelCaseUrlConverter.java
+++ b/grails-core/src/main/groovy/grails/web/CamelCaseUrlConverter.java
@@ -18,6 +18,7 @@ package grails.web;
 import grails.util.GrailsNameUtils;
 import org.springframework.util.StringUtils;
 
+
 /**
  * URL converter that allows for camel case URLs
  *
@@ -32,7 +33,16 @@ public class CamelCaseUrlConverter implements UrlConverter {
         }
 
         if (propertyOrClassName.contains(".")) {
-            return GrailsNameUtils.getFullClassName(propertyOrClassName);
+            String[] parts = propertyOrClassName.split("\\.");
+            StringBuilder buffer = new StringBuilder();
+            int last = parts.length - 1;
+            for (int i = 0; i < parts.length; i++) {
+                buffer.append(GrailsNameUtils.getPropertyName(parts[i]));
+                if (i < last) {
+                    buffer.append(".");
+                }
+            }
+            return buffer.toString();
         } else {
             return GrailsNameUtils.getPropertyName(propertyOrClassName);
         }

--- a/grails-core/src/main/groovy/grails/web/CamelCaseUrlConverter.java
+++ b/grails-core/src/main/groovy/grails/web/CamelCaseUrlConverter.java
@@ -30,6 +30,11 @@ public class CamelCaseUrlConverter implements UrlConverter {
         if (!StringUtils.hasText(propertyOrClassName)) {
             return propertyOrClassName;
         }
-        return GrailsNameUtils.getPropertyName(propertyOrClassName);
+
+        if (propertyOrClassName.contains(".")) {
+            return GrailsNameUtils.getFullClassName(propertyOrClassName);
+        } else {
+            return GrailsNameUtils.getPropertyName(propertyOrClassName);
+        }
     }
 }

--- a/grails-core/src/main/groovy/grails/web/HyphenatedUrlConverter.java
+++ b/grails-core/src/main/groovy/grails/web/HyphenatedUrlConverter.java
@@ -33,15 +33,17 @@ public class HyphenatedUrlConverter implements UrlConverter {
 
         StringBuilder builder = new StringBuilder();
         char[] charArray = propertyOrClassName.toCharArray();
+        char lastChar = ' ';
         for (char c : charArray) {
             if (Character.isUpperCase(c)) {
-                if (builder.length() > 0) {
+                if (builder.length() > 0 && lastChar != '.') {
                     builder.append('-');
                 }
                 builder.append(Character.toLowerCase(c));
             } else {
                 builder.append(c);
             }
+            lastChar = c;
         }
         return builder.toString();
     }

--- a/grails-core/src/test/groovy/grails/web/CamelCaseUrlConverterSpec.groovy
+++ b/grails-core/src/test/groovy/grails/web/CamelCaseUrlConverterSpec.groovy
@@ -29,7 +29,8 @@ class CamelCaseUrlConverterSpec extends Specification {
             'myURLHelper'          | 'myURLHelper'
             'MYUrlHelper'          | 'MYUrlHelper'
             'myNamespace.v1'       | 'myNamespace.v1'
-            'MyNamespace.v1'       | 'MyNamespace.v1'
+            'MyNamespace.v1'       | 'myNamespace.v1'
+            'MyNamespace.V1'       | 'myNamespace.v1'
             ''                     | ''
             null                   | null
     }

--- a/grails-core/src/test/groovy/grails/web/CamelCaseUrlConverterSpec.groovy
+++ b/grails-core/src/test/groovy/grails/web/CamelCaseUrlConverterSpec.groovy
@@ -28,6 +28,8 @@ class CamelCaseUrlConverterSpec extends Specification {
             'MyURLHelper'          | 'myURLHelper'
             'myURLHelper'          | 'myURLHelper'
             'MYUrlHelper'          | 'MYUrlHelper'
+            'myNamespace.v1'       | 'myNamespace.v1'
+            'MyNamespace.v1'       | 'MyNamespace.v1'
             ''                     | ''
             null                   | null
     }

--- a/grails-core/src/test/groovy/grails/web/HyphenatedUrlConverterSpec.groovy
+++ b/grails-core/src/test/groovy/grails/web/HyphenatedUrlConverterSpec.groovy
@@ -30,6 +30,7 @@ class HyphenatedUrlConverterSpec extends Specification {
             'MYUrlHelper'          | 'm-y-url-helper'
             'myNamespace.v1'       | 'my-namespace.v1'
             'MyNamespace.v1'       | 'my-namespace.v1'
+            'MyNamespace.V1'       | 'my-namespace.v1'
             ''                     | ''
             null                   | null
     }

--- a/grails-core/src/test/groovy/grails/web/HyphenatedUrlConverterSpec.groovy
+++ b/grails-core/src/test/groovy/grails/web/HyphenatedUrlConverterSpec.groovy
@@ -28,6 +28,8 @@ class HyphenatedUrlConverterSpec extends Specification {
             'MyURLHelper'          | 'my-u-r-l-helper'
             'myURLHelper'          | 'my-u-r-l-helper'
             'MYUrlHelper'          | 'm-y-url-helper'
+            'myNamespace.v1'       | 'my-namespace.v1'
+            'MyNamespace.v1'       | 'my-namespace.v1'
             ''                     | ''
             null                   | null
     }


### PR DESCRIPTION
This is a fix for #10904 but I'm not sure this is how we should really fix it because maybe there are some collateral effects and actually we're not converting the `property` to camel case for the "dot" properties.

I think that it should be better to keep the `namespace` without modification here:
https://github.com/grails/grails-core/blob/3.3.x/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy#L133

Changing that line to:
```
def namespace = controller.namespace
```
because `namespace` is something "internal" that it is not exposed to the user.

What do you think @graemerocher @jameskleeh? 