### PR TITLE
Fix Reloading Status 

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -657,7 +657,7 @@ public enum Environment {
             return reloadingAgentEnabled;
         }
         try {
-            Class.forName("org.springsource.loaded.TypeRegistry");
+            Class.forName("org.springframework.boot.devtools.restart.Restarter");
             reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
         }
         catch (ClassNotFoundException e) {


### PR DESCRIPTION
Due to the switch from spring-loaded to spring-boot-dev-tools, reloading status was being reported incorrectly in the default scaffolding generated on project creation. 

There could probably be some additional cleanup along with this. There seems to be some overlap in various places that could probably be cleaned up but I didn't want to be overzealous. 

The following could probably be refactored to just `Environment.isReloadingAgentEnabled()`:
https://github.com/grails/grails-core/blob/7ab9e47ad805fbeb9433a488dd33f91bef44c0fa/grails-core/src/main/groovy/grails/dev/Support.groovy#L50
https://github.com/grails/grails-core/blob/160f5c59206ccb63bdc75174e64abb85cb41babc/grails-plugin-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsGrailsPlugin.groovy#L66
https://github.com/grails/grails-core/blob/7ab9e47ad805fbeb9433a488dd33f91bef44c0fa/grails-core/src/main/groovy/org/grails/spring/beans/factory/OptimizedAutowireCapableBeanFactory.java#L67

There are also lots of uses of [Environment.isReloadEnabled()](https://github.com/grails/grails-core/blob/7ab9e47ad805fbeb9433a488dd33f91bef44c0fa/grails-bootstrap/src/main/groovy/grails/util/Environment.java#L622-L628) directly which seems incomplete if for some reason spring-boot-devtools isn't on the classpath. Shouldn't everything be using `isReloadingAgentEnabled()`?

I intended to add some tests but without spring-boot-devtools in grails-bootstrap's classpath I'm not sure how that would be possible. 