### PR TITLE
adding warning around plugin and app grails version mis-match

### DIFF
--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -423,7 +423,7 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
         try {
             versionNumber = Integer.valueOf(version.replaceAll("\\.|-|[A-Z]+", ""));
         } catch (Exception e) {
-            System.out.println(e.getMessage());
+            LOG.error(e.getMessage());
         }
         return versionNumber;
     }

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -18,7 +18,6 @@ package grails.plugins;
 import grails.util.Environment;
 import grails.util.GrailsClassUtils;
 import groovy.lang.GroovyClassLoader;
-import groovy.lang.GroovyObject;
 import groovy.lang.GroovySystem;
 import groovy.lang.MetaClassRegistry;
 import org.apache.commons.logging.Log;
@@ -44,7 +43,6 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.util.Assert;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -419,7 +419,13 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
     }
 
     private Integer convertVersionNumber(String version) {
-        return Integer.valueOf(version.replaceAll("\\.|-|[A-Z]+", ""));
+        Integer versionNumber = 0;
+        try {
+            versionNumber = Integer.valueOf(version.replaceAll("\\.|-|[A-Z]+", ""));
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+        return versionNumber;
     }
 
     private GrailsPlugin createBinaryGrailsPlugin(Class<?> pluginClass, BinaryGrailsPluginDescriptor binaryDescriptor) {

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -419,7 +419,7 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
     }
 
     private Integer convertVersionNumber(String version) {
-        return Integer.valueOf(version.replaceAll("\\.", ""));
+        return Integer.valueOf(version.replaceAll("\\.|-|[A-Z]+", ""));
     }
 
     private GrailsPlugin createBinaryGrailsPlugin(Class<?> pluginClass, BinaryGrailsPluginDescriptor binaryDescriptor) {


### PR DESCRIPTION
Application logger must be set to WARN in order to see warnings. When either `findCorePlugins()` or `findUserPlugins(gcl)` a check will be performed to see if the plugin grailsVersion is in line with the application grailsVersion.

Case 1: plugin grailsVersion specified as follows "3.3.6 > *"
    - will log a warning if the application version is less than the minimum plugin version

Case 2: plugin grailsVersion specified as follows "3.3.5 > 3.3.8"
    - will log a warning if the application version is less than the minimum plugin version
    - will log a warning if the application version is greater than the maximum plugin version