### PR TITLE
Fixed `getParts()` throwing an exception

### DIFF
--- a/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -348,7 +348,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
      * {@inheritDoc }
      */
     Map<String, MultipartFile> getFileMap() {
-        return multipartFiles
+        return multipartFiles.toSingleValueMap()
     }
 
     /**
@@ -409,7 +409,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
     }
 
     Collection<Part> getParts() {
-        getFileMap().values().collect {new MockPart(it)}
+        getMultiFileMap().values().flatten().collect {new MockPart(it)}
     }
 
     Part getPart(String name) {


### PR DESCRIPTION
Method `getParts()` is trowing an exception as `multipartFiles` is `MultiValueMap`


```

	at heist.MoonControllerSpec.upload file with message(MoonControllerSpec.groovy:562)
Caused by: org.codehaus.groovy.runtime.InvokerInvocationException: java.lang.AssertionError: org.springframework.web.multipart.MultipartException: Could not parse multipart servlet request; nested exception is groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.grails.plugins.testing.MockPart(java.util.LinkedList)
	... 1 more
Caused by: java.lang.AssertionError: org.springframework.web.multipart.MultipartException: Could not parse multipart servlet request; nested exception is groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.grails.plugins.testing.MockPart(java.util.LinkedList)
	at com.agorapulse.gru.GruContext.throwErrorIfPresent(GruContext.java:126)
	at com.agorapulse.gru.Gru.verify(Gru.java:141)
	at com.agorapulse.gru.Gru.asBoolean(Gru.java:124)
	... 1 more
Caused by: org.springframework.web.multipart.MultipartException: Could not parse multipart servlet request; nested exception is groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.grails.plugins.testing.MockPart(java.util.LinkedList)
	at org.springframework.web.multipart.support.StandardMultipartHttpServletRequest.parseRequest(StandardMultipartHttpServletRequest.java:112)
	at org.springframework.web.multipart.support.StandardMultipartHttpServletRequest.<init>(StandardMultipartHttpServletRequest.java:86)
	at org.springframework.web.multipart.support.StandardServletMultipartResolver.resolveMultipart(StandardServletMultipartResolver.java:80)
	at org.grails.web.mapping.DefaultUrlMappingInfo.getResolvedRequest(DefaultUrlMappingInfo.java:250)
	at org.grails.web.mapping.DefaultUrlMappingInfo.tryMultipartParams(DefaultUrlMappingInfo.java:240)
	at org.grails.web.mapping.DefaultUrlMappingInfo.checkDispatchAction(DefaultUrlMappingInfo.java:218)
	at org.grails.web.mapping.DefaultUrlMappingInfo.getActionName(DefaultUrlMappingInfo.java:197)
	at org.grails.web.mapping.mvc.GrailsControllerUrlMappingInfo.getActionName(GrailsControllerUrlMappingInfo.groovy:29)
	at com.agorapulse.gru.grails.minions.UrlMappingsMinion.getActionName(UrlMappingsMinion.groovy:96)
	at com.agorapulse.gru.grails.Grails.run_closure3(Grails.groovy:57)
	at groovy.lang.Closure.call(Closure.java:418)
	at groovy.lang.Closure.call(Closure.java:434)
	at com.agorapulse.gru.Squad.ask(Squad.java:93)
	at com.agorapulse.gru.grails.Grails.run(Grails.groovy:57)
	at com.agorapulse.gru.Gru.test(Gru.java:105)
	... 1 more
Caused by: groovy.lang.GroovyRuntimeException: Could not find matching constructor for: org.grails.plugins.testing.MockPart(java.util.LinkedList)
	at org.grails.plugins.testing.GrailsMockHttpServletRequest.getParts_closure2(GrailsMockHttpServletRequest.groovy:412)
	at groovy.lang.Closure.call(Closure.java:418)
	at groovy.lang.Closure.call(Closure.java:434)
	at org.grails.plugins.testing.GrailsMockHttpServletRequest.getParts(GrailsMockHttpServletRequest.groovy:412)
	at org.springframework.web.multipart.support.StandardMultipartHttpServletRequest.parseRequest(StandardMultipartHttpServletRequest.java:93)
	... 15 more
```