### PR TITLE
Open up configureDirectoryWatcher to avoid IllegalAccessError

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
+++ b/grails-core/src/main/groovy/grails/boot/GrailsApp.groovy
@@ -405,7 +405,7 @@ class GrailsApp extends SpringApplication {
         }
     }
 
-    protected void configureDirectoryWatcher(DirectoryWatcher directoryWatcher, String location) {
+    void configureDirectoryWatcher(DirectoryWatcher directoryWatcher, String location) {
         directoryWatcher.addWatchDirectory(new File(location, "grails-app"), ['groovy', 'java'])
         directoryWatcher.addWatchDirectory(new File(location, "src/main/groovy"), ['groovy', 'java'])
         directoryWatcher.addWatchDirectory(new File(location, "src/main/java"), ['groovy', 'java'])


### PR DESCRIPTION
Getting this exception when starting a 4.1.0 snapshot
```
Exception in thread "main" java.lang.IllegalAccessError: tried to access method grails.boot.GrailsApp.configureDirectoryWatcher(Lorg/grails/io/watch/DirectoryWatcher;Ljava/lang/String;)V from class grails.boot.GrailsApp$configureDirectoryWatcher$0
	at grails.boot.GrailsApp$configureDirectoryWatcher$0.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:51)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:171)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:194)
	at grails.boot.GrailsApp.enableDevelopmentModeWatch(GrailsApp.groovy:236)
	at grails.boot.GrailsApp.run(GrailsApp.groovy:106)
	at grails.boot.GrailsApp.run(GrailsApp.groovy:456)
	at grails.boot.GrailsApp.run(GrailsApp.groovy:443)
	at foo.Application.main(Application.groovy:11)
```

Unsure if groovy 3 is more strict on accessing protected - this works but if there is a better solution let me know!