### PR TITLE
Have unset and default be the same for controller scope

### DIFF
--- a/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
+++ b/grails-core/src/main/groovy/org/grails/core/DefaultGrailsControllerClass.java
@@ -77,7 +77,7 @@ public class DefaultGrailsControllerClass extends AbstractInjectableGrailsClass 
     public void setGrailsApplication(GrailsApplication grailsApplication) {
         this.grailsApplication = grailsApplication;
         if (this.scope == null) {
-            this.scope = grailsApplication.getConfig().getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, "prototype");
+            this.scope = grailsApplication.getConfig().getProperty(Settings.CONTROLLERS_DEFAULT_SCOPE, SCOPE_SINGLETON);
         }
     }
 

--- a/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/core/DefaultGrailsControllerClassSpec.groovy
@@ -16,12 +16,12 @@ class DefaultGrailsControllerClassSpec extends Specification {
         given:
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "the configuration value is used"
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     void "test getScope when scope is not specified on the controller, and not specified in config"() {
@@ -29,36 +29,36 @@ class DefaultGrailsControllerClassSpec extends Specification {
         def controllerClass = new DefaultGrailsControllerClass(NotSpecifiedController)
         controllerClass.setGrailsApplication(new DefaultGrailsApplication())
 
-        expect: "the default scope is prototype"
-        controllerClass.getScope() == PROTOTYPE
-        !controllerClass.isSingleton()
+        expect: "the default scope is singleton"
+        controllerClass.getScope() == SINGLETON
+        controllerClass.isSingleton()
     }
 
     void "test getScope when scope is specified on the controller, and not specified in config"() {
         given:
-        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+        def controllerClass = new DefaultGrailsControllerClass(PrototypeController)
 
         expect:
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     void "test getScope when scope is specified both in the controller and config"() {
         given:
-        def controllerClass = new DefaultGrailsControllerClass(SingletonController)
+        def controllerClass = new DefaultGrailsControllerClass(PrototypeController)
         def grailsApplication = new DefaultGrailsApplication()
-        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, PROTOTYPE)
+        grailsApplication.getConfig().put(Settings.CONTROLLERS_DEFAULT_SCOPE, SINGLETON)
         controllerClass.setGrailsApplication(grailsApplication)
 
         expect: "controller's setting to have priority"
-        controllerClass.getScope() == SINGLETON
-        controllerClass.isSingleton()
+        controllerClass.getScope() == PROTOTYPE
+        !controllerClass.isSingleton()
     }
 
     class NotSpecifiedController {
     }
 
-    class SingletonController {
-        static scope = "singleton"
+    class PrototypeController {
+        static scope = "prototype"
     }
 }


### PR DESCRIPTION
It is confusing to have the unset value be prototype and the "default" new app template value be singleton. This aligns unset and default.

Also this default config value should be removed from profiles as it's actually the default now :)

RE: https://stackoverflow.com/questions/63002377/grails-4-controllers-where-in-grails-4-code-can-i-find-a-proof-that-grails-cont/63004029#63004029

