### PR TITLE
Added Jakarta Annotation API to Grails BOM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ ext {
                 modules:['api']
         ],
         'jakarta.annotation-api': [
-                version: $jakartaAnnotationApiVersion,
+                version: jakartaAnnotationApiVersion,
                 group:'jakarta.annotation',
                 names:['jakarta.annotation-api'],
                 modules:[]

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ ext {
                 names:['javax.annotation'],
                 modules:['api']
         ],
+        'jakarta.annotation-api': [
+                version: $jakartaAnnotationApiVersion,
+                group:'jakarta.annotation',
+                names:['jakarta.annotation-api'],
+                modules:[]
+        ],
         'micronaut': [
                 version: micronautVersion,
                 group:'io.micronaut',

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ gspVersion=5.0.0.RC1
 h2.version=1.4.199
 h2Version=1.4.200
 hibernateDatastoreVersion=7.1.0.RC2
+jakartaAnnotationApiVersion=2.0.0
 jansiVersion=1.18
 javaParserCoreVersion=3.15.14
 javaxAnnotationApiVersion=1.3.2


### PR DESCRIPTION
Micronaut depends on Jakarta Annotation API 2.0.0, so we need to override SpringBoot BOM