### PR TITLE
Fixes issue #11327. JSONTokener should support BigInteger and BigDecimal

### DIFF
--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/json/JSONObjectTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/json/JSONObjectTests.groovy
@@ -43,4 +43,28 @@ class JSONObjectTests extends GroovyTestCase {
         assertEquals j1, j2
         assertTrue j1 == j2
     }
+
+    void testJSONObjectShouldSupportBigIntegerAndBigDecimal() {
+        String input = '''
+            {"v1":0, "v2":9999999999999999, "v3":88888888888888888888888888888888,
+            "v4":-11111, "v5":1.1111111E15, "v6":-8.88888888888888888E25,
+            "v7":0.00, "v8":999.999, "v9":333.333333333333, "v10":1.1111E-7,
+            "v11":-9.33333333333E-20}
+        '''
+
+        JSONObject json = grails.converters.JSON.parse(input)
+
+        assertEquals(json.v1, Integer.valueOf(0))
+        assertEquals(json.v2, Long.valueOf(9999999999999999L))
+        assertEquals(json.v3, new BigInteger('88888888888888888888888888888888'))
+        assertEquals(json.v4, Integer.valueOf(-11111))
+        assertEquals(json.v5, Long.valueOf(1111111100000000L))
+        assertEquals(json.v6, new BigInteger('-88888888888888888800000000'))
+        assertEquals(json.v7, Double.valueOf(0.0))
+        assertEquals(json.v8, Double.valueOf(999.999))
+        assertEquals(json.v9, new BigDecimal('333.333333333333'))
+        assertEquals(json.v10, Double.valueOf(1.1111E-7))
+        assertEquals(json.v11, new BigDecimal('-9.33333333333E-20'))
+    }
+
 }

--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
@@ -1,5 +1,6 @@
 package org.grails.web.json;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -403,18 +404,27 @@ public class JSONTokener {
                     }
                 }
             }
+
+            BigDecimal number;
             try {
-                return Integer.valueOf(s);
+                number = new BigDecimal(s);
             } catch (Exception e) {
+                return s;
+            }
+
+            if (number.scale() == 0) {
                 try {
-                    return Long.valueOf(s);
-                } catch (Exception f) {
+                    return number.intValueExact();
+                } catch (Exception e) {
                     try {
-                        return Double.valueOf(s);
-                    } catch (Exception g) {
-                        return s;
+                        return number.longValueExact();
+                    } catch (Exception f) {
+                        return number.toBigInteger();
                     }
                 }
+            } else {
+                double doubleValue = number.doubleValue();
+                return number.equals(BigDecimal.valueOf(doubleValue)) ? doubleValue : number;
             }
         }
         return s;


### PR DESCRIPTION
Backwards for 3.3.x.

See #11334 