### PR TITLE
Upgrade to spring-boot 1.5.10.RELEASE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
     slf4jVersion = "1.7.22"
 
     spockVersion = '1.1-groovy-2.4'
-    springBootVersion = "1.5.8.RELEASE"
+    springBootVersion = "1.5.10.RELEASE"
     springLoadedVersion = "1.2.8.RELEASE"
     directoryWatcherVersion = "0.3.0"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"


### PR DESCRIPTION
https://spring.io/blog/2018/01/31/spring-boot-1-5-10-available-now

Few CVE's and uses Spring 4.3.14 which was upgraded here: https://github.com/grails/grails-core/pull/10929