### PR TITLE
Remove obsolete JVM parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   global:
   - TERM=dumb
   - MALLOC_ARENA_MAX=1
-  - GRADLE_OPTS="-Xmx768m -Xms256m -XX:MaxPermSize=372m -XX:+CMSClassUnloadingEnabled"
+  - GRADLE_OPTS="-Xmx768m -Xms256m -XX:+CMSClassUnloadingEnabled"
   - GIT_NAME="Graeme Rocher"
   - GIT_EMAIL="graeme.rocher@gmail.com"
   - secure: HMX1CzkCcj9Qal1Syk3kJR1VBQcmT5Uo986dL4r28q00YoyrfRjtAIqvCJSKO1t7aCeJkG74sdeNs43EYpkXCAS9c/ffWAWK1G+YAO5XgJi9cWj/B5F6MGD3YAbO86PIUceq3VcoGztflBB7i9N9YakYt41vnMPULHFBEpLtfOQ=

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To build Grails, clone this GitHub repository and execute the install Gradle tar
 
 If you encounter out of memory errors when trying to run the install target, try adjusting Gradle build settings. For example:
 
-    export GRADLE_OPTS="-Xmx2G -Xms2G -XX:NewSize=512m -XX:MaxNewSize=512m -XX:MaxPermSize=1G"
+    export GRADLE_OPTS="-Xmx2G -Xms2G -XX:NewSize=512m -XX:MaxNewSize=512m"
 
 Performing a Release
 ---

--- a/grails-docs/src/test/resources/docs/guide/gettingStarted.html
+++ b/grails-docs/src/test/resources/docs/guide/gettingStarted.html
@@ -748,7 +748,7 @@ java -Dgrails.env=prod -jar build/libs/mywar-0.1.war</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M -XX:MaxPermSize=256m</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M</code></pre>
 </div>
 </div>
 

--- a/grails-docs/src/test/resources/docs/guide/pages/deployingAnApplication.html
+++ b/grails-docs/src/test/resources/docs/guide/pages/deployingAnApplication.html
@@ -198,7 +198,7 @@ java -Dgrails.env=prod -jar build/libs/mywar-0.1.war</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M -XX:MaxPermSize=256m</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M</code></pre>
 </div>
 </div>
 

--- a/grails-docs/src/test/resources/docs/guide/single.backup.html
+++ b/grails-docs/src/test/resources/docs/guide/single.backup.html
@@ -1984,7 +1984,7 @@ java -Dgrails.env=prod -jar build/libs/mywar-0.1.war</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M -XX:MaxPermSize=256m</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M</code></pre>
 </div>
 </div>
 

--- a/grails-docs/src/test/resources/docs/guide/single.html
+++ b/grails-docs/src/test/resources/docs/guide/single.html
@@ -1984,7 +1984,7 @@ java -Dgrails.env=prod -jar build/libs/mywar-0.1.war</code></pre>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M -XX:MaxPermSize=256m</code></pre>
+<pre class="CodeRay highlight"><code data-lang="bash">-server -Xmx768M</code></pre>
 </div>
 </div>
 


### PR DESCRIPTION
Since Grails 4 already requires JDK 8 the PermGen space-related `XX:MaxPermSize` is obsolete.