### PR TITLE
Update and fix tests 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,5 +33,5 @@ servletApiVersion=4.0.1
 asyncVersion=4.0.0
 gspVersion=4.0.0
 legacyConvertersVersion=4.0.0
-testingSupportVersion=2.1.0
+testingSupportVersion=2.1.1
 scaffoldingCoreVersion=2.1.0

--- a/grails-plugin-databinding/src/main/groovy/org/grails/databinding/converters/DefaultConvertersConfiguration.java
+++ b/grails-plugin-databinding/src/main/groovy/org/grails/databinding/converters/DefaultConvertersConfiguration.java
@@ -20,10 +20,10 @@ import grails.core.GrailsApplication;
 import grails.databinding.TypedStructuredBindingEditor;
 import grails.databinding.converters.FormattedValueConverter;
 import grails.databinding.converters.ValueConverter;
-import io.micronaut.context.exceptions.NoSuchBeanException;
 import org.grails.databinding.converters.web.LocaleAwareBigDecimalConverter;
 import org.grails.databinding.converters.web.LocaleAwareNumberConverter;
 import org.grails.plugins.databinding.DataBindingConfigurationProperties;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.LocaleResolver;
@@ -47,7 +47,7 @@ public class DefaultConvertersConfiguration {
         LocaleResolver localResolver;
         try {
             localResolver = grailsApplication.getMainContext().getBean(LocaleResolver.class);
-        } catch (NoSuchBeanException e) {
+        } catch (NoSuchBeanDefinitionException e) {
             localResolver = null;
         }
         this.localResolver = localResolver;

--- a/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesConfiguration.java
+++ b/grails-plugin-mimetypes/src/main/groovy/org/grails/plugins/web/mime/MimeTypesConfiguration.java
@@ -23,10 +23,7 @@ import grails.web.mime.MimeType;
 import grails.web.mime.MimeTypeProvider;
 import grails.web.mime.MimeTypeResolver;
 import grails.web.mime.MimeUtility;
-import groovy.transform.CompileStatic;
-import groovy.transform.TypeCheckingMode;
 import io.micronaut.context.BeanDefinitionRegistry;
-import io.micronaut.context.annotation.Factory;
 import org.grails.web.mime.DefaultMimeTypeResolver;
 import org.grails.web.mime.DefaultMimeUtility;
 import org.springframework.context.ApplicationContext;
@@ -36,7 +33,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/SpyBeanSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/SpyBeanSpec.groovy
@@ -1,10 +1,8 @@
 package grails.test.mixin
 
-import grails.databinding.SimpleMapDataBindingSource;
+import grails.databinding.SimpleMapDataBindingSource
 import grails.databinding.converters.ValueConverter
-import org.grails.plugins.databinding.DataBindingGrailsPlugin;
 import org.grails.spring.beans.factory.InstanceFactoryBean
-import org.grails.plugins.databinding.AbstractDataBindingGrailsPlugin
 import org.grails.testing.GrailsUnitTest
 import spock.lang.Specification
 
@@ -13,15 +11,10 @@ import spock.lang.Specification
  */
 class SpyBeanSpec extends Specification implements GrailsUnitTest {
 
-    def myAddressValueConverter=Spy(MyAddressValueConverter)
+    def myAddressValueConverterMock =Spy(MyAddressValueConverter)
 
     Closure doWithSpring() {{ ->
-        def plugin = new DataBindingGrailsPlugin()
-        plugin.grailsApplication = delegate.application
-        def otherClosure= plugin.doWithSpring().clone()
-        otherClosure.delegate=delegate
-        otherClosure.call()
-        myAddressValueConverter(InstanceFactoryBean, myAddressValueConverter, MyAddressValueConverter)
+        myAddressValueConverter(InstanceFactoryBean, myAddressValueConverterMock, MyAddressValueConverter)
     }}
 
     def "it's possible to use Spy instances as beans as well"() {
@@ -31,9 +24,9 @@ class SpyBeanSpec extends Specification implements GrailsUnitTest {
         when:
         binder.bind person, [name:'Lari', address:'Espoo,Finland'] as SimpleMapDataBindingSource
         then:
-        1 * myAddressValueConverter.canConvert('Espoo,Finland')
-        1 * myAddressValueConverter.convert('Espoo,Finland')
-        0 * myAddressValueConverter._
+        1 * myAddressValueConverterMock.canConvert('Espoo,Finland')
+        1 * myAddressValueConverterMock.convert('Espoo,Finland')
+        0 * myAddressValueConverterMock._
         person.address.city=='Espoo'
         person.address.country=='Finland'
     }

--- a/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
@@ -17,12 +17,11 @@
 package grails.rest.web
 
 import grails.artefact.Artefact
+import grails.core.support.proxy.ProxyHandler
 import grails.persistence.Entity
 import grails.testing.gorm.DomainUnitTest
 import grails.testing.web.controllers.ControllerUnitTest
-import org.grails.plugins.web.mime.MimeTypesFactoryBean
 import grails.web.mime.MimeType
-import grails.core.support.proxy.ProxyHandler
 import org.grails.web.util.GrailsApplicationAttributes
 import org.springframework.web.servlet.ModelAndView
 import spock.lang.Issue
@@ -30,10 +29,10 @@ import spock.lang.Specification
 
 class RespondMethodSpec extends Specification implements ControllerUnitTest<BookController>, DomainUnitTest<Book> {
 
-    void setup() {
-        def ga = grailsApplication
-        ga.config.grails.mime.types =
-            [ html: ['text/html','application/xhtml+xml'],
+    Closure doWithConfig() {{ config ->
+        // unit tests in real applications will not need to do
+        // this because the real Config.groovy will be loaded
+        config.grails.mime.types = [html         : ['text/html', 'application/xhtml+xml'],
             xml: ['text/xml', 'application/xml'],
             text: 'text/plain',
             js: 'text/javascript',
@@ -46,13 +45,7 @@ class RespondMethodSpec extends Specification implements ControllerUnitTest<Book
             form: 'application/x-www-form-urlencoded',
             multipartForm: 'multipart/form-data'
         ]
-
-        defineBeans {
-            mimeTypes(MimeTypesFactoryBean) {
-                grailsApplication = ga
-            }
-        }
-    }
+    }}
 
     void "Test that the respond method produces the correct model for a domain instance and no specific content type"() {
         given:"A book instance"

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/mime/WithFormatContentTypeSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/mime/WithFormatContentTypeSpec.groovy
@@ -2,7 +2,6 @@ package org.grails.web.mime
 
 import grails.artefact.Artefact
 import grails.testing.web.controllers.ControllerUnitTest
-import grails.util.Holders
 import grails.web.mime.MimeType
 import spock.lang.Issue
 import spock.lang.Specification

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -659,7 +659,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
         def formatString
         if(code) {
             def locale = getLocale()
-            formatString = messageSource.getMessage(code, [] as Object[], locale)
+            formatString = messageSource.getMessage((String) code, [] as Object[], locale)
         }
         if(!formatString) {
             formatString = super.getFormatString(annotation)


### PR DESCRIPTION
Now with grails-testing-support v2.1.1, we removed the deprecated way of initializing beans via MimeTypeGrailsPlugin and DataBindingGrailsPlugin. So, we need to update some of the tests accordingly.