### PR TITLE
Fix eclipse target directory resolution problems with new groovy-eclipse

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -151,7 +151,9 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
         File targetDirectory = null
         if(source.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit') {
             targetDirectory = GroovyEclipseCompilationHelper.resolveEclipseCompilationTargetDirectory(source)
-        }
+        } else {
+			targetDirectory = source.configuration.targetDirectory
+		}
         if(targetDirectory == null) {
             targetDirectory = new File('build/classes/main')
         }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -148,8 +148,8 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
     }
 
     static File resolveCompilationTargetDirectory(SourceUnit source) {
-        File targetDirectory = source.configuration.targetDirectory
-        if(targetDirectory==null && source.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit') {
+        File targetDirectory = null
+        if(source.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit') {
             targetDirectory = GroovyEclipseCompilationHelper.resolveEclipseCompilationTargetDirectory(source)
         }
         if(targetDirectory == null) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GroovyEclipseCompilationHelper.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GroovyEclipseCompilationHelper.groovy
@@ -32,12 +32,29 @@ class GroovyEclipseCompilationHelper {
      * @return The File that represents the root directory or null
      */
     static File resolveEclipseCompilationTargetDirectory(SourceUnit sourceUnit) {
+
         if (sourceUnit.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit') {
             StandardEvaluationContext context = new StandardEvaluationContext()
             context.setTypeLocator(new StandardTypeLocator(sourceUnit.getClass().getClassLoader()))
             context.setRootObject(sourceUnit)
             try {
-                return (File) new SpelExpressionParser().parseExpression("eclipseFile.workspace.root.getFolder(T(org.eclipse.jdt.core.JavaCore).create(eclipseFile.project).outputLocation.makeAbsolute()).rawLocation.makeAbsolute().toFile().absoluteFile").getValue(context)
+				// Honour the targetDirectory within the source configuration directory.
+				File targetDirectory = sourceUnit.configuration.targetDirectory
+				
+				if (targetDirectory == null) {
+					
+					// Resolve as before.
+					targetDirectory = ((File) new SpelExpressionParser().parseExpression("eclipseFile.project.getFolder(T(org.eclipse.jdt.core.JavaCore).create(eclipseFile.project).outputLocation).rawLocation.makeAbsolute().toFile().absoluteFile").getValue(context))
+					
+				} else if (!targetDirectory.isAbsolute()) {
+					// Target directory is set and is not absolute.
+					// We should assume that this is a path relative to the current eclipse project,
+					// and needs resolving appropriately.
+					targetDirectory = ((File) new SpelExpressionParser().parseExpression("eclipseFile.project.getFolder('${targetDirectory.path}').rawLocation.makeAbsolute().toFile().absoluteFile").getValue(context))
+					
+				}
+				// Else absolute file location. We should return as-is.
+				return targetDirectory
             } catch (Throwable e) {
                 // Not running Eclipse IDE, probably using the Eclipse compiler with Maven
                 return null


### PR DESCRIPTION
Now that groovy eclipse sets the outputDirectory, we need to make sure we still resolve the file path against the project if it isn't an absolute path.
Fixes: #11138 