### PR TITLE
Phase 1: Enable Spring Boot configuration metadata processor for existing @ConfigurationProperties modules (#15469)

### DIFF
--- a/grails-cache/build.gradle
+++ b/grails-cache/build.gradle
@@ -38,6 +38,8 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
+    annotationProcessor platform(project(':grails-bom'))
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-core')
     api project(':grails-web-boot')

--- a/grails-databinding/build.gradle
+++ b/grails-databinding/build.gradle
@@ -35,6 +35,8 @@ group = 'org.apache.grails'
 dependencies {
 
     implementation platform(project(':grails-bom'))
+    annotationProcessor platform(project(':grails-bom'))
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-core')
     api project(':grails-web-core')

--- a/grails-views-gson/build.gradle
+++ b/grails-views-gson/build.gradle
@@ -36,6 +36,8 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
+    annotationProcessor platform(project(':grails-bom'))
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-views-core') // Used in public API
     api project(':grails-rest-transforms') // Used in public API

--- a/grails-views-markup/build.gradle
+++ b/grails-views-markup/build.gradle
@@ -36,6 +36,8 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
+    annotationProcessor platform(project(':grails-bom'))
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-views-core') // Used in public API
     api project(':grails-core') // Used in public API

--- a/grails-web-url-mappings/build.gradle
+++ b/grails-web-url-mappings/build.gradle
@@ -35,8 +35,6 @@ group = 'org.apache.grails.web'
 dependencies {
 
     implementation platform(project(':grails-bom'))
-    annotationProcessor platform(project(':grails-bom'))
-    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-web-common')
     compileOnly 'org.apache.grails.views:grails-gsp-core', {

--- a/grails-web-url-mappings/build.gradle
+++ b/grails-web-url-mappings/build.gradle
@@ -35,6 +35,8 @@ group = 'org.apache.grails.web'
 dependencies {
 
     implementation platform(project(':grails-bom'))
+    annotationProcessor platform(project(':grails-bom'))
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     api project(':grails-web-common')
     compileOnly 'org.apache.grails.views:grails-gsp-core', {


### PR DESCRIPTION
This pull request addresses part of the work for issue number 15469. It makes Spring Boots configuration metadata processor work in some modules that already use the ConfigurationProperties annotation.

Here are the modules that were updated:

- grails-databinding
- grails-web-url-mappings
- grails-cache
- grails-views-gson
- grails-views-markup

These are the changes that were made:

- A new dependency was added:

annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"

- The Grails BOM was applied to the annotation processor configuration. This means the dependency will be resolved correctly when the project is built.

So how does the process work?

When the code is compiled, the Spring Boot configuration processor automatically makes a file called

META-INF/spring-configuration-metadata.json

This keeps the configuration metadata in sync with the source code. It also reduces the need to manually keep metadata files up to date. The default values and property names come from the existing ConfigurationProperties classes.

The above is what was checked to make sure everything works:

- Java 17 was. Set up in the development container
- The Gradle compilation was completed successfully for the updated modules
- The generated metadata was checked in the build output for an example like the grails-databinding module
- 
Some things to note:

This pull request only does the part of the work for issue number 15469.

The configuration metadata for DSL will be done in later parts.