### PR TITLE
Hot reload for Grails 4 & JDK 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ ext {
     groovyVersion = System.getenv('CI_GROOVY_VERSION') ?: "2.5.6"
     isBuildSnapshot = grailsVersion.endsWith(".BUILD-SNAPSHOT")
     isTravisBuild = System.getenv().get("TRAVIS") == 'true'
+    springLoadedCommonOptions = "-Xverify:none -Dspringloaded.synchronize=true -Djdk.reflect.allowGetCallerClass=true"
     dependencyVersions = [
         'javax.annotation-api': [
                 version: javaxAnnotationApiVersion,
@@ -83,6 +84,12 @@ ext {
             version: directoryWatcherVersion,
             group  : 'io.methvin',
             names  : ['directory-watcher'],
+            modules: ['']
+        ],
+        springLoaded: [
+            version: springLoadedVersion,
+            group  : 'org.springframework',
+            names  : ['springloaded'],
             modules: ['']
         ],
         async: [

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ springVersion=5.1.11.RELEASE
 spockVersion=1.2-groovy-2.5
 micronautVersion=1.1.4
 micronautSpringVersion=1.0.2
+springLoadedVersion=1.2.8.RELEASE
 gradleSdkVendorVersion=1.1.1
 jaxbVersion=2.3.1
 javaxAnnotationApiVersion=1.3.2

--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -667,21 +667,20 @@ public enum Environment {
         }
         catch (ClassNotFoundException e) {
             reloadingAgentEnabled = false;
-        }
-        try {
-            String jvmVersion = System.getProperty("java.specification.version");
-            if(jvmVersion.equals("1.8")) {
-                Class.forName("org.springsource.loaded.TypeRegistry");
-                reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
-                LOG.debug("Found spring-loaded on the class path");
-            } else {
-                LOG.warn("Found spring-loaded on classpath but JVM is not 1.8 - skipping");
+            try {
+                String jvmVersion = System.getProperty("java.specification.version");
+                if(jvmVersion.equals("1.8")) {
+                    Class.forName("org.springsource.loaded.TypeRegistry");
+                    LOG.debug("Found spring-loaded on the class path");
+                    reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
+                } else {
+                    LOG.warn("Found spring-loaded on classpath but JVM is not 1.8 - skipping");
+                }
+            }
+            catch (ClassNotFoundException e1) {
+                reloadingAgentEnabled = false;
             }
         }
-        catch (ClassNotFoundException e) {
-            reloadingAgentEnabled = false;
-        }
-        LOG.debug("reloadingAgentEnabled {}", reloadingAgentEnabled);
         return reloadingAgentEnabled;
     }
 

--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -657,7 +657,7 @@ public enum Environment {
             return reloadingAgentEnabled;
         }
         try {
-            Class.forName("org.springframework.boot.devtools.RemoteSpringApplication");
+            Class.forName("org.springsource.loaded.TypeRegistry");
             reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
         }
         catch (ClassNotFoundException e) {

--- a/grails-bootstrap/src/main/groovy/grails/util/Environment.java
+++ b/grails-bootstrap/src/main/groovy/grails/util/Environment.java
@@ -23,6 +23,8 @@ import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.grails.io.support.Resource;
 import org.grails.io.support.UrlResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,13 +53,15 @@ public enum Environment {
     TEST,
 
     /**
-     * For the application data source, primarly for backward compatability for those applications
+     * For the application data source, primarily for backward compatibility for those applications
      * that use ApplicationDataSource.groovy.
      */
     APPLICATION,
 
     /** A custom environment */
     CUSTOM;
+
+    private static final Logger LOG = LoggerFactory.getLogger(Environment.class);
 
     /**
      * Constant used to resolve the environment via System.getProperty(Environment.KEY)
@@ -657,12 +661,27 @@ public enum Environment {
             return reloadingAgentEnabled;
         }
         try {
-            Class.forName("org.springsource.loaded.TypeRegistry");
+            Class.forName("org.springframework.boot.devtools.RemoteSpringApplication");
             reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
+            LOG.debug("Found spring-dev-tools on the class path");
         }
         catch (ClassNotFoundException e) {
             reloadingAgentEnabled = false;
         }
+        try {
+            String jvmVersion = System.getProperty("java.specification.version");
+            if(jvmVersion.equals("1.8")) {
+                Class.forName("org.springsource.loaded.TypeRegistry");
+                reloadingAgentEnabled = Environment.getCurrent().isReloadEnabled();
+                LOG.debug("Found spring-loaded on the class path");
+            } else {
+                LOG.warn("Found spring-loaded on classpath but JVM is not 1.8 - skipping");
+            }
+        }
+        catch (ClassNotFoundException e) {
+            reloadingAgentEnabled = false;
+        }
+        LOG.debug("reloadingAgentEnabled {}", reloadingAgentEnabled);
         return reloadingAgentEnabled;
     }
 

--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTraceFilterer.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTraceFilterer.java
@@ -46,6 +46,7 @@ public class DefaultStackTraceFilterer implements StackTraceFilterer {
         "net.sf.cglib.proxy.",
         "sun.",
         "java.lang.reflect.",
+        "org.springframework.boot.devtools.",
         "org.springsource.loaded.",
         "com.opensymphony.",
         "javax.servlet."

--- a/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTraceFilterer.java
+++ b/grails-bootstrap/src/main/groovy/org/grails/exceptions/reporting/DefaultStackTraceFilterer.java
@@ -46,7 +46,7 @@ public class DefaultStackTraceFilterer implements StackTraceFilterer {
         "net.sf.cglib.proxy.",
         "sun.",
         "java.lang.reflect.",
-        "org.springframework.boot.devtools.",
+        "org.springsource.loaded.",
         "com.opensymphony.",
         "javax.servlet."
     };

--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -103,7 +103,7 @@ class GrailsApp extends SpringApplication {
         log.debug("Current base directory is [{}]. Reloading base directory is [{}]", new File("."), BuildSettings.BASE_DIR)
 
         if(environment.isReloadEnabled()) {
-            log.debug("Reloading status: ", environment.isReloadEnabled())
+            log.debug("Reloading status: {}", environment.isReloadEnabled())
             enableDevelopmentModeWatch(environment, applicationContext)
         }
         printRunStatus(applicationContext)
@@ -326,8 +326,6 @@ class GrailsApp extends SpringApplication {
             }
             directoryWatcher.start()
         }
-
-
     }
 
     static boolean isDevelopmentModeActive() {

--- a/grails-core/src/main/groovy/grails/dev/Support.groovy
+++ b/grails-core/src/main/groovy/grails/dev/Support.groovy
@@ -47,7 +47,9 @@ class Support {
         }
 
         def environment = Environment.current
-        if(environment.isReloadEnabled() && !ClassUtils.isPresent("org.springsource.loaded.SpringLoaded", System.classLoader)) {
+        if(environment.isReloadEnabled() &&
+                (!ClassUtils.isPresent("org.springsource.loaded.SpringLoaded", System.classLoader) ||
+                        !ClassUtils.isPresent("org.springsource.loaded.TypeRegistry", System.classLoader))) {
             def grailsHome = System.getenv(Environment.ENV_GRAILS_HOME)
 
             if(grailsHome) {

--- a/grails-core/src/main/groovy/grails/dev/Support.groovy
+++ b/grails-core/src/main/groovy/grails/dev/Support.groovy
@@ -47,7 +47,7 @@ class Support {
         }
 
         def environment = Environment.current
-        if(environment.isReloadEnabled() && !ClassUtils.isPresent("org.springframework.boot.devtools.RemoteSpringApplication", System.classLoader)) {
+        if(environment.isReloadEnabled() && !ClassUtils.isPresent("org.springsource.loaded.SpringLoaded", System.classLoader)) {
             def grailsHome = System.getenv(Environment.ENV_GRAILS_HOME)
 
             if(grailsHome) {


### PR DESCRIPTION
Add back in the option for hot reloading from spring-loaded. Though spring-loaded is all but abandoned - it does work well for Java 8. For hot reloading on JDK 8/11+ JRebel works as well.

This is needed as large projects can not tolerate upgrades due to how long dev-tools restarts take (sometimes up to 3 minutes per change). With spring loaded & a native file watcher on osx/linux this is sub second. Users can choose which option - dev-tools is still the default.

To enable:

`build.gradle`
```groovy
dependencies {
    // Remove dev-tools from classpath
    // developmentOnly("org.springframework.boot:spring-boot-devtools") 
    agent "org.springframework:springloaded:1.2.8.RELEASE"
    // (Optional) Native OSX file watcher
    runtimeOnly "io.methvin:directory-watcher:0.9.6"
    //...
}
```