### PR TITLE
Update Grails Views to 2.0.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -33,6 +33,6 @@ servletApiVersion=4.0.1
 asyncVersion=4.0.0
 legacyConvertersVersion=4.0.1
 testingSupportVersion=2.1.2
-viewsVersion=2.0.2
+viewsVersion=2.0.3
 scaffoldingCoreVersion=2.1.0
 gspVersion=4.0.2


### PR DESCRIPTION
Fixes issue with template resolution on windows.
Can be worked around by setting the version explicitly per project, but this brings up the baseline version.