### PR TITLE
Fix auto reloading with the Micronaut Declarative HTTP Client

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -420,6 +420,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
             project.configurations {
                 agent
             }
+            project.dependencies.add("runtimeOnly", "io.micronaut:micronaut-inject-groovy")
             project.afterEvaluate(new AgentTasksEnhancer())
         }
     }


### PR DESCRIPTION
Update GrailsGradlePlugin.groovy to add "micronaut-inject-groovy" to the runtimeOnly classpath when reloading is enabled.