### PR TITLE
Fix for 11673 "Partial URI for Location HTTP-header is missing context-path"

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
+++ b/grails-web-url-mappings/src/main/groovy/grails/web/mapping/ResponseRedirector.groovy
@@ -122,7 +122,7 @@ class ResponseRedirector {
         if (absolute) {
             redirectURI = processedActualUri.contains("://") ? processedActualUri : serverBaseURL + processedActualUri
         } else {
-            redirectURI = processedActualUri
+            redirectURI = linkGenerator.contextPath + processedActualUri
         }
 
         String redirectUrl = useJessionId ? response.encodeRedirectURL(redirectURI) : redirectURI

--- a/grails-web-url-mappings/src/test/groovy/grails/web/mapping/AbstractUrlMappingsSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/grails/web/mapping/AbstractUrlMappingsSpec.groovy
@@ -17,10 +17,17 @@ import spock.lang.Specification
  */
 abstract class AbstractUrlMappingsSpec extends Specification{
 
+    static final String CONTEXT_PATH = 'app-context'
+
     def setup() {
         WebUtils.clearGrailsWebRequest()
     }
 
+    LinkGenerator getLinkGeneratorWithContextPath(Closure mappings) {
+        LinkGeneratorFactory linkGeneratorFactory = new LinkGeneratorFactory()
+        linkGeneratorFactory.contextPath = CONTEXT_PATH
+        linkGeneratorFactory.create(mappings)
+    }
     LinkGenerator getLinkGenerator(Closure mappings) {
         new LinkGeneratorFactory().create(mappings)
     }


### PR DESCRIPTION
Fix for https://github.com/grails/grails-core/issues/11673 "Partial URI for Location HTTP-header is missing context-path"