### PR TITLE
Update Spring Version to mitigate CVE-2018-1270,1271,1272

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ ext {
     springLoadedVersion = "1.2.8.RELEASE"
     directoryWatcherVersion = "0.3.0"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
-    springVersion = "4.3.9.RELEASE"
+    springVersion = "4.3.15.RELEASE"
     ehcacheVersion = "2.4.6"
     junitVersion = "4.12"
     concurrentlinkedhashmapVersion = "1.4.2"


### PR DESCRIPTION
Multiple CVE reports affect 4.3.9, so follow the recommended upgrade according to Pivotal.

See:
https://spring.io/blog/2018/04/05/multiple-cve-reports-published-for-the-spring-framework

*    https://pivotal.io/security/cve-2018-1270
*    https://pivotal.io/security/cve-2018-1271
*    https://pivotal.io/security/cve-2018-1272

All three recommend upgrading to 4.3.15.RELEASE or later. Grails 3.2.x is the earliest version that uses `springVersion` 4.3.x. 

A similar change will possibly be needed in the Grails 3.3.x branch, upgrading `springVersion` to 5.0.4.
