### PR TITLE
Set StaticCompile prop to false from GrailsApp

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -58,6 +58,7 @@ class GrailsApp extends SpringApplication {
 
     private static boolean developmentModeActive = false
     private static DirectoryWatcher directoryWatcher
+    private static final String COMPILE_STATIC_PROP = 'micronaut.groovy.config.compileStatic'
 
     boolean enableBeanCreationProfiler = false
     ConfigurableEnvironment configuredEnvironment
@@ -148,7 +149,7 @@ class GrailsApp extends SpringApplication {
         if (objectMapper != null) {
             beanExcludes.add(objectMapper)
         }
-        def micronautContext = new io.micronaut.context.DefaultApplicationContext(micronautConfiguration);
+        def micronautContext = new io.micronaut.context.DefaultApplicationContext(micronautConfiguration)
         micronautContext
                 .environment
                 .addPropertySource("grails-config", [(MicronautBeanFactoryConfiguration.PREFIX + ".bean-excludes"): (Object)beanExcludes])
@@ -183,6 +184,7 @@ class GrailsApp extends SpringApplication {
         }
 
         def env = Environment.current
+        environment.systemProperties[COMPILE_STATIC_PROP] = "false"
         environment.addActiveProfile(env.name)
         configuredEnvironment = environment
     }

--- a/grails-core/src/test/groovy/grails/boot/StaticCompilePropSpec.groovy
+++ b/grails-core/src/test/groovy/grails/boot/StaticCompilePropSpec.groovy
@@ -15,5 +15,6 @@ class StaticCompilePropSpec extends Specification {
         then:
         environment
         environment.systemProperties['micronaut.groovy.config.compileStatic'] == "false"
+        System.getProperty('micronaut.groovy.config.compileStatic') == "false"
     }
 }

--- a/grails-core/src/test/groovy/grails/boot/StaticCompilePropSpec.groovy
+++ b/grails-core/src/test/groovy/grails/boot/StaticCompilePropSpec.groovy
@@ -1,0 +1,19 @@
+package grails.boot
+
+import org.springframework.core.env.ConfigurableEnvironment
+import spock.lang.Specification
+
+class StaticCompilePropSpec extends Specification {
+
+    void "test that compileStatic system property is set to avoid static compilation exception with application.groovy"() {
+
+        when:
+        GrailsApp app = new GrailsApp(GrailsTestConfigurationClass.class)
+        app.run()
+        ConfigurableEnvironment environment = app.getConfiguredEnvironment()
+
+        then:
+        environment
+        environment.systemProperties['micronaut.groovy.config.compileStatic'] == "false"
+    }
+}


### PR DESCRIPTION
This property will be used once micronaut-projects/micronaut-groovy#36 merged and released.

Fixes the breaking change in #11423 i.e. ConfigurationException with `application.groovy` after adding `micronaut-runtime-groovy` dependency to compile scope which applies CompileStatic ASTTransformationCustomizer.