### PR TITLE
Fix replace for existing tasks in Gradle

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -495,11 +495,14 @@ class GrailsGradlePlugin extends GroovyPlugin {
 
     @CompileStatic
     protected void registerFindMainClassTask(Project project) {
-        def findMainClassTask = project.tasks.create(name: "findMainClass", type: FindMainClassTask, overwrite: true)
-        findMainClassTask.mustRunAfter project.tasks.withType(GroovyCompile)
-        def bootRepackageTask = project.tasks.findByName("bootRepackage")
-        if(bootRepackageTask) {
-            bootRepackageTask.dependsOn findMainClassTask
+        TaskContainer taskContainer = project.tasks
+        if (taskContainer.findByName("findMainClass") == null) {
+            def findMainClassTask = project.tasks.create(name: "findMainClass", type: FindMainClassTask, overwrite: true)
+            findMainClassTask.mustRunAfter project.tasks.withType(GroovyCompile)
+            def bootRepackageTask = project.tasks.findByName("bootRepackage")
+            if (bootRepackageTask) {
+                bootRepackageTask.dependsOn findMainClassTask
+            }
         }
     }
 

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
@@ -42,7 +42,7 @@ class GrailsWebGradlePlugin extends GrailsGradlePlugin {
 
         TaskContainer taskContainer = project.tasks
         if (taskContainer.findByName("urlMappingsReport") == null) {
-            taskContainer.create(name: "urlMappingsReport", type: ApplicationContextCommandTask, overwrite: true) {
+            taskContainer.create(name: "urlMappingsReport", type: ApplicationContextCommandTask) {
                 classpath = project.sourceSets.main.runtimeClasspath + project.configurations.console
                 systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.name)
                 command = 'url-mappings-report'

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/GrailsWebGradlePlugin.groovy
@@ -17,6 +17,7 @@ package org.grails.gradle.plugin.web
 
 import grails.util.Environment
 import org.gradle.api.Project
+import org.gradle.api.tasks.TaskContainer
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.grails.gradle.plugin.commands.ApplicationContextCommandTask
 import org.grails.gradle.plugin.core.GrailsGradlePlugin
@@ -39,10 +40,14 @@ class GrailsWebGradlePlugin extends GrailsGradlePlugin {
     void apply(Project project) {
         super.apply(project)
 
-        project.tasks.create(name: "urlMappingsReport", type: ApplicationContextCommandTask, overwrite: true) {
-            classpath = project.sourceSets.main.runtimeClasspath + project.configurations.console
-            systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.name)
-            command = 'url-mappings-report'
+        TaskContainer taskContainer = project.tasks
+        if (taskContainer.findByName("urlMappingsReport") == null) {
+            taskContainer.create(name: "urlMappingsReport", type: ApplicationContextCommandTask, overwrite: true) {
+                classpath = project.sourceSets.main.runtimeClasspath + project.configurations.console
+                systemProperty Environment.KEY, System.getProperty(Environment.KEY, Environment.DEVELOPMENT.name)
+                command = 'url-mappings-report'
+            }
         }
+
     }
 }


### PR DESCRIPTION
Gradle 6.x will fail builds when trying to replace an existing task: https://github.com/gradle/gradle/commit/686ad3fd41cf3e56b99b2c6dfd2048978c923935#diff-c1f28c1e4f6ce6dd164dd64d233b8f2f

Spotted this in one of our builds:

```
Caused by: org.gradle.api.internal.tasks.DefaultTaskContainer$TaskCreationException: Could not create task ':findMainClass'.
        at org.gradle.api.internal.tasks.DefaultTaskContainer.taskCreationException(DefaultTaskContainer.java:720)
        at org.gradle.api.internal.tasks.DefaultTaskContainer.access$600(DefaultTaskContainer.java:77)
        at org.gradle.api.internal.tasks.DefaultTaskContainer$1.call(DefaultTaskContainer.java:181)
        at org.grails.gradle.plugin.core.GrailsGradlePlugin.registerFindMainClassTask(GrailsGradlePlugin.groovy:498)
```

Hopefully this can be included on a 3.3.x release