### PR TITLE
Fix overlapping task outputs preventing build cache usage

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsCodeStylePlugin.groovy
@@ -148,17 +148,19 @@ class GrailsCodeStylePlugin implements Plugin<Project> {
             it.toolVersion = project.findProperty('checkstyleVersion')
         }
 
-        project.tasks.withType(Checkstyle).configureEach {
-            it.group = 'verification'
-            it.onlyIf { !project.hasProperty('skipCodeStyle') }
+        project.tasks.withType(Checkstyle).configureEach { Checkstyle task ->
+            task.group = 'verification'
+            task.onlyIf { !project.hasProperty('skipCodeStyle') }
 
             // Redirect XML report output to a single directory to consolidate
-            // reports across all subprojects into one known location
-            it.reports.xml.outputLocation.set(
+            // reports across all subprojects into one known location.
+            // Include the task name to avoid overlapping outputs when a project has
+            // multiple source sets (e.g. grails-cache has ast + main).
+            task.reports.xml.outputLocation.set(
                     project.extensions.getByType(GrailsCodeStyleExtension)
                             .reportsDirectory.get()
                             .dir('checkstyle')
-                            .file(project.name + '.xml')
+                            .file("${project.name}-${task.name}.xml")
             )
         }
     }
@@ -172,18 +174,20 @@ class GrailsCodeStylePlugin implements Plugin<Project> {
             it.toolVersion = project.findProperty('codenarcVersion')
         }
 
-        project.tasks.withType(CodeNarc).configureEach {
-            it.group = 'verification'
-            it.onlyIf { !project.hasProperty('skipCodeStyle') }
+        project.tasks.withType(CodeNarc).configureEach { CodeNarc task ->
+            task.group = 'verification'
+            task.onlyIf { !project.hasProperty('skipCodeStyle') }
 
             // Redirect XML report output to a single directory to consolidate
-            // reports across all subprojects into one known location
-            it.reports.xml.required.set(true)
-            it.reports.xml.outputLocation.set(
+            // reports across all subprojects into one known location.
+            // Include the task name to avoid overlapping outputs when a project has
+            // multiple source sets.
+            task.reports.xml.required.set(true)
+            task.reports.xml.outputLocation.set(
                     project.extensions.getByType(GrailsCodeStyleExtension)
                             .reportsDirectory.get()
                             .dir('codenarc')
-                            .file(project.name + '.xml')
+                            .file("${project.name}-${task.name}.xml")
             )
         }
     }

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -43,6 +43,8 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.bundling.Jar
 
 import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
@@ -212,8 +214,14 @@ class SbomPlugin implements Plugin<Project> {
                         def bom = new JsonSlurper().parse(f)
 
                         // timestamp is not reproducible: https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/292
-                        ZonedDateTime buildDate = lookupProperty(project, 'buildDate')
-                        bom['metadata']['timestamp'] = DateTimeFormatter.ISO_INSTANT.format(buildDate.truncatedTo(ChronoUnit.SECONDS))
+                        // Use a fixed epoch when SOURCE_DATE_EPOCH is not set so the SBOM is identical between
+                        // builds. This prevents the non-reproducible timestamp from changing the jar checksum
+                        // and cascading cache misses through the compile classpath of downstream projects.
+                        boolean isReproducibleBuild = lookupProperty(project, 'isReproducibleBuild')
+                        ZonedDateTime sbomTimestamp = isReproducibleBuild ?
+                                lookupProperty(project, 'buildDate') as ZonedDateTime :
+                                Instant.EPOCH.atZone(ZoneOffset.UTC)
+                        bom['metadata']['timestamp'] = DateTimeFormatter.ISO_INSTANT.format(sbomTimestamp.truncatedTo(ChronoUnit.SECONDS))
 
                         // components[*]
                         def comps = (bom instanceof Map && bom.components instanceof List) ? bom.components : []

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsAppBaseDirProvider.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsAppBaseDirProvider.groovy
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.gradle.plugin.core
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.process.CommandLineArgumentProvider
+
+import grails.util.BuildSettings
+
+/**
+ * Provides the {@code -Dgrails.build.base.dir} system property to forked JVM tasks
+ * while using {@link PathSensitivity#RELATIVE} so that the absolute project directory
+ * path does not break build cache relocatability.
+ */
+@CompileStatic
+class GrailsAppBaseDirProvider implements CommandLineArgumentProvider {
+
+    @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    final File appBaseDir
+
+    GrailsAppBaseDirProvider(File appBaseDir) {
+        this.appBaseDir = appBaseDir
+    }
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-D${BuildSettings.APP_BASE_DIR}=${appBaseDir.absolutePath}".toString()]
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsAppBaseDirProvider.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsAppBaseDirProvider.groovy
@@ -20,23 +20,26 @@ package org.grails.gradle.plugin.core
 
 import groovy.transform.CompileStatic
 
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.Internal
 import org.gradle.process.CommandLineArgumentProvider
 
 import grails.util.BuildSettings
 
 /**
- * Provides the {@code -Dgrails.build.base.dir} system property to forked JVM tasks
- * while using {@link PathSensitivity#RELATIVE} so that the absolute project directory
- * path does not break build cache relocatability.
+ * Provides the {@code -Dgrails.build.base.dir} system property to forked JVM tasks.
+ *
+ * The directory is marked {@link Internal} rather than {@code @InputDirectory} because
+ * the project directory encompasses task output directories (e.g. {@code build/}).
+ * Declaring it as {@code @InputDirectory} causes Gradle to report implicit dependency
+ * violations between the consuming task (e.g. {@code test}) and every task that writes
+ * into the project directory (e.g. {@code compileIntegrationTestGroovy}, {@code jar}).
+ * The actual inputs that matter for caching (classpath, source sets) are already tracked
+ * by their respective tasks.
  */
 @CompileStatic
 class GrailsAppBaseDirProvider implements CommandLineArgumentProvider {
 
-    @InputDirectory
-    @PathSensitive(PathSensitivity.RELATIVE)
+    @Internal
     final File appBaseDir
 
     GrailsAppBaseDirProvider(File appBaseDir) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -188,9 +188,10 @@ class GrailsGradlePlugin extends GroovyPlugin {
     }
 
     private void configureGroovyCompiler(Project project) {
-        Provider<RegularFile> groovyCompilerConfigFile = project.layout.buildDirectory.file('grailsGroovyCompilerConfig.groovy')
-
         project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
+            // Use a task-specific config file to avoid overlapping outputs when multiple
+            // GroovyCompile tasks exist in the same project (e.g. compileGroovy, compileTestGroovy).
+            Provider<RegularFile> groovyCompilerConfigFile = project.layout.buildDirectory.file("grailsGroovyCompilerConfig-${c.name}.groovy")
             c.outputs.file(groovyCompilerConfigFile)
 
             Closure<String> userScriptGenerator = getGroovyCompilerScript(c, project)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -538,7 +538,9 @@ class GrailsGradlePlugin extends GroovyPlugin {
             task.systemProperty(Metadata.APPLICATION_NAME, project.name)
             task.systemProperty(Metadata.APPLICATION_VERSION, (project.version instanceof Serializable ? project.version : project.version.toString()))
             task.systemProperty(Metadata.APPLICATION_GRAILS_VERSION, grailsVersion)
-            task.systemProperty(BuildSettings.APP_BASE_DIR, project.projectDir.absolutePath)
+            // Use a CommandLineArgumentProvider so that the absolute project directory path
+            // is normalized for build cache relocatability (PathSensitivity.RELATIVE).
+            task.jvmArgumentProviders.add(new GrailsAppBaseDirProvider(project.projectDir))
             task.systemProperty(BuildSettings.PROJECT_TARGET_DIR, project.layout.buildDirectory.get().asFile.name)
             task.systemProperty(Environment.KEY, defaultGrailsEnv)
             task.systemProperty(Environment.FULL_STACKTRACE, System.getProperty(Environment.FULL_STACKTRACE) ?: '')


### PR DESCRIPTION
## Summary

Two issues prevent Gradle build cache from working for GroovyCompile, Checkstyle, and CodeNarc tasks:

1. **`GrailsGradlePlugin.configureGroovyCompiler()`** adds the same output file (`build/grailsGroovyCompilerConfig.groovy`) to every `GroovyCompile` task in a project. When a project has multiple `GroovyCompile` tasks (e.g. `compileGroovy`, `compileTestGroovy`, `compileIntegrationTestGroovy`), Gradle detects overlapping outputs and refuses to cache any of them.

2. **`GrailsCodeStylePlugin`** redirects all Checkstyle/CodeNarc XML reports to `rootProject.buildDir/reports/codestyle/{tool}/{project.name}.xml`. Projects with multiple source sets (e.g. `grails-cache` has `ast` + `main`) have multiple tasks writing to the same report file, again causing overlapping outputs.

## Fix

- Use task-specific config file names (`grailsGroovyCompilerConfig-{taskName}.groovy`) so each `GroovyCompile` task has a unique output path.
- Include the task name in report file paths (`{project.name}-{taskName}.xml`) so each Checkstyle/CodeNarc task has a unique report location.