### PR TITLE
Grails 3.2.x branch: Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
     fi
 install: "/bin/true"
 script:
-- JAVA_HOME=$(jdk_switcher home openjdk7) ./travis-build.sh
+- ./travis-build.sh
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,13 @@ env:
   - secure: ICWgIGwHFH37nlY9k094qnnKy0tW2XDSOtGsvHb65AxsPsXB1zqj7Qd76Fboo1xFGQGpg+S6AHekY6Ch1prNOpkpPHw35UaQzaRqUxFUhfZYiD0rlmvzKrvKTesrFLy4LJwrTzGCQrViYgqfHvCeQ3r53wWff6nu8uFmMOPmGNY=
   - secure: XdMql6e7ToSMuhZuG1baCm6IDvj+X7pAbK210awH8Yww8lGGu2NryHBQliv0CLqd7tkjKSUHP3y/22O8H46Xc0+7ucWF8JwlMvtBeSuK/U/p/R7tOkLNeBuAXj9Xxd1oe9aRQrZS5AT2zkCkMGxTd7uGcm5p9MO0MmypFHzjPlE=
 before_install:
-  # Workaround for https://github.com/gradle/gradle/issues/2421:
-  # download all Gradle distributions with openjdk8
-  - JAVA_HOME=$(jdk_switcher home openjdk8) ./gradlew
+  # Work around missing crypto in openjdk7, see https://github.com/gradle/gradle/issues/2421
+  - |
+    if [ "$TRAVIS_JDK_VERSION" == "openjdk7" ]; then
+      sudo wget "https://bouncycastle.org/download/bcprov-ext-jdk15on-158.jar" -O "${JAVA_HOME}/jre/lib/ext/bcprov-ext-jdk15on-158.jar"
+      sudo perl -pi.bak -e 's/^(security\.provider\.)([0-9]+)/$1.($2+1)/ge' /etc/java-7-openjdk/security/java.security
+      echo "security.provider.1=org.bouncycastle.jce.provider.BouncyCastleProvider" | sudo tee -a /etc/java-7-openjdk/security/java.security
+    fi
 install: "/bin/true"
 script:
 - JAVA_HOME=$(jdk_switcher home openjdk7) ./travis-build.sh


### PR DESCRIPTION
Recently, the builds for Grails 3.2.x have been failing. It looks like the builds are fixed after updating some Travis settings. Following is the error:

```
:grails-validation:compileTestGroovy FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':grails-validation:compileTestGroovy'.
> Failed to run Gradle Compiler Daemon
   > Process 'Gradle Compiler Daemon 1' finished with non-zero exit value 137
```