### PR TITLE
Suggested fix for #12150: SimpleDataBinder fails when target class and embedded class implements interfaces

### DIFF
--- a/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -105,7 +105,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
      * @see DataBindingSource
@@ -115,7 +115,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
      * @param listener A listener which will be notified of data binding events triggered
@@ -128,11 +128,11 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
-     * @param whiteList A list of property names to be included during this 
-     * data binding.  All other properties represented in the binding source 
+     * @param whiteList A list of property names to be included during this
+     * data binding.  All other properties represented in the binding source
      * will be ignored
      * @see DataBindingSource
      */
@@ -141,14 +141,14 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
-     * @param whiteList A list of property names to be included during this 
-     * data binding.  All other properties represented in the binding source 
+     * @param whiteList A list of property names to be included during this
+     * data binding.  All other properties represented in the binding source
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.  
+     * this data binding.
      * @see DataBindingSource
      */
     void bind(obj, DataBindingSource source, List whiteList, List blackList) {
@@ -156,9 +156,9 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
-     * @param gpath A GPathResult which represents the data being bound.  
+     * @param gpath A GPathResult which represents the data being bound.
      * @see DataBindingSource
      */
     void bind(obj, GPathResult gpath) {
@@ -166,7 +166,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
      * @param filter Only properties beginning with filter will be included in the
@@ -174,11 +174,11 @@ class SimpleDataBinder implements DataBinder {
      * source contains data for properties &quot;person.name&quot; and &quot;author.name&quot;
      * the value of &quot;person.name&quot; will be bound to obj.name.  The value of
      * &quot;author.name&quot; will be ignored.
-     * @param whiteList A list of property names to be included during this 
-     * data binding.  All other properties represented in the binding source 
+     * @param whiteList A list of property names to be included during this
+     * data binding.  All other properties represented in the binding source
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.  
+     * this data binding.
      * @see DataBindingSource
      */
     void bind(obj, DataBindingSource source, String filter, List whiteList, List blackList) {
@@ -186,7 +186,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     * 
+     *
      * @param obj The object being bound to
      * @param source The data binding source
      * @param filter Only properties beginning with filter will be included in the
@@ -194,11 +194,11 @@ class SimpleDataBinder implements DataBinder {
      * source contains data for properties &quot;person.name&quot; and &quot;author.name&quot;
      * the value of &quot;person.name&quot; will be bound to obj.name.  The value of
      * &quot;author.name&quot; will be ignored.
-     * @param whiteList A list of property names to be included during this 
-     * data binding.  All other properties represented in the binding source 
+     * @param whiteList A list of property names to be included during this
+     * data binding.  All other properties represented in the binding source
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.  
+     * this data binding.
      * @param listener A listener which will be notified of data binding events triggered
      * by this binding
      * @see DataBindingSource
@@ -376,7 +376,7 @@ class SimpleDataBinder implements DataBinder {
         }
     }
 
-        
+
     @CompileStatic(TypeCheckingMode.SKIP)
     protected initializeArray(obj, String propertyName, Class arrayType, int index) {
         Object[] array = obj[propertyName]
@@ -395,8 +395,8 @@ class SimpleDataBinder implements DataBinder {
     protected boolean isBasicType(Class c) {
         BASIC_TYPES.contains(c) || c.isPrimitive()
     }
-    
-    
+
+
     protected Class<?> getReferencedTypeForCollectionInClass(String propertyName, Class clazz) {
         Class referencedType
         def field = getField(clazz, propertyName)
@@ -465,7 +465,7 @@ class SimpleDataBinder implements DataBinder {
         }
         return (Collection)val
     }
-    
+
     protected getDefaultCollectionInstanceForType(Class type) {
         def val
         if (List.isAssignableFrom(type)) {
@@ -540,7 +540,7 @@ class SimpleDataBinder implements DataBinder {
         }
         converter
     }
-    
+
     /**
      * @param annotation An instance of grails.databinding.BindingUsing or org.grails.databinding.BindingUsing
      * @return the value Class of the annotation
@@ -553,7 +553,7 @@ class SimpleDataBinder implements DataBinder {
         }
         value
     }
-    
+
     /**
      * @param annotation An instance of grails.databinding.BindingFormat or org.grails.databinding.BindingFormat
      * @return the value String of the annotation
@@ -595,7 +595,7 @@ class SimpleDataBinder implements DataBinder {
             enumClass.valueOf(value)
         } catch (IllegalArgumentException iae) {}
     }
-    
+
     protected preprocessValue(propertyValue) {
         propertyValue
     }
@@ -611,10 +611,10 @@ class SimpleDataBinder implements DataBinder {
                 }
             }
         }
-        
+
         setPropertyValue obj, source, metaProperty, propertyValue, listener, convertCollectionElements
     }
-    
+
     protected setPropertyValue(obj, DataBindingSource source, MetaProperty metaProperty, propertyValue, DataBindingListener listener, boolean convertCollectionElements) {
         def propName = metaProperty.name
         def propertyType
@@ -622,6 +622,9 @@ class SimpleDataBinder implements DataBinder {
         if (metaProperty instanceof MetaBeanProperty) {
             def mbp = (MetaBeanProperty)metaProperty
             propertyType = mbp.getter?.returnType ?: mbp.field?.type
+            if(propertyType?.interface) {
+                propertyType = mbp.field?.type
+            }
             propertyGetter = mbp.getter
         }
         if (propertyType == null || propertyType == Object) {
@@ -744,9 +747,9 @@ class SimpleDataBinder implements DataBinder {
         }
         else{
             obj[propName] = propertyType.newInstance()
-        }        
+        }
     }
-    
+
     protected ValueInitializer getPropertyInitializer(obj, String propName){
         def initializer = getValueInitializerForField obj, propName
         initializer
@@ -771,7 +774,7 @@ class SimpleDataBinder implements DataBinder {
         initializer
     }
     /**
-     * @param annotation An instance of grails.databinding.BindInitializer 
+     * @param annotation An instance of grails.databinding.BindInitializer
      * @return the value Class of the annotation
      */
     protected Class getValueOfBindInitializer(Annotation annotation) {
@@ -782,7 +785,7 @@ class SimpleDataBinder implements DataBinder {
         }
         value
     }
-    
+
     protected convert(Class typeToConvertTo, value) {
         if (value == null || typeToConvertTo.isAssignableFrom(value?.getClass())) {
             return value

--- a/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -32,6 +32,7 @@ import org.grails.databinding.xml.GPathResultMap
 import java.lang.annotation.Annotation
 import java.lang.reflect.Array
 import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
 
 /**
@@ -622,7 +623,7 @@ class SimpleDataBinder implements DataBinder {
         if (metaProperty instanceof MetaBeanProperty) {
             def mbp = (MetaBeanProperty)metaProperty
             propertyType = mbp.getter?.returnType ?: mbp.field?.type
-            if(propertyType?.interface) {
+            if(propertyType && (propertyType.interface || Modifier.isAbstract(propertyType.modifiers))) {
                 propertyType = mbp.field?.type
             }
             propertyGetter = mbp.getter

--- a/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -106,7 +106,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
      * @see DataBindingSource
@@ -116,7 +116,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
      * @param listener A listener which will be notified of data binding events triggered
@@ -129,11 +129,11 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
-     * @param whiteList A list of property names to be included during this
-     * data binding.  All other properties represented in the binding source
+     * @param whiteList A list of property names to be included during this 
+     * data binding.  All other properties represented in the binding source 
      * will be ignored
      * @see DataBindingSource
      */
@@ -142,14 +142,14 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
-     * @param whiteList A list of property names to be included during this
-     * data binding.  All other properties represented in the binding source
+     * @param whiteList A list of property names to be included during this 
+     * data binding.  All other properties represented in the binding source 
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.
+     * this data binding.  
      * @see DataBindingSource
      */
     void bind(obj, DataBindingSource source, List whiteList, List blackList) {
@@ -157,9 +157,9 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
-     * @param gpath A GPathResult which represents the data being bound.
+     * @param gpath A GPathResult which represents the data being bound.  
      * @see DataBindingSource
      */
     void bind(obj, GPathResult gpath) {
@@ -167,7 +167,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
      * @param filter Only properties beginning with filter will be included in the
@@ -175,11 +175,11 @@ class SimpleDataBinder implements DataBinder {
      * source contains data for properties &quot;person.name&quot; and &quot;author.name&quot;
      * the value of &quot;person.name&quot; will be bound to obj.name.  The value of
      * &quot;author.name&quot; will be ignored.
-     * @param whiteList A list of property names to be included during this
-     * data binding.  All other properties represented in the binding source
+     * @param whiteList A list of property names to be included during this 
+     * data binding.  All other properties represented in the binding source 
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.
+     * this data binding.  
      * @see DataBindingSource
      */
     void bind(obj, DataBindingSource source, String filter, List whiteList, List blackList) {
@@ -187,7 +187,7 @@ class SimpleDataBinder implements DataBinder {
     }
 
     /**
-     *
+     * 
      * @param obj The object being bound to
      * @param source The data binding source
      * @param filter Only properties beginning with filter will be included in the
@@ -195,11 +195,11 @@ class SimpleDataBinder implements DataBinder {
      * source contains data for properties &quot;person.name&quot; and &quot;author.name&quot;
      * the value of &quot;person.name&quot; will be bound to obj.name.  The value of
      * &quot;author.name&quot; will be ignored.
-     * @param whiteList A list of property names to be included during this
-     * data binding.  All other properties represented in the binding source
+     * @param whiteList A list of property names to be included during this 
+     * data binding.  All other properties represented in the binding source 
      * will be ignored
      * @param blackList A list of properties names to be excluded during
-     * this data binding.
+     * this data binding.  
      * @param listener A listener which will be notified of data binding events triggered
      * by this binding
      * @see DataBindingSource
@@ -377,7 +377,7 @@ class SimpleDataBinder implements DataBinder {
         }
     }
 
-
+        
     @CompileStatic(TypeCheckingMode.SKIP)
     protected initializeArray(obj, String propertyName, Class arrayType, int index) {
         Object[] array = obj[propertyName]
@@ -396,8 +396,8 @@ class SimpleDataBinder implements DataBinder {
     protected boolean isBasicType(Class c) {
         BASIC_TYPES.contains(c) || c.isPrimitive()
     }
-
-
+    
+    
     protected Class<?> getReferencedTypeForCollectionInClass(String propertyName, Class clazz) {
         Class referencedType
         def field = getField(clazz, propertyName)
@@ -466,7 +466,7 @@ class SimpleDataBinder implements DataBinder {
         }
         return (Collection)val
     }
-
+    
     protected getDefaultCollectionInstanceForType(Class type) {
         def val
         if (List.isAssignableFrom(type)) {
@@ -541,7 +541,7 @@ class SimpleDataBinder implements DataBinder {
         }
         converter
     }
-
+    
     /**
      * @param annotation An instance of grails.databinding.BindingUsing or org.grails.databinding.BindingUsing
      * @return the value Class of the annotation
@@ -554,7 +554,7 @@ class SimpleDataBinder implements DataBinder {
         }
         value
     }
-
+    
     /**
      * @param annotation An instance of grails.databinding.BindingFormat or org.grails.databinding.BindingFormat
      * @return the value String of the annotation
@@ -596,7 +596,7 @@ class SimpleDataBinder implements DataBinder {
             enumClass.valueOf(value)
         } catch (IllegalArgumentException iae) {}
     }
-
+    
     protected preprocessValue(propertyValue) {
         propertyValue
     }
@@ -612,10 +612,10 @@ class SimpleDataBinder implements DataBinder {
                 }
             }
         }
-
+        
         setPropertyValue obj, source, metaProperty, propertyValue, listener, convertCollectionElements
     }
-
+    
     protected setPropertyValue(obj, DataBindingSource source, MetaProperty metaProperty, propertyValue, DataBindingListener listener, boolean convertCollectionElements) {
         def propName = metaProperty.name
         def propertyType
@@ -748,9 +748,9 @@ class SimpleDataBinder implements DataBinder {
         }
         else{
             obj[propName] = propertyType.newInstance()
-        }
+        }        
     }
-
+    
     protected ValueInitializer getPropertyInitializer(obj, String propName){
         def initializer = getValueInitializerForField obj, propName
         initializer
@@ -775,7 +775,7 @@ class SimpleDataBinder implements DataBinder {
         initializer
     }
     /**
-     * @param annotation An instance of grails.databinding.BindInitializer
+     * @param annotation An instance of grails.databinding.BindInitializer 
      * @return the value Class of the annotation
      */
     protected Class getValueOfBindInitializer(Annotation annotation) {
@@ -786,7 +786,7 @@ class SimpleDataBinder implements DataBinder {
         }
         value
     }
-
+    
     protected convert(Class typeToConvertTo, value) {
         if (value == null || typeToConvertTo.isAssignableFrom(value?.getClass())) {
             return value

--- a/grails-databinding/src/test/groovy/grails/databinding/SimpleDataBinderSpec.groovy
+++ b/grails-databinding/src/test/groovy/grails/databinding/SimpleDataBinderSpec.groovy
@@ -614,7 +614,7 @@ class SimpleDataBinderSpec extends Specification {
     }
 
     @Issue('https://github.com/grails/grails-core/issues/12150')
-    void 'binding when class and embedded classes both implements an interface'() {
+    void 'Test binding when class and embedded classes both implements an interface'() {
         given:
         SimpleDataBinder binder = new SimpleDataBinder()
 
@@ -627,6 +627,22 @@ class SimpleDataBinderSpec extends Specification {
 
         then:
         classWithInterface.a.data == 'abc'
+    }
+
+    @Issue('https://github.com/grails/grails-core/issues/12150')
+    void 'Test binding when class and embedded classes extends abstract class and implements an interface'() {
+        given:
+        SimpleDataBinder binder = new SimpleDataBinder()
+
+        and:
+        SimpleMapDataBindingSource input = [a: [data: 'abc']] as SimpleMapDataBindingSource
+        FromAbstractB fromAbstractB = new FromAbstractB()
+
+        when:
+        binder.bind(fromAbstractB, input)
+
+        then:
+        fromAbstractB.a.data == 'abc'
     }
 }
 
@@ -718,4 +734,12 @@ class ClassA implements InterfaceA {
 
 class ClassB implements InterfaceB {
     ClassA a
+}
+
+class AbstractB {
+    ClassA a
+}
+
+class FromAbstractB extends AbstractB {
+
 }

--- a/grails-databinding/src/test/groovy/grails/databinding/SimpleDataBinderSpec.groovy
+++ b/grails-databinding/src/test/groovy/grails/databinding/SimpleDataBinderSpec.groovy
@@ -141,17 +141,17 @@ class SimpleDataBinderSpec extends Specification {
         obj.sqlDate == nowSqlDate
         obj.calendar == nowCalendar
     }
-
+    
     @Issue('GRAILS-10925')
     void 'Test binding a Date to a Date property marked with @BindingFormat'() {
         given:
         def binder = new SimpleDataBinder()
         def obj = new DateContainer()
         def nowDate = new Date()
-
+        
         when:
         binder.bind obj, [formattedUtilDate: nowDate] as SimpleMapDataBindingSource
-
+        
         then:
         obj.formattedUtilDate == nowDate
     }
@@ -519,44 +519,44 @@ class SimpleDataBinderSpec extends Specification {
         widget.names[1] == null
         widget.names[2] == 'two'
     }
-
+    
     void 'Test @BindUsing on a List<Integer>'() {
         given:
         def binder = new SimpleDataBinder()
         def widget = new Widget()
-
+        
         when:
         binder.bind widget, [listOfIntegers: '4'] as SimpleMapDataBindingSource
-
+        
         then:
         widget.listOfIntegers == [0, 1, 2, 3]
     }
-
+    
     @Issue('GRAILS-10853')
     void 'Test adding new elements to a Set using indexed properties'() {
         given:
         def binder = new SimpleDataBinder()
         def widget = new Widget()
-
+        
         when:
         binder.bind widget, ['factories[2]': [name: 'Tres'], 'factories[0]': [name: 'Uno'], 'factories[1]': [name: 'Dos']] as SimpleMapDataBindingSource
-
+        
         then:
         widget.factories.size() == 3
         widget.factories.find { it.name == 'Uno' }
         widget.factories.find { it.name == 'Dos' }
         widget.factories.find { it.name == 'Tres' }
     }
-
+    
     @Issue('GRAILS-10865')
     void 'Test binding to an inherited typed collection'() {
         given:
         def binder = new SimpleDataBinder()
         def obj = new ClassWithInheritedTypedCollection()
-
+        
         when:
         binder.bind obj, [list: ['1', '2', '3'], 'map[one]': '1', 'map[two]': '2' ] as SimpleMapDataBindingSource
-
+        
         then:
         obj.list == [1, 2, 3]
         obj.map.one == 1
@@ -664,7 +664,7 @@ class Widget {
     byte[] byteArray
     Integer[] integers
     List<String> names
-    @BindUsing({ obj, source ->
+    @BindUsing({ obj, source -> 
         def cnt = source['listOfIntegers'] as int
         def result = []
         cnt.times { result << it }


### PR DESCRIPTION
Retrieving the meta bean property for a field that is also implementing an interface, returns the interface not the actual class type. This makes binding fail, because it tries to instantiate the interface instead of the actual class.