### PR TITLE
fix:issue related to grom docs

### DIFF
--- a/grails-data-docs/guide-rx/src/main/docs/associations/lazyLoadingManyEnded.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/associations/lazyLoadingManyEnded.adoc
@@ -21,7 +21,7 @@ under the License.
 
 In the previous section we discussed the implications of association proxies for single-ended associations. However, the same applies with many-ended associations.
 
-In the case of collection types, these implement the link:../api/grails/gorm/rx/collection/RxPersistentCollection.html[RxPersistentCollection] and again can be subscribed to:
+In the case of collection types, these implement the link:../../api/grails/gorm/rx/collection/RxPersistentCollection.html[RxPersistentCollection] and again can be subscribed to:
 
 
 [source,groovy]

--- a/grails-data-docs/guide-rx/src/main/docs/associations/lazyLoadingSingleEnded.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/associations/lazyLoadingSingleEnded.adoc
@@ -43,7 +43,7 @@ for (Book book in books) {
 }
 ----
 
-In the above example RxGORM has no choice but to block in order to load the association lazy and access the `name`! Typically, you do not want your reactive application to block at any point, so in order to get around this, each proxy loaded by GORM implements the link:../api/grails/gorm/rx/proxy/ObservableProxy.html[ObservableProxy] interface. That means the above code can be written in a non-blocking manner:
+In the above example RxGORM has no choice but to block in order to load the association lazy and access the `name`! Typically, you do not want your reactive application to block at any point, so in order to get around this, each proxy loaded by GORM implements the link:../../api/grails/gorm/rx/proxy/ObservableProxy.html[ObservableProxy] interface. That means the above code can be written in a non-blocking manner:
 
 [source,groovy]
 ----

--- a/grails-data-docs/guide-rx/src/main/docs/gettingStarted/creatingDomainClasses.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/gettingStarted/creatingDomainClasses.adoc
@@ -23,7 +23,7 @@ When using RxGORM each entity that you persist to the database is known as a dom
 
 If you are using RxGORM within Grails you can create a domain class with the `create-domain-class` command provided by the command line. Alternatively if you are not using Grails simply creating a Groovy class within `src/main/groovy` of your project will suffice.
 
-A domain class must as a minimum implement the link:../api/grails/gorm/rx/RxEntity.html[RxEntity] trait.
+A domain class must as a minimum implement the link:../../api/grails/gorm/rx/RxEntity.html[RxEntity] trait.
 
 However, when using RxGORM for MongoDB you should instead implement the `grails.gorm.rx.mongodb.RxMongoEntity` trait. For example:
 

--- a/grails-data-docs/guide-rx/src/main/docs/gettingStarted/firstSteps.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/gettingStarted/firstSteps.adoc
@@ -57,7 +57,7 @@ new RxMongoDatastoreClient(
 
 <1> The `MongoClient` instance
 <2> The name of the default database to save objects to
-<3> One or many classes that implement link:../api/grails/gorm/rx/RxEntity.html[RxEntity]
+<3> One or many classes that implement link:../../api/grails/gorm/rx/RxEntity.html[RxEntity]
 
 The `org.grails.datastore.rx.mongodb.RxMongoDatastoreClient` class is required to initialize RxGORM for MongoDB.
 

--- a/grails-data-docs/guide-rx/src/main/docs/querying/whereQueries.adoc
+++ b/grails-data-docs/guide-rx/src/main/docs/querying/whereQueries.adoc
@@ -27,7 +27,7 @@ def query = Book.where {
 }
 ----
 
-Note that no query is actually executed directly, instead the `where(Closure)` method returns an instance of link:../api/grails/gorm/rx/DetachedCriteria.html[DetachedCriteria].
+Note that no query is actually executed directly, instead the `where(Closure)` method returns an instance of link:../../api/grails/gorm/rx/DetachedCriteria.html[DetachedCriteria].
 
 Like an `rx.Observable`, the `DetachedCriteria` class can be subscribed to:
 

--- a/grails-data-graphql/docs/src/main/docs/guide/customizations/configuration.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/customizations/configuration.adoc
@@ -23,7 +23,7 @@ The schema has several properties that can be modified.
 
 === List Arguments
 
-A map where the key is a string (one of link:{api}/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html#ARGUMENTS[EntityDataFetcher.ARGUMENTS]) and the value is the class the argument should be coerced into.
+A map where the key is a string (one of link:../../../api/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html#ARGUMENTS[EntityDataFetcher.ARGUMENTS]) and the value is the class the argument should be coerced into.
 
 [source,groovy]
 ----
@@ -71,7 +71,7 @@ The following options are available to configure for Grails applications using t
 |If the setting is not provided, the `grails.databinding.dateParsingLenient` will be used.
 |`grails.gorm.graphql.listArguments`
 |Map<String, Class>
-|The default arguments in link:{api}/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html#ARGUMENTS[EntityDataFetcher.ARGUMENTS]
+|The default arguments in link:../../../api/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html#ARGUMENTS[EntityDataFetcher.ARGUMENTS]
 |
 |`grails.gorm.graphql.browser`
 | Boolean
@@ -83,11 +83,11 @@ The following options are available to configure for Grails applications using t
 
 Data fetchers in GraphQL have a "context". The context is really just an Object field that can contain anything you like with the purpose of exposing it to the data fetching environment. For example, the default context created by the plugin is a Map that contains the request locale. The locale is used to render validation error messages.
 
-TIP: If you prefer to set the context to a custom class, implement link:{api}/org/grails/gorm/graphql/fetcher/context/LocaleAwareContext.html[LocaleAwareContext] and the default validation errors response handler will retrieve the locale from the object.
+TIP: If you prefer to set the context to a custom class, implement link:../../../api/org/grails/gorm/graphql/fetcher/context/LocaleAwareContext.html[LocaleAwareContext] and the default validation errors response handler will retrieve the locale from the object.
 
 It is common to need to manipulate the context to include data that some or all of your data fetchers might need. If a fetcher needs to be aware of the current user and you are using the spring security plugin, you may want to add the `springSecurityService` to the context.
 
-To customize the context, register a bean named "graphQLContextBuilder" of type link:{api}/org/grails/gorm/graphql/plugin/GraphQLContextBuilder.html[GraphQLContextBuilder]. If the default errors handler is being used, extend from link:{api}/org/grails/gorm/graphql/plugin/DefaultGraphQLContextBuilder.html[DefaultGraphQLContextBuilder] and add to the result of the super method call.
+To customize the context, register a bean named "graphQLContextBuilder" of type link:../../../api/org/grails/gorm/graphql/plugin/GraphQLContextBuilder.html[GraphQLContextBuilder]. If the default errors handler is being used, extend from link:../../../api/org/grails/gorm/graphql/plugin/DefaultGraphQLContextBuilder.html[DefaultGraphQLContextBuilder] and add to the result of the super method call.
 
 [source,groovy]
 .src/main/groovy/demo/MyGraphQLContextBuilder.groovy

--- a/grails-data-graphql/docs/src/main/docs/guide/customizations/namingConvention.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/customizations/namingConvention.adoc
@@ -19,7 +19,7 @@ under the License.
 
 == Custom Naming Conventions
 
-The names used to describe entities is configurable through the use of an link:{api}/org/grails/gorm/graphql/entity/GraphQLEntityNamingConvention.html[GraphQLEntityNamingConvention].
+The names used to describe entities is configurable through the use of an link:../../../api/org/grails/gorm/graphql/entity/GraphQLEntityNamingConvention.html[GraphQLEntityNamingConvention].
 
 The class controls the name of the default operations and the names of the GraphQL types built from the GORM entities.
 
@@ -37,7 +37,7 @@ schema.namingConvention = new MyNamingConvention()
 
 === Grails
 
-To override the naming convention in a Grails application, register a bean with the name "graphQLEntityNamingConvention" that extends link:{api}/org/grails/gorm/graphql/entity/GraphQLEntityNamingConvention.html[GraphQLEntityNamingConvention].
+To override the naming convention in a Grails application, register a bean with the name "graphQLEntityNamingConvention" that extends link:../../../api/org/grails/gorm/graphql/entity/GraphQLEntityNamingConvention.html[GraphQLEntityNamingConvention].
 
 [source,groovy]
 .resources.groovy

--- a/grails-data-graphql/docs/src/main/docs/guide/customizations/operations.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/customizations/operations.adoc
@@ -97,7 +97,7 @@ By configuring the list operation to paginate, instead of a list of results bein
 
 ==== Customization
 
-It is possible to customize how the pagination response is created through the creation of a link:{api}/org/grails/gorm/graphql/response/pagination/GraphQLPaginationResponseHandler.html[GraphQLPaginationResponseHandler].
+It is possible to customize how the pagination response is created through the creation of a link:../../../api/org/grails/gorm/graphql/response/pagination/GraphQLPaginationResponseHandler.html[GraphQLPaginationResponseHandler].
 
 How you can supply your own pagination response handler depends on whether the library is being used standalone or part of a Grails application.
 
@@ -123,7 +123,7 @@ beans = {
 }
 ----
 
-NOTE: Data fetchers must respond according to the object type definition created by the pagination response handler. When supplying your own data fetcher, implement link:{api}/org/grails/gorm/graphql/fetcher/PaginatingGormDataFetcher.html[PaginatingGormDataFetcher] and the response handler will be populated for you. The response handler is responsible for creating the response in order to assure it is compatible.
+NOTE: Data fetchers must respond according to the object type definition created by the pagination response handler. When supplying your own data fetcher, implement link:../../../api/org/grails/gorm/graphql/fetcher/PaginatingGormDataFetcher.html[PaginatingGormDataFetcher] and the response handler will be populated for you. The response handler is responsible for creating the response in order to assure it is compatible.
 
 == Custom Operations
 
@@ -231,24 +231,24 @@ The above example will function properly, however it is missing out on one of th
 |===
 |Type|Class
 |GET
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/SingleEntityDataFetcher.html[SingleEntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/SingleEntityDataFetcher.html[SingleEntityDataFetcher]
 |LIST
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html[EntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.html[EntityDataFetcher]
 |LIST (Paginated Response)
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/PaginatedEntityDataFetcher.html[PaginatedEntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/PaginatedEntityDataFetcher.html[PaginatedEntityDataFetcher]
 |CREATE
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/CreateEntityDataFetcher.html[CreateEntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/CreateEntityDataFetcher.html[CreateEntityDataFetcher]
 |UPDATE
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/UpdateEntityDataFetcher.html[UpdateEntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/UpdateEntityDataFetcher.html[UpdateEntityDataFetcher]
 |DELETE
-|link:{api}/org/grails/gorm/graphql/fetcher/impl/DeleteEntityDataFetcher.html[EntityDataFetcher]
+|link:../../../api/org/grails/gorm/graphql/fetcher/impl/DeleteEntityDataFetcher.html[EntityDataFetcher]
 |===
 
-If the data fetcher you wish to create does not fit well in any of the above use cases, you can extend directly from link:{api}/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.html[DefaultGormDataFetcher], which has all of the query optimization logic.
+If the data fetcher you wish to create does not fit well in any of the above use cases, you can extend directly from link:../../../api/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.html[DefaultGormDataFetcher], which has all of the query optimization logic.
 
-All of the classes above have a constructor which takes in a link:{gormapi}org/grails/datastore/mapping/model/PersistentEntity.html[PersistentEntity]. The easiest way to get a persistent entity from a domain class is to execute the static `gormPersistentEntity` method.
+All of the classes above have a constructor which takes in a link:../../../api/org/grails/datastore/mapping/model/PersistentEntity.html[PersistentEntity]. The easiest way to get a persistent entity from a domain class is to execute the static `gormPersistentEntity` method.
 
-Using the above information, we can change the `authorByName` to extend from the link:{api}/org/grails/gorm/graphql/fetcher/impl/SingleEntityDataFetcher.html[SingleEntityDataFetcher] class because we are returning a single `Author`.
+Using the above information, we can change the `authorByName` to extend from the link:../../../api/org/grails/gorm/graphql/fetcher/impl/SingleEntityDataFetcher.html[SingleEntityDataFetcher] class because we are returning a single `Author`.
 
 
 [source,groovy]

--- a/grails-data-graphql/docs/src/main/docs/guide/customizations/responseHandlers.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/customizations/responseHandlers.adoc
@@ -21,7 +21,7 @@ The way the provided operations respond after deleting a GORM entity instance an
 
 == Delete Response
 
-Delete responses are handled by a link:{api}/org/grails/gorm/graphql/response/delete/GraphQLDeleteResponseHandler.html[GraphQLDeleteResponseHandler]. The default implementation responds with an object that has a single property, `success`. You can register your own handler to override the default.
+Delete responses are handled by a link:../../../api/org/grails/gorm/graphql/response/delete/GraphQLDeleteResponseHandler.html[GraphQLDeleteResponseHandler]. The default implementation responds with an object that has a single property, `success`. You can register your own handler to override the default.
 
 For reference, see the link:https://github.com/apache/grails-core/blob/HEAD/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/response/delete/DefaultGraphQLDeleteResponseHandler.groovy[default handler].
 
@@ -49,7 +49,7 @@ graphQLDeleteResponseHandler(MyDeleteResponseHandler)
 
 == Validation Error Response
 
-Validation error responses are handled by a link:{api}/org/grails/gorm/graphql/response/errors/GraphQLErrorsResponseHandler.html[GraphQLErrorsResponseHandler].
+Validation error responses are handled by a link:../../../api/org/grails/gorm/graphql/response/errors/GraphQLErrorsResponseHandler.html[GraphQLErrorsResponseHandler].
 
 For reference, see the link:https://github.com/apache/grails-core/blob/HEAD/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/response/errors/DefaultGraphQLErrorsResponseHandler.groovy[default handler].
 

--- a/grails-data-graphql/docs/src/main/docs/guide/dataBinders.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/dataBinders.adoc
@@ -21,7 +21,7 @@ Data binders are responsible for taking the domain argument to a create or updat
 
 == Get The Manager
 
-To register a data binders, you need to get a reference to the link:{api}/org/grails/gorm/graphql/binding/GraphQLDataBinderManager.html[GraphQLDataBinderManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
+To register a data binders, you need to get a reference to the link:../../../api/org/grails/gorm/graphql/binding/GraphQLDataBinderManager.html[GraphQLDataBinderManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
 
 === Standalone
 

--- a/grails-data-graphql/docs/src/main/docs/guide/dataFetchers.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/dataFetchers.adoc
@@ -17,11 +17,11 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-This library provides a means for overriding the data fetchers used for the default provided operations. That is done through the use of a link:{api}/org/grails/gorm/graphql/fetcher/manager/GraphQLDataFetcherManager.html[GraphQLDataFetcherManager].
+This library provides a means for overriding the data fetchers used for the default provided operations. That is done through the use of a link:../../../api/org/grails/gorm/graphql/fetcher/manager/GraphQLDataFetcherManager.html[GraphQLDataFetcherManager].
 
 == Get The Manager
 
-To register a fetcher, you need to get a reference to the link:{api}/org/grails/gorm/graphql/fetcher/manager/GraphQLDataFetcherManager.html[GraphQLDataFetcherManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
+To register a fetcher, you need to get a reference to the link:../../../api/org/grails/gorm/graphql/fetcher/manager/GraphQLDataFetcherManager.html[GraphQLDataFetcherManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
 
 === Standalone
 
@@ -84,7 +84,7 @@ fetcherManager.registerDeletingDataFetcher(Author, new DeleteEntityDataFetcher(A
 })
 ----
 
-TIP: A class exists to use for soft deletes: link:{api}/org/grails/gorm/graphql/fetcher/impl/SoftDeleteEntityDataFetcher.html[SoftDeleteEntityDataFetcher]
+TIP: A class exists to use for soft deletes: link:../../../api/org/grails/gorm/graphql/fetcher/impl/SoftDeleteEntityDataFetcher.html[SoftDeleteEntityDataFetcher]
 
 There are 3 types of data fetchers that can be registered.
 
@@ -102,7 +102,7 @@ Reading data fetchers are designed to execute read only queries. They don't requ
 
 == Query Optimization
 
-All of the default data fetcher classes extend from link:{api}/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.html[DefaultGormDataFetcher]. If you are creating your own custom data fetcher class, it is highly recommended to extend from it as well. The main reason for doing so is to take advantage of the built in query optimization. Based on what fields are requested in any given request, the default data fetchers will execute a query that will join any associations that have been requested. This feature ensures that each API call is as efficient as possible.
+All of the default data fetcher classes extend from link:../../../api/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.html[DefaultGormDataFetcher]. If you are creating your own custom data fetcher class, it is highly recommended to extend from it as well. The main reason for doing so is to take advantage of the built in query optimization. Based on what fields are requested in any given request, the default data fetchers will execute a query that will join any associations that have been requested. This feature ensures that each API call is as efficient as possible.
 
 For example, consider the following domain structure:
 
@@ -147,11 +147,11 @@ Example generated SQL:
 
 `select * from book b inner join author a on b.author_id = a.id where b.id = 5`
 
-The logic for retrieving the list of properties to be joined is contained within the link:{api}/org/grails/gorm/graphql/entity/EntityFetchOptions.html[EntityFetchOptions] class. If you prefer not to extend from the default gorm data fetcher, it is possible to make use of this class in your own data fetcher.
+The logic for retrieving the list of properties to be joined is contained within the link:../../../api/org/grails/gorm/graphql/entity/EntityFetchOptions.html[EntityFetchOptions] class. If you prefer not to extend from the default gorm data fetcher, it is possible to make use of this class in your own data fetcher.
 
 === Custom Property Data Fetchers
 
-When adding a custom property to a domain class, it may be the case that a separate query is being executed on another domain class. Normally that query would not be able to benefit from the automatic join operations based on the requested fields in that domain class. When providing the closure to retrieve the relevant data, a second parameter is available. The second parameter to the closure will be an instance of link:{api}/org/grails/gorm/graphql/fetcher/impl/ClosureDataFetchingEnvironment.html[ClosureDataFetchingEnvironment].
+When adding a custom property to a domain class, it may be the case that a separate query is being executed on another domain class. Normally that query would not be able to benefit from the automatic join operations based on the requested fields in that domain class. When providing the closure to retrieve the relevant data, a second parameter is available. The second parameter to the closure will be an instance of link:../../../api/org/grails/gorm/graphql/fetcher/impl/ClosureDataFetchingEnvironment.html[ClosureDataFetchingEnvironment].
 
 The environment is an extension of the GraphQL Java `DataFetchingEnvironment`. In addition to everything the standard environment has, the environment also has methods for retrieving the fetch options or the list of join properties to use in your query.
 

--- a/grails-data-graphql/docs/src/main/docs/guide/gettingStarted.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/gettingStarted.adoc
@@ -19,7 +19,7 @@ under the License.
 
 == Standalone Projects
 
-For standalone projects, it is up to the developer how and when the schema gets created. A mapping context is required to create a schema. The mapping context is available on all link:{gormapi}/org/grails/datastore/mapping/core/Datastore.html#getMappingContext()[datastore implementations]. See the link:https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#outsideGrails#outsideGrails[GORM documentation] for information on creating a datastore.
+For standalone projects, it is up to the developer how and when the schema gets created. A mapping context is required to create a schema. The mapping context is available on all link:../../../api/org/grails/datastore/mapping/core/Datastore.html#getMappingContext()[datastore implementations]. See the link:https://grails.apache.org/docs/latest/grails-data/hibernate5/manual/index.html#outsideGrails#outsideGrails[GORM documentation] for information on creating a datastore.
 
 The example below is the simplest way possible to generate a schema.
 

--- a/grails-data-graphql/docs/src/main/docs/guide/interceptors.adoc
+++ b/grails-data-graphql/docs/src/main/docs/guide/interceptors.adoc
@@ -21,11 +21,11 @@ This library provides 2 types of interceptors, data fetcher and schema. Data fet
 
 Schema interceptors allow users to hook directly into the schema creation process to modify the schema directly before it is created. This option is for users who are comfortable with the link:https://github.com/graphql-java/graphql-java[graphql-java] library and would like to manipulate the schema as they see fit.
 
-NOTE: Any interceptor can implement link:{gormapi}/org/grails/datastore/mapping/core/Ordered.html[Ordered] to control the order it is invoked.
+NOTE: Any interceptor can implement link:../../../api/org/grails/datastore/mapping/core/Ordered.html[Ordered] to control the order it is invoked.
 
 == Get The Manager
 
-To register a data fetcher interceptor, you need to get a reference to the link:{api}/org/grails/gorm/graphql/interceptor/manager/GraphQLInterceptorManager.html[GraphQLInterceptorManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
+To register a data fetcher interceptor, you need to get a reference to the link:../../../api/org/grails/gorm/graphql/interceptor/manager/GraphQLInterceptorManager.html[GraphQLInterceptorManager]. If you are using the manager provided by default, how you access it will depend on whether you are using the plugin or standalone.
 
 === Standalone
 
@@ -70,7 +70,7 @@ TIP: If you need to customize more than 1 manager, only a single bean needs to b
 
 == Data Fetcher Interceptors
 
-All data fetcher interceptors must implement the link:{api}/org/grails/gorm/graphql/interceptor/GraphQLFetcherInterceptor.html[GraphQLFetcherInterceptor] interface. A link:{api}/org/grails/gorm/graphql/interceptor/impl/BaseGraphQLFetcherInterceptor[base class] is also available to extend from that allows all fetchers to proceed.
+All data fetcher interceptors must implement the link:../../../api/org/grails/gorm/graphql/interceptor/GraphQLFetcherInterceptor.html[GraphQLFetcherInterceptor] interface. A link:../../../api/org/grails/gorm/graphql/interceptor/impl/BaseGraphQLFetcherInterceptor[base class] is also available to extend from that allows all fetchers to proceed.
 
 For all interceptor methods, if the return value is `false`, further interceptors will not be executed and the resulting data will be `null`.
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/ormdsl/fetchingDSL.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/ormdsl/fetchingDSL.adoc
@@ -181,7 +181,7 @@ def person = Person.where { id == 1 }.join("pet").get()
 assert person.pet instanceof Dog
 ----
 
-In the above example the `pet` association is no longer lazy because it is being retrieved along with the `Person` and thus no proxies are necessary. There are cases when it makes sense for a proxy to be returned, mostly in the case where its impossible to know if the data will be used or not. For those cases in order to access properties of the subclasses, the proxy must be unwrapped. To unwrap a proxy inject an instance of link:../api/org/grails/datastore/mapping/proxy/ProxyHandler.html[ProxyHandler] and pass the proxy to the `unwrap` method.
+In the above example the `pet` association is no longer lazy because it is being retrieved along with the `Person` and thus no proxies are necessary. There are cases when it makes sense for a proxy to be returned, mostly in the case where its impossible to know if the data will be used or not. For those cases in order to access properties of the subclasses, the proxy must be unwrapped. To unwrap a proxy inject an instance of link:../../../api/org/grails/datastore/mapping/proxy/ProxyHandler.html[ProxyHandler] and pass the proxy to the `unwrap` method.
 
 [source,groovy]
 ----
@@ -189,7 +189,7 @@ def person = Person.get(1)
 assert proxyHandler.unwrap(person.pet) instanceof Dog
 ----
 
-For cases where dependency injection is impractical or not available, a helper method link:../api/org/grails/orm/hibernate/cfg/GrailsHibernateUtil.html#unwrapIfProxy(java.lang.Object)[GrailsHibernateUtil.unwrapIfProxy(Object)] can be used instead.
+For cases where dependency injection is impractical or not available, a helper method link:../../../api/org/grails/orm/hibernate/cfg/GrailsHibernateUtil.html#unwrapIfProxy(java.lang.Object)[GrailsHibernateUtil.unwrapIfProxy(Object)] can be used instead.
 
 Unwrapping a proxy is different than initializing it. Initializing a proxy simply populates the underlying instance with data from the database, however unwrapping a returns the inner target.
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/configurationReference.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/configurationReference.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-You can refer to the link:../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings] class for all available configuration options, but below is a table of the common ones:
+You can refer to the link:../../../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings] class for all available configuration options, but below is a table of the common ones:
 
 [format="csv", options="header"]
 |===
@@ -64,4 +64,4 @@ name,description,default value
 
 In addition, any additional settings that start with `hibernate.` are passed through to Hibernate, so if there is any specific feature of Hibernate you wish to configure that is possible.
 
-TIP: The above table covers the common configuration options. For all configuration refer to properties of the link:../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings] class.
+TIP: The above table covers the common configuration options. For all configuration refer to properties of the link:../../../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings] class.

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/hibernateCustomization.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/hibernateCustomization.adoc
@@ -21,7 +21,7 @@ If you want to hook into GORM and customize how Hibernate is configured there ar
 
 Firstly, as mentioned previously, any configuration you specify when configuring GORM for Hibernate will be passed through to Hibernate so you can configure any setting of Hibernate itself.
 
-For more advanced configuration you may want to configure or supply a new link:../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactory.html[HibernateConnectionSourceFactory] instance or a link:../api/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.html[HibernateMappingContextConfiguration] or both.
+For more advanced configuration you may want to configure or supply a new link:../../../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactory.html[HibernateConnectionSourceFactory] instance or a link:../../../api/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.html[HibernateMappingContextConfiguration] or both.
 
 ==== The HibernateConnectionSourceFactory
 
@@ -35,7 +35,7 @@ The `HibernateConnectionSourceFactory` has a few useful setters that allow you t
 
 ==== The HibernateMappingContextConfiguration
 
-link:../api/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.html[HibernateMappingContextConfiguration] is built by the `HibernateConnectionSourceFactory`, but a customized version can be specified using the `hibernate.configClass` setting in your configuration:
+link:../../../api/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.html[HibernateMappingContextConfiguration] is built by the `HibernateConnectionSourceFactory`, but a customized version can be specified using the `hibernate.configClass` setting in your configuration:
 
 [source,yaml]
 .grails-app/conf/application.yml

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/index.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/configuration/index.adoc
@@ -19,7 +19,7 @@ under the License.
 
 GORM for Hibernate can be configured with the `grails-app/conf/application.yml` file when using Grails, the `src/main/resources/application.yml` file when using Spring Boot or by passing a `Map` or instanceof the `PropertyResolver` interface to the `org.grails.orm.hibernate.HibernateDatastore` class when used standalone.
 
-All configuration options are read and materialized into an instance of link:../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings].
+All configuration options are read and materialized into an instance of link:../../../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.html[HibernateConnectionSourceSettings].
 
 === Configuration Example
 
@@ -42,9 +42,9 @@ hibernate:
         region.factory_class: org.hibernate.cache.ehcache.EhCacheRegionFactory
 ----
 
-Each one of the settings under the `dataSource` block is set on the link:../api/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.html[DataSourceSettings] property of `HibernateConnectionSourceSettings`.
+Each one of the settings under the `dataSource` block is set on the link:../../../api/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.html[DataSourceSettings] property of `HibernateConnectionSourceSettings`.
 
-Whilst each setting under the `hibernate` block is set on the link:../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.HibernateSettings.html[HibernateSettings] property.
+Whilst each setting under the `hibernate` block is set on the link:../../../api/org/grails/orm/hibernate/connections/HibernateConnectionSourceSettings.HibernateSettings.html[HibernateSettings] property.
 
 === Configuration Reference
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/domainClasses/inheritanceInGORM.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/domainClasses/inheritanceInGORM.adoc
@@ -63,7 +63,7 @@ However, excessive use of inheritance and table-per-subclass can result in poor 
 ==== Polymorphic Queries
 
 
-The upshot of inheritance is that you get the ability to polymorphically query. For example using the link:../api/org/grails/datastore/gorm/GormEntity.html#list()[list()] method on the `Content` super class will return all subclasses of `Content`:
+The upshot of inheritance is that you get the ability to polymorphically query. For example using the link:../../../api/org/grails/datastore/gorm/GormEntity.html#list()[list()] method on the `Content` super class will return all subclasses of `Content`:
 
 [source,groovy]
 ----

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/databasePerTenant.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/databasePerTenant.adoc
@@ -21,7 +21,7 @@ Using a database per tenant is the most secure way to isolate each tenants data 
 
 ==== Configuration
 
-In order to activate database-per-tenant multi-tenancy you need to set the multi-tenancy mode to `DATABASE` in your configuration and supply a link:../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
+In order to activate database-per-tenant multi-tenancy you need to set the multi-tenancy mode to `DATABASE` in your configuration and supply a link:../../../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
 
 [source,yaml]
 ----
@@ -44,7 +44,7 @@ The above example uses a built-in `TenantResolver` implementation that works wit
 
 ==== Multi Tenant Domain Classes
 
-With the above configuration in place you then to need to implement the link:../api/grails/gorm/MultiTenant.html[MultiTenant] trait in the domain classes you want to be regarded as multi tenant:
+With the above configuration in place you then to need to implement the link:../../../api/grails/gorm/MultiTenant.html[MultiTenant] trait in the domain classes you want to be regarded as multi tenant:
 
 
 [source,groovy]
@@ -76,7 +76,7 @@ SessionFactory sessionFactory = hibernateDatastore
 
 ==== Multi Tenancy with Sessions
 
-When working with GORM typically you need a session bound to the current thread in order for GORM and transactions to work consistently. If you switch to a different tenant then it may be that the session bound to the current thread no longer matches the underlying `SessionFactory` being used by the tenant. With this in mind you may wants to use the link:../api/grails/gorm/multitenancy/Tenants.html[Tenants] class to ensure the correct session is bound for the current tenant:
+When working with GORM typically you need a session bound to the current thread in order for GORM and transactions to work consistently. If you switch to a different tenant then it may be that the session bound to the current thread no longer matches the underlying `SessionFactory` being used by the tenant. With this in mind you may wants to use the link:../../../api/grails/gorm/multitenancy/Tenants.html[Tenants] class to ensure the correct session is bound for the current tenant:
 
 [source,groovy]
 ----
@@ -114,7 +114,7 @@ List<Book> books = withId(HibernateDatastore, "moreBooks") {
 
 Provisioning and creating SQL databases at runtime is non-trivial and beyond the scope of what GORM offers, however the <<connectionSources, ConnectionSources API>> does provide a way to hook into GORM to make this possible.
 
-By default an link:../api/org/grails/datastore/mapping/core/connections/InMemoryConnectionSources.html[InMemoryConnectionSources] object is used which will read the connection sources from the application configuration and store them in-memory.
+By default an link:../../../api/org/grails/datastore/mapping/core/connections/InMemoryConnectionSources.html[InMemoryConnectionSources] object is used which will read the connection sources from the application configuration and store them in-memory.
 
 However, it is possible to configure an alternate implementation:
 

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/discriminatorMultiTenancy.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/discriminatorMultiTenancy.adoc
@@ -23,7 +23,7 @@ WARNING: When using a discriminator all data for all tenants is stored in a sing
 
 ==== Configuration
 
-In order to activate discriminator-based multi-tenancy you need to set the multi-tenancy mode to `DISCRIMINATOR` in your configuration and supply a link:../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
+In order to activate discriminator-based multi-tenancy you need to set the multi-tenancy mode to `DISCRIMINATOR` in your configuration and supply a link:../../../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
 
 [source,yaml]
 ----
@@ -37,11 +37,11 @@ dataSource:
     url: jdbc:h2:mem:books
 ----
 
-NOTE: The specified `TenantResolver` will also need to implement the link:../api/org/grails/datastore/mapping/multitenancy/AllTenantsResolver.html[AllTenantsResolver] interface, which has an additional method to resolve all known tenants.
+NOTE: The specified `TenantResolver` will also need to implement the link:../../../api/org/grails/datastore/mapping/multitenancy/AllTenantsResolver.html[AllTenantsResolver] interface, which has an additional method to resolve all known tenants.
 
 ==== Mapping Domain Classes
 
-Like the other forms of multi-tenancy you then need to implement the link:../api/grails/gorm/MultiTenant.html[MultiTenant] trait in the domain classes that are multi-tenant. In addition, you also need to specify a discriminator column. The default discriminator column is called `tenantId`, for example:
+Like the other forms of multi-tenancy you then need to implement the link:../../../api/grails/gorm/MultiTenant.html[MultiTenant] trait in the domain classes that are multi-tenant. In addition, you also need to specify a discriminator column. The default discriminator column is called `tenantId`, for example:
 
 
 [source,groovy]
@@ -68,7 +68,7 @@ class Book implements MultiTenant<Book> {
 
 ==== Querying and Caveats
 
-The discriminator-based multi-tenancy transparently adds a Hibernate filter that is activated when you query the domain class and you can also use the link:../api/grails/gorm/multitenancy/Tenants.html[Tenants] API to switch between tenants:
+The discriminator-based multi-tenancy transparently adds a Hibernate filter that is activated when you query the domain class and you can also use the link:../../../api/grails/gorm/multitenancy/Tenants.html[Tenants] API to switch between tenants:
 
 [source,groovy]
 ----

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/schemaPerTenant.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/multiTenancy/schemaPerTenant.adoc
@@ -21,7 +21,7 @@ Schema-per-tenant is when a single database is used, but a different database sc
 
 ==== Configuration
 
-In order to activate schema-per-tenant multi-tenancy you need to set the multi-tenancy mode to `SCHEMA` in your configuration and supply a link:../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
+In order to activate schema-per-tenant multi-tenancy you need to set the multi-tenancy mode to `SCHEMA` in your configuration and supply a link:../../../api/org/grails/datastore/mapping/multitenancy/TenantResolver.html[TenantResolver]:
 
 [source,yaml]
 ----
@@ -37,13 +37,13 @@ dataSource:
 
 The `TenantResolver` can optionally implement the `AllTenantsResolver` interface and return the schema names of all tenants. This gives you the option to hard code these, place them in configuration or read them from the default schema dynamically.
 
-If the `AllTenantsResolver` resolver is not implemented then GORM will use the configured link:../api/org/grails/org/hibernate/jdbc/schema/SchemaHandler.html[SchemaHandler] to resolve all the schema names from the database which it will use for the tenants.
+If the `AllTenantsResolver` resolver is not implemented then GORM will use the configured link:../../../api/org/grails/orm/hibernate/support/SchemaHandler.html[SchemaHandler] to resolve all the schema names from the database which it will use for the tenants.
 
 ==== Runtime Schema Creation
 
 On startup, if `dataSource.dbCreate` is set to create the database at runtime, then GORM will attempt to create the schemas if they are missing.
 
-To do this it uses an instance link:../api/org/grails/org/hibernate/jdbc/schema/SchemaHandler.html[SchemaHandler] which by default uses the `CREATE SCHEMA [name]` syntax, but can be overridden and customized for other database dialects as necessary.
+To do this it uses an instance link:../../../api/org/grails/orm/hibernate/support/SchemaHandler.html[SchemaHandler] which by default uses the `CREATE SCHEMA [name]` syntax, but can be overridden and customized for other database dialects as necessary.
 
 If you want to use this feature and create schemas at runtime depending on the database you may need to configure an alternate implementation:
 


### PR DESCRIPTION
I fixed the broken links in the grails-data/gorm documentation that were reported in issue #14990.
 I found several AsciiDoc files that had incorrect relative paths for API documentation links, which would cause link checkers to flag them as broken.
 
 I went through multiple documentation files and updated the links:
 
   In RxGORM docs, I changed ../api/ paths to ../../api/ to fix the relative navigation
    In GraphQL docs, I converted {api}/ attributes to proper relative paths like ../../../api/
    In Hibernate5 docs, I corrected ../api/ to ../../../api/ to match where docs are generated
    I also fixed various API links in the multi-tenancy documentation files
    
The changes maintain proper AsciiDoc syntax and all documentation builds successfully now.
 I tested the .\gradlew grails-doc:docs command and it completes without errors, which means the links should resolve properly when the docs are generated. This should fix the broken links that lychee and other link checkers were reporting.