### PR TITLE
Clarify assertUrlMapping's Groovydoc

### DIFF
--- a/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
+++ b/grails-plugin-testing/src/main/groovy/grails/test/mixin/web/UrlMappingsUnitTestMixin.groovy
@@ -159,11 +159,14 @@ class UrlMappingsUnitTestMixin extends ControllerUnitTestMixin {
     }
 
     /**
-     * Asserts a URL mapping maps to the controller and action specified by named parameters. Example:
+     * Asserts a URL mapping maps to the specified controller, action, and parameters. Example:
      *
      * <pre>
      * <code>
-     *           assertUrlMapping("/action1", controller: "grailsUrlMappingsTestCaseFake", action: "action1")
+     *           assertUrlMapping("/action1", controller: "grailsUrlMappingsTestCaseFake", action: "action1") {
+     *              param1 = "value1"
+     *              param2 = "value2"
+     *           }
      * </code>
      * </pre>
      * @param assertions The assertions as named parameters


### PR DESCRIPTION
Clarified the doc example reusing a unit test.