### PR TITLE
Update Grails BOM key for Jakarta Annotataion API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,11 +36,11 @@ ext {
                 names:['javax.annotation'],
                 modules:['api']
         ],
-        'jakarta.annotation': [
+        'jakarta-annotation': [
                 version: jakartaAnnotationApiVersion,
                 group:'jakarta.annotation',
                 names:['jakarta.annotation-api'],
-                modules:[]
+                modules:['']
         ],
         'micronaut': [
                 version: micronautVersion,


### PR DESCRIPTION
Rename Grails BOM key for Jakarta Annotation API to the correct value in order to update SpringBoot BOM