### PR TITLE
Preserve url defining mode in url mapping evaluator

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingEvaluator.java
@@ -704,12 +704,13 @@ public class DefaultUrlMappingEvaluator implements UrlMappingEvaluator, ClassLoa
                                 String controllerName = controller.toString();
                                 mappingInfo.setController(controllerName);
                                 parentResources.push(new ParentResource(controllerName, uri, false));
+                                Boolean oldUrlDefiningMode = urlDefiningMode;
                                 try {
                                     urlDefiningMode = true;
                                     invokeLastArgumentIfClosure(args);
                                 } finally {
                                     parentResources.pop();
-                                    urlDefiningMode = false;
+                                    urlDefiningMode = oldUrlDefiningMode;
                                 }
                                 if (controller != null) {
                                     createResourceRestfulMappings(controllerName, mappingInfo.getPlugin(), mappingInfo.getNamespace(), version, urlData, currentConstraints, calculateIncludes(namedArguments, DEFAULT_RESOURCES_INCLUDES));

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/CollectionWithVariableUrlMappingSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/CollectionWithVariableUrlMappingSpec.groovy
@@ -15,4 +15,17 @@ class CollectionWithVariableUrlMappingSpec extends AbstractUrlMappingsSpec {
         expect:
         urlMappingsHolder.matchAll('/tickets/history/1', 'GET')
     }
+
+    void 'test backwards-compatibility with group mappings'() {
+        given:
+        def urlMappingsHolder = getUrlMappingsHolder {
+            group('/api') {
+                '/photo'(resources: 'photo', includes: ['show'])
+                "/foo/${id}"(controller: 'foo', action: 'show')
+            }
+        }
+
+        expect:
+        urlMappingsHolder.matchAll('/api/foo/123', 'GET')
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/grails/grails-core/issues/11104

Preserve the old url defining mode so subsequent controller mappings inside a group are not affected.