### PR TITLE
Customize ValueConverter over existing standard ValueConverter

### DIFF
--- a/grails-plugin-databinding/build.gradle
+++ b/grails-plugin-databinding/build.gradle
@@ -7,4 +7,15 @@ dependencies {
 
     compile project(':grails-core'), project(':grails-web')
 
+    testCompile project(':grails-test-suite-base')
+    testCompile "org.grails:grails-web-testing-support:$testingSupportVersion", {
+        exclude module:'grails-plugin-codecs'
+        exclude module:'grails-plugin-rest'
+        exclude module:'grails-plugin-interceptors'
+        exclude module:'grails-test'
+        exclude module:'grails-core'
+        exclude module:'async'
+        exclude module:'gsp'
+    }
+
 }

--- a/grails-plugin-databinding/src/main/groovy/org/grails/plugins/databinding/DataBindingConfiguration.java
+++ b/grails-plugin-databinding/src/main/groovy/org/grails/plugins/databinding/DataBindingConfiguration.java
@@ -12,6 +12,7 @@ import org.grails.web.databinding.bindingsource.*;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 @Configuration
 public class DataBindingConfiguration {
@@ -37,7 +38,10 @@ public class DataBindingConfiguration {
         final ApplicationContext mainContext = grailsApplication.getMainContext();
         final ValueConverter[] mainContextConverters = mainContext
                 .getBeansOfType(ValueConverter.class).values().toArray(new ValueConverter[0]);
-        dataBinder.setValueConverters(ArrayUtils.concat(valueConverters, mainContextConverters));
+        final ValueConverter[] allValueConverters = ArrayUtils.concat(valueConverters, mainContextConverters);
+        AnnotationAwareOrderComparator.sort(allValueConverters);
+        dataBinder.setValueConverters(allValueConverters);
+
         final FormattedValueConverter[] mainContextFormattedValueConverters = mainContext
                 .getBeansOfType(FormattedValueConverter.class).values().toArray(new FormattedValueConverter[0]);
         dataBinder.setFormattedValueConverters(ArrayUtils.concat(formattedValueConverters, mainContextFormattedValueConverters));

--- a/grails-plugin-databinding/src/test/groovy/org/grails/plugins/databinding/DataBindingConfigurationSpec.groovy
+++ b/grails-plugin-databinding/src/test/groovy/org/grails/plugins/databinding/DataBindingConfigurationSpec.groovy
@@ -1,0 +1,136 @@
+package org.grails.plugins.databinding
+
+import grails.databinding.converters.ValueConverter
+import grails.web.databinding.WebDataBinding
+import org.grails.testing.GrailsUnitTest
+import org.springframework.core.annotation.Order
+import spock.lang.Specification
+
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.time.Month
+import java.time.ZoneId
+
+@SuppressWarnings("GrMethodMayBeStatic")
+class DataBindingConfigurationSpec extends Specification implements GrailsUnitTest, WebDataBinding {
+
+
+    void setup() {
+        defineBeans {
+            myValueConverter1(MyValueConverter)
+            myValueConverter2(MyValueConverter2)
+            myDateValueConverter(MyDateValueConverter)
+        }
+    }
+
+    void "test that grailsWebDataBinder exists"() {
+
+        expect:
+        grailsApplication.mainContext.containsBean("grailsWebDataBinder")
+    }
+
+    void "test custom ValueConverter are ordered if defined with @Order"() {
+
+        when:
+        Map source = ["name": "John Doe", "prop": "test"]
+        Person person = new Person()
+        person.setProperties(source)
+
+        then:
+        person.prop.value == "test2"
+
+    }
+
+    void "test customize data binding for the types which have standard ValueConverters using @Order"() {
+        when:
+        Map source = ["name": "John Doe", "prop": "test", "dob": "12031990"]
+        Person person = new Person()
+        person.setProperties(source)
+
+        then:
+        person.prop.value == "test2"
+        person.dob
+        Month.MARCH == getMonth(person.dob)
+    }
+
+    private Month getMonth(Date date) {
+        date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate().getMonth()
+    }
+
+    @Order(value = 1)
+    static class MyDateValueConverter implements ValueConverter {
+
+        @Override
+        boolean canConvert(Object value) {
+            return value instanceof String
+        }
+
+        @Override
+        Object convert(Object value) {
+            if (value) {
+                DateFormat formatter = new SimpleDateFormat("ddMMyyyy")
+                return formatter.parse((String) value)
+            }
+            return value
+        }
+
+        @Override
+        Class<?> getTargetType() {
+            Date.class
+        }
+    }
+
+    @Order(value = 2)
+    static class MyValueConverter implements ValueConverter {
+
+        @Override
+        boolean canConvert(Object value) {
+            return value instanceof String
+        }
+
+        @Override
+        Object convert(Object value) {
+            new MyCustomProp((String) value + "1")
+        }
+
+        @Override
+        Class<?> getTargetType() {
+            MyCustomProp.class
+        }
+    }
+
+    @Order(value = 1)
+    static class MyValueConverter2 implements ValueConverter {
+
+        @Override
+        boolean canConvert(Object value) {
+            return value instanceof String
+        }
+
+        @Override
+        Object convert(Object value) {
+            new MyCustomProp((String) value + "2")
+        }
+
+        @Override
+        Class<?> getTargetType() {
+            MyCustomProp.class
+        }
+    }
+
+    static class MyCustomProp {
+        String value
+
+        MyCustomProp(String value) {
+            this.value = value
+        }
+    }
+
+    static class Person implements WebDataBinding {
+        String name
+        Date dob
+        MyCustomProp prop
+
+        Person() {}
+    }
+}


### PR DESCRIPTION
We can annotate our custom `ValueConverter` with `@Order(value=-1)` annotation which will give priority to our implementation over the standard one.

Fixes #11472 

@graemerocher I will send another PR to change the default for Grails standard `ValueConverter` from `Ordered.LOWEST_PRECEDENCE` to `0`. 