### PR TITLE
Added micronaut-runtime-groovy as compile dependency

### DIFF
--- a/grails-plugin-databinding/build.gradle
+++ b/grails-plugin-databinding/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compileOnly "io.micronaut.spring:micronaut-spring-annotation:$micronautSpringVersion"
 
     compile project(':grails-core'), project(':grails-web')
+    compile "io.micronaut:micronaut-runtime-groovy:$micronautRuntimeGroovyVersion"
 
     testCompile project(':grails-test-suite-base')
     testCompile "org.grails:grails-web-testing-support:$testingSupportVersion", {


### PR DESCRIPTION
For GroovyPropertySourceLoader to read configuration from application.groovy

Fixes #11423 