### PR TITLE
 Fail test when setupSpeck throws exception

### DIFF
--- a/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/spock/GrailsSpecTestType.groovy
+++ b/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/spock/GrailsSpecTestType.groovy
@@ -144,7 +144,7 @@ class GrailsSpecTestType extends GrailsTestTypeSupport {
                 }
             })
         }
-        junit.run(runRequest)
+        result.failCount = junit.run(runRequest).failureCount
         result
     }
 

--- a/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/spock/listener/OverallRunListener.groovy
+++ b/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/spock/listener/OverallRunListener.groovy
@@ -61,6 +61,7 @@ class OverallRunListener extends RunListener {
         // I can't think of a situation where this would be called without
         // a perSpecListener being available, even if it does happen
         // our handling options are very limited at this point in execution.
+        this.result.failCount = result.failureCount
         getPerSpecRunListener()?.finish()
     }
 


### PR DESCRIPTION
Fixes https://github.com/spockframework/spock/issues/179#issuecomment-136057603 for 2.5.x

It is enough to have at least one of
* https://github.com/grails/grails-core/commit/af76a7f7920c400516dbc18f079dd3c131678f93
* https://github.com/grails/grails-core/commit/b5db8ee61531ca8cea7f2dbb74384ce933558fb3

to fix https://github.com/spockframework/spock/issues/179#issuecomment-136057603

Another option is to enable back https://github.com/grails/grails-core/blob/693fec1d3bf7dc35514920efddb7a2f5e02e5c48/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/junit4/result/JUnit4ResultGrailsTestTypeResultAdapter.groovy#L21 with https://github.com/grails/grails-core/blob/693fec1d3bf7dc35514920efddb7a2f5e02e5c48/grails-test/src/main/groovy/org/codehaus/groovy/grails/test/junit4/result/JUnit4ResultGrailsTestTypeResultAdapter.groovy#L33