### PR TITLE
fix for g:include - issue 10991: 

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/UrlMappingUtils.java
@@ -174,7 +174,6 @@ public class UrlMappingUtils {
             Map<String, Object> urlAttrs = new HashMap<>();
             urlAttrs.put("controller", info.getControllerName());
             urlAttrs.put("action", info.getActionName());
-            urlAttrs.put("params", info.getParameters());
 
             forwardUrl.append(linkGenerator.link(urlAttrs));
         }

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/UrlMappingUtilsSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/UrlMappingUtilsSpec.groovy
@@ -1,12 +1,37 @@
 package org.grails.web.mapping
 
+import grails.web.mapping.LinkGenerator
+import grails.web.mapping.UrlMappingInfo
+import grails.web.servlet.mvc.GrailsParameterMap
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.grails.web.util.GrailsApplicationAttributes
+import org.grails.web.util.IncludedContent
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.web.servlet.ModelAndView
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class UrlMappingUtilsSpec extends Specification {
 
+    private MockHttpServletRequest request
+    private MockHttpServletResponse response
+    private GrailsApplicationAttributes attr
+    private GrailsWebRequest webRequest
+    private LinkGenerator linkGenerator
+
+    void setup() {
+        request = new MockHttpServletRequest()
+        response = new MockHttpServletResponse()
+        attr = Mock(GrailsApplicationAttributes.class)
+        linkGenerator = Mock(LinkGenerator.class)
+        webRequest = new GrailsWebRequest(request, response, attr)
+        webRequest.setAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, new ModelAndView(), 0)
+        request.setAttribute(GrailsApplicationAttributes.WEB_REQUEST, webRequest)
+    }
+
     @Unroll
-    def "test buildDispatchUrlForMapping"() {
+    void "test buildDispatchUrlForMapping"() {
         expect:
         expected == UrlMappingUtils.findAllParamsNotInUrlMappingKeywords(params)
 
@@ -14,5 +39,19 @@ class UrlMappingUtilsSpec extends Specification {
         params                      | expected
         [id: 1, controller: 'home'] | [id: 1]
         [id: 1, format: 'json']     | [id: 1, format: 'json']
+    }
+
+    void "test includeForUrlMappingInfo when linkGenerator is passed in"() {
+        given:
+            final String retUrl = '/testAction'
+            final UrlMappingInfo info = new ForwardUrlMappingInfo(controllerName: 'testController', actionName: 'testAction')
+            final Map model = [:]
+
+        when:
+            final IncludedContent includedContent = UrlMappingUtils.includeForUrlMappingInfo(request, response, info, model, linkGenerator)
+        then:
+            1 * linkGenerator.link(_ as Map) >> { Map m -> return retUrl }
+        and:
+            includedContent
     }
 }


### PR DESCRIPTION
fix for g:include - issue #10991 This adds an overloaded includeForUrlMappingInfo and buildDispatcherUrlForMapping that allows reverse url mapping. Before the fix is fully functional this will also require grails-gsp branch issue-10991 https://github.com/grails/grails-gsp/pull/23 to be merged and grails-gsp will have to be updated to current grails build (as it is only on 3.2.10) to pickup changes in this branch.  

This branch can be merged with no known side effects as it currently preserves the previous functionality to prevent breaking potential other usages of includeForUrlMappingInfo or buildDispatcherUrlForMapping