### PR TITLE
OSX File watcher not loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ ext {
     spockVersion = '1.0-groovy-2.4'
     springBootVersion = "1.4.6.RELEASE"
     springLoadedVersion = "1.2.8.RELEASE"
-    directoryWatcherVersion = "0.3.0"
+    directoryWatcherVersion = "0.5.1"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
     springVersion = "4.3.16.RELEASE"
     ehcacheVersion = "2.4.6"

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -474,7 +474,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
             }
             project.dependencies {
                 agent "org.springframework:springloaded"
-                agent "io.methvin:directory-watcher"
+                runtimeOnly "io.methvin:directory-watcher"
             }
             project.afterEvaluate(new AgentTasksEnhancer())
         }


### PR DESCRIPTION
This fixes the scope of the OSX directory watcher causing the issue described in #10989.

Also Updates to the latest version of the file watcher.

This should be merged up to **3.3.x branch** as well.

(Also I'm not an gradle expert so any feedback appreciated)