### PR TITLE
fix: prompt before removing old SVN release folder during promotion

### DIFF
--- a/.github/scripts/releaseDistributions.sh
+++ b/.github/scripts/releaseDistributions.sh
@@ -58,20 +58,18 @@ svn_exists() {
   svn ls "${svn_flags[@]}" --depth=empty "${url}" >/dev/null 2>&1
 }
 
-old_release_folder="$(svn ls "${svn_flags[@]}" "${RELEASE_ROOT}" | awk -F/ 'NF{print $1; exit}')"
-if [[ -n "${old_release_folder}" ]]; then
-  PRIOR_RELEASE_URL="${RELEASE_ROOT}/${old_release_folder}"
-  read -r -p "Remove old release folder '${old_release_folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm
+for folder in $(svn ls "${svn_flags[@]}" "${RELEASE_ROOT}"); do
+  folder=$(echo "$folder" | sed 's|/$||')
+  PRIOR_RELEASE_URL="${RELEASE_ROOT}/${folder}"
+  read -r -p "Remove old release folder '${folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm
   if [[ "${confirm}" =~ ^[Yy]$ ]]; then
     echo "🗑️ Deleting old release folder: ${PRIOR_RELEASE_URL}"
-    svn rm "${svn_flags[@]}" -m "Remove previous release ${old_release_folder}" "${PRIOR_RELEASE_URL}"
+    svn rm "${svn_flags[@]}" -m "Remove previous release ${folder}" "${PRIOR_RELEASE_URL}"
     echo "✅ Deleted old release folder"
   else
     echo "⏭️ Skipping removal of old release folder: ${PRIOR_RELEASE_URL}"
   fi
-else
-  echo "ℹ️ No existing release subfolder found under ${RELEASE_ROOT}"
-fi
+done
 
 DEV_VERSION_URL="$DEV_ROOT/${RELEASE_VERSION}"
 RELEASE_VERSION_URL="$RELEASE_ROOT/${RELEASE_VERSION}"

--- a/.github/scripts/releaseDistributions.sh
+++ b/.github/scripts/releaseDistributions.sh
@@ -61,8 +61,8 @@ svn_exists() {
 for folder in $(svn ls "${svn_flags[@]}" "${RELEASE_ROOT}"); do
   folder=$(echo "$folder" | sed 's|/$||')
   PRIOR_RELEASE_URL="${RELEASE_ROOT}/${folder}"
-  read -r -p "Remove old release folder '${folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm
-  if [[ "${confirm}" =~ ^[Yy]$ ]]; then
+  read -r -p "Remove old release folder '${folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm < /dev/tty
+  if [[ "${confirm}" =~ ^[Yy](es)?$ ]]; then
     echo "🗑️ Deleting old release folder: ${PRIOR_RELEASE_URL}"
     svn rm "${svn_flags[@]}" -m "Remove previous release ${folder}" "${PRIOR_RELEASE_URL}"
     echo "✅ Deleted old release folder"

--- a/.github/scripts/releaseDistributions.sh
+++ b/.github/scripts/releaseDistributions.sh
@@ -61,9 +61,14 @@ svn_exists() {
 old_release_folder="$(svn ls "${svn_flags[@]}" "${RELEASE_ROOT}" | awk -F/ 'NF{print $1; exit}')"
 if [[ -n "${old_release_folder}" ]]; then
   PRIOR_RELEASE_URL="${RELEASE_ROOT}/${old_release_folder}"
-  echo "🗑️ Deleting old release folder: ${PRIOR_RELEASE_URL}"
-  svn rm "${svn_flags[@]}" -m "Remove previous release ${old_release_folder}" "${PRIOR_RELEASE_URL}"
-  echo "✅ Deleted old release folder"
+  read -r -p "Remove old release folder '${old_release_folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm
+  if [[ "${confirm}" =~ ^[Yy]$ ]]; then
+    echo "🗑️ Deleting old release folder: ${PRIOR_RELEASE_URL}"
+    svn rm "${svn_flags[@]}" -m "Remove previous release ${old_release_folder}" "${PRIOR_RELEASE_URL}"
+    echo "✅ Deleted old release folder"
+  else
+    echo "⏭️ Skipping removal of old release folder: ${PRIOR_RELEASE_URL}"
+  fi
 else
   echo "ℹ️ No existing release subfolder found under ${RELEASE_ROOT}"
 fi

--- a/.github/scripts/releaseDistributions.sh
+++ b/.github/scripts/releaseDistributions.sh
@@ -60,6 +60,7 @@ svn_exists() {
 
 for folder in $(svn ls "${svn_flags[@]}" "${RELEASE_ROOT}"); do
   folder=$(echo "$folder" | sed 's|/$||')
+  [[ "${folder}" == "${RELEASE_VERSION}" ]] && continue
   PRIOR_RELEASE_URL="${RELEASE_ROOT}/${folder}"
   read -r -p "Remove old release folder '${folder}' at ${PRIOR_RELEASE_URL}? [y/N] " confirm < /dev/tty
   if [[ "${confirm}" =~ ^[Yy](es)?$ ]]; then


### PR DESCRIPTION
**Description**

This PR addresses issue #15551. During parallel releases (e.g. 7.0.10 and 7.1.0-RC1), the promotion script was automatically deleting the old release folder, which could remove a still-current release. This change adds an interactive prompt before deleting, so the operator can choose whether to remove the old folder.

**Changes**
A [y/N] interactive prompt was added so the operator must explicitly confirm before the deletion occurs. If they answer anything other than y/Y/yes/Yes, the deletion is skipped and the promotion continues as normal.

**Verification**
 Verified using a local mock of the `svn` command, testing three scenarios:
  - Answering `y` — old folder was deleted and promotion completed
  - Answering `n` — deletion was skipped and promotion completed
  - Pressing Enter (default `N`) — deletion was skipped and promotion completed
  - Answering `y , y` — both folders deleted, then promoted                                                                                                            
  - Answering `n , n` — both folders skipped, then promoted                                                                                                            
  - Answering `y , n` — first folder deleted, second skipped, then promoted                                                                                            
  - Answering `yes/Yes` — both full-word confirmations accepted, both deleted, then promoted  