### PR TITLE
Allow define httpMethods as arbitrary parameters in url mappings

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -18,7 +18,6 @@ package org.grails.web.mapping;
 import grails.core.GrailsApplication;
 import grails.core.GrailsControllerClass;
 import grails.core.support.ClassLoaderAware;
-import grails.gorm.validation.Constrained;
 import grails.gorm.validation.ConstrainedProperty;
 import grails.gorm.validation.DefaultConstrainedProperty;
 import grails.io.IOUtils;
@@ -30,7 +29,12 @@ import grails.web.mapping.UrlMappingData;
 import grails.web.mapping.UrlMappingEvaluator;
 import grails.web.mapping.UrlMappingParser;
 import grails.web.mapping.exceptions.UrlMappingException;
-import groovy.lang.*;
+import groovy.lang.Binding;
+import groovy.lang.Closure;
+import groovy.lang.GroovyClassLoader;
+import groovy.lang.GroovyObject;
+import groovy.lang.GroovyObjectSupport;
+import groovy.lang.Script;
 import org.codehaus.groovy.runtime.IOGroovyMethods;
 import org.grails.datastore.gorm.validation.constraints.builder.ConstrainedPropertyBuilder;
 import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator;
@@ -54,7 +58,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>A UrlMapping evaluator that evaluates Groovy scripts that are in the form:</p>
@@ -363,6 +375,14 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             getMetaMappingInfo().setView(viewName);
         }
 
+        public void setMethod(Object method) {
+            getMetaMappingInfo().setHttpMethod(method.toString());
+        }
+
+        public Object getMethod() {
+            return getMetaMappingInfo().getHttpMethod();
+        }
+
         public void name(Map<String, UrlMapping> m) {
             for (Map.Entry<String, UrlMapping> entry : m.entrySet()) {
                 entry.getValue().setMappingName(entry.getKey());
@@ -431,10 +451,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return get(arguments, uri, null);
         }
         public UrlMapping get(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.GET);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.GET.toString();
+            return regexUrlMapping;
         }
 
 
@@ -453,10 +471,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return post(arguments, uri, null);
         }
         public UrlMapping post(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.POST);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.POST.toString();
+            return regexUrlMapping;
         }
 
         /**
@@ -474,10 +490,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return put(arguments, uri, null);
         }
         public UrlMapping put(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.PUT);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.PUT.toString();
+            return regexUrlMapping;
         }
 
         /**
@@ -495,10 +509,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return patch(arguments, uri, null);
         }
         public UrlMapping patch(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.PATCH);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.PATCH.toString();
+            return regexUrlMapping;
         }
 
         /**
@@ -516,10 +528,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return delete(arguments, uri, null);
         }
         public UrlMapping delete(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.DELETE);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.DELETE.toString();
+            return regexUrlMapping;
         }
         /**
          * Matches the HEAD method
@@ -536,10 +546,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return head(arguments, uri, null);
         }
         public UrlMapping head(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.HEAD);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.HEAD.toString();
+            return regexUrlMapping;
         }
 
         /**
@@ -557,10 +565,8 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
             return options(arguments, uri, null);
         }
         public UrlMapping options(RegexUrlMapping regexUrlMapping) {
-            urlMappings.remove(regexUrlMapping);
-            RegexUrlMapping newMapping = new RegexUrlMapping(regexUrlMapping, HttpMethod.OPTIONS);
-            urlMappings.add(newMapping);
-            return newMapping;
+            regexUrlMapping.httpMethod = HttpMethod.OPTIONS.toString();
+            return regexUrlMapping;
         }
         /**
          * Define Url mapping collections that are nested directly below the parent resource (without the id)

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -30,7 +30,6 @@ import org.grails.web.servlet.mvc.GrailsWebRequest;
 import org.grails.web.servlet.mvc.exceptions.ControllerExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpMethod;
 import org.springframework.util.Assert;
 import org.springframework.validation.Errors;
 import org.springframework.validation.MapBindingResult;
@@ -39,7 +38,15 @@ import org.springframework.web.context.request.RequestContextHolder;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -87,9 +94,7 @@ public class RegexUrlMapping extends AbstractUrlMapping {
     public RegexUrlMapping(UrlMappingData data, Object controllerName, Object actionName, Object namespace, Object pluginName, Object viewName, String httpMethod, String version, ConstrainedProperty[] constraints, GrailsApplication grailsApplication) {
         this(null, data, controllerName, actionName, namespace, pluginName, viewName, httpMethod, version, constraints, grailsApplication);
     }
-    public RegexUrlMapping(RegexUrlMapping regexUrlMapping, HttpMethod httpMethod) {
-        this(regexUrlMapping.urlData, regexUrlMapping.controllerName, regexUrlMapping.actionName, regexUrlMapping.namespace, regexUrlMapping.pluginName, regexUrlMapping.viewName, httpMethod.toString(), regexUrlMapping.version, regexUrlMapping.constraints, regexUrlMapping.grailsApplication);
-    }
+
     /**
      * Constructs a new RegexUrlMapping for the given pattern, controller name, action name and constraints.
      *

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/UrlMappingsWithHttpMethodNotInNamedParametersSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/UrlMappingsWithHttpMethodNotInNamedParametersSpec.groovy
@@ -1,0 +1,99 @@
+package org.grails.web.mapping
+
+import grails.core.DefaultGrailsApplication
+import grails.core.GrailsApplication
+import org.grails.support.MockApplicationContext
+import spock.lang.Issue
+import spock.lang.Specification
+
+class UrlMappingsWithHttpMethodNotInNamedParametersSpec extends Specification {
+
+    def mappings1 = {
+        "/foo"(controller: 'example', action: 'fooGet') {
+            method = 'GET'
+            arbitrary = 'foo - get'
+        }
+        "/foo"(controller: 'example', action: 'fooPost') {
+            method = 'POST'
+            arbitrary = 'foo - post'
+        }
+    }
+
+    def mappings2 = {
+        get "/bar"(controller: 'example', action: 'barGet') {
+            arbitrary = 'bar - get'
+        }
+        post "/bar"(controller: 'example', action: 'barPost') {
+            arbitrary = 'bar - post'
+        }
+    }
+
+    def mappings3 = {
+        "/baz" {
+            controller = 'example'
+            action = 'getBaz'
+            method = 'GET'
+            arbitrary = 'baz - get'
+        }
+        "/baz" {
+            controller = 'example'
+            action = 'postBaz'
+            method = 'POST'
+            arbitrary = 'baz - post'
+        }
+    }
+
+    @Issue('10855')
+    void 'The http method can be defined as an arbitrary variable with controller and action defined as named parameters'() {
+        given: 'a URL mapping evaluator'
+        def ctx = new MockApplicationContext()
+        ctx.registerMockBean(GrailsApplication.APPLICATION_ID, new DefaultGrailsApplication())
+        def evaluator = new DefaultUrlMappingEvaluator(ctx)
+
+        when: 'the mappings are evaluated'
+        def mappings = evaluator.evaluateMappings(mappings1)
+
+        then:
+        mappings.size() == 2
+        mappings[0].httpMethod == 'GET'
+        mappings[0].parameterValues.arbitrary == 'foo - get'
+        mappings[1].httpMethod == 'POST'
+        mappings[1].parameterValues.arbitrary == 'foo - post'
+    }
+
+    @Issue('10855')
+    void 'It is possible to define arbitrary variables with http method define before the url'() {
+        given: 'a URL mapping evaluator'
+        def ctx = new MockApplicationContext()
+        ctx.registerMockBean(GrailsApplication.APPLICATION_ID, new DefaultGrailsApplication())
+        def evaluator = new DefaultUrlMappingEvaluator(ctx)
+
+        when: 'the mappings are evaluated'
+        def mappings = evaluator.evaluateMappings(mappings2)
+
+        then:
+        mappings.size() == 2
+        mappings[0].httpMethod == 'GET'
+        mappings[0].parameterValues.arbitrary == 'bar - get'
+        mappings[1].httpMethod == 'POST'
+        mappings[1].parameterValues.arbitrary == 'bar - post'
+    }
+
+    @Issue('10855')
+    void 'It is possible to define arbitrary variables and http method with mapping information defined as a closure'() {
+        given: 'a URL mapping evaluator'
+        def ctx = new MockApplicationContext()
+        ctx.registerMockBean(GrailsApplication.APPLICATION_ID, new DefaultGrailsApplication())
+        def evaluator = new DefaultUrlMappingEvaluator(ctx)
+
+        when: 'the mappings are evaluated'
+        def mappings = evaluator.evaluateMappings(mappings3)
+
+        then:
+        mappings.size() == 2
+        mappings[0].httpMethod == 'GET'
+        mappings[0].parameterValues.arbitrary == 'baz - get'
+        mappings[1].httpMethod == 'POST'
+        mappings[1].parameterValues.arbitrary == 'baz - post'
+    }
+}


### PR DESCRIPTION
Allow define httpMethods as arbitrary parameters in url mappings. Fixes #10855.