### PR TITLE
create more consistent behavior on handling mime types in respond().

### DIFF
--- a/grails-plugin-mimetypes/src/main/groovy/org/grails/web/mime/HttpServletResponseExtension.groovy
+++ b/grails-plugin-mimetypes/src/main/groovy/org/grails/web/mime/HttpServletResponseExtension.groovy
@@ -181,10 +181,8 @@ class HttpServletResponseExtension {
         HttpServletRequest request = webRequest.getCurrentRequest()
         MimeType[] result = (MimeType[]) request.getAttribute(GrailsApplicationAttributes.RESPONSE_MIME_TYPES)
         if (!result) {
-            def formatOverride = webRequest?.params?.format
-            if (!formatOverride) {
-                formatOverride = request.getAttribute(GrailsApplicationAttributes.RESPONSE_FORMAT)
-            }
+            //Use existing getFormat logic which handles params.format Mime Type Cache when a ?format is used and a Url Mapping has ?.format
+            def formatOverride = getFormat(response)
             if (formatOverride) {
                 def allMimes = getMimeTypes()
                 MimeType mime = allMimes.find { MimeType it -> it.extension == formatOverride }


### PR DESCRIPTION
The ResponseExtension methods have some redundant code that cause some inconsistent behavior. If one calls `response.format` before using the `respond` method, you may get a different behavior. This Fixes #11406