### PR TITLE
Fixes GSP Configuration for compileGroovyPages... Be sure to target latest grails-gsp after PR merge for this to work

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/web/gsp/GroovyPageForkCompileTask.groovy
@@ -85,6 +85,12 @@ class GroovyPageForkCompileTask extends AbstractCompile {
                         javaExecSpec.setMaxHeapSize( compileOptions.forkOptions.memoryMaximumSize )
                         javaExecSpec.setMinHeapSize( compileOptions.forkOptions.memoryInitialSize )
 
+                        //This is the OLD Style and seems kinda silly to be hard coded this way. but restores functionality
+                        //for now
+                        def configFiles = [
+                            project.file("grails-app/conf/application.yml").canonicalPath,
+                            project.file("grails-app/conf/application.groovy").canonicalPath
+                        ].join(',')
 
                         def arguments = [
                             srcDir.canonicalPath,
@@ -93,7 +99,7 @@ class GroovyPageForkCompileTask extends AbstractCompile {
                             targetCompatibility,
                             packageName,
                             serverpath,
-                            project.file("grails-app/conf/application.yml").canonicalPath,
+                            configFiles,
                             compileOptions.encoding
                         ]
 


### PR DESCRIPTION
compileGroovyPages forked was not adhering to GSP configuration settings in application.yml nor application.groovy. this fixes that along with the related PR in the grails-gsp project