### PR TITLE
#11507 Add conversion from camel case to kebab

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoader.groovy
+++ b/grails-core/src/main/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoader.groovy
@@ -91,7 +91,11 @@ class MicronautGroovyPropertySourceLoader extends AbstractPropertySourceLoader {
             }
         }
         for (key in keys) {
-            configObject[camelToKebabCase(key)] = configObject[key]
+            if (!configObject[camelToKebabCase(key)]) {
+                configObject[camelToKebabCase(key)] = configObject[key]
+            } else {
+                throw new ConfigurationException("Key [" + key + "] defined as both camel and kebab case.")
+            }
         }
     }
 

--- a/grails-core/src/main/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoader.groovy
+++ b/grails-core/src/main/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoader.groovy
@@ -41,6 +41,7 @@ class MicronautGroovyPropertySourceLoader extends AbstractPropertySourceLoader {
                         appVersion: Metadata.getCurrent().getApplicationVersion())
                 try {
                     def configObject = configSlurper.parse(input.getText("UTF-8"))
+                    convertKeysToKebab(configObject)
                     def propertySource = new NavigableMap()
                     propertySource.merge(configObject, false)
                     finalMap.putAll(propertySource)
@@ -73,4 +74,25 @@ class MicronautGroovyPropertySourceLoader extends AbstractPropertySourceLoader {
     Set<String> getExtensions() {
         return Collections.singleton("groovy")
     }
+
+    private void convertKeysToKebab(ConfigObject configObject) {
+        def camelToKebabCase = {String text ->
+            text.replaceAll(/([A-Z])/, /-$1/).toLowerCase().replaceAll(/^-/, '')
+        }
+        List<String> keys = []
+        for (key in configObject.keySet()) {
+            if (key.getClass() == String && configObject[key]) {
+                if (configObject[key].getClass() == ConfigObject) {
+                    convertKeysToKebab(configObject[key] as ConfigObject)
+                }
+                if (camelToKebabCase(key as String) != key) {
+                    keys.add(key as String)
+                }
+            }
+        }
+        for (key in keys) {
+            configObject[camelToKebabCase(key)] = configObject[key]
+        }
+    }
+
 }

--- a/grails-core/src/test/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoaderSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoaderSpec.groovy
@@ -67,6 +67,39 @@ info:
         Metadata.reset()
     }
 
+    void "test parsing configuration file with camel cased keys"() {
+        setup:
+        InputStream inputStream = new ByteArrayInputStream(applicationGroovyWithCamelCaseVars)
+        MicronautGroovyPropertySourceLoader groovyPropertySourceLoader = new MicronautGroovyPropertySourceLoader()
+        Map<String, Object> finalMap = [:]
+
+        when:
+        groovyPropertySourceLoader.processInput("test-application.groovy", inputStream, finalMap)
+
+        then:
+        noExceptionThrown()
+        finalMap.containsKey("micronaut.http.services.example-service.url")
+        finalMap.containsKey("micronaut.http.services.example-service.path")
+        finalMap.get("micronaut.http.services.example-service.url")
+        finalMap.get("micronaut.http.services.example-service.path")
+    }
+
+    void "test parsing configuration file with flattened camel cased keys"() {
+        setup:
+        InputStream inputStream = new ByteArrayInputStream(applicationGroovyWithFlatCamelCaseVars)
+        MicronautGroovyPropertySourceLoader groovyPropertySourceLoader = new MicronautGroovyPropertySourceLoader()
+        Map<String, Object> finalMap = [:]
+
+        when:
+        groovyPropertySourceLoader.processInput("test-application.groovy", inputStream, finalMap)
+
+        then:
+        noExceptionThrown()
+        finalMap.containsKey("micronaut.http.services.example-service.url")
+        finalMap.containsKey("micronaut.http.services.example-service.path")
+        finalMap.get("micronaut.http.services.example-service.url")
+        finalMap.get("micronaut.http.services.example-service.path")
+    }
 
     private byte[] getApplicationGroovyWithDsl() {
         '''
@@ -88,6 +121,28 @@ userHomeVar=userHome
 grailsHomeVar=grailsHome
 appNameVar=appName
 appVersionVar=appVersion
+'''.bytes
+    }
+
+    private byte[] getApplicationGroovyWithCamelCaseVars() {
+'''
+micronaut{
+    http {
+        services{
+            exampleService{
+                url = "http://localhost:8080"
+                path = "/example"
+            }
+        }
+    }
+}
+'''.bytes
+    }
+
+    private byte[] getApplicationGroovyWithFlatCamelCaseVars() {
+'''
+micronaut.http.services.exampleService.url = "http://localhost:8080"
+micronaut.http.services.exampleService.path = "/example"
 '''.bytes
     }
 }

--- a/grails-core/src/test/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoaderSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/cfg/MicronautGroovyPropertySourceLoaderSpec.groovy
@@ -1,6 +1,7 @@
 package org.grails.core.cfg
 
 import grails.util.Metadata
+import io.micronaut.context.exceptions.ConfigurationException
 import org.grails.config.NavigableMap
 import spock.lang.Specification
 
@@ -101,6 +102,19 @@ info:
         finalMap.get("micronaut.http.services.example-service.path")
     }
 
+    void "test parsing configuration file with duplicated keys"() {
+        setup:
+        InputStream inputStream = new ByteArrayInputStream(applicationGroovyWithCamelCaseAndKebabCaseVars)
+        MicronautGroovyPropertySourceLoader groovyPropertySourceLoader = new MicronautGroovyPropertySourceLoader()
+        Map<String, Object> finalMap = [:]
+
+        when:
+        groovyPropertySourceLoader.processInput("test-application.groovy", inputStream, finalMap)
+
+        then:
+        thrown ConfigurationException
+    }
+
     private byte[] getApplicationGroovyWithDsl() {
         '''
 grails.gorm.default.constraints = {
@@ -143,6 +157,13 @@ micronaut{
 '''
 micronaut.http.services.exampleService.url = "http://localhost:8080"
 micronaut.http.services.exampleService.path = "/example"
+'''.bytes
+    }
+
+    private byte[] getApplicationGroovyWithCamelCaseAndKebabCaseVars() {
+'''
+micronaut.http.services.exampleService.url = "http://localhost:8080"
+micronaut.http.services."example-service".url = "http://localhost:8080"
 '''.bytes
     }
 }


### PR DESCRIPTION
This adds a step to the MicronautGroovyPropertySourceLoader to convert camel case keys to kebab case to fix the issue described in #11507. 

I also added two test cases to show the desired input/output combinations.

