### PR TITLE
Bind data for command and domain source fix of #11054

### DIFF
--- a/grails-core/src/main/groovy/grails/beans/util/LazyBeanMap.groovy
+++ b/grails-core/src/main/groovy/grails/beans/util/LazyBeanMap.groovy
@@ -31,6 +31,7 @@ import org.grails.datastore.mapping.reflect.ClassPropertyFetcher
  * </p>
  * @since 2.4
  * @author Graeme Rocher
+ * @deprecated use {@link LazyMetaPropertyMap} instead
  */
 @CompileStatic
 class LazyBeanMap implements Map<String,Object>{

--- a/grails-core/src/main/groovy/grails/beans/util/LazyMetaPropertyMap.java
+++ b/grails-core/src/main/groovy/grails/beans/util/LazyMetaPropertyMap.java
@@ -39,7 +39,7 @@ public class LazyMetaPropertyMap implements Map {
 
     private MetaClass metaClass;
     private Object instance;
-    private static List<String> EXCLUDES = Arrays.asList("properties", GormProperties.IDENTITY, GormProperties.VERSION, "domainClass", "dirty", GormProperties.ERRORS, "dirtyPropertyNames");
+    private static List<String> EXCLUDES = Arrays.asList("class", "constraints", "hasMany", "mapping", "properties", GormProperties.IDENTITY, GormProperties.VERSION, "domainClass", "dirty", GormProperties.ERRORS, "dirtyPropertyNames");
 
     /**
      * Constructs the map

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/binding/BindCommandObjectsSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/binding/BindCommandObjectsSpec.groovy
@@ -1,0 +1,91 @@
+package org.grails.web.binding
+
+import grails.artefact.Artefact
+import grails.gorm.transactions.Transactional
+import grails.persistence.Entity
+import grails.testing.gorm.DomainUnitTest
+import grails.testing.web.controllers.ControllerUnitTest
+import grails.validation.Validateable
+import spock.lang.Issue
+import spock.lang.Specification
+
+class BindCommandObjectsSpec extends Specification implements ControllerUnitTest<BindCommandController>, DomainUnitTest<MyAuthor>  {
+    static final String NAME = 'My name is...'
+
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1145')
+    void "Test bind command to domain with constraints"() {
+        when:
+        def model = controller.bindDomain()
+
+        then:
+        model.domain
+        !model.domain.hasErrors()
+        model.domain.name == '111'
+    }
+
+
+    @Issue('https://github.com/grails/grails-core/issues/11054')
+    void "Test bind domain to command"() {
+        when:
+        controller.createDomain()
+        def model = controller.bindDomainToCommand()
+
+        then:
+        model.domain
+        model.domain.name == BindCommandObjectsSpec.NAME
+        model.command.name == BindCommandObjectsSpec.NAME
+        model.command.placeOfBirth
+    }
+}
+
+@Artefact('Controller')
+class BindCommandController {
+    def bindDomain(){
+        def domain = new MyAuthor(hairColour: "black")
+        def command = new AuthorFieldCommand(name: "111")
+        bindData(domain, command, [exclude: ['placeOfBirth']])
+        domain.validate()
+        [domain:domain]
+    }
+
+    @Transactional
+    def createDomain(){
+        def city = new MyCity(name: 'BIG').save()
+        def a = new MyAuthor(name: BindCommandObjectsSpec.NAME, placeOfBirth: city, hairColour: 'red' ).save(flush:true)
+
+    }
+
+    def bindDomainToCommand(){
+        def domain = MyAuthor.findByName(BindCommandObjectsSpec.NAME)
+        def command = new AuthorFieldCommand()
+        bindData(command, domain)
+        [command:command, domain:domain]
+    }
+}
+
+
+@Entity
+class MyAuthor {
+    String name
+    String hairColour
+    MyCity placeOfBirth
+
+    static constraints = {
+        name nullable:true
+        placeOfBirth nullable:true
+    }
+}
+@Entity
+class MyCity {
+    String name
+}
+
+
+class AuthorFieldCommand implements Validateable{
+    MyCity placeOfBirth
+    String name
+    static constraints = {
+        placeOfBirth nullable:true
+    }
+}
+

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
@@ -15,10 +15,10 @@
  */
 package org.grails.web.databinding.bindingsource
 
+import grails.beans.util.LazyMetaPropertyMap
 import grails.databinding.CollectionDataBindingSource
 import grails.databinding.SimpleMapDataBindingSource;
 import groovy.transform.CompileStatic
-import grails.beans.util.LazyBeanMap
 import grails.databinding.DataBindingSource
 import grails.web.databinding.DataBindingUtils
 
@@ -52,7 +52,7 @@ class DefaultDataBindingSourceCreator implements DataBindingSourceCreator {
         } else if(bindingSource instanceof Map) {
             dataBindingSource = new SimpleMapDataBindingSource(DataBindingUtils.convertPotentialGStrings((Map) bindingSource))
         } else {
-            dataBindingSource = new SimpleMapDataBindingSource(new LazyBeanMap(bindingSource))
+            dataBindingSource = new SimpleMapDataBindingSource(new LazyMetaPropertyMap(bindingSource))
         }
         dataBindingSource
     }

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
@@ -51,8 +51,10 @@ class DefaultDataBindingSourceCreator implements DataBindingSourceCreator {
             dataBindingSource = createDataBindingSource(bindingTargetType, (HttpServletRequest)bindingSource)
         } else if(bindingSource instanceof Map) {
             dataBindingSource = new SimpleMapDataBindingSource(DataBindingUtils.convertPotentialGStrings((Map) bindingSource))
-        } else {
+        } else if (bindingSource != null){
             dataBindingSource = new SimpleMapDataBindingSource(new LazyMetaPropertyMap(bindingSource))
+        } else {
+            dataBindingSource = new SimpleMapDataBindingSource(Collections.emptyMap()) // LazyMetaPropertyMap dislike null source
         }
         dataBindingSource
     }

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/DefaultDataBindingSourceCreator.groovy
@@ -51,7 +51,7 @@ class DefaultDataBindingSourceCreator implements DataBindingSourceCreator {
             dataBindingSource = createDataBindingSource(bindingTargetType, (HttpServletRequest)bindingSource)
         } else if(bindingSource instanceof Map) {
             dataBindingSource = new SimpleMapDataBindingSource(DataBindingUtils.convertPotentialGStrings((Map) bindingSource))
-        } else if (bindingSource != null){
+        } else if (bindingSource){
             dataBindingSource = new SimpleMapDataBindingSource(new LazyMetaPropertyMap(bindingSource))
         } else {
             dataBindingSource = new SimpleMapDataBindingSource(Collections.emptyMap()) // LazyMetaPropertyMap dislike null source


### PR DESCRIPTION
How to add an integration test? The bug #11054 is between gorm and data-binding. I have no idea how to make a unit test for this case without real gorm entity.