### PR TITLE
issue-11271

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
@@ -467,7 +467,8 @@ public class JSONTokener {
      * @return A JSONException object, suitable for throwing
      */
     public JSONException syntaxError(String message) {
-        return new JSONException(message + toString());
+
+        return new JSONException(message + toRegexSafeString());
     }
 
 
@@ -478,6 +479,15 @@ public class JSONTokener {
      */
     @Override
     public String toString() {
+        return " at character " + this.myIndex + " of " + this.mySource;
+    }
+
+    /**
+     * Make a regex safe printable string of this JSONTokener.
+     *
+     * @return " at character [this.myIndex] of [this.mySource]"
+     */
+    public String toRegexSafeString() {
         int endIndex = mySource.length();
         boolean appendDots = false;
         if (endIndex > 20) {
@@ -491,6 +501,6 @@ public class JSONTokener {
             output.append("...");
         }
         return Matcher.quoteReplacement(output.toString());
-
     }
+
 }

--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
@@ -478,6 +478,19 @@ public class JSONTokener {
      */
     @Override
     public String toString() {
-        return " at character " + this.myIndex + " of " + this.mySource;
+        int endIndex = mySource.length();
+        boolean appendDots = false;
+        if (endIndex > 20) {
+            // only show first 20 characters of source to prevent reDOS attacks, especially in Java 8 regexp engine
+            // see https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS for more info
+            endIndex = 19;
+            appendDots = true;
+        }
+        StringBuffer output = new StringBuffer(" at character " + this.myIndex + " of " + this.mySource.substring(0, endIndex));
+        if (appendDots) {
+            output.append("...");
+        }
+        return Matcher.quoteReplacement(output.toString());
+
     }
 }


### PR DESCRIPTION
Because quoted input values are parsed through regex engine in Java. this was causing a reDOS attack and freezing the app up in a loop if a user passed in malicious data. If a JSON parse error occurs, I switched it to only print the first 20 chars and a "..." AND called Matcher.quoteReplacementString on it as well for extra safety. Supposedly it's easy to break the Java 8 regex engine and 9+ is more robust to these types of things but that doesn't help Grails 3.3.x much.