### PR TITLE
Implemented Forked GSP Compiler on Gradle to work similar to grails-views

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,9 +30,9 @@ h2.version=1.4.199
 gradleNexusPluginVersion=2.3.1
 gradleNexusStagingPluginVersion=0.12.0
 servletApiVersion=4.0.1
-# These need to be released once 4.0.0 is available
 asyncVersion=4.0.0
-gspVersion=4.0.0
 legacyConvertersVersion=4.0.0
 testingSupportVersion=2.1.1
 scaffoldingCoreVersion=2.1.0
+# These need to be released once 4.0.4 is available
+gspVersion=4.0.1.BUILD-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,8 +31,7 @@ gradleNexusPluginVersion=2.3.1
 gradleNexusStagingPluginVersion=0.12.0
 servletApiVersion=4.0.1
 asyncVersion=4.0.0
-legacyConvertersVersion=4.0.0
+legacyConvertersVersion=4.0.1
 testingSupportVersion=2.1.1
 scaffoldingCoreVersion=2.1.0
-# These need to be released once 4.0.4 is available
-gspVersion=4.0.1.BUILD-SNAPSHOT
+gspVersion=4.0.1

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -1,0 +1,120 @@
+package org.grails.gradle.plugin.web.gsp
+
+import grails.io.ResourceUtils
+import groovy.transform.CompileDynamic
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.tools.shell.util.PackageHelper
+import org.gradle.api.Action
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+import org.gradle.process.ExecResult
+import org.gradle.process.JavaExecSpec
+
+/**
+ * Abstract Gradle task for compiling templates, using GenericGroovyTemplateCompiler
+ *
+ * @author Graeme Rocher
+ * @since 1.0
+ */
+@CompileStatic
+class GroovyPageForkCompileTask extends AbstractCompile {
+
+    @Input
+    @Optional
+    String packageName
+
+    @InputDirectory
+    File srcDir
+
+    @Input
+    File tmpDir
+
+    @Input
+    @Optional
+    String serverpath
+
+    @Nested
+    GspCompileOptions compileOptions = new GspCompileOptions()
+
+    @Override
+    void setSource(Object source) {
+        try {
+            srcDir = project.file(source)
+            if(srcDir.exists() && !srcDir.isDirectory()) {
+                throw new IllegalArgumentException("The source for GSP compilation must be a single directory, but was $source")
+            }
+            super.setSource(source)
+        } catch (e) {
+            throw new IllegalArgumentException("The source for GSP compilation must be a single directory, but was $source")
+        }
+    }
+
+    @TaskAction
+    void execute(IncrementalTaskInputs inputs) {
+        compile()
+    }
+
+    protected void compile() {
+
+        if(packageName == null) {
+            packageName = project.name
+            if(!packageName) {
+                packageName = project.projectDir.canonicalFile.name
+            }
+        }
+
+        ExecResult result = project.javaexec(
+                new Action<JavaExecSpec>() {
+                    @Override
+                    @CompileDynamic
+                    void execute(JavaExecSpec javaExecSpec) {
+                        javaExecSpec.setMain(getCompilerName())
+                        javaExecSpec.setClasspath(getClasspath())
+
+                        def jvmArgs = compileOptions.forkOptions.jvmArgs
+                        if(jvmArgs) {
+                            javaExecSpec.jvmArgs(jvmArgs)
+                        }
+                        javaExecSpec.setMaxHeapSize( compileOptions.forkOptions.memoryMaximumSize )
+                        javaExecSpec.setMinHeapSize( compileOptions.forkOptions.memoryInitialSize )
+
+
+                        def arguments = [
+                            srcDir.canonicalPath,
+                            destinationDir.canonicalPath,
+                            tmpDir.canonicalPath,
+                            targetCompatibility,
+                            packageName,
+                            serverpath,
+                            project.file("grails-app/conf/application.yml").canonicalPath,
+                            compileOptions.encoding
+                        ]
+
+                        prepareArguments(arguments)
+                        javaExecSpec.args(arguments)
+                    }
+
+                }
+        )
+        result.assertNormalExitValue()
+
+    }
+
+    void prepareArguments(List<String> arguments) {
+        // no-op
+    }
+
+    protected String getCompilerName() {
+        "org.grails.web.pages.GroovyPageCompilerForkTask"
+    }
+
+
+    String getFileExtension() {
+        "gsp"
+    }
+}

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -16,10 +16,12 @@ import org.gradle.process.ExecResult
 import org.gradle.process.JavaExecSpec
 
 /**
- * Abstract Gradle task for compiling templates, using GenericGroovyTemplateCompiler
+ * Abstract Gradle task for compiling templates, using GroovyPageCompilerForkTask
+ * This Task is a Forked Java Task that is configurable with fork options provided
+ * by {@link GspCompileOptions}
  *
- * @author Graeme Rocher
- * @since 1.0
+ * @author David Estes
+ * @since 4.0
  */
 @CompileStatic
 class GroovyPageForkCompileTask extends AbstractCompile {

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPagePlugin.groovy
@@ -49,19 +49,23 @@ class GroovyPagePlugin implements Plugin<Project> {
         }
 
         def allTasks = project.tasks
-        def compileGroovyPages = allTasks.create("compileGroovyPages", GroovyPageCompileTask) {
+        def compileGroovyPages = allTasks.create("compileGroovyPages", GroovyPageForkCompileTask) {
             destinationDir = destDir
+            tmpDir = getTmpDir(project)
             source = project.file("${project.projectDir}/grails-app/views")
             serverpath = "/WEB-INF/grails-app/views/"
-            classpath = allClasspath
         }
 
-        def compileWebappGroovyPages = allTasks.create("compileWebappGroovyPages", GroovyPageCompileTask) {
+        compileGroovyPages.setClasspath( allClasspath )
+
+        def compileWebappGroovyPages = allTasks.create("compileWebappGroovyPages", GroovyPageForkCompileTask) {
             destinationDir = destDir
             source = project.file("${project.projectDir}/src/main/webapp")
+            tmpDir = getTmpDir(project)
             serverpath = "/"
-            classpath = allClasspath
         }
+
+        compileWebappGroovyPages.setClasspath( allClasspath )
 
 
         compileGroovyPages.dependsOn( allTasks.findByName("classes") )
@@ -88,6 +92,12 @@ class GroovyPagePlugin implements Plugin<Project> {
 
     protected FileCollection resolveClassesDirs(SourceSetOutput output, Project project) {
         output?.classesDirs ?: project.files(new File(project.buildDir, "classes/main"))
+    }
+
+    protected File getTmpDir(Project project) {
+        def tmpdir = new File(project.buildDir as String, "gsptmp")
+        tmpdir.mkdirs()
+        return tmpdir
     }
 
 }

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
@@ -2,6 +2,12 @@ package org.grails.gradle.plugin.web.gsp
 
 import org.gradle.api.tasks.compile.GroovyForkOptions
 
+/**
+* Presents the Compile Options used by the {@llink GroovyPageForkCompileTask}
+*
+* @author David Estes
+* @since 4.0
+*/
 class GspCompileOptions {
 	String encoding = "UTF-8"
     GroovyForkOptions forkOptions = new GroovyForkOptions()

--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GspCompileOptions.groovy
@@ -1,0 +1,8 @@
+package org.grails.gradle.plugin.web.gsp
+
+import org.gradle.api.tasks.compile.GroovyForkOptions
+
+class GspCompileOptions {
+	String encoding = "UTF-8"
+    GroovyForkOptions forkOptions = new GroovyForkOptions()
+}

--- a/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -29,7 +29,6 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.Part
-import groovy.json.JsonSlurper
 import grails.web.mime.MimeType
 import org.grails.web.util.GrailsApplicationAttributes
 import org.grails.web.servlet.mvc.GrailsWebRequest
@@ -242,11 +241,7 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
      */
     def getJSON() {
         if (!cachedJson) {
-            String encoding = this.getCharacterEncoding();
-            if (encoding == null) {
-                encoding = "UTF-8";
-            }
-            cachedJson = new JsonSlurper().parseText(request.inputStream,encoding)
+            cachedJson = GrailsMockHttpServletRequest.classLoader.loadClass("grails.converters.JSON").parse(this)
         }
         return cachedJson
     }

--- a/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
+++ b/grails-test/src/main/groovy/org/grails/plugins/testing/GrailsMockHttpServletRequest.groovy
@@ -29,7 +29,7 @@ import javax.servlet.ServletResponse
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import javax.servlet.http.Part
-
+import groovy.json.JsonSlurper
 import grails.web.mime.MimeType
 import org.grails.web.util.GrailsApplicationAttributes
 import org.grails.web.servlet.mvc.GrailsWebRequest
@@ -242,7 +242,11 @@ class GrailsMockHttpServletRequest extends MockHttpServletRequest implements Mul
      */
     def getJSON() {
         if (!cachedJson) {
-            cachedJson = GrailsMockHttpServletRequest.classLoader.loadClass("grails.converters.JSON").parse(this)
+            String encoding = this.getCharacterEncoding();
+            if (encoding == null) {
+                encoding = "UTF-8";
+            }
+            cachedJson = new JsonSlurper().parseText(request.inputStream,encoding)
         }
         return cachedJson
     }


### PR DESCRIPTION
compileGroovyPages is running in the gradle runtime as an ant task. This is bad for large projects. Converted compiler to use the new Forked Compiler in grails-gsp PR grails/grails-gsp#57 . These go together