### PR TITLE
Improvise JSONObject getter methods to pass/accept default values

### DIFF
--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java
@@ -265,6 +265,21 @@ public class JSONObject implements JSONElement, Map {
 
 
     /**
+     * Get the value object associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key does not exist.
+     * @return The object associated with the key. If the key is not found then return the default value.
+     */
+    public Object get(String key, Object defValue) {
+        try {
+            return get(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
+    }
+
+    /**
      * Get the boolean value associated with a key.
      *
      * @param key A key string.
@@ -284,6 +299,23 @@ public class JSONObject implements JSONElement, Map {
         }
         throw new JSONException("JSONObject[" + quote(key) +
                 "] is not a Boolean.");
+    }
+
+
+    /**
+     * Get the boolean value associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key does not exist or if the value is not a Boolean or the String
+     *                 "true" or "false".
+     * @return The truth.
+     */
+    public boolean getBoolean(String key, boolean defValue) {
+        try {
+            return getBoolean(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
     }
 
 
@@ -308,6 +340,22 @@ public class JSONObject implements JSONElement, Map {
 
 
     /**
+     * Get the double value associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key does not exist or if the value is not a Number object and cannot be
+     *                converted to a number.
+     * @return The numeric value.
+     */
+    public double getDouble(String key, double defValue) {
+        try {
+            return getDouble(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
+    }
+
+    /**
      * Get the int value associated with a key. If the number value is too
      * large for an int, it will be clipped.
      *
@@ -320,6 +368,23 @@ public class JSONObject implements JSONElement, Map {
         Object o = get(key);
         return o instanceof Number ?
                 ((Number) o).intValue() : (int) getDouble(key);
+    }
+
+
+    /**
+     * Get the int value associated with a key. If the number value is too
+     * large for an int, it will be clipped.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key is not found or if the value cannot be converted to an integer.
+     * @return The integer value.
+     */
+    public int getInt(String key, int defValue) {
+        try {
+            return getInt(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
     }
 
 
@@ -342,6 +407,22 @@ public class JSONObject implements JSONElement, Map {
 
 
     /**
+     * Get the JSONArray value associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key is not found or if the value is not a JSONArray.
+     * @return A JSONArray which is the value.
+     */
+    public JSONArray getJSONArray(String key, JSONArray defValue) {
+        try {
+            return getJSONArray(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
+    }
+
+
+    /**
      * Get the JSONObject value associated with a key.
      *
      * @param key A key string.
@@ -356,6 +437,22 @@ public class JSONObject implements JSONElement, Map {
         }
         throw new JSONException("JSONObject[" + quote(key) +
                 "] is not a JSONObject.");
+    }
+
+
+    /**
+     * Get the JSONObject value associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key is not found or if the value is not a JSONObject.
+     * @return A JSONObject which is the value.
+     */
+    public JSONObject getJSONObject(String key, JSONObject defValue) {
+        try {
+            return getJSONObject(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
     }
 
 
@@ -376,6 +473,23 @@ public class JSONObject implements JSONElement, Map {
 
 
     /**
+     * Get the long value associated with a key. If the number value is too
+     * long for a long, it will be clipped.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key is not found or if the value cannot be converted to a long.
+     * @return The long value.
+     */
+    public long getLong(String key, long defValue) {
+        try {
+            return getLong(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
+    }
+
+
+    /**
      * Get the string associated with a key.
      *
      * @param key A key string.
@@ -384,6 +498,22 @@ public class JSONObject implements JSONElement, Map {
      */
     public String getString(String key) throws JSONException {
         return get(key).toString();
+    }
+
+
+    /**
+     * Get the string associated with a key.
+     *
+     * @param key A key string.
+     * @param defValue Value to return if the key does not exist.
+     * @return A string which is the value.
+     */
+    public String getString(String key, String defValue) {
+        try {
+            return getString(key);
+        } catch (JSONException ignore) {
+            return defValue;
+        }
     }
 
 


### PR DESCRIPTION
## Current Problem

Consider you have a `JSONObject` as given below-

```groovy
JSONObject requestData = request.JSON // or new JSONObject(data)
```

To read a property, let's say `rating` from the `requestData`, the Grails developer has to write a lengthy code-

```groovy
Integer usersRating = 5  // 5 being the default value
if (requestData.has("rating") {
    usersRating = requestData.getInt("rating")
}
```

or

```groovy
Integer usersRating = 5  // 5 being the default value

try {
    usersRating = requestData.getInt("rating")
} catch (JSONException ignore) {
    usersRating = 5
}
```

or

```groovy
Integer usersRating = (requestData.getInt("rating") ?? 5) as Integer
```

These approaches-

1. Increases the number of lines.
2. Reduces code readability
3. Increases chances of code failure if someone has not handled the missing key scenario.
4. Unnecessary typecasting.

## Solution

This PR adds overloaded methods (with 2nd argument as the default value) for 8 getter methods of `JSONObject` which does not throw `JSONException` instead it returns the default values. So one can simply write-

```groovy
Integer usersRating = requestData.getInt("rating", 5)
```

## Motivation

This technique is used by [`SharedPreference`](https://developer.android.com/reference/android/content/SharedPreferences#getInt(java.lang.String,%20int)) in Android.