### PR TITLE
#11462 Update grails-testing-support v2.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,5 +33,5 @@ servletApiVersion=4.0.1
 asyncVersion=4.0.0
 gspVersion=4.0.0
 legacyConvertersVersion=4.0.0
-testingSupportVersion=2.0.0
+testingSupportVersion=2.1.0
 scaffoldingCoreVersion=2.1.0


### PR DESCRIPTION
To support MicronautContext as the parent context in the GrailsUnitTest. This is required to test #11462 