### PR TITLE
DefaultUrlMappingInfo#getUrlData should return the urlData item when available

### DIFF
--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/DefaultUrlMappingInfo.java
@@ -284,7 +284,7 @@ public class DefaultUrlMappingInfo extends AbstractUrlMappingInfo {
 
     @Override
     public UrlMappingData getUrlData() {
-        return null;
+        return urlData;
     }
 
     @Override


### PR DESCRIPTION
I am trying to get request path info to use with Micrometer. Without a suitable path, all endpoints report as `root` which is not desirable. The `DefaultUrlMappingData` seems to be the best I can hope for, as it will give us access to a pattern which has something like `/book/(*)/author/(*)`.

However, when trying to use the `UrlMappingData`, I noticed that `DefaultUrlMappingInfo` will never return the `urlData`, even when it is available (it's used in `#toString()`).

My suspicion is that when the `UrlMappingData#getUrlPattern` method was added a default implementation was created for each of the implementing classes but not modified in this instance. (See 65dd138e3583fefb929348972dd733e4b134abf1).

