### PR TITLE
Issue #11278: Add null safety for any use of ReaderSource.getURI()

### DIFF
--- a/grails-bootstrap/src/main/groovy/org/grails/io/support/MainClassFinder.groovy
+++ b/grails-bootstrap/src/main/groovy/org/grails/io/support/MainClassFinder.groovy
@@ -35,6 +35,10 @@ class MainClassFinder {
      */
     static String searchMainClass(URI path) {
 
+        if (!path) {
+            return null
+        }
+
         def pathStr = path.toString()
         if(mainClasses.containsKey(pathStr)) {
             return mainClasses.get(pathStr)


### PR DESCRIPTION
I've modified `MainClassFinder.searchMainClass(URI path)` to return null if the path is null.

This fix is for issues #11278