### PR TITLE
Prevent NPE in the toString of DefaultUrlMappingInfo.java

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
@@ -158,6 +158,9 @@ public class DefaultUrlMappingInfo extends AbstractUrlMappingInfo {
 
     @Override
     public String toString() {
+        if (urlData == null) {
+            return null;
+        }
         return urlData.getUrlPattern();
     }
 


### PR DESCRIPTION
Return `null` and do not call `urlData.getUrlPattern();` when `urlData` is null.

Fixes #11458