### PR TITLE
Fixing issue #11634 Port append on grails absolute url if no serverUrl Specified

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -462,10 +462,14 @@ public class GrailsWebRequest extends DispatcherServletWebRequest  {
         if (baseUrl == null) {
             HttpServletRequest request=getCurrentRequest();
             String scheme =request.getScheme();
+            String forwardedScheme = request.getHeader("X-Forwarded-Proto");
             StringBuilder sb=new StringBuilder();
             sb.append(scheme).append("://").append(request.getServerName());
+
             int port = request.getServerPort();
-            if (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443)) {
+            
+            //ignore port append if the request was forwarded from a VIP as actual source port is now not known
+            if (forwardedScheme != null && (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443))) {
                 sb.append(":").append(port);
             }
             String contextPath = request.getContextPath();

--- a/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/servlet/mvc/GrailsWebRequest.java
@@ -469,7 +469,7 @@ public class GrailsWebRequest extends DispatcherServletWebRequest  {
             int port = request.getServerPort();
             
             //ignore port append if the request was forwarded from a VIP as actual source port is now not known
-            if (forwardedScheme != null && (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443))) {
+            if (forwardedScheme == null && (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443))) {
                 sb.append(":").append(port);
             }
             String contextPath = request.getContextPath();


### PR DESCRIPTION
The Grails WebRequest sets the baseUrl incorrectly when using a VIP terminated endpoint . X-Forwarded-Proto header should be checked if it exists and if so, don't append a port to the scheme.