### PR TITLE
Update spring-boot 1.5.19 and spring 4.3.22

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,11 +48,11 @@ ext {
     slf4jVersion = "1.7.25"
 
     spockVersion = '1.1-groovy-2.4'
-    springBootVersion = "1.5.18.RELEASE"
+    springBootVersion = "1.5.19.RELEASE"
     springLoadedVersion = "1.2.8.RELEASE"
     directoryWatcherVersion = "0.5.1"
     springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
-    springVersion = "4.3.21.RELEASE"
+    springVersion = "4.3.22.RELEASE"
     junitVersion = "4.12"
     concurrentlinkedhashmapVersion = "1.4.2"
     cglibVersion = "2.2.2"


### PR DESCRIPTION
I know y'all just did this, but 1.5.19 has a jetty version bump in it's dependencies that would unblock our app in the move to support JDK 10/11. Figured I'd update normal spring for kicks at the same time.