### PR TITLE
Issue #11318 apply generated annotation

### DIFF
--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ASTValidationErrorsHelper.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ASTValidationErrorsHelper.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Modifier;
 
 import grails.compiler.ast.GrailsArtefactClassInjector;
 import grails.validation.ValidationErrors;
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
@@ -97,9 +98,12 @@ public class ASTValidationErrorsHelper implements ASTErrorsHelper {
                     new BooleanExpression(errorsIsNullExpression), newEvaluatorExpression,
                     new ExpressionStatement(new EmptyExpression()));
             initErrorsMethodCode.addStatement(initErrorsIfNullStatement);
-            paramTypeClassNode.addMethod(new MethodNode(INIT_ERRORS_METHOD_NAME,
+
+            MethodNode methodNode = new MethodNode(INIT_ERRORS_METHOD_NAME,
                     Modifier.PRIVATE, ClassHelper.VOID_TYPE,
-                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, initErrorsMethodCode));
+                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, initErrorsMethodCode);
+            paramTypeClassNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(paramTypeClassNode, methodNode);
         }
     }
 
@@ -110,9 +114,12 @@ public class ASTValidationErrorsHelper implements ASTErrorsHelper {
             Expression nullOutErrorsFieldExpression = new BinaryExpression(ERRORS_EXPRESSION,
                     EQUALS_SYMBOL, NULL_EXPRESSION);
             clearErrorsMethodCode.addStatement(new ExpressionStatement(nullOutErrorsFieldExpression));
-            paramTypeClassNode.addMethod(new MethodNode(CLEAR_ERRORS_METHOD_NAME,
+
+            MethodNode methodNode = new MethodNode(CLEAR_ERRORS_METHOD_NAME,
                     Modifier.PUBLIC, ClassHelper.VOID_TYPE,
-                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, clearErrorsMethodCode));
+                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, clearErrorsMethodCode);
+            paramTypeClassNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(paramTypeClassNode, methodNode);
         }
     }
 
@@ -124,9 +131,12 @@ public class ASTValidationErrorsHelper implements ASTErrorsHelper {
             hasErrorsMethodCode.addStatement(new ExpressionStatement(initErrorsMethodCallExpression));
             final Statement returnStatement = new ReturnStatement(new BooleanExpression(new MethodCallExpression(ERRORS_EXPRESSION, HAS_ERRORS_METHOD_NAME, EMPTY_TUPLE)));
             hasErrorsMethodCode.addStatement(returnStatement);
-            paramTypeClassNode.addMethod(new MethodNode(HAS_ERRORS_METHOD_NAME,
+
+            MethodNode methodNode = new MethodNode(HAS_ERRORS_METHOD_NAME,
                     Modifier.PUBLIC, new ClassNode(Boolean.class),
-                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, hasErrorsMethodCode));
+                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, hasErrorsMethodCode);
+            paramTypeClassNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(paramTypeClassNode, methodNode);
         }
     }
 
@@ -138,9 +148,12 @@ public class ASTValidationErrorsHelper implements ASTErrorsHelper {
             getErrorsMethodCode.addStatement(new ExpressionStatement(initErrorsMethodCallExpression));
             final Statement returnStatement = new ReturnStatement(ERRORS_EXPRESSION);
             getErrorsMethodCode.addStatement(returnStatement);
-            paramTypeClassNode.addMethod(new MethodNode(GET_ERRORS_METHOD_NAME,
+
+            MethodNode methodNode = new MethodNode(GET_ERRORS_METHOD_NAME,
                     Modifier.PUBLIC, ERRORS_CLASS_NODE,
-                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, getErrorsMethodCode));
+                    GrailsArtefactClassInjector.ZERO_PARAMETERS, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, getErrorsMethodCode);
+            paramTypeClassNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(paramTypeClassNode, methodNode);
         }
     }
 
@@ -155,6 +168,7 @@ public class ASTValidationErrorsHelper implements ASTErrorsHelper {
                     Modifier.PUBLIC, ClassHelper.VOID_TYPE,
                     new Parameter[]{new Parameter(ERRORS_CLASS_NODE, errorsArgumentName)}, GrailsArtefactClassInjector.EMPTY_CLASS_ARRAY, new ExpressionStatement(assignErrorsExpression));
             paramTypeClassNode.addMethod(setErrorsMethod);
+            AnnotatedNodeUtils.markAsGenerated(paramTypeClassNode, setErrorsMethod);
         }
     }
 }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/AbstractGrailsArtefactTransformer.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/AbstractGrailsArtefactTransformer.java
@@ -23,6 +23,7 @@ import groovy.lang.Mixin;
 import java.lang.reflect.Modifier;
 import java.util.*;
 
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
@@ -294,6 +295,7 @@ public abstract class AbstractGrailsArtefactTransformer implements GrailsArtefac
             lookupMethod = populateAutowiredApiLookupMethod(classNode, implementationNode, apiProperty, lookupMethodName, methodBody);
             classNode.addMethod(lookupMethod);
             GrailsASTUtils.addCompileStaticAnnotation(lookupMethod);
+            AnnotatedNodeUtils.markAsGenerated(classNode, lookupMethod);
         }
         return lookupMethod;
     }
@@ -341,7 +343,9 @@ public abstract class AbstractGrailsArtefactTransformer implements GrailsArtefac
                     new ClassExpression(classNode), new ConstantExpression(apiProperty)), Token.newSymbol(Types.EQUAL, 0, 0),
                     new VariableExpression(setterParameter))));
 
-            GrailsASTUtils.addCompileStaticAnnotation(classNode.addMethod(setterName, Modifier.PUBLIC | Modifier.STATIC, ClassHelper.VOID_TYPE, new Parameter[]{setterParameter}, null, setterBody));
+            MethodNode methodNode = classNode.addMethod(setterName, Modifier.PUBLIC | Modifier.STATIC, ClassHelper.VOID_TYPE, new Parameter[]{setterParameter}, null, setterBody);
+            GrailsASTUtils.addCompileStaticAnnotation(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
         }
     }
 

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/ApplicationClassInjector.groovy
@@ -22,6 +22,7 @@ import grails.io.ResourceUtils
 import grails.util.BuildSettings
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.ast.expr.ArgumentListExpression
@@ -108,7 +109,7 @@ class ApplicationClassInjector implements GrailsArtefactClassInjector {
                             GrailsASTUtils.error(source, classNode, "Do not place Groovy sources in common package names such as 'org', 'com', 'io' or 'net' as this can result in performance degradation of classpath scanning")
                         }
                         packageNamesBody.addStatement(new ReturnStatement(new ExpressionStatement(new ListExpression(packageNames.toList()))))
-                        classNode.addMethod("packageNames", Modifier.PUBLIC, collectionClassNode, ZERO_PARAMETERS, null, packageNamesBody)
+                        AnnotatedNodeUtils.markAsGenerated(classNode, classNode.addMethod("packageNames", Modifier.PUBLIC, collectionClassNode, ZERO_PARAMETERS, null, packageNamesBody))
                     }
                 }
 

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import grails.compiler.ast.AstTransformer;
 import grails.compiler.ast.GrailsArtefactClassInjector;
 import grails.compiler.ast.GrailsDomainClassInjector;
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.GenericsType;
@@ -198,6 +199,7 @@ public class DefaultGrailsDomainClassInjector implements GrailsDomainClassInject
             MethodNode mn = new MethodNode("toString", Modifier.PUBLIC, new ClassNode(String.class), new Parameter[0], new ClassNode[0], s);
             classNode.addMethod(mn);
             classesWithInjectedToString.add(classNode);
+            AnnotatedNodeUtils.markAsGenerated(classNode, mn);
         }
     }
 

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/EnhancesTraitTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/EnhancesTraitTransformation.groovy
@@ -19,6 +19,7 @@ import grails.artefact.Enhances
 import grails.compiler.traits.TraitInjector
 import groovy.transform.CompilationUnitAware
 import groovy.transform.CompileStatic
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils
 import org.codehaus.groovy.ast.*
 import org.codehaus.groovy.ast.expr.CastExpression
 import org.codehaus.groovy.ast.expr.ClassExpression
@@ -29,7 +30,10 @@ import org.codehaus.groovy.control.CompilePhase
 import org.codehaus.groovy.control.SourceUnit
 import org.codehaus.groovy.transform.GroovyASTTransformation
 
+import java.lang.reflect.Modifier
+
 import static java.lang.reflect.Modifier.*
+
 /**
  * Implementation for {@link Enhances)
  *
@@ -75,10 +79,14 @@ class EnhancesTraitTransformation extends AbstractArtefactTypeAstTransformation 
 
 
             def classNodeRef = ClassHelper.make(traitClassName).getPlainNodeReference()
-            transformerNode.addMethod("getTrait", PUBLIC, ClassHelper.CLASS_Type.getPlainNodeReference(), GrailsASTUtils.ZERO_PARAMETERS, null, new ReturnStatement( new ClassExpression(classNodeRef)))
+            MethodNode getTraitMethodNode = transformerNode.addMethod(
+                    "getTrait", PUBLIC, ClassHelper.CLASS_Type.getPlainNodeReference(), GrailsASTUtils.ZERO_PARAMETERS, null, new ReturnStatement( new ClassExpression(classNodeRef)))
+            AnnotatedNodeUtils.markAsGenerated(transformerNode, getTraitMethodNode)
 
             def strArrayType = ClassHelper.STRING_TYPE.makeArray()
-            transformerNode.addMethod("getArtefactTypes", PUBLIC, strArrayType, GrailsASTUtils.ZERO_PARAMETERS, null, new ReturnStatement( CastExpression.asExpression(strArrayType, expr)))
+            MethodNode getArtefactTypesMethodNode = transformerNode.addMethod(
+                    "getArtefactTypes", PUBLIC, strArrayType, GrailsASTUtils.ZERO_PARAMETERS, null, new ReturnStatement( CastExpression.asExpression(strArrayType, expr)))
+            AnnotatedNodeUtils.markAsGenerated(transformerNode, getArtefactTypesMethodNode)
 
             def ast = source.AST
             transformerNode.module = ast

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GrailsASTUtils.java
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GrailsASTUtils.java
@@ -23,6 +23,7 @@ import groovy.lang.MissingMethodException;
 import groovy.transform.CompileStatic;
 import groovy.transform.TypeChecked;
 import groovy.transform.TypeCheckingMode;
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.*;
 import org.codehaus.groovy.ast.stmt.*;
@@ -291,6 +292,8 @@ public class GrailsASTUtils {
         }
 
         classNode.addMethod(methodNode);
+        AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
+
         return methodNode;
     }
 
@@ -429,8 +432,7 @@ public class GrailsASTUtils {
         }
 
         classNode.addMethod(methodNode);
-
-        return methodNode;
+        return AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
     }
 
     /**
@@ -471,6 +473,7 @@ public class GrailsASTUtils {
             } else {
                 constructorNode = new ConstructorNode(Modifier.PUBLIC, constructorBody);
                 classNode.addConstructor(constructorNode);
+                AnnotatedNodeUtils.markAsGenerated(classNode, constructorNode);
             }
             constructorNode.addAnnotation(new AnnotationNode(new ClassNode(GrailsDelegatingConstructor.class)));
             return constructorNode;
@@ -481,6 +484,7 @@ public class GrailsASTUtils {
             if (cn == null) {
                 cn = new ConstructorNode(Modifier.PUBLIC, copyParameters(constructorParams, genericsPlaceholders), null, constructorBody);
                 classNode.addConstructor(cn);
+                AnnotatedNodeUtils.markAsGenerated(classNode, cn);
             }
             else {
                 List<AnnotationNode> annotations = cn.getAnnotations(new ClassNode(GrailsDelegatingConstructor.class));
@@ -494,7 +498,9 @@ public class GrailsASTUtils {
             ConstructorNode defaultConstructor = getDefaultConstructor(classNode);
             if (defaultConstructor == null) {
                 // add empty
-                classNode.addConstructor(new ConstructorNode(Modifier.PUBLIC, new BlockStatement()));
+                ConstructorNode constructorNode = new ConstructorNode(Modifier.PUBLIC, new BlockStatement());
+                classNode.addConstructor(constructorNode);
+                AnnotatedNodeUtils.markAsGenerated(classNode, constructorNode);
             }
             cn.addAnnotation(new AnnotationNode(new ClassNode(GrailsDelegatingConstructor.class)));
             return cn;
@@ -984,6 +990,7 @@ public class GrailsASTUtils {
         MethodNode existing = controllerClassNode.getMethod(methodNode.getName(), methodNode.getParameters());
         if (existing == null) {
             controllerClassNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(controllerClassNode, methodNode);
         }
     }
 

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/ASTValidationErrorsHelperSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/ASTValidationErrorsHelperSpec.groovy
@@ -1,5 +1,6 @@
 package org.grails.compiler.injection
 
+import groovy.transform.Generated
 import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.classgen.GeneratorContext
 import org.codehaus.groovy.control.SourceUnit
@@ -9,6 +10,8 @@ import org.grails.compiler.injection.GrailsAwareClassLoader
 import org.springframework.validation.Errors
 
 import spock.lang.Specification
+
+import java.lang.reflect.Method
 
 class ASTValidationErrorsHelperSpec extends Specification {
 
@@ -71,5 +74,26 @@ class ASTValidationErrorsHelperSpec extends Specification {
 
         then:
             localErrors.is(widget.getErrors())
+    }
+
+    void 'Test injected errors property methods are marked with Generated annotation'() {
+        given:
+        def widgetClass = gcl.parseClass('class MyWidget{}')
+
+        and: 'injected method names to it'
+        List<String> injectedMethodNames = [
+            "setErrors",
+            "getErrors",
+            "hasErrors",
+            "clearErrors",
+            "initErrors"
+        ]
+
+        expect: 'injected methods marked as Generated'
+        widgetClass.getMethods().each { Method widgetMethod ->
+            if (widgetMethod.name in injectedMethodNames) {
+                assert widgetMethod.isAnnotationPresent(Generated)
+            }
+        }
     }
 }

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/DefaultDomainClassInjectorSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/DefaultDomainClassInjectorSpec.groovy
@@ -1,6 +1,7 @@
 package org.grails.compiler.injection
 
 import grails.persistence.Entity
+import groovy.transform.Generated
 import groovy.transform.ToString
 import spock.lang.Specification
 
@@ -16,6 +17,9 @@ class DefaultDomainClassInjectorSpec extends Specification {
 
         then:
         test.toString().endsWith("Test : 1")
+
+        and: 'toString is marked as Generated'
+        test.class.getMethod('toString').isAnnotationPresent(Generated)
     }
 
     void "test domain with groovy.transform.ToString"() {
@@ -25,6 +29,9 @@ class DefaultDomainClassInjectorSpec extends Specification {
 
         then:
         test.toString().endsWith("TestWithGroovy(1)")
+
+        and: 'toString is marked as Generated'
+        test.class.getMethod('toString').isAnnotationPresent(Generated)
     }
 
     @Entity

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/Controller.groovy
@@ -28,6 +28,7 @@ import grails.web.api.WebAttributes
 import grails.web.databinding.DataBinder
 import grails.web.databinding.DataBindingUtils
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.codehaus.groovy.runtime.InvokerHelper
 import org.grails.compiler.web.ControllerActionTransformer
 import org.grails.core.artefact.DomainClassArtefactHandler
@@ -87,6 +88,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param callable
      * @return  The result of the closure execution selected
      */
+    @Generated
     def withFormat(Closure callable) {
         HttpServletResponse response = GrailsWebRequest.lookup().currentResponse
         mimeTypesSupport.withFormat((HttpServletResponse)response, callable)
@@ -98,6 +100,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param headerName The header name
      * @param headerValue The header value
      */
+    @Generated
     void header(String headerName, headerValue) {
         if (headerValue != null) {
             final HttpServletResponse response = getResponse()
@@ -112,6 +115,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param collectionToPopulate The collection to populate
      * @param request The request
      */
+    @Generated
     void bindData(Class targetType, Collection collectionToPopulate, ServletRequest request) {
         DataBindingUtils.bindToCollection targetType, collectionToPopulate, request
     }
@@ -120,6 +124,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * Return true if there are an errors
      * @return true if there are errors
      */
+    @Generated
     boolean hasErrors() {
         getErrors()?.hasErrors()
     }
@@ -129,6 +134,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      *
      * @param errors The error instance
      */
+    @Generated
     void setErrors(Errors errors) {
         def webRequest = currentRequestAttributes()
         setErrorsInternal(webRequest, errors)
@@ -140,6 +146,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      *
      * @return The Errors instance
      */
+    @Generated
     Errors getErrors() {
         def webRequest = currentRequestAttributes()
         getErrorsInternal(webRequest)
@@ -151,6 +158,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      *
      * @return The ModelAndView
      */
+    @Generated
     ModelAndView getModelAndView() {
         (ModelAndView)currentRequestAttributes().getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
     }
@@ -160,6 +168,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      *
      * @param mav The ModelAndView
      */
+    @Generated
     void setModelAndView(ModelAndView mav) {
         currentRequestAttributes().setAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, mav, 0)
     }
@@ -169,6 +178,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      *
      * @return The action URI
      */
+    @Generated
     String getActionUri() {
         "/${getControllerName()}/${getActionName()}"
     }
@@ -177,6 +187,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * Returns the URI of the currently executing controller
      * @return The controller URI
      */
+    @Generated
     String getControllerUri() {
         "/${getControllerName()}"
     }
@@ -187,6 +198,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param name The name of the template
      * @return The template URI
      */
+    @Generated
     String getTemplateUri(String name) {
         getGrailsAttributes().getTemplateUri(name, getRequest())
     }
@@ -197,6 +209,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param name The name of the view
      * @return The template URI
      */
+    @Generated
     String getViewUri(String name) {
         getGrailsAttributes().getViewUri(name, getRequest())
     }
@@ -207,6 +220,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param argMap The arguments
      * @return null
      */
+    @Generated
     void redirect(Map argMap) {
 
         if (argMap.isEmpty()) {
@@ -246,6 +260,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @param callable The closure to execute
      * @return The result of the closure execution
      */
+    @Generated
     TokenResponseHandler withForm(Closure callable) {
         withForm getWebRequest(), callable
     }
@@ -265,6 +280,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * }
      * </code></pre>
      */
+    @Generated
     TokenResponseHandler withForm(GrailsWebRequest webRequest, Closure callable) {
         TokenResponseHandler handler
         if (isTokenValid(webRequest)) {
@@ -317,14 +333,15 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
         }
         if (tokensHolderInSession.isEmpty()) request.getSession(false)?.removeAttribute(SynchronizerTokensHolder.HOLDER)
     }
- 
-     public static ApplicationContext getStaticApplicationContext() {
+
+    @Generated
+    public static ApplicationContext getStaticApplicationContext() {
          RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes()
          if (!(requestAttributes instanceof GrailsWebRequest)) {
              return ContextLoader.getCurrentWebApplicationContext()
          }
          ((GrailsWebRequest)requestAttributes).getApplicationContext()
-     }
+    }
 
 
     /**
@@ -342,6 +359,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
      * @return the initialized command object or null if the command object is a domain class, the body or
      * parameters included an id and no corresponding record was found in the database.
      */
+    @Generated
     def initializeCommandObject(final Class type, final String commandObjectParameterName) throws Exception {
         final HttpServletRequest request = getRequest()
         def commandObjectInstance = null
@@ -463,6 +481,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
         commandParams
     }
 
+    @Generated
     @SuppressWarnings("unchecked")
     Method getExceptionHandlerMethodFor(final Class<? extends Exception> exceptionType) throws Exception {
         if(!Exception.class.isAssignableFrom(exceptionType)) {

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/RequestForwarder.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/RequestForwarder.groovy
@@ -19,6 +19,7 @@ import grails.web.UrlConverter
 import grails.web.api.WebAttributes
 import grails.web.mapping.LinkGenerator
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.web.mapping.UrlMappingUtils
 import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
 import org.grails.web.servlet.mvc.GrailsWebRequest
@@ -43,6 +44,7 @@ trait RequestForwarder implements WebAttributes {
     private UrlConverter urlConverter
     private LinkGenerator linkGenerator
 
+    @Generated
     @Autowired(required=false)
     void setUrlConverter(UrlConverter urlConverter) {
         this.urlConverter = urlConverter
@@ -61,6 +63,7 @@ trait RequestForwarder implements WebAttributes {
      * @param params The parameters
      * @return The forwarded URL
      */
+    @Generated
     String forward(Map params) {
 
         GrailsWebRequest webRequest = getWebRequest()

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRedirector.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRedirector.groovy
@@ -26,6 +26,7 @@ import grails.web.mapping.mvc.RedirectEventListener
 import grails.web.mapping.mvc.exceptions.CannotRedirectException
 import grails.web.mvc.FlashScope
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.core.artefact.ControllerArtefactHandler
 import org.grails.core.artefact.DomainClassArtefactHandler
 import org.grails.datastore.mapping.model.config.GormProperties
@@ -47,26 +48,30 @@ trait ResponseRedirector implements WebAttributes {
 
     private LinkGenerator linkGenerator
 
-    boolean useJsessionId = false
+    private boolean useJsessionId = false
 
     private RequestDataValueProcessor requestDataValueProcessor
     private Collection<RedirectEventListener> redirectListeners
 
+    @Generated
     @Autowired(required=false)
     void setRedirectListeners(Collection<RedirectEventListener> redirectListeners) {
         this.redirectListeners = redirectListeners
     }
 
+    @Generated
     @Autowired(required = false)
     void setRequestDataValueProcessor(RequestDataValueProcessor requestDataValueProcessor) {
         this.requestDataValueProcessor = requestDataValueProcessor
     }
 
+    @Generated
     @Autowired
     void setGrailsLinkGenerator(LinkGenerator linkGenerator) {
         this.linkGenerator = linkGenerator
     }
 
+    @Generated
     LinkGenerator getGrailsLinkGenerator() {
         if(this.linkGenerator == null) {
             this.linkGenerator = webRequest.getApplicationContext().getBean(LinkGenerator)
@@ -80,6 +85,7 @@ trait ResponseRedirector implements WebAttributes {
      * @param object A domain class
      * @return null
      */
+    @Generated
     void redirect(object) {
         if(object) {
 
@@ -105,6 +111,7 @@ trait ResponseRedirector implements WebAttributes {
      * @param argMap The arguments
      * @return null
      */
+    @Generated
     void redirect(Map argMap) {
 
         if (argMap.isEmpty()) {
@@ -124,6 +131,7 @@ trait ResponseRedirector implements WebAttributes {
      * Obtains the chain model which is used to chain request attributes from one request to the next via flash scope
      * @return The chainModel
      */
+    @Generated
     Map getChainModel() {
         (Map)getFlash().get(FlashScope.CHAIN_MODEL)
     }
@@ -136,6 +144,7 @@ trait ResponseRedirector implements WebAttributes {
      *
      * @return Result of the redirect call
      */
+    @Generated
     void chain(Map args) {
         String controller = (args.controller ?: GrailsNameUtils.getLogicalPropertyName( getClass().name, ControllerArtefactHandler.TYPE)).toString()
         String action = args.action?.toString()
@@ -179,5 +188,15 @@ trait ResponseRedirector implements WebAttributes {
             url = response.encodeRedirectURL(url)
         }
         response.sendRedirect url
+    }
+
+    @Generated
+    boolean isUseJsessionId() {
+        return useJsessionId
+    }
+
+    @Generated
+    void setUseJsessionId(boolean useJsessionId) {
+        this.useJsessionId = useJsessionId
     }
 }

--- a/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
+++ b/grails-plugin-controllers/src/main/groovy/grails/artefact/controller/support/ResponseRenderer.groovy
@@ -26,6 +26,7 @@ import grails.web.mime.MimeType
 import grails.web.mime.MimeUtility
 import groovy.json.StreamingJsonBuilder
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import groovy.util.slurpersupport.GPathResult
 import groovy.xml.StreamingMarkupBuilder
 import org.grails.gsp.GroovyPageTemplate
@@ -71,16 +72,19 @@ trait ResponseRenderer extends WebAttributes {
     private GroovyPageLayoutFinder groovyPageLayoutFinder
     private GrailsPluginManager pluginManager
 
+    @Generated
     @Autowired(required = false)
     void setGroovyPageLayoutFinder(GroovyPageLayoutFinder groovyPageLayoutFinder) {
         this.groovyPageLayoutFinder = groovyPageLayoutFinder
     }
 
+    @Generated
     @Autowired(required = false)
     void setMimeUtility(MimeUtility mimeUtility) {
         this.mimeUtility = mimeUtility
     }
 
+    @Generated
     @Autowired(required = false)
     void setActionResultTransformers(ActionResultTransformer[] actionResultTransformers) {
         this.actionResultTransformers = actionResultTransformers.toList()
@@ -91,6 +95,7 @@ trait ResponseRenderer extends WebAttributes {
      *
      * @param object The object to render
      */
+    @Generated
     void render(object) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -110,6 +115,7 @@ trait ResponseRenderer extends WebAttributes {
      *
      * @param closure The markup to render
      */
+    @Generated
     void render(Closure closure) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -125,6 +131,7 @@ trait ResponseRenderer extends WebAttributes {
      * @param argMap The name arguments
      * @param closure The closure to render
      */
+    @Generated
     void render(Map argMap, Closure closure) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -155,6 +162,7 @@ trait ResponseRenderer extends WebAttributes {
      * @param argMap The named arguments
      * @param body The text to render
      */
+    @Generated
     void render(Map argMap, CharSequence body) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -171,6 +179,7 @@ trait ResponseRenderer extends WebAttributes {
      *
      * @param txt The text to render
      */
+    @Generated
     void render(CharSequence txt) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -197,6 +206,7 @@ trait ResponseRenderer extends WebAttributes {
      * @param argMap The named arguments
      * @param writable The writable
      */
+    @Generated
     void render(Map argMap, Writable writable) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse
@@ -214,6 +224,7 @@ trait ResponseRenderer extends WebAttributes {
      *
      * @param argMap The named argument map
      */
+    @Generated
     void render(Map argMap) {
         GrailsWebRequest webRequest = (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
         HttpServletResponse response = webRequest.currentResponse

--- a/grails-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerActionTransformer.java
+++ b/grails-plugin-controllers/src/main/groovy/org/grails/compiler/web/ControllerActionTransformer.java
@@ -52,6 +52,7 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletResponse;
 
 import groovy.transform.CompilationUnitAware;
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.*;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
@@ -778,6 +779,7 @@ public class ControllerActionTransformer implements GrailsArtefactClassInjector,
                             BlockStatement constructorLogic = new BlockStatement();
                             ConstructorNode constructorNode = new ConstructorNode(Modifier.PUBLIC, constructorLogic);
                             commandObjectNode.addConstructor(constructorNode);
+                            AnnotatedNodeUtils.markAsGenerated(commandObjectNode, constructorNode);
                             constructorLogic.addStatements(objectInitializerStatements);
                         }
                         argumentIsValidateable = true;

--- a/grails-plugin-controllers/src/test/groovy/grails/artefact/ControllerTraitGeneratedSpec.groovy
+++ b/grails-plugin-controllers/src/test/groovy/grails/artefact/ControllerTraitGeneratedSpec.groovy
@@ -1,0 +1,22 @@
+package grails.artefact
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class ControllerTraitGeneratedSpec extends Specification {
+
+    void "test that all Controller trait methods are marked as Generated"() {
+        // It will test also RequestForwarder, ResponseRedirector and ResponseRenderer traits, cause Controller implements them
+
+        expect: "all Controller methods are marked as Generated on implementation class"
+        Controller.getMethods().each { Method traitMethod ->
+            assert TestController.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestController implements Controller {
+
+}

--- a/grails-plugin-domain-class/src/main/groovy/grails/artefact/DomainClass.groovy
+++ b/grails-plugin-domain-class/src/main/groovy/grails/artefact/DomainClass.groovy
@@ -18,6 +18,7 @@ package grails.artefact
 import grails.util.Holders
 import grails.validation.Constrained
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.web.plugins.support.DefaultConstrainedDiscovery
@@ -38,6 +39,7 @@ trait DomainClass {
     /**
      * @return The constrained properties for this domain class
      */
+    @Generated
     static Map<String, Constrained> getConstrainedProperties() {
         MappingContext mappingContext = Holders?.grailsApplication?.mappingContext
         PersistentEntity persistentEntity = mappingContext?.getPersistentEntity(this.name)

--- a/grails-plugin-domain-class/src/test/groovy/grails/persistence/DomainClassTraitSpec.groovy
+++ b/grails-plugin-domain-class/src/test/groovy/grails/persistence/DomainClassTraitSpec.groovy
@@ -1,7 +1,9 @@
 package grails.persistence
 
+import grails.artefact.DomainClass
 import grails.core.DefaultGrailsApplication
 import grails.util.Holders
+import groovy.transform.Generated
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultValidatorRegistry
 import org.grails.datastore.mapping.core.connections.ConnectionSourceSettings
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
@@ -9,6 +11,8 @@ import org.grails.datastore.mapping.model.MappingContext
 import org.springframework.context.ApplicationContext
 import spock.lang.Issue
 import spock.lang.Specification
+
+import java.lang.reflect.Method
 
 /**
  * @author James Kleeh
@@ -35,6 +39,9 @@ class DomainClassTraitSpec extends Specification {
         expect:
         !Person.constrainedProperties.name.blank
         new Person().constrainedProperties.name.inList == ['Joe']
+
+        and: 'it is annotated as Generated'
+        Person.class.getMethod('getConstrainedProperties').isAnnotationPresent(Generated)
     }
 
     @Entity

--- a/grails-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grails-plugin-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -25,6 +25,7 @@ import grails.web.api.WebAttributes
 import grails.web.databinding.DataBinder
 import grails.web.mapping.UrlMappingInfo
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.plugins.web.controllers.metaclass.RenderDynamicMethod
 import org.grails.plugins.web.interceptors.GrailsInterceptorHandlerInterceptorAdapter
 import org.grails.plugins.web.interceptors.InterceptorArtefactHandler
@@ -55,22 +56,24 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
     /**
      * The order the interceptor should execute in
      */
-    int order = 0
+    private int order = 0
 
     /**
      * The matchers defined by this interceptor
      */
-    final Collection<Matcher> matchers = new ConcurrentLinkedQueue<>()
+    private final Collection<Matcher> matchers = new ConcurrentLinkedQueue<>()
 
     /**
      * @return Whether the current interceptor does match
      */
+    @Generated
     boolean doesMatch() {
         doesMatch(request)
     }
     /**
      * @return Whether the current interceptor does match
      */
+    @Generated
     boolean doesMatch(HttpServletRequest request) {
         Collection<Matcher> allMatchers = matchers
         if (allMatchers.isEmpty()) {
@@ -108,6 +111,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
     /**
      * Matches all requests
      */
+    @Generated
     Matcher matchAll() {
         def matcher = new UrlMappingMatcher(this)
         matcher.matchAll()
@@ -118,6 +122,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
     /**
      * @return The current model
      */
+    @Generated
     Map<String, Object> getModel() {
         def modelAndView = (ModelAndView) currentRequestAttributes().getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
         return modelAndView?.modelMap
@@ -128,6 +133,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param model The model to set
      */
+    @Generated
     void setModel(Map<String, Object> model) {
         def request = currentRequestAttributes()
         def modelAndView = (ModelAndView) request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
@@ -141,6 +147,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
     /**
      * @return The current view
      */
+    @Generated
     String getView() {
         def modelAndView = (ModelAndView) currentRequestAttributes().getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
         return modelAndView?.viewName
@@ -151,6 +158,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param view The name of the view
      */
+    @Generated
     void setView(String view) {
         def request = currentRequestAttributes()
         def modelAndView = (ModelAndView) request.getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
@@ -166,6 +174,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @return The ModelAndView
      */
+    @Generated
     ModelAndView getModelAndView() {
         (ModelAndView) currentRequestAttributes().getAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, 0)
     }
@@ -175,6 +184,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param mav The ModelAndView
      */
+    @Generated
     void setModelAndView(ModelAndView mav) {
         currentRequestAttributes().setAttribute(GrailsApplicationAttributes.MODEL_AND_VIEW, mav, 0)
     }
@@ -184,6 +194,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param t The exception or null if none was thrown
      */
+    @Generated
     Throwable getThrowable() {
         def request = currentRequestAttributes()
 
@@ -195,6 +206,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param arguments The match arguments
      */
+    @Generated
     Matcher match(Map arguments) {
         def matcher = new UrlMappingMatcher(this)
         matcher.matches(arguments)
@@ -207,6 +219,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @return Whether the action should continue and execute
      */
+    @Generated
     boolean before() { true }
 
     /**
@@ -214,6 +227,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @return True if view rendering should continue, false otherwise
      */
+    @Generated
     boolean after() { true }
 
     /**
@@ -221,6 +235,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param t The exception instance if an exception was thrown, null otherwise
      */
+    @Generated
     void afterView() {}
 
     /**
@@ -229,6 +244,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      * @param headerName The header name
      * @param headerValue The header value
      */
+    @Generated
     void header(String headerName, headerValue) {
         if (headerValue != null) {
             final HttpServletResponse response = getResponse()
@@ -241,6 +257,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
      *
      * @param argMap
      */
+    @Generated
     void render(Map argMap) {
         boolean isRenderView = argMap.containsKey(RenderDynamicMethod.ARGUMENT_VIEW)
         if (isRenderView) {
@@ -265,4 +282,27 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
         }
     }
 
+    /**
+     * The order the interceptor should execute in
+     */
+    @Generated
+    int getOrder() {
+        return order
+    }
+
+    /**
+     * The order the interceptor should execute in
+     */
+    @Generated
+    void setOrder(int order) {
+        this.order = order
+    }
+
+    /**
+     * The matchers defined by this interceptor
+     */
+    @Generated
+    Collection<Matcher> getMatchers() {
+        return matchers
+    }
 }

--- a/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-plugin-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -16,6 +16,7 @@
 package grails.artefact
 
 import grails.util.GrailsWebMockUtil
+import groovy.transform.Generated
 import org.grails.plugins.web.interceptors.InterceptorArtefactHandler
 import org.grails.web.mapping.ForwardUrlMappingInfo
 import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
@@ -28,6 +29,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import javax.servlet.http.HttpServletRequest
+import java.lang.reflect.Method
 
 /**
  * @author graemerocher
@@ -362,6 +364,13 @@ class InterceptorSpec extends Specification {
     void clearMatch(i, HttpServletRequest request) {
         request.removeAttribute(i.getClass().name + InterceptorArtefactHandler.MATCH_SUFFIX)
     }
+
+    void "test that all Interceptor trait methods are marked as Generated"() {
+        expect: "all Interceptor methods are marked as Generated on implementation class"
+        Interceptor.getMethods().each { Method traitMethod ->
+            assert TestGeneratedAnnotations.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
 }
 
 class TestInterceptor implements Interceptor {
@@ -450,4 +459,8 @@ class TestExcludeUriWithContextPathInterceptor implements Interceptor {
     TestExcludeUriWithContextPathInterceptor() {
         matchAll().excludes(uri: "/grails/mgmt/*")
     }
+}
+
+class TestGeneratedAnnotations implements Interceptor {
+
 }

--- a/grails-plugin-rest/src/main/groovy/grails/artefact/controller/RestResponder.groovy
+++ b/grails-plugin-rest/src/main/groovy/grails/artefact/controller/RestResponder.groovy
@@ -23,7 +23,9 @@ import grails.rest.Resource
 import grails.rest.render.Renderer
 import grails.rest.render.RendererRegistry
 import grails.web.mime.MimeType
+import groovy.transform.Generated
 import org.grails.datastore.mapping.model.config.GormProperties
+import org.grails.web.sitemesh.GroovyPageLayoutFinder
 import org.grails.web.util.GrailsApplicationAttributes
 import groovy.transform.CompileStatic
 import groovy.transform.TypeCheckingMode
@@ -48,16 +50,35 @@ trait RestResponder {
 
     private String PROPERTY_RESPONSE_FORMATS = "responseFormats"
 
-    @Autowired(required = false)
-    RendererRegistry rendererRegistry
+    private RendererRegistry rendererRegistry
+    private ProxyHandler proxyHandler
 
+    @Generated
     @Autowired(required = false)
-    ProxyHandler proxyHandler
-    
+    void setRendererRegistry(RendererRegistry rendererRegistry) {
+        this.rendererRegistry = rendererRegistry
+    }
+
+    @Generated
+    RendererRegistry getRendererRegistry() {
+        return this.rendererRegistry
+    }
+
+    @Generated
+    @Autowired(required = false)
+    void setProxyHandler(ProxyHandler proxyHandler) {
+        this.proxyHandler = proxyHandler
+    }
+
+    @Generated
+    ProxyHandler getProxyHandler() {
+        return this.proxyHandler
+    }
 
     /**
      * Same as {@link RestResponder#respond(java.lang.Object, java.lang.Object, java.util.Map)}, but here to support Groovy named arguments
      */
+    @Generated
     def respond(Map args, value) {
         internalRespond value, args
     }
@@ -72,6 +93,7 @@ trait RestResponder {
      * @param value The value
      * @return
      */
+    @Generated
     def respond(Map value) {
         internalRespond value
     }
@@ -79,6 +101,7 @@ trait RestResponder {
     /**
      * Same as {@link RestResponder#respond(java.util.Map)}, but here to support Groovy named arguments
      */
+    @Generated
     def respond(Map namedArgs, Map value) {
         internalRespond value, namedArgs
     }
@@ -94,6 +117,7 @@ trait RestResponder {
      * @param args The arguments
      * @return
      */
+    @Generated
     def respond(value, Map args = [:]) {
         internalRespond value, args
     }

--- a/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/LinkableTransform.groovy
+++ b/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/LinkableTransform.groovy
@@ -18,6 +18,7 @@ package org.grails.plugins.web.rest.transform
 import grails.rest.Link
 import grails.rest.Linkable
 import groovy.transform.CompileStatic
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils
 import org.codehaus.groovy.ast.ASTNode
 import org.codehaus.groovy.ast.AnnotationNode
 import org.codehaus.groovy.ast.ClassHelper
@@ -67,14 +68,17 @@ class LinkableTransform implements ASTTransformation{
             linkMethodBody.addStatement(new ExpressionStatement(new MethodCallExpression(resourceLinksVariable, "add", linkArg)))
             def linkMethod = new MethodNode(LINK_METHOD, PUBLIC, ClassHelper.VOID_TYPE, [mapParameter] as Parameter[], null, linkMethodBody)
             classNode.addMethod(linkMethod)
+            AnnotatedNodeUtils.markAsGenerated(classNode, linkMethod)
 
             def linkParameter = new Parameter(new ClassNode(Link), LINK_METHOD)
             def linkMethod2 = new MethodNode(LINK_METHOD, PUBLIC, ClassHelper.VOID_TYPE, [linkParameter] as Parameter[], null, new ExpressionStatement(new MethodCallExpression(resourceLinksVariable, "add", new VariableExpression(linkParameter))));
             classNode.addMethod(linkMethod2)
+            AnnotatedNodeUtils.markAsGenerated(classNode, linkMethod2)
         }
         if (classNode.getMethods(LINKS_METHOD).isEmpty()) {
             def linksMethod = new MethodNode(LINKS_METHOD, PUBLIC, new ClassNode(Collection), ZERO_PARAMETERS, null, new ReturnStatement(resourceLinksVariable))
             classNode.addMethod(linksMethod)
+            AnnotatedNodeUtils.markAsGenerated(classNode, linksMethod)
         }
     }
 

--- a/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/ResourceTransform.groovy
+++ b/grails-plugin-rest/src/main/groovy/org/grails/plugins/web/rest/transform/ResourceTransform.groovy
@@ -16,6 +16,8 @@
 package org.grails.plugins.web.rest.transform
 
 import grails.io.IOUtils
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils
+import org.grails.compiler.injection.GrailsASTUtils
 import org.grails.datastore.gorm.transactions.transform.TransactionalTransform
 
 import static java.lang.reflect.Modifier.*
@@ -194,6 +196,7 @@ class ResourceTransform implements ASTTransformation, CompilationUnitAware {
                     urlMappingsSetter.addAnnotation(qualifierAnnotation)
                     urlMappingsSetter.addAnnotation(controllerMethodAnnotation)
                     newControllerClassNode.addMethod(urlMappingsSetter)
+                    AnnotatedNodeUtils.markAsGenerated(newControllerClassNode, urlMappingsSetter)
                     processVariableScopes(source, newControllerClassNode, urlMappingsSetter)
 
 
@@ -225,6 +228,7 @@ class ResourceTransform implements ASTTransformation, CompilationUnitAware {
                     initialiseUrlMappingsMethod.addAnnotation(new AnnotationNode(new ClassNode(PostConstruct).getPlainNodeReference()))
                     initialiseUrlMappingsMethod.addAnnotation(controllerMethodAnnotation)
                     newControllerClassNode.addMethod(initialiseUrlMappingsMethod)
+                    AnnotatedNodeUtils.markAsGenerated(newControllerClassNode, initialiseUrlMappingsMethod)
                     processVariableScopes(source, newControllerClassNode, initialiseUrlMappingsMethod)
                 }
             }
@@ -249,7 +253,9 @@ class ResourceTransform implements ASTTransformation, CompilationUnitAware {
     ConstructorNode addConstructor(ClassNode controllerClassNode, ClassNode domainClassNode, boolean readOnly) {
         BlockStatement constructorBody = new BlockStatement()
         constructorBody.addStatement(new ExpressionStatement(new ConstructorCallExpression(ClassNode.SUPER, new TupleExpression(new ClassExpression(domainClassNode),new ConstantExpression(readOnly, true)))))
-        controllerClassNode.addConstructor(Modifier.PUBLIC, ZERO_PARAMETERS, ClassNode.EMPTY_ARRAY, constructorBody)
+        ConstructorNode constructorNode = controllerClassNode.addConstructor(Modifier.PUBLIC, ZERO_PARAMETERS, ClassNode.EMPTY_ARRAY, constructorBody)
+        AnnotatedNodeUtils.markAsGenerated(controllerClassNode, constructorNode)
+        return constructorNode
     }
     
     void setCompilationUnit(CompilationUnit unit) {

--- a/grails-plugin-rest/src/test/groovy/grails/artefact/controller/RestResponderTraitGeneratedSpec.groovy
+++ b/grails-plugin-rest/src/test/groovy/grails/artefact/controller/RestResponderTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package grails.artefact.controller
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class RestResponderTraitGeneratedSpec extends Specification {
+
+    void "test that all RestResponder trait methods are marked as Generated"() {
+        expect: "all RestResponder methods are marked as Generated on implementation class"
+        RestResponder.getMethods().each { Method traitMethod ->
+            assert TestResponder.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestResponder implements RestResponder {
+
+}

--- a/grails-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/transform/LinkableTransformSpec.groovy
+++ b/grails-plugin-rest/src/test/groovy/org/grails/plugins/web/rest/transform/LinkableTransformSpec.groovy
@@ -1,7 +1,10 @@
 package org.grails.plugins.web.rest.transform
 
 import grails.web.Action
+import groovy.transform.Generated
 import spock.lang.Specification
+
+import java.lang.reflect.Method
 
 /**
  * @author Graeme Rocher
@@ -29,5 +32,11 @@ class LinkableTransformSpec extends Specification {
         then:"The link is added to the available links"
             links[0].href == '/foo'
 
+        when: "find all added methods"
+            List<Method> addedLinkMethods = book.getClass().getMethods().findAll {it.name == 'link' || it.name == 'links'}
+        then: "they are marked as Generated"
+            addedLinkMethods.each {
+                assert it.isAnnotationPresent(Generated)
+            }
     }
 }

--- a/grails-plugin-validation/src/main/groovy/grails/validation/DefaultASTValidateableHelper.java
+++ b/grails-plugin-validation/src/main/groovy/grails/validation/DefaultASTValidateableHelper.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.groovy.ast.tools.AnnotatedNodeUtils;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
 import org.codehaus.groovy.ast.FieldNode;
@@ -160,8 +161,10 @@ public class DefaultASTValidateableHelper implements ASTValidateableHelper{
             final MethodNode methodNode = new MethodNode(getConstraintsMethodName, Modifier.STATIC | Modifier.PUBLIC, new ClassNode(Map.class), ZERO_PARAMETERS, null, methodBlockStatement);
             if (classNode.redirect() == null) {
                 classNode.addMethod(methodNode);
+                AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
             } else {
                 classNode.redirect().addMethod(methodNode);
+                AnnotatedNodeUtils.markAsGenerated(classNode.redirect(), methodNode);
             }
         }
     }
@@ -222,9 +225,11 @@ public class DefaultASTValidateableHelper implements ASTValidateableHelper{
             final StaticMethodCallExpression invokeValidateInstanceExpression = new StaticMethodCallExpression(validationSupportClassNode, "validateInstance", validateInstanceArguments);
             validateMethodCode.addStatement(new ExpressionStatement(invokeValidateInstanceExpression));
             final Parameter fieldsToValidateParameter = new Parameter(new ClassNode(List.class), fieldsToValidateParameterName);
-            classNode.addMethod(new MethodNode(
-                  VALIDATE_METHOD_NAME, Modifier.PUBLIC, ClassHelper.boolean_TYPE,
-                  new Parameter[]{fieldsToValidateParameter}, EMPTY_CLASS_ARRAY, validateMethodCode));
+            MethodNode methodNode = new MethodNode(
+                    VALIDATE_METHOD_NAME, Modifier.PUBLIC, ClassHelper.boolean_TYPE,
+                    new Parameter[]{fieldsToValidateParameter}, EMPTY_CLASS_ARRAY, validateMethodCode);
+            classNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
         }
         final MethodNode noArgValidateMethod = classNode.getMethod(VALIDATE_METHOD_NAME,ZERO_PARAMETERS);
         if (noArgValidateMethod == null) {
@@ -234,9 +239,11 @@ public class DefaultASTValidateableHelper implements ASTValidateableHelper{
             validateInstanceArguments.addExpression(new CastExpression(new ClassNode(List.class), new ConstantExpression(null)));
             final Expression callListArgValidateMethod = new MethodCallExpression(new VariableExpression("this"), VALIDATE_METHOD_NAME, validateInstanceArguments);
             validateMethodCode.addStatement(new ReturnStatement(callListArgValidateMethod));
-            classNode.addMethod(new MethodNode(
-                  VALIDATE_METHOD_NAME, Modifier.PUBLIC, ClassHelper.boolean_TYPE,
-                  ZERO_PARAMETERS, EMPTY_CLASS_ARRAY, validateMethodCode));
+            MethodNode methodNode = new MethodNode(
+                    VALIDATE_METHOD_NAME, Modifier.PUBLIC, ClassHelper.boolean_TYPE,
+                    ZERO_PARAMETERS, EMPTY_CLASS_ARRAY, validateMethodCode);
+            classNode.addMethod(methodNode);
+            AnnotatedNodeUtils.markAsGenerated(classNode, methodNode);
         }
     }
 }

--- a/grails-plugin-validation/src/main/groovy/grails/validation/Validateable.groovy
+++ b/grails-plugin-validation/src/main/groovy/grails/validation/Validateable.groovy
@@ -18,6 +18,7 @@ package grails.validation
 import grails.util.Holders
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.datastore.gorm.support.BeforeValidateHelper
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
@@ -41,19 +42,27 @@ import org.springframework.validation.FieldError
 trait Validateable {
     private BeforeValidateHelper beforeValidateHelper = new BeforeValidateHelper()
     private static Map<String, Constrained> constraintsMapInternal
-    Errors errors
+
+    private Errors errors
 
     /**
      * @return The errors
      */
+    @Generated
     Errors getErrors() {
         initErrors()
         errors
     }
 
+    @Generated
+    void setErrors(Errors errors) {
+        this.errors = errors
+    }
+
     /**
      * @return Whether the object has errors
      */
+    @Generated
     Boolean hasErrors() {
         initErrors()
         errors.hasErrors()
@@ -62,6 +71,7 @@ trait Validateable {
     /**
      * Clear the errors
      */
+    @Generated
     void clearErrors() {
         errors = null
     }
@@ -69,6 +79,7 @@ trait Validateable {
     /**
      * @return The map of applied constraints
      */
+    @Generated
     static Map<String, Constrained> getConstraintsMap() {
         if (constraintsMapInternal == null) {
             org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluator evaluator = findConstraintsEvaluator()
@@ -89,6 +100,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate() {
         validate null, null, null
     }
@@ -98,6 +110,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(Closure<?>... adHocConstraintsClosures) {
         validate(null, null, adHocConstraintsClosures)
     }
@@ -107,6 +120,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(Map<String, Object> params) {
         validate params, null
     }
@@ -116,6 +130,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
         validate(null, params, adHocConstraintsClosures)
     }
@@ -125,6 +140,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(List fieldsToValidate) {
         validate fieldsToValidate, null, null
     }
@@ -134,6 +150,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(List fieldsToValidate, Closure<?>... adHocConstraintsClosures) {
         validate(fieldsToValidate, null, adHocConstraintsClosures)
     }
@@ -143,6 +160,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(List fieldsToValidate, Map<String, Object> params) {
         validate fieldsToValidate, params, null
     }
@@ -152,6 +170,7 @@ trait Validateable {
      *
      * @return True if it is valid
      */
+    @Generated
     boolean validate(List fieldsToValidate, Map<String, Object> params, Closure<?>... adHocConstraintsClosures) {
         beforeValidateHelper.invokeBeforeValidate(this, fieldsToValidate)
 
@@ -236,6 +255,7 @@ trait Validateable {
         }
     }
 
+    @Generated
     static boolean defaultNullable() {
         false
     }

--- a/grails-plugin-validation/src/test/groovy/grails/validation/DefaultASTValidateableHelperSpec.groovy
+++ b/grails-plugin-validation/src/test/groovy/grails/validation/DefaultASTValidateableHelperSpec.groovy
@@ -1,7 +1,7 @@
 package grails.validation
 
 import grails.util.Holders
-
+import groovy.transform.Generated
 import org.grails.web.context.ServletEnvironmentGrailsApplicationDiscoveryStrategy
 import org.springframework.web.context.support.GenericWebApplicationContext
 import org.codehaus.groovy.ast.ClassNode
@@ -15,6 +15,8 @@ import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.WebApplicationContext
 
 import spock.lang.Specification
+
+import java.lang.reflect.Method
 
 /**
  * Tests relevant to grails.validation.Validateable
@@ -78,6 +80,11 @@ class DefaultASTValidateableHelperSpec extends Specification {
             constraints.count.range == 1..10
     }
 
+    void 'Test constraints getter method is marked as Generated'() {
+        expect:
+        widgetClass.getMethod('getConstraints').isAnnotationPresent(Generated)
+    }
+
     void 'Test validate method returns has a declared return type of boolean, not Boolean'() {
         when:
             def validateListArgMethod = widgetClass.metaClass.methods.find {
@@ -116,6 +123,20 @@ class DefaultASTValidateableHelperSpec extends Specification {
         then:
             !isValid
             3 == errorCount
+    }
+
+    void 'Test validate method is marked as Generated'() {
+        when:
+        Method validateListArgMethod = widgetClass.getMethods().find { Method it ->
+            'validate' == it.name && it.parameterTypes.length == 1
+        }
+        Method validateNoArgMethod = widgetClass.getMethods().find { Method it ->
+            'validate' == it.name && it.parameterTypes.length == 0
+        }
+
+        then:
+        validateListArgMethod.isAnnotationPresent(Generated)
+        validateNoArgMethod.isAnnotationPresent(Generated)
     }
 
     void 'Test clearErrors'() {

--- a/grails-plugin-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
+++ b/grails-plugin-validation/src/test/groovy/grails/validation/ValidateableTraitSpec.groovy
@@ -2,12 +2,15 @@ package grails.validation
 
 import grails.util.ClosureToMapPopulator
 import grails.util.Holders
+import groovy.transform.Generated
 import org.grails.core.support.GrailsApplicationDiscoveryStrategy
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.springframework.context.support.GenericApplicationContext
 import org.springframework.validation.FieldError
 import spock.lang.Issue
 import spock.lang.Specification
+
+import java.lang.reflect.Method
 
 /**
  * Ensure validation logic for command object with {@code Validateable} and whether or not compatible with domain class.
@@ -297,6 +300,13 @@ class ValidateableTraitSpec extends Specification {
         then:
         obj.someValidateable.validate(['name'])
     }
+
+    void "test that all Validateable trait methods are marked as Generated"() {
+        expect: "all Validateable methods are marked as Generated on implementation class"
+        Validateable.getMethods().each { Method traitMethod ->
+            assert TestGeneratedAnnotations.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
 }
 
 class MyValidateable implements Validateable {
@@ -397,4 +407,8 @@ class SubClassValidateable extends SuperClassValidateable implements Validateabl
     static constraints = {
         subName matches: /SUB/
     }
+}
+
+class TestGeneratedAnnotations implements Validateable {
+
 }

--- a/grails-shell/src/main/groovy/org/grails/cli/profile/commands/events/CommandEvents.groovy
+++ b/grails-shell/src/main/groovy/org/grails/cli/profile/commands/events/CommandEvents.groovy
@@ -16,6 +16,7 @@
 package org.grails.cli.profile.commands.events
 
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.grails.cli.profile.commands.script.GroovyScriptCommand
 
 
@@ -35,6 +36,7 @@ trait CommandEvents {
      * @param eventName The name of the event
      * @param callable The closure that is executed when the event is fired
      */
+    @Generated
     void on(String eventName, @DelegatesTo(GroovyScriptCommand) Closure callable) {
         EventStorage.registerEvent(eventName, callable)
     }
@@ -46,6 +48,7 @@ trait CommandEvents {
      * @param eventName The name of the event
      * @param callable The closure that is executed when the event is fired
      */
+    @Generated
     void before(String commandName, @DelegatesTo(GroovyScriptCommand) Closure callable) {
         EventStorage.registerEvent("${commandName}Start", callable)
     }
@@ -56,6 +59,7 @@ trait CommandEvents {
      * @param eventName The name of the event
      * @param callable The closure that is executed when the event is fired
      */
+    @Generated
     void after(String commandName, @DelegatesTo(GroovyScriptCommand) Closure callable) {
         EventStorage.registerEvent("${commandName}End", callable)
     }
@@ -66,6 +70,7 @@ trait CommandEvents {
      * @param eventName The name of the event
      * @param args The arguments to the event
      */
+    @Generated
     void notify(String eventName, Object...args) {
         EventStorage.fireEvent(this, eventName, args)
     }

--- a/grails-shell/src/test/groovy/org/grails/cli/profile/commands/events/CommandEventsTraitGeneratedSpec.groovy
+++ b/grails-shell/src/test/groovy/org/grails/cli/profile/commands/events/CommandEventsTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package org.grails.cli.profile.commands.events
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class CommandEventsTraitGeneratedSpec extends Specification {
+
+    void "test that all CommandEvents trait methods are marked as Generated"() {
+        expect: "all CommandEvents methods are marked as Generated on implementation class"
+        CommandEvents.getMethods().each { Method traitMethod ->
+            assert TestCommandEvents.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestCommandEvents implements CommandEvents {
+
+}

--- a/grails-web-common/src/main/groovy/grails/web/api/ServletAttributes.groovy
+++ b/grails-web-common/src/main/groovy/grails/web/api/ServletAttributes.groovy
@@ -17,6 +17,7 @@
 package grails.web.api
 
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.springframework.context.ApplicationContext
 import org.springframework.web.context.support.WebApplicationContextUtils
 
@@ -38,10 +39,12 @@ trait ServletAttributes implements WebAttributes {
     private ServletContext servletContext
     private ApplicationContext applicationContext
 
+    @Generated
     HttpServletRequest getRequest() {
         currentRequestAttributes().getCurrentRequest()
     }
 
+    @Generated
     HttpSession getSession() {
         return currentRequestAttributes().getSession()
     }
@@ -50,6 +53,7 @@ trait ServletAttributes implements WebAttributes {
      * Obtains the ApplicationContext instance
      * @return The ApplicationContext instance
      */
+    @Generated
     ApplicationContext getApplicationContext() {
         if (applicationContext == null) {
             this.applicationContext = WebApplicationContextUtils.getRequiredWebApplicationContext(getServletContext());
@@ -62,6 +66,7 @@ trait ServletAttributes implements WebAttributes {
      *
      * @return The HttpServletResponse instance
      */
+    @Generated
     HttpServletResponse getResponse() {
         currentRequestAttributes().getCurrentResponse()
     }
@@ -71,6 +76,7 @@ trait ServletAttributes implements WebAttributes {
      *
      * @return The ServletContext instance
      */
+    @Generated
     ServletContext getServletContext() {
         if (servletContext == null) {
             servletContext = currentRequestAttributes().getServletContext()

--- a/grails-web-common/src/main/groovy/grails/web/api/WebAttributes.groovy
+++ b/grails-web-common/src/main/groovy/grails/web/api/WebAttributes.groovy
@@ -20,6 +20,7 @@ import grails.core.GrailsControllerClass
 import grails.plugins.GrailsPluginManager
 import grails.web.mvc.FlashScope
 import grails.web.servlet.mvc.GrailsParameterMap
+import groovy.transform.Generated
 import org.grails.web.util.GrailsApplicationAttributes
 import groovy.transform.CompileStatic
 
@@ -41,6 +42,7 @@ trait WebAttributes {
     
     private GrailsApplication grailsApplication
 
+    @Generated
     GrailsWebRequest currentRequestAttributes() {
         (GrailsWebRequest)RequestContextHolder.currentRequestAttributes()
     }
@@ -50,6 +52,7 @@ trait WebAttributes {
      *
      * @return The GrailsApplicationAttributes instance
      */
+    @Generated
     GrailsApplicationAttributes getGrailsAttributes() {
         currentRequestAttributes().getAttributes()
     }
@@ -58,6 +61,7 @@ trait WebAttributes {
      * Obtains the currently executing controller name
      * @return The controller name
      */
+    @Generated
     String getControllerName() {
         currentRequestAttributes().getControllerName()
     }
@@ -66,6 +70,7 @@ trait WebAttributes {
      * Obtains the currently executing controller namespace
      * @return The controller name
      */
+    @Generated
     String getControllerNamespace() {
         currentRequestAttributes().getControllerNamespace()
     }
@@ -75,6 +80,7 @@ trait WebAttributes {
      *
      * @return The controller class
      */
+    @Generated
     GrailsControllerClass getControllerClass() {
         currentRequestAttributes().getControllerClass()
     }
@@ -85,6 +91,7 @@ trait WebAttributes {
      * @param delegate The object the method is being invoked on
      * @return The plugin context path
      */
+    @Generated
     String getPluginContextPath() {
         GrailsPluginManager manager = getGrailsApplication().getMainContext().getBean(GrailsPluginManager.class)
         final String pluginPath = manager ? manager.getPluginPathForInstance(this) : null
@@ -95,6 +102,7 @@ trait WebAttributes {
      * Obtains the currently executing action name
      * @return The action name
      */
+    @Generated
     String getActionName() {
         currentRequestAttributes().getActionName()
     }
@@ -104,6 +112,7 @@ trait WebAttributes {
      *
      * @return The FlashScope instance
      */
+    @Generated
     FlashScope getFlash() {
         currentRequestAttributes().getFlashScope()
     }
@@ -113,6 +122,7 @@ trait WebAttributes {
      *
      * @return The GrailsParameterMap instance
      */
+    @Generated
     GrailsParameterMap getParams() {
         currentRequestAttributes().getParams()
     }
@@ -121,6 +131,7 @@ trait WebAttributes {
      *
      * @return The GrailsWebRequest instance
      */
+    @Generated
     GrailsWebRequest getWebRequest() {
         currentRequestAttributes()
     }
@@ -129,6 +140,7 @@ trait WebAttributes {
      * Obtains the GrailsApplication instance
      * @return The GrailsApplication instance
      */
+    @Generated
     GrailsApplication getGrailsApplication() {
         if (grailsApplication == null) {
             grailsApplication = getGrailsAttributes().getGrailsApplication()

--- a/grails-web-common/src/test/groovy/grails/web/api/ServletAttributesTraitGeneratedSpec.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/api/ServletAttributesTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package grails.web.api
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class ServletAttributesTraitGeneratedSpec extends Specification {
+
+    void "test that all ServletAttributes trait methods are marked as Generated"() {
+        expect: "all ServletAttributes methods are marked as Generated on implementation class"
+        ServletAttributes.getMethods().each { Method traitMethod ->
+            assert TestServletAttributes.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestServletAttributes implements ServletAttributes {
+
+}

--- a/grails-web-common/src/test/groovy/grails/web/api/WebAttributesTraitGeneratedSpec.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/api/WebAttributesTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package grails.web.api
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class WebAttributesTraitGeneratedSpec extends Specification {
+
+    void "test that all WebAttributes trait methods are marked as Generated"() {
+        expect: "all WebAttributes methods are marked as Generated on implementation class"
+        WebAttributes.getMethods().each { Method traitMethod ->
+            assert TestWebAttributes.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestWebAttributes implements WebAttributes {
+
+}

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/DataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/DataBinder.groovy
@@ -17,6 +17,7 @@ package grails.web.databinding
 
 import grails.databinding.CollectionDataBindingSource
 import groovy.transform.CompileStatic
+import groovy.transform.Generated
 import org.springframework.validation.BindingResult
 
 /**
@@ -32,32 +33,39 @@ import org.springframework.validation.BindingResult
 @CompileStatic
 trait DataBinder {
 
+    @Generated
     BindingResult bindData(target, bindingSource, Map includeExclude) {
         bindData target, bindingSource, includeExclude, null
     }
 
+    @Generated
     BindingResult bindData(target, bindingSource) {
         bindData target, bindingSource, Collections.EMPTY_MAP, null
     }
 
+    @Generated
     BindingResult bindData(target, bindingSource, String filter) {
         bindData target, bindingSource, Collections.EMPTY_MAP, filter
     }
 
+    @Generated
     BindingResult bindData(target, bindingSource, List excludes) {
         bindData target, bindingSource, [exclude: excludes], null
     }
 
+    @Generated
     BindingResult bindData(target, bindingSource, List excludes, String filter) {
         bindData target, bindingSource, [exclude: excludes], filter
     }
 
+    @Generated
     BindingResult bindData(target, bindingSource, Map includeExclude, String filter) {
         List includeList = convertToListIfCharSequence(includeExclude?.include)
         List excludeList = convertToListIfCharSequence(includeExclude?.exclude)
         DataBindingUtils.bindObjectToInstance target, bindingSource, includeList, excludeList, filter
     }
 
+    @Generated
     void bindData(Class targetType, Collection collectionToPopulate, CollectionDataBindingSource collectionBindingSource) {
         DataBindingUtils.bindToCollection targetType, collectionToPopulate, collectionBindingSource
     }

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/WebDataBinding.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/WebDataBinding.groovy
@@ -16,7 +16,7 @@
 package grails.web.databinding
 
 import groovy.transform.CompileStatic
-
+import groovy.transform.Generated
 import org.grails.web.databinding.DataBindingLazyMetaPropertyMap
 import org.springframework.validation.BindingResult
 
@@ -34,6 +34,7 @@ trait WebDataBinding {
      * @param bindingSource The binding source
      * @return The BindingResult
      */
+    @Generated
     BindingResult setProperties(final bindingSource) {
         DataBindingUtils.bindObjectToInstance(this, bindingSource)
     }
@@ -45,6 +46,7 @@ trait WebDataBinding {
      @link DataBindingLazyMetaPropertyMap
      }
      */
+    @Generated
     Map<?, ?> getProperties() {
         new DataBindingLazyMetaPropertyMap(this)
     }

--- a/grails-web-databinding/src/test/groovy/grails/web/databinding/DataBinderTraitGeneratedSpec.groovy
+++ b/grails-web-databinding/src/test/groovy/grails/web/databinding/DataBinderTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package grails.web.databinding
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class DataBinderTraitGeneratedSpec extends Specification {
+
+    void "test that all DataBinder trait methods are marked as Generated"() {
+        expect: "all DataBinder methods are marked as Generated on implementation class"
+        DataBinder.getMethods().each { Method traitMethod ->
+            assert TestDataBinder.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestDataBinder implements DataBinder {
+
+}

--- a/grails-web-databinding/src/test/groovy/grails/web/databinding/WebDataBindingTraitGeneratedSpec.groovy
+++ b/grails-web-databinding/src/test/groovy/grails/web/databinding/WebDataBindingTraitGeneratedSpec.groovy
@@ -1,0 +1,20 @@
+package grails.web.databinding
+
+import groovy.transform.Generated
+import spock.lang.Specification
+
+import java.lang.reflect.Method
+
+class WebDataBindingTraitGeneratedSpec extends Specification {
+
+    void "test that all WebDataBinding trait methods are marked as Generated"() {
+        expect: "all WebDataBinding methods are marked as Generated on implementation class"
+        WebDataBinding.getMethods().each { Method traitMethod ->
+            assert TestWebDataBinding.class.getMethod(traitMethod.name, traitMethod.parameterTypes).isAnnotationPresent(Generated)
+        }
+    }
+}
+
+class TestWebDataBinding implements WebDataBinding {
+
+}


### PR DESCRIPTION
Solution for #11318 in grails-core.
Mark grails-core Traits methods as Generated and also with AST transformation added methods/constructors, so Jacoco could ignore them in its coverage reports.
If it is okay solution, then will go through also "core" plugins in their repositories.