### PR TITLE
Upgrade to Spring Boot 3.5.14

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ ext {
             'jna.version'                   : '5.17.0',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '3.5.13',
+            'spring-boot.version'           : '3.5.14',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly


### PR DESCRIPTION
## Summary

- Bumps `spring-boot.version` from `3.5.13` to `3.5.14` in `dependencies.gradle`.
- Release notes: https://github.com/spring-projects/spring-boot/releases/tag/v3.5.14