### PR TITLE
Cleanup and align `application.yml` in generated applications

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading60x.adoc
@@ -869,3 +869,43 @@ The legacy `org.grails.web.converters.marshaller.json.EnumMarshaller` and `org.g
 ==== 13. Upgrading the Spring Security Plugin
 
 If your application uses the Grails Spring Security plugin, please consult the https://apache.github.io/grails-spring-security/snapshot/guide/index.html#upgrading-from-previous-versions[Upgrading from Previous Versions] section of the Spring Security plugin documentation for specific upgrade instructions related to Grails 7.
+
+==== 14. Changes in CLI- and Forge-generated configuration files
+
+From Grails 7.0.11 onwards, the CLIs (`grails-shell-cli` and `grails-forge-cli`) and the https://start.grails.org[Grails Forge website] no longer include several previously generated properties in `application.yml`.
+
+Most of the removed entries simply restated framework defaults, so omitting them reduces clutter without changing behavior. However, `grails.urlmapping.cache.maxsize` is a special case: older generated applications explicitly set it to `1000`, while the framework default is now `5000`. If you want to preserve the older generated cache size, keep that property in your application.
+
+If the application you are upgrading relies on a custom value for any of the following properties, or if you want to preserve the previous generated value of `grails.urlmapping.cache.maxsize`, keep that setting in your `application.yml` file.
+
+These are the properties that were removed from generated `application.yml` files:
+
+[source,yml]
+.application.yml
+----
+grails:
+  controllers:
+    defaultScope: singleton # already framework default
+  converters:
+    encoding: UTF-8 # already framework default
+  mime:
+    disable:
+      accept:
+        header:
+          userAgents: # already framework default
+            - Gecko
+            - WebKit
+            - Presto
+            - Trident
+  urlmapping:
+    cache:
+      maxsize: 1000 # Attention! framework default: 5000
+  views:
+    default:
+      codec: html # redundant because GSP expressions already default to html encoding
+    gsp:
+      codecs:
+        expression: html # already framework default
+        taglib: none # already framework default
+        staticparts: none # already framework default
+----

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -79,7 +79,6 @@ public class GrailsGsp implements DefaultFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final Map<String, Object> config = generatorContext.getConfiguration();
-        config.put("grails.mime.disable.accept.header.userAgents", Arrays.asList("Gecko", "WebKit", "Presto", "Trident"));
         config.put("grails.mime.types.all", "*/*");
         config.put("grails.mime.types.atom", "application/atom+xml");
         config.put("grails.mime.types.css", "text/css");

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/GrailsGsp.java
@@ -95,10 +95,7 @@ public class GrailsGsp implements DefaultFeature {
         config.put("grails.mime.types.xml", Arrays.asList("text/xml", "application/xml"));
         config.put("grails.views.gsp.encoding", "UTF-8");
         config.put("grails.views.gsp.htmlcodec", "xml");
-        config.put("grails.views.gsp.codecs.expression", "html");
         config.put("grails.views.gsp.codecs.scriptlet", "html");
-        config.put("grails.views.gsp.codecs.taglib", "none");
-        config.put("grails.views.gsp.codecs.staticparts", "none");
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.grails")
                 .artifactId("grails-gsp")

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/json/ViewJson.java
@@ -63,7 +63,6 @@ public class ViewJson extends GrailsViews implements DefaultFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final Map<String, Object> config = generatorContext.getConfiguration();
-        config.put("grails.mime.disable.accept.header.userAgents", Arrays.asList("Gecko", "WebKit", "Presto", "Trident"));
         config.put("grails.mime.types.json", Arrays.asList("application/json", "text/json"));
         config.put("grails.mime.types.hal", Arrays.asList("application/hal+json", "application/hal+xml"));
         config.put("grails.mime.types.xml", Arrays.asList("text/xml", "application/xml"));

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/view/markup/ViewMarkup.java
@@ -59,7 +59,6 @@ public class ViewMarkup extends GrailsViews implements Feature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final Map<String, Object> config = generatorContext.getConfiguration();
-        config.put("grails.mime.disable.accept.header.userAgents", Arrays.asList("Gecko", "WebKit", "Presto", "Trident"));
         config.put("grails.mime.types.xml", Arrays.asList("text/xml", "application/xml"));
         config.put("grails.mime.types.atom", "application/atom+xml");
         config.put("grails.mime.types.json", Arrays.asList("application/json", "text/json"));

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
@@ -51,9 +51,4 @@ public class GrailsWeb implements DefaultFeature {
         return applicationType != ApplicationType.PLUGIN;
     }
 
-    @Override
-    public void apply(GeneratorContext generatorContext) {
-        final Map<String, Object> config = generatorContext.getConfiguration();
-        config.put("grails.views.default.codec", "html");
-    }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/web/GrailsWeb.java
@@ -20,12 +20,10 @@ package org.grails.forge.feature.web;
 
 import jakarta.inject.Singleton;
 import org.grails.forge.application.ApplicationType;
-import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
 import org.grails.forge.options.Options;
 
-import java.util.Map;
 import java.util.Set;
 
 @Singleton

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -73,7 +73,6 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         final GeneratorContext ctx = buildGeneratorContext(["grails-gsp"])
 
         then:
-        ctx.getConfiguration().get("grails.mime.disable.accept.header.userAgents") == Arrays.asList("Gecko", "WebKit", "Presto", "Trident")
         ctx.getConfiguration().get("grails.mime.types.all") == "*/*"
         ctx.getConfiguration().get("grails.mime.types.atom") == "application/atom+xml"
         ctx.getConfiguration().get("grails.mime.types.css") == "text/css"

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -62,10 +62,7 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         then:
         ctx.getConfiguration().containsKey("grails.views.gsp.encoding")
         ctx.getConfiguration().containsKey("grails.views.gsp.htmlcodec")
-        ctx.getConfiguration().containsKey("grails.views.gsp.codecs.expression")
         ctx.getConfiguration().containsKey("grails.views.gsp.codecs.scriptlet")
-        ctx.getConfiguration().containsKey("grails.views.gsp.codecs.taglib")
-        ctx.getConfiguration().containsKey("grails.views.gsp.codecs.staticparts")
     }
 
     void "test mime configuration"() {

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewJsonSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/json/ViewJsonSpec.groovy
@@ -106,7 +106,6 @@ class ViewJsonSpec extends ApplicationContextSpec implements CommandOutputFixtur
         final GeneratorContext ctx = buildGeneratorContext(["views-json"], new Options(null), ApplicationType.REST_API)
 
         then:
-        ctx.getConfiguration().get("grails.mime.disable.accept.header.userAgents") == Arrays.asList("Gecko", "WebKit", "Presto", "Trident")
         ctx.getConfiguration().get("grails.mime.types.json") == Arrays.asList("application/json", "text/json")
         ctx.getConfiguration().get("grails.mime.types.hal") == Arrays.asList("application/hal+json", "application/hal+xml")
         ctx.getConfiguration().get("grails.mime.types.xml") == Arrays.asList("text/xml", "application/xml")

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/web/GrailsWebSpec.groovy
@@ -19,14 +19,11 @@
 
 package org.grails.forge.feature.web
 
-import groovy.yaml.YamlSlurper
 import org.grails.forge.ApplicationContextSpec
 import org.grails.forge.application.ApplicationType
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.DevelopmentReloading
-import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
-import org.grails.forge.options.TestFramework
 
 class GrailsWebSpec extends ApplicationContextSpec implements CommandOutputFixture{
 
@@ -39,13 +36,4 @@ class GrailsWebSpec extends ApplicationContextSpec implements CommandOutputFixtu
         buildGradle.contains("apply plugin: \"org.apache.grails.gradle.grails-web\"")
     }
 
-    void "test grails-web configuration"() {
-        when:
-        final def output = generate(ApplicationType.WEB, new Options(DevelopmentReloading.DEVTOOLS))
-        final String applicationYaml = output["grails-app/conf/application.yml"]
-        def config = new YamlSlurper().parseText(applicationYaml)
-
-        then:
-        config.grails.views.default.codec == 'html'
-    }
 }

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -7,16 +7,3 @@ grails:
     codegen:
         defaultPackage: @grails.codegen.defaultPackage@
         profile: @grails.profile@
-environments:
-    development:
-        management:
-            endpoints:
-                enabled-by-default: true
-                web:
-                    base-path: '/actuator'
-                    exposure:
-                        include: '*'
-    production:
-        management:
-            endpoints:
-                enabled-by-default: false

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -1,12 +1,12 @@
-grails:
-    profile: @grails.profile@
-    codegen:
-        defaultPackage: @grails.codegen.defaultPackage@
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
+grails:
+    profile: @grails.profile@
+    codegen:
+        defaultPackage: @grails.codegen.defaultPackage@
 spring:
     jmx:
         unique-names: true

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -8,9 +8,6 @@ grails:
         defaultPackage: @grails.codegen.defaultPackage@
         profile: @grails.profile@
 spring:
-    groovy:
-        template:
-            check-template-location: false
     devtools:
         restart:
             additional-exclude:

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -4,9 +4,9 @@ info:
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
 grails:
-    profile: @grails.profile@
     codegen:
         defaultPackage: @grails.codegen.defaultPackage@
+        profile: @grails.profile@
 spring:
     jmx:
         unique-names: true

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -7,16 +7,6 @@ grails:
     codegen:
         defaultPackage: @grails.codegen.defaultPackage@
         profile: @grails.profile@
-spring:
-    devtools:
-        restart:
-            additional-exclude:
-                - '*.gsp'
-                - '**/*.gsp'
-                - '*.gson'
-                - '**/*.gson'
-                - 'logback-spring.xml'
-                - '*.properties'
 environments:
     development:
         management:

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -2,11 +2,6 @@ grails:
     profile: @grails.profile@
     codegen:
         defaultPackage: @grails.codegen.defaultPackage@
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -8,8 +8,6 @@ grails:
         defaultPackage: @grails.codegen.defaultPackage@
         profile: @grails.profile@
 spring:
-    jmx:
-        unique-names: true
     groovy:
         template:
             check-template-location: false

--- a/grails-profiles/base/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/base/skeleton/grails-app/conf/application.yml
@@ -10,8 +10,6 @@ grails:
 spring:
     jmx:
         unique-names: true
-    main:
-        banner-mode: "off"
     groovy:
         template:
             check-template-location: false

--- a/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
@@ -25,8 +25,5 @@ grails:
             rss: application/rss+xml
             text: text/plain
             all: '*/*'            
-    urlmapping:
-        cache:
-            maxsize: 1000
     converters:
         encoding: UTF-8

--- a/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
@@ -25,5 +25,3 @@ grails:
             rss: application/rss+xml
             text: text/plain
             all: '*/*'            
-    converters:
-        encoding: UTF-8

--- a/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
@@ -1,13 +1,5 @@
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             json:
               - application/json

--- a/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/rest-api/skeleton/grails-app/conf/application.yml
@@ -28,7 +28,5 @@ grails:
     urlmapping:
         cache:
             maxsize: 1000
-    controllers:
-        defaultScope: singleton
     converters:
         encoding: UTF-8

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -23,9 +23,6 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
     converters:
         encoding: UTF-8
     views:

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -24,8 +24,6 @@ grails:
               - text/xml
               - application/xml
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -23,8 +23,6 @@ grails:
             xml:
               - text/xml
               - application/xml
-    converters:
-        encoding: UTF-8
     views:
         default:
             codec: html

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -26,8 +26,6 @@ grails:
     urlmapping:
         cache:
             maxsize: 1000
-    controllers:
-        defaultScope: singleton
     converters:
         encoding: UTF-8
     views:

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -28,7 +28,4 @@ grails:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
                 scriptlet: html
-                taglib: none
-                staticparts: none

--- a/grails-profiles/web/skeleton/grails-app/conf/application.yml
+++ b/grails-profiles/web/skeleton/grails-app/conf/application.yml
@@ -1,13 +1,5 @@
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml

--- a/grails-test-examples/app1/grails-app/conf/application.yml
+++ b/grails-test-examples/app1/grails-app/conf/application.yml
@@ -23,10 +23,6 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-  groovy:
-    template:
-      check-template-location: false
 
 ---
 grails11951:
@@ -47,14 +43,6 @@ reactor:
       backlog: 1024
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -77,27 +65,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
     cors:
         enabled: true
         mappings:

--- a/grails-test-examples/app2/grails-app/conf/application.yml
+++ b/grails-test-examples/app2/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,27 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
                 scriptlets: html
-                taglib: none
-                staticparts: none
 
 ---
 dataSource:

--- a/grails-test-examples/app3/grails-app/conf/application.yml
+++ b/grails-test-examples/app3/grails-app/conf/application.yml
@@ -23,11 +23,6 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
@@ -61,28 +56,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
                 scriptlets: html
-                taglib: none
-                staticparts: none
-
 ---
 dataSource:
     pooled: true

--- a/grails-test-examples/async-events-pubsub-demo/grails-app/conf/application.yml
+++ b/grails-test-examples/async-events-pubsub-demo/grails-app/conf/application.yml
@@ -19,18 +19,7 @@ info:
     version: '@info.app.version@'
     grailsVersion: '@info.app.grailsVersion@'
 grails:
-  views:
-    default:
-      codec: html
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       json:
         - application/json

--- a/grails-test-examples/cache/grails-app/conf/application.yml
+++ b/grails-test-examples/cache/grails-app/conf/application.yml
@@ -18,45 +18,14 @@ grails:
     profile: web-plugin
     codegen:
         defaultPackage: cache
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    jmx:
-        unique-names: true
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-    devtools:
-        restart:
-            exclude:
-                - grails-app/views/**
-                - grails-app/i18n/**
-                - grails-app/conf/**
-management:
-    endpoints:
-        enabled-by-default: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -80,27 +49,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-endpoints:
-    jmx:
-        unique-names: true
+                scriptlet: html
 ---
 environments:
     test:

--- a/grails-test-examples/datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/datasources/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,27 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
 
 ---
 grails:

--- a/grails-test-examples/demo33/grails-app/conf/application.yml
+++ b/grails-test-examples/demo33/grails-app/conf/application.yml
@@ -21,52 +21,17 @@ grails:
     spring:
         transactionManagement:
             proxies: false
-    gorm:
-        # Whether to autowire entities. 
-        # Disabled by default for performance reasons.
-        autowire: false         
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
 spring:
-    jmx:
-        unique-names: true
     main:
-        banner-mode: "off"
         allow-circular-references: true
-    groovy:
-        template:
-            check-template-location: false
-    devtools:
-        restart:
-            additional-exclude:
-                - '*.gsp'
-                - '**/*.gsp'
-                - '*.gson'
-                - '**/*.gson'
-                - 'logback.groovy'
-                - '*.properties'
-management:
-    endpoints:
-        enabled-by-default: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -90,28 +55,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-endpoints:
-    jmx:
-        unique-names: true
-
+                scriptlet: html
 ---
 hibernate:
     cache:

--- a/grails-test-examples/exploded/grails-app/conf/application.yml
+++ b/grails-test-examples/exploded/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
     name: '@info.app.name@'
     version: '@info.app.version@'
     grailsVersion: '@info.app.grailsVersion@'
-spring:
-  groovy:
-    template:
-      check-template-location: false
-
 ---
 grails:
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -61,28 +48,15 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  controllers:
-    defaultScope: singleton
-  converters:
-    encoding: UTF-8
   hibernate:
     cache:
       queries: false
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
-        scriptlets: html
-        taglib: none
-        staticparts: none
-
+        scriptlet: html
 ---
 dataSource:
   pooled: true

--- a/grails-test-examples/external-configuration/grails-app/conf/application.yml
+++ b/grails-test-examples/external-configuration/grails-app/conf/application.yml
@@ -17,34 +17,14 @@ grails:
   profile: web
   codegen:
     defaultPackage: test.app
-  gorm:
-    reactor:
-      # Whether to translate GORM events into Reactor events
-      # Disabled by default for performance reasons
-      events: false
 info:
   app:
     name: '@info.app.name@'
     version: '@info.app.version@'
     grailsVersion: '@info.app.grailsVersion@'
-spring:
-  main:
-    banner-mode: "off"
-  groovy:
-    template:
-      check-template-location: false
-
 ---
 grails:
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -68,24 +48,12 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  controllers:
-    defaultScope: singleton
-  converters:
-    encoding: UTF-8
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
-        scriptlets: html
-        taglib: none
-        staticparts: none
+        scriptlet: html
 ---
 hibernate:
   cache:
@@ -133,6 +101,7 @@ environments:
 ---
 test:
   config:
+    number: 12345
     value: "From application.yml"
 ---
 grails:

--- a/grails-test-examples/external-configuration/src/integration-test/groovy/test/app/ConfigurationPrioritySpec.groovy
+++ b/grails-test-examples/external-configuration/src/integration-test/groovy/test/app/ConfigurationPrioritySpec.groovy
@@ -217,7 +217,7 @@ class ConfigurationPrioritySpec extends Specification {
 
     def "deeply nested properties are accessible"() {
         when: "accessing deeply nested property"
-        def codec = grailsApplication.config.getProperty('grails.views.gsp.codecs.expression', String)
+        def codec = grailsApplication.config.getProperty('grails.views.gsp.codecs.scriptlet', String)
 
         then: "property is retrieved"
         codec == 'html'

--- a/grails-test-examples/external-configuration/src/integration-test/groovy/test/app/EnvironmentConfigurationSpec.groovy
+++ b/grails-test-examples/external-configuration/src/integration-test/groovy/test/app/EnvironmentConfigurationSpec.groovy
@@ -103,23 +103,23 @@ class EnvironmentConfigurationSpec extends Specification {
 
         then: "nested properties are accessible"
         config.getProperty('grails.mime.types.json', List) != null
-        config.getProperty('grails.controllers.defaultScope', String) == 'singleton'
+        config.getProperty('grails.mime.types.text', String) == 'text/plain'
     }
 
     def "can access configuration as flat properties"() {
         when: "getting flat property"
-        def defaultScope = grailsApplication.config.getProperty('grails.controllers.defaultScope', String)
+        def textMimeType = grailsApplication.config.getProperty('grails.mime.types.text', String)
 
         then: "property is retrieved"
-        defaultScope == 'singleton'
+        textMimeType == 'text/plain'
     }
 
     def "configuration supports type conversion"() {
         when: "getting property with type conversion"
-        def cacheMaxSize = grailsApplication.config.getProperty('grails.urlmapping.cache.maxsize', Integer)
+        def number = grailsApplication.config.getProperty('test.config.number', Integer)
 
         then: "property is converted to integer"
-        cacheMaxSize == 1000
+        number == 12345
     }
 
     def "configuration supports default values"() {
@@ -150,7 +150,6 @@ class EnvironmentConfigurationSpec extends Specification {
 
         then: "GSP encoding is configured"
         config.getProperty('grails.views.gsp.encoding', String) == 'UTF-8'
-        config.getProperty('grails.views.default.codec', String) == 'html'
     }
 
     // ========== Hibernate Configuration Tests ==========
@@ -179,19 +178,6 @@ class EnvironmentConfigurationSpec extends Specification {
         config.getProperty('info.app.name', String) != null
     }
 
-    // ========== Spring Configuration Tests ==========
-
-    def "Spring banner mode is configured"() {
-        expect: "banner mode is off"
-        grailsApplication.config.getProperty('spring.main.banner-mode', String) == 'off'
-    }
-
-    def "Spring template location check is disabled"() {
-        expect: "template check is false"
-        grailsApplication.config.getProperty('spring.groovy.template.check-template-location', Boolean) == false ||
-        grailsApplication.config.getProperty('spring.groovy.template.check-template-location', String) == 'false'
-    }
-
     // ========== Environment Object Tests ==========
 
     def "Environment object provides utility methods"() {
@@ -212,10 +198,10 @@ class EnvironmentConfigurationSpec extends Specification {
 
     def "configuration is immutable at runtime by default"() {
         when: "attempting to modify config"
-        def originalValue = grailsApplication.config.getProperty('grails.controllers.defaultScope', String)
+        def originalValue = grailsApplication.config.getProperty('grails.mime.types.text', String)
 
         then: "original value is accessible"
-        originalValue == 'singleton'
+        originalValue == 'text/plain'
 
         // Note: Modern Spring Boot configuration is generally immutable
         // Runtime changes require specific mechanisms

--- a/grails-test-examples/geb-gebconfig/grails-app/conf/application.yml
+++ b/grails-test-examples/geb-gebconfig/grails-app/conf/application.yml
@@ -20,25 +20,12 @@ info:
     grailsVersion: '@info.app.grailsVersion@'
 grails:
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
         scriptlet: html
-        taglib: none
-        staticparts: none
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml

--- a/grails-test-examples/geb/grails-app/conf/application.yml
+++ b/grails-test-examples/geb/grails-app/conf/application.yml
@@ -20,25 +20,12 @@ info:
     grailsVersion: '@info.app.grailsVersion@'
 grails:
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
         scriptlet: html
-        taglib: none
-        staticparts: none
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml

--- a/grails-test-examples/gorm/grails-app/conf/application.yml
+++ b/grails-test-examples/gorm/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,28 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-
+                scriptlet: html
 ---
 hibernate:
   cache:

--- a/grails-test-examples/gsp-layout/grails-app/conf/application.yml
+++ b/grails-test-examples/gsp-layout/grails-app/conf/application.yml
@@ -21,14 +21,6 @@ info:
 grails:
   profile: web
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -57,9 +49,4 @@ grails:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
         scriptlet: html
-        taglib: none
-        staticparts: none
-    default:
-      codec: html

--- a/grails-test-examples/gsp-sitemesh3/grails-app/conf/application.yml
+++ b/grails-test-examples/gsp-sitemesh3/grails-app/conf/application.yml
@@ -21,14 +21,6 @@ info:
 grails:
   profile: web
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -57,9 +49,4 @@ grails:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
         scriptlet: html
-        taglib: none
-        staticparts: none
-    default:
-      codec: html

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: example
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       html:

--- a/grails-test-examples/hibernate5/grails-data-service/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-data-service/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: example
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       json:
         - application/json
@@ -49,11 +41,6 @@ grails:
       rss: application/rss+xml
       text: text/plain
       all: '*/*'
-  urlmapping:
-    cache:
-      maxsize: 1000
-  converters:
-    encoding: UTF-8
 ---
 hibernate:
   cache:

--- a/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-database-per-tenant/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: datasources
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -54,25 +46,15 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  converters:
-    encoding: UTF-8
   hibernate:
     cache:
       queries: false
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
-        scriptlets: html
-        taglib: none
-        staticparts: none
+        scriptlet: html
 ---
 grails:
   gorm:

--- a/grails-test-examples/hibernate5/grails-hibernate/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-hibernate/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: functional.tests
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -55,22 +47,12 @@ grails:
       xml:
         - text/xml
         - application/xml
-    urlmapping:
-      cache:
-        maxsize: 1000
-    converters:
-      encoding: UTF-8
     views:
-      default:
-        codec: html
       gsp:
         encoding: UTF-8
         htmlcodec: xml
         codecs:
-          expression: html
-          scriptlets: html
-          taglib: none
-          staticparts: none
+          scriptlet: html
 ---
 hibernate:
   configClass: functional.tests.CustomHibernateMappingContextConfiguration

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: datasources
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -54,25 +46,15 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  converters:
-    encoding: UTF-8
   hibernate:
     cache:
       queries: false
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
-        scriptlets: html
-        taglib: none
-        staticparts: none
+        scriptlet: html
 ---
 dataSources:
   dataSource:

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/grails-app/conf/application.yml
@@ -28,14 +28,6 @@ grails:
       mode: DISCRIMINATOR
       tenantResolverClass: org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       html:

--- a/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-partitioned-multi-tenancy/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: datasources
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -54,25 +46,15 @@ grails:
       xml:
         - text/xml
         - application/xml
-    urlmapping:
-      cache:
-        maxsize: 1000
-    converters:
-      encoding: UTF-8
     hibernate:
       cache:
         queries: false
     views:
-      default:
-        codec: html
       gsp:
         encoding: UTF-8
         htmlcodec: xml
         codecs:
-          expression: html
-          scriptlets: html
-          taglib: none
-          staticparts: none
+          scriptlet: html
 ---
 grails:
   gorm:

--- a/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-schema-per-tenant/grails-app/conf/application.yml
@@ -14,24 +14,16 @@
 # limitations under the License.
 
 info:
-    app:
-        name: '@info.app.name@'
-        version: '@info.app.version@'
-        grailsVersion: '@info.app.grailsVersion@'
+  app:
+    name: '@info.app.name@'
+    version: '@info.app.version@'
+    grailsVersion: '@info.app.grailsVersion@'
 ---
 grails:
   profile: web
   codegen:
     defaultPackage: schemapertenant
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -54,25 +46,15 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  converters:
-    encoding: UTF-8
   hibernate:
     cache:
       queries: false
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-          expression: html
-          scriptlets: html
-          taglib: none
-          staticparts: none
+          scriptlet: html
 ---
 grails:
   gorm:

--- a/grails-test-examples/hibernate5/issue450/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/issue450/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
   codegen:
     defaultPackage: multitenantcomposite
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -55,22 +47,12 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  converters:
-    encoding: UTF-8
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
         scriptlet: html
-        taglib: none
-        staticparts: none
 ---
 grails:
   gorm:

--- a/grails-test-examples/hyphenated/grails-app/conf/application.yml
+++ b/grails-test-examples/hyphenated/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -62,24 +49,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
     web:
         url:
             converter: hyphenated
@@ -90,11 +65,6 @@ hibernate:
         use_second_level_cache: true
         use_query_cache: false
         region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
-
-endpoints:
-    jmx:
-        unique-names: true
-
 dataSource:
     pooled: true
     jmxExport: true

--- a/grails-test-examples/issue-11102/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-11102/grails-app/conf/application.yml
@@ -18,40 +18,14 @@ grails:
     profile: web
     codegen:
         defaultPackage: issue11102
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-
-# Spring Actuator Endpoints are Disabled by Default
-endpoints:
-    enabled: false
-    jmx:
-        enabled: true
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -75,28 +49,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-endpoints:
-    jmx:
-        unique-names: true
-
+                scriptlet: html
 ---
 hibernate:
     cache:

--- a/grails-test-examples/issue-11767/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-11767/grails-app/conf/application.yml
@@ -25,14 +25,6 @@ info:
     grailsVersion: '@info.app.grailsVersion@'
 grails:
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml

--- a/grails-test-examples/issue-15228/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-15228/grails-app/conf/application.yml
@@ -20,14 +20,6 @@ info:
     grailsVersion: '@info.app.grailsVersion@'
 grails:
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-          - Gecko
-          - WebKit
-          - Presto
-          - Trident
     types:
       all: '*/*'
       atom: application/atom+xml

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,27 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
 
 ---
 dataSource:

--- a/grails-test-examples/issue-views-182/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-views-182/grails-app/conf/application.yml
@@ -18,40 +18,14 @@ grails:
     profile: rest-api
     codegen:
         defaultPackage: issueviews182
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-
-# Spring Actuator Endpoints are Disabled by Default
-endpoints:
-    enabled: false
-    jmx:
-        enabled: true
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             json:
               - application/json
@@ -69,14 +43,6 @@ grails:
             rss: application/rss+xml
             text: text/plain
             all: '*/*'            
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
-
 ---
 hibernate:
     cache:

--- a/grails-test-examples/micronaut-groovy-only/grails-app/conf/application.yml
+++ b/grails-test-examples/micronaut-groovy-only/grails-app/conf/application.yml
@@ -18,48 +18,17 @@ grails:
     profile: web
     codegen:
         defaultPackage: micronautgroovyonly
-    gorm:
-        reactor:
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    jmx:
-        unique-names: true
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-    devtools:
-        restart:
-            additional-exclude:
-                - '*.gsp'
-                - '**/*.gsp'
-                - '*.gson'
-                - '**/*.gson'
-                - 'logback.groovy'
-                - '*.properties'
-management:
-    endpoints:
-        enabled-by-default: false
 app:
     name: test-micronaut-groovy-only
 
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -83,18 +52,6 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
-management:
-    endpoints:
-        jmx:
-            unique-names: true
-
 ---
 hibernate:
     cache:

--- a/grails-test-examples/micronaut/grails-app/conf/application.yml
+++ b/grails-test-examples/micronaut/grails-app/conf/application.yml
@@ -18,50 +18,17 @@ grails:
     profile: web
     codegen:
         defaultPackage: micronaut
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    jmx:
-        unique-names: true
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-    devtools:
-        restart:
-            additional-exclude:
-                - '*.gsp'
-                - '**/*.gsp'
-                - '*.gson'
-                - '**/*.gson'
-                - 'logback.groovy'
-                - '*.properties'
-management:
-    endpoints:
-        enabled-by-default: false
 app:
     name: test-micronaut-app
 
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -85,29 +52,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
                 scriptlet: html
-                taglib: none
-                staticparts: none
-management:
-    endpoints:
-        jmx:
-            unique-names: true
-
 ---
 hibernate:
     cache:

--- a/grails-test-examples/mongodb/base/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/base/grails-app/conf/application.yml
@@ -20,26 +20,18 @@ info:
         grailsVersion: '@info.app.grailsVersion@'
 ---
 grails:
-  profile: web
-  codegen:
-    defaultPackage: functional.tests
-  gorm:
-    failOnError: true
-  mongodb:
-    url: mongodb://${spring.data.mongodb.host:localhost}:${spring.data.mongodb.port:27017}/mydb
-    options:
-      maxWaitTime: 10000
+    profile: web
+    codegen:
+        defaultPackage: functional.tests
+    gorm:
+        failOnError: true
+    mongodb:
+        url: mongodb://${spring.data.mongodb.host:localhost}:${spring.data.mongodb.port:27017}/mydb
+        options:
+            maxWaitTime: 10000
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -63,19 +55,9 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html

--- a/grails-test-examples/mongodb/database-per-tenant/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/database-per-tenant/grails-app/conf/application.yml
@@ -24,11 +24,8 @@ info:
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
 spring:
-  groovy:
-        template:
-            check-template-location: false
-  main:
-    allow-circular-references: true
+    main:
+        allow-circular-references: true
 
 ---
 grails:
@@ -48,14 +45,6 @@ grails:
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -79,21 +68,9 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html

--- a/grails-test-examples/mongodb/gson-templates/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/gson-templates/grails-app/conf/application.yml
@@ -24,9 +24,6 @@ info:
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
 spring:
-    groovy:
-        template:
-            check-template-location: false
     autoconfigure:
         exclude:
             # No need to start MongoDB, we only need access to the Point class from gorm-mongodb
@@ -34,14 +31,6 @@ spring:
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             json:
                 - application/json
@@ -65,29 +54,13 @@ grails:
             multipartForm: multipart/form-data
             pdf: application/pdf
             all: '*/*'
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
 ---
-endpoints:
-    jmx:
-        unique-names: true
-
 dataSource:
     pooled: true
     jmxExport: true

--- a/grails-test-examples/mongodb/hibernate5/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/hibernate5/grails-app/conf/application.yml
@@ -24,14 +24,6 @@ grails:
     codegen:
         defaultPackage: functional.tests
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -55,22 +47,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
 ---
 hibernate:
     dialect: 'org.hibernate.dialect.H2Dialect'

--- a/grails-test-examples/mongodb/test-data-service/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/test-data-service/grails-app/conf/application.yml
@@ -18,40 +18,17 @@ grails:
     profile: rest-api
     codegen:
         defaultPackage: example
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
 spring:
-    jmx:
-        unique-names: true
     main:
-        banner-mode: "off"
         allow-circular-references: true
-    groovy:
-        template:
-            check-template-location: false
-management:
-    endpoints:
-        enabled-by-default: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             json:
               - application/json
@@ -69,14 +46,6 @@ grails:
             rss: application/rss+xml
             text: text/plain
             all: '*/*'            
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
-
 ---
 grails:
     mongodb:

--- a/grails-test-examples/namespaces/grails-app/conf/application.yml
+++ b/grails-test-examples/namespaces/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,28 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-
+                scriptlet: html
 ---
 dataSource:
     pooled: true

--- a/grails-test-examples/plugins/exploded/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/exploded/grails-app/conf/application.yml
@@ -18,40 +18,14 @@ grails:
   profile: web-plugin
   codegen:
     defaultPackage: exploded
-  gorm:
-    reactor:
-      # Whether to translate GORM events into Reactor events
-      # Disabled by default for performance reasons
-      events: false
 info:
   app:
     name: '@info.app.name@'
     version: '@info.app.version@'
     grailsVersion: '@info.app.grailsVersion@'
-spring:
-  main:
-    banner-mode: "off"
-  groovy:
-    template:
-      check-template-location: false
-
-# Spring Actuator Endpoints are Disabled by Default
-endpoints:
-  enabled: false
-  jmx:
-    enabled: true
-
 ---
 grails:
   mime:
-    disable:
-      accept:
-        header:
-          userAgents:
-            - Gecko
-            - WebKit
-            - Presto
-            - Trident
     types:
       all: '*/*'
       atom: application/atom+xml
@@ -75,24 +49,9 @@ grails:
       xml:
         - text/xml
         - application/xml
-  urlmapping:
-    cache:
-      maxsize: 1000
-  controllers:
-    defaultScope: singleton
-  converters:
-    encoding: UTF-8
   views:
-    default:
-      codec: html
     gsp:
       encoding: UTF-8
       htmlcodec: xml
       codecs:
-        expression: html
-        scriptlets: html
-        taglib: none
-        staticparts: none
-endpoints:
-  jmx:
-    unique-names: true
+        scriptlet: html

--- a/grails-test-examples/plugins/exploded/src/integration-test/groovy/exploded/PluginDependencySpec.groovy
+++ b/grails-test-examples/plugins/exploded/src/integration-test/groovy/exploded/PluginDependencySpec.groovy
@@ -102,7 +102,7 @@ class PluginDependencySpec extends Specification {
 
         then: "config values are accessible"
         // The actual value depends on plugin load order
-        config.getProperty('grails.controllers.defaultScope', String) != null
+        config.getProperty('grails.mime.types.text', String) != null
     }
 
     // ========== Plugin Bean Registration Tests ==========

--- a/grails-test-examples/plugins/issue11005/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/issue11005/grails-app/conf/application.yml
@@ -18,40 +18,14 @@ grails:
     profile: web-plugin
     codegen:
         defaultPackage: issue11005
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-
-# Spring Actuator Endpoints are Disabled by Default
-endpoints:
-    enabled: false
-    jmx:
-        enabled: true
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -75,24 +49,9 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-endpoints:
-    jmx:
-        unique-names: true
+                scriptlet: html

--- a/grails-test-examples/plugins/loadafter/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/loadafter/grails-app/conf/application.yml
@@ -18,40 +18,14 @@ grails:
     profile: web-plugin
     codegen:
         defaultPackage: loadafter
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-
-# Spring Actuator Endpoints are Disabled by Default
-endpoints:
-    enabled: false
-    jmx:
-        enabled: true
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -75,24 +49,9 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-endpoints:
-    jmx:
-        unique-names: true
+                scriptlet: html

--- a/grails-test-examples/plugins/loadfirst/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/loadfirst/grails-app/conf/application.yml
@@ -15,30 +15,17 @@
 
 ---
 grails:
-  profile: web-plugin
-  codegen:
-    defaultPackage: loadfirst
+    profile: web-plugin
+    codegen:
+        defaultPackage: loadfirst
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-  groovy:
-    template:
-      check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,28 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-
+                scriptlet: html
 ---
 dataSource:
     pooled: true
@@ -122,5 +96,3 @@ environments:
                testOnReturn: false
                jdbcInterceptors: ConnectionState
                defaultTransactionIsolation: TRANSACTION_READ_COMMITTED
-
-

--- a/grails-test-examples/plugins/loadsecond/grails-app/conf/application.yml
+++ b/grails-test-examples/plugins/loadsecond/grails-app/conf/application.yml
@@ -15,30 +15,17 @@
 
 ---
 grails:
-  profile: web-plugin
-  codegen:
-    defaultPackage: loadsecond
+    profile: web-plugin
+    codegen:
+        defaultPackage: loadsecond
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-  groovy:
-    template:
-      check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,28 +48,15 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     hibernate:
         cache:
             queries: false
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-
+                scriptlet: html
 ---
 dataSource:
     pooled: true
@@ -122,5 +96,3 @@ environments:
                testOnReturn: false
                jdbcInterceptors: ConnectionState
                defaultTransactionIsolation: TRANSACTION_READ_COMMITTED
-
-

--- a/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
@@ -23,22 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -61,25 +48,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
-
+                scriptlet: html
 ---
 hibernate:
     cache:

--- a/grails-test-examples/scaffolding/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding/grails-app/conf/application.yml
@@ -17,58 +17,14 @@ grails:
     profile: web
     codegen:
         defaultPackage: com.example
-    gorm:
-        reactor:
-            # Whether to translate GORM events into Reactor events
-            # Disabled by default for performance reasons
-            events: false
 info:
     app:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    jmx:
-        unique-names: true
-    main:
-        banner-mode: "off"
-    groovy:
-        template:
-            check-template-location: false
-    devtools:
-        restart:
-            additional-exclude:
-                - '*.gsp'
-                - '**/*.gsp'
-                - '*.gson'
-                - '**/*.gson'
-                - 'logback-spring.xml'
-                - '*.properties'
-environments:
-    development:
-        management:
-            endpoints:
-                enabled-by-default: true
-                web:
-                    base-path: '/actuator'
-                    exposure:
-                        include: '*'
-    production:
-        management:
-            endpoints:
-                enabled-by-default: false
-
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             all: '*/*'
             atom: application/atom+xml
@@ -92,25 +48,12 @@ grails:
             xml:
               - text/xml
               - application/xml
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
                 scriptlet: html
-                taglib: none
-                staticparts: none
-
 ---
 hibernate:
     cache:

--- a/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
+++ b/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
@@ -23,21 +23,9 @@ info:
         name: '@info.app.name@'
         version: '@info.app.version@'
         grailsVersion: '@info.app.grailsVersion@'
-spring:
-    groovy:
-        template:
-            check-template-location: false
 ---
 grails:
     mime:
-        disable:
-            accept:
-                header:
-                    userAgents:
-                        - Gecko
-                        - WebKit
-                        - Presto
-                        - Trident
         types:
             json:
                 - application/json
@@ -61,24 +49,12 @@ grails:
             multipartForm: multipart/form-data
             pdf: application/pdf
             all: '*/*'
-    urlmapping:
-        cache:
-            maxsize: 1000
-    controllers:
-        defaultScope: singleton
-    converters:
-        encoding: UTF-8
     views:
-        default:
-            codec: html
         gsp:
             encoding: UTF-8
             htmlcodec: xml
             codecs:
-                expression: html
-                scriptlets: html
-                taglib: none
-                staticparts: none
+                scriptlet: html
 ---
 hibernate:
     cache:
@@ -86,11 +62,6 @@ hibernate:
         use_second_level_cache: false
         use_query_cache: false
         #region.factory_class: 'org.hibernate.cache.ehcache.EhCacheRegionFactory'
-        
-endpoints:
-    jmx:
-        unique-names: true
-
 dataSource:
     pooled: true
     jmxExport: true


### PR DESCRIPTION
Many config values in generated `application.yml` files are redundant as they only restate the default values.
This is creating a lot of confusing boilerplate that's never changed, gets copied around, gets outdated and only leads to confusion.

I guess it has served as some form of documentation of the available configuration options, but I think we should move this to the Guide documentation as is already in the pipeline.

There are still some config values left in the `application.yml` files that actually do not match default values so these are left in the file for the time being.