### PR TITLE
Support backward compatiblity with Metadata

### DIFF
--- a/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/util/Metadata.groovy
@@ -392,4 +392,9 @@ class Metadata extends PropertySourcePropertyResolver {
     Object navigate(String... path) {
         return ((Optional<Object>) ((PropertyResolver) this).getProperty(path.join(".").toString(), Object)).orElse(null)
     }
+
+    @Deprecated
+    Object getProperty(String propertyName) {
+        return get(propertyName)
+    }
 }


### PR DESCRIPTION
For example - Metadata.current['info.app.name'] should work