### PR TITLE
JavaScript encoder should replace CRLF with LF, fixes 10956

### DIFF
--- a/grails-encoder/src/main/groovy/org/grails/encoder/impl/JavaScriptEncoder.java
+++ b/grails-encoder/src/main/groovy/org/grails/encoder/impl/JavaScriptEncoder.java
@@ -58,7 +58,9 @@ public class JavaScriptEncoder extends AbstractCharReplacementEncoder {
             case '\t':
                 return "\\t";
             case '\n':
-                if (previousChar != '\r') {
+                if (previousChar == '\r') {
+                    return "";
+                } else {
                     return "\\n";
                 }
             case '\r':

--- a/grails-encoder/src/test/groovy/org/grails/encoder/impl/JavaScriptCodecTests.groovy
+++ b/grails-encoder/src/test/groovy/org/grails/encoder/impl/JavaScriptCodecTests.groovy
@@ -11,6 +11,18 @@ class JavaScriptCodecTests extends GroovyTestCase {
         assertEquals("\\u0027\\u0027", codec.encode("''"))
         assertEquals('\\u005c', codec.encode('\\'))
     }
+
+    void testEncodeNewlines() {
+        // CRLF should be collapsed to LF
+        assertEquals("\n", codec.encode("\r\n"))
+
+        // All other combinations should pass through
+        assertEquals("\r", codec.encode("\r"))
+        assertEquals("\n", codec.encode("\n"))
+        assertEquals("\r\r", codec.encode("\r\r"))
+        assertEquals("\n\n", codec.encode("\n\n"))
+        assertEquals("\n\r", codec.encode("\n\r"))
+    }
     
     void testEncodeSeparators() {
         String separators="\u2028\u2029"; // http://timelessrepo.com/json-isnt-a-javascript-subset


### PR DESCRIPTION
See https://github.com/grails/grails-core/issues/10956