### PR TITLE
Tests for #10993

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/org/grails/validation/UrlConstrainedPropertyBuilderForCommandsTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/validation/UrlConstrainedPropertyBuilderForCommandsTests.groovy
@@ -1,0 +1,54 @@
+package org.grails.validation
+
+import grails.persistence.Entity
+import grails.testing.gorm.DomainUnitTest
+import grails.validation.Validateable
+import spock.lang.Specification
+
+class UrlConstrainedPropertyBuilderForCommandsTests extends Specification implements DomainUnitTest<FooConstraintsPerson> {
+
+    void 'test empty url constraint'() {
+        given:
+        def cmd = new UrlConstraintsCommand()
+
+        expect:
+        cmd.validate()
+    }
+
+    void 'test a valid url'() {
+        given:
+        def cmd = new UrlConstraintsCommand(url: 'http://grails.org')
+
+        expect:
+        cmd.validate()
+    }
+
+    void 'test an invalid url'() {
+        given:
+        def cmd = new UrlConstraintsCommand(url: 'http://foo')
+
+        expect:
+        !cmd.validate()
+        cmd.hasErrors()
+        cmd.errors.errorCount == 1
+        cmd.errors.getFieldErrors('url').size() == 1
+        cmd.errors.getFieldErrors('url')[0].rejectedValue == 'http://foo'
+    }
+}
+
+@Entity
+class FooConstraintsPerson {
+    String url
+
+    static constraints = {
+        url nullable: true, url: true
+    }
+}
+
+class UrlConstraintsCommand implements Validateable {
+    String url
+
+    static constraints = {
+        importFrom FooConstraintsPerson
+    }
+}


### PR DESCRIPTION
The fix for #10993 is in grails-data-mapping: https://github.com/grails/grails-data-mapping/pull/1090. These only include the tests.

If we merge this now will break the build until we start using datastore version `6.1.10.BUILD-SNAPSHOT`.