### PR TITLE
Fix default response type handling

### DIFF
--- a/grails-plugin-mimetypes/src/main/groovy/org/grails/web/mime/HttpServletResponseExtension.groovy
+++ b/grails-plugin-mimetypes/src/main/groovy/org/grails/web/mime/HttpServletResponseExtension.groovy
@@ -181,8 +181,10 @@ class HttpServletResponseExtension {
         HttpServletRequest request = webRequest.getCurrentRequest()
         MimeType[] result = (MimeType[]) request.getAttribute(GrailsApplicationAttributes.RESPONSE_MIME_TYPES)
         if (!result) {
-            //Use existing getFormat logic which handles params.format Mime Type Cache when a ?format is used and a Url Mapping has ?.format
-            def formatOverride = getFormat(response)
+            def formatOverride = webRequest?.params?.format
+            if (!formatOverride) {
+                formatOverride = request.getAttribute(GrailsApplicationAttributes.RESPONSE_FORMAT)
+            }
             if (formatOverride) {
                 def allMimes = getMimeTypes()
                 MimeType mime = allMimes.find { MimeType it -> it.extension == formatOverride }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
@@ -88,7 +88,7 @@ public abstract class AbstractUrlMappingInfo implements UrlMappingInfo {
             if (param instanceof CharSequence) {
                 param = param.toString();
             }
-            dispatchParams.putIfAbsent(name, param);
+            dispatchParams.put(name, param);
         }
 
         final String viewName = getViewName();

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/AbstractUrlMappingInfo.java
@@ -88,7 +88,7 @@ public abstract class AbstractUrlMappingInfo implements UrlMappingInfo {
             if (param instanceof CharSequence) {
                 param = param.toString();
             }
-            dispatchParams.put(name, param);
+            dispatchParams.putIfAbsent(name, param);
         }
 
         final String viewName = getViewName();

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -611,7 +611,10 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                         lastGroup = lastGroup.substring(1);
                     }
                 }
-                params.put(propertyName, lastGroup);
+                // if the format is specified but the value is empty, ignore it
+                if (!(FORMAT_PARAMETER.equals(propertyName) && GrailsStringUtils.isEmpty(lastGroup))) {
+                    params.put(propertyName, lastGroup);
+                }
                 break;
             }
             else {
@@ -632,7 +635,10 @@ public class RegexUrlMapping extends AbstractUrlMapping {
                     if(FORMAT_PARAMETER.equals(propertyName) && lastGroup.startsWith(".")) {
                         lastGroup = lastGroup.substring(1);
                     }
-                    params.put(propertyName, lastGroup);
+                    // if the format is specified but the value is empty, ignore it
+                    if (!(FORMAT_PARAMETER.equals(propertyName) && GrailsStringUtils.isEmpty(lastGroup))) {
+                        params.put(propertyName, lastGroup);
+                    }
                 }
             }
 


### PR DESCRIPTION
Revert https://github.com/grails/grails-core/commit/745f29b217f0a4ad866796f9138c0136c5b64276, which caused https://github.com/grails/grails-core/issues/11623. Basically when an "Accept" header was missing (or other format override), the new behavior defaulted to HTML all the time, regardless of `static responseFormats = ['json']` being specified on the controller. There may be room to simplify this code, but calling `getFormat` caused the aforementioned issue.

Find a different way to fix the original issue, https://github.com/grails/grails-core/issues/11406 (including a unit test). The OP of this ticket discovered that the `format` parameter was being overwritten by the configuration in `UrlMappings.groovy`. Calling `response.format` seemed to properly set the response's mime-type based on the query parameter. 

~Instead, I introduced a change to `UrlMappingsInfo` that only overwrote the `params` of the web request if the key didn't already exist. I checked this against the OP's example code and it appeared to fix their issue just the same.~

*Edit: It turns out this strategy broke controller and action overrides (and may have allowed users to arbitrarily select their controller/action via query parameter). So the `UrlMappings` _must_ have the final say on the request parameters for this reason. TIL.

So now the fix is to simply toss out the format parameter if it is null or empty.