### PR TITLE
Allow to bind java.sql.Date. Fixes #11126

### DIFF
--- a/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
+++ b/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
@@ -165,10 +165,6 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
                 return DefaultGroovyMethods.subMap(wrappedMap, (Collection)key);
             }
         }
-        if ("date.struct".equals(returnValue)) {
-            returnValue = lazyEvaluateDateParam(key);
-            nestedDateMap.put(key, returnValue);
-        }
         return returnValue;
     }
 
@@ -209,6 +205,12 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
      */
     @Override
     public Date getDate(String name) {
+        Object returnValue = wrappedMap.get(name);
+        if ("date.struct".equals(returnValue)) {
+            returnValue = lazyEvaluateDateParam(name);
+            nestedDateMap.put(name, returnValue);
+            return (Date)returnValue;
+        }
         Date date = super.getDate(name);
         if (date == null) {
             // try lookup format from messages.properties


### PR DESCRIPTION
Fixes #11126 

- Do not treat in a special way "date.struct" during data binding because it will
be handled layer by the right structued editor
- Introducing breaking change in params.getDate("foo") to build the date from
different parameters "foo", "foo_year", "foo_month" and "foo_day"

This PR needs to be merged with https://github.com/grails/grails-doc/pull/687