### PR TITLE
Fixes issue #11394 Spring Loaded enhancer is not enabling cache or setting profile correctly

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/agent/AgentTasksEnhancer.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/agent/AgentTasksEnhancer.groovy
@@ -58,6 +58,8 @@ class AgentTasksEnhancer implements Action<Project> {
             if(agentConfig.exclusions) {
                 agentArgs.put('exclusions', agentConfig.exclusions)
             }
+            agentArgs.put("profile","grails")
+            agentArgs.put("caching","true")
             exec.systemProperty('springloaded', agentArgs.collect { entry -> "$entry.key=$entry.value"}.join(';'))
         }
 


### PR DESCRIPTION
This improves springloaded reload performance by turning the cache back on and setting the profile to Grails which helps springloaded deal with some grails specific scenarios better.