### PR TITLE
fix(wrapper): honor PREFERRED_GRAILS_VERSION and repair publish CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -398,10 +398,19 @@ jobs:
         if: success()
         run: |
           export GRAILS_WRAPPER_ALLOWED_TYPES='SNAPSHOT'
+          # Pin the wrapper to this branch's snapshot; otherwise it resolves the
+          # globally latest SNAPSHOT in the Apache repo (e.g. 8.0.0-SNAPSHOT from
+          # the main development branch), which may be compiled for a newer Java
+          # runtime than this job's JDK and fail with UnsupportedClassVersionError.
+          PROJECT_VERSION=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)
           cp grails-wrapper/build/distributions/apache-grails-wrapper-*.zip build/wrapper.zip
           cd build
           unzip wrapper -d tmp
           mv tmp/apache-grails-wrapper-* tmp/wrapper
+          # The wrapper reads `grailsVersion` from gradle.properties in its CWD
+          # (see grails.init.GrailsVersion#getPreferredGrailsVersion) to select
+          # which Grails CLI snapshot to download.
+          echo "grailsVersion=${PROJECT_VERSION}" > gradle.properties
           ./tmp/wrapper/grailsw --version
       - name: "📤 Upload Wrapper Zip to Workflow Summary Page"
         uses: actions/upload-artifact@v7.0.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -396,27 +396,23 @@ jobs:
           ./gradlew :grails-wrapper:distZip
       - name: "✅ Verify grails-wrapper"
         if: success()
+        env:
+          GRAILS_WRAPPER_ALLOWED_TYPES: 'SNAPSHOT'
         run: |
-          export GRAILS_WRAPPER_ALLOWED_TYPES='SNAPSHOT'
-          # Pin the wrapper to this branch's snapshot; otherwise it resolves the
-          # globally latest SNAPSHOT in the Apache repo (e.g. 8.0.0-SNAPSHOT from
-          # the main development branch), which may be compiled for a newer Java
-          # runtime than this job's JDK and fail with UnsupportedClassVersionError.
-          PROJECT_VERSION=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)
+          # Pin the wrapper to this branch's snapshot so it doesn't resolve the
+          # globally latest SNAPSHOT in the Apache repo, which may be compiled
+          # for a newer Java runtime than this job's JDK.
+          export PREFERRED_GRAILS_VERSION=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)
           cp grails-wrapper/build/distributions/apache-grails-wrapper-*.zip build/wrapper.zip
           cd build
           unzip wrapper -d tmp
           mv tmp/apache-grails-wrapper-* tmp/wrapper
-          # The wrapper reads `grailsVersion` from gradle.properties in its CWD
-          # (see grails.init.GrailsVersion#getPreferredGrailsVersion) to select
-          # which Grails CLI snapshot to download.
-          echo "grailsVersion=${PROJECT_VERSION}" > gradle.properties
           ./tmp/wrapper/grailsw --version
       - name: "📤 Upload Wrapper Zip to Workflow Summary Page"
         uses: actions/upload-artifact@v7.0.0
         with:
           name: apache-grails-wrapper-SNAPSHOT-bin
-          path: tmp/wrapper
+          path: build/tmp/wrapper
   publishForge:
     if: github.repository_owner == 'apache' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: [ buildForge, publishGradle, publish ]

--- a/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
@@ -166,14 +166,16 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
         }
 
         String overrideGrailsVersion = System.getenv(PREFERRED_GRAILS_VERSION_ENV);
-        if (overrideGrailsVersion != null && !overrideGrailsVersion.trim().isEmpty()) {
-            try {
-                return new GrailsVersion(overrideGrailsVersion.trim());
-            } catch (Exception e) {
-                System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in " + PREFERRED_GRAILS_VERSION_ENV);
-                e.printStackTrace();
-                System.exit(1);
-            }
+        if (overrideGrailsVersion == null || (overrideGrailsVersion = overrideGrailsVersion.trim()).isEmpty()) {
+            return null;
+        }
+
+        try {
+            return new GrailsVersion(overrideGrailsVersion);
+        } catch (Exception e) {
+            System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in " + PREFERRED_GRAILS_VERSION_ENV);
+            e.printStackTrace();
+            System.exit(1);
         }
 
         return null;
@@ -193,18 +195,18 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
             System.exit(1);
         }
 
-        if (!properties.containsKey(GRAILS_VERSION_PROPERTY)) {
+        String grailsVersion = properties.getProperty(GRAILS_VERSION_PROPERTY);
+        if (grailsVersion == null) {
             return null;
         }
-
-        String grailsVersion = properties.getProperty(GRAILS_VERSION_PROPERTY);
-        if (grailsVersion == null || grailsVersion.trim().isEmpty()) {
+        grailsVersion = grailsVersion.trim();
+        if (grailsVersion.isEmpty()) {
             System.out.println("A blank Grails Version was specified in gradle.properties for key [" + GRAILS_VERSION_PROPERTY + "]");
             System.exit(1);
         }
 
         try {
-            return new GrailsVersion(grailsVersion.trim());
+            return new GrailsVersion(grailsVersion);
         } catch (Exception e) {
             System.out.println("An invalid Grails Version [" + grailsVersion + "] was specified in gradle.properties");
             e.printStackTrace();

--- a/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
@@ -141,11 +141,14 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
      * <p>Precedence matches the documented behaviour in the wrapper README:
      * <ol>
      *   <li>Inside a Grails project (a {@code gradle.properties} containing a
-     *       {@code grailsVersion} key), use that value and ignore environment
-     *       variables.</li>
+     *       {@code grailsVersion} key with a non-blank value), use that value
+     *       and ignore environment variables. A present-but-blank value or an
+     *       unparseable version is treated as a project misconfiguration and
+     *       exits the process.</li>
      *   <li>Outside a Grails project (no {@code gradle.properties}, or one
      *       without {@code grailsVersion}), honour the
-     *       {@code PREFERRED_GRAILS_VERSION} environment variable.</li>
+     *       {@code PREFERRED_GRAILS_VERSION} environment variable. A
+     *       whitespace-only value is treated as unset.</li>
      *   <li>Otherwise return {@code null} and let the wrapper resolve the
      *       latest version from Maven metadata.</li>
      * </ol>
@@ -196,7 +199,8 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
 
         String grailsVersion = properties.getProperty(GRAILS_VERSION_PROPERTY);
         if (grailsVersion == null || grailsVersion.trim().isEmpty()) {
-            return null;
+            System.out.println("A blank Grails Version was specified in gradle.properties for key [" + GRAILS_VERSION_PROPERTY + "]");
+            System.exit(1);
         }
 
         try {

--- a/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
@@ -33,6 +33,15 @@ import java.util.stream.Collectors;
  */
 public class GrailsVersion implements Comparable<GrailsVersion> {
 
+    /** Environment variable honoured outside a Grails project to pin the wrapper to a specific version. */
+    public static final String PREFERRED_GRAILS_VERSION_ENV = "PREFERRED_GRAILS_VERSION";
+
+    /** Environment variable used to restrict which release types the wrapper will resolve (e.g. {@code SNAPSHOT,RC}). */
+    public static final String GRAILS_WRAPPER_ALLOWED_TYPES_ENV = "GRAILS_WRAPPER_ALLOWED_TYPES";
+
+    /** Property key read from {@code gradle.properties} to pin the wrapper to a specific version inside a project. */
+    public static final String GRAILS_VERSION_PROPERTY = "grailsVersion";
+
     private static final Pattern VERSION_PATTERN = Pattern.compile("^(\\d+)[.](\\d+)[.](\\d+)-?(.*)$");
 
     private static final Pattern RC = Pattern.compile("^RC(\\d+)$");
@@ -86,7 +95,7 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
     }
 
     public static LinkedHashSet<GrailsReleaseType> getAllowedReleaseTypes(GrailsVersion preferredVersion, GrailsWrapper wrapper) {
-        String raw = System.getenv("GRAILS_WRAPPER_ALLOWED_TYPES");
+        String raw = System.getenv(GRAILS_WRAPPER_ALLOWED_TYPES_ENV);
         if (raw == null || raw.trim().isEmpty()) {
             if (preferredVersion != null) {
                 //inside a grails project pull the equivalent version type or newer
@@ -116,7 +125,7 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
                 try {
                     return GrailsReleaseType.valueOf(input);
                 } catch (Exception e) {
-                    throw new IllegalStateException("Invalid Value in GRAILS_WRAPPER_ALLOWED_TYPES: " + input);
+                    throw new IllegalStateException("Invalid Value in " + GRAILS_WRAPPER_ALLOWED_TYPES_ENV + ": " + input);
                 }
             })
             .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -153,12 +162,12 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
             return fromProperties;
         }
 
-        String overrideGrailsVersion = System.getenv("PREFERRED_GRAILS_VERSION");
+        String overrideGrailsVersion = System.getenv(PREFERRED_GRAILS_VERSION_ENV);
         if (overrideGrailsVersion != null && !overrideGrailsVersion.trim().isEmpty()) {
             try {
                 return new GrailsVersion(overrideGrailsVersion.trim());
             } catch (Exception e) {
-                System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in PREFERRED_GRAILS_VERSION");
+                System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in " + PREFERRED_GRAILS_VERSION_ENV);
                 e.printStackTrace();
                 System.exit(1);
             }
@@ -181,11 +190,11 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
             System.exit(1);
         }
 
-        if (!properties.containsKey("grailsVersion")) {
+        if (!properties.containsKey(GRAILS_VERSION_PROPERTY)) {
             return null;
         }
 
-        String grailsVersion = properties.getProperty("grailsVersion");
+        String grailsVersion = properties.getProperty(GRAILS_VERSION_PROPERTY);
         if (grailsVersion == null || grailsVersion.trim().isEmpty()) {
             return null;
         }

--- a/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
+++ b/grails-wrapper/src/main/java/grails/init/GrailsVersion.java
@@ -123,8 +123,51 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
     }
 
     public static GrailsVersion getPreferredGrailsVersion() {
-        // Check for a properties file in case inside a grails project
-        File gradleProperties = new File("gradle.properties");
+        return getPreferredGrailsVersion(new File("gradle.properties"));
+    }
+
+    /**
+     * Determine the preferred Grails version.
+     *
+     * <p>Precedence matches the documented behaviour in the wrapper README:
+     * <ol>
+     *   <li>Inside a Grails project (a {@code gradle.properties} containing a
+     *       {@code grailsVersion} key), use that value and ignore environment
+     *       variables.</li>
+     *   <li>Outside a Grails project (no {@code gradle.properties}, or one
+     *       without {@code grailsVersion}), honour the
+     *       {@code PREFERRED_GRAILS_VERSION} environment variable.</li>
+     *   <li>Otherwise return {@code null} and let the wrapper resolve the
+     *       latest version from Maven metadata.</li>
+     * </ol>
+     *
+     * @param gradleProperties the properties file to inspect; exposed as a
+     *                         parameter for testability
+     * @return the pinned {@link GrailsVersion} or {@code null} if none was
+     *         specified
+     */
+    static GrailsVersion getPreferredGrailsVersion(File gradleProperties) {
+        GrailsVersion fromProperties = readVersionFromProperties(gradleProperties);
+        if (fromProperties != null) {
+            // Inside a Grails project: gradle.properties wins and the env var is intentionally ignored per the wrapper README.
+            return fromProperties;
+        }
+
+        String overrideGrailsVersion = System.getenv("PREFERRED_GRAILS_VERSION");
+        if (overrideGrailsVersion != null && !overrideGrailsVersion.trim().isEmpty()) {
+            try {
+                return new GrailsVersion(overrideGrailsVersion.trim());
+            } catch (Exception e) {
+                System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in PREFERRED_GRAILS_VERSION");
+                e.printStackTrace();
+                System.exit(1);
+            }
+        }
+
+        return null;
+    }
+
+    private static GrailsVersion readVersionFromProperties(File gradleProperties) {
         if (!gradleProperties.exists()) {
             return null;
         }
@@ -143,24 +186,12 @@ public class GrailsVersion implements Comparable<GrailsVersion> {
         }
 
         String grailsVersion = properties.getProperty("grailsVersion");
-        if (grailsVersion == null) {
-            String overrideGrailsVersion = System.getenv("PREFERRED_GRAILS_VERSION");
-            if (overrideGrailsVersion != null) {
-                try {
-                    return new GrailsVersion(overrideGrailsVersion);
-                } catch (Exception e) {
-                    System.out.println("An invalid Grails Version [" + overrideGrailsVersion + "] was specified in PREFERRED_GRAILS_VERSION");
-                    e.printStackTrace();
-                    System.exit(1);
-                }
-            }
-
-            System.out.println("gradle.properties does not contain grailsVersion; assuming latest Grails Version");
+        if (grailsVersion == null || grailsVersion.trim().isEmpty()) {
             return null;
         }
 
         try {
-            return new GrailsVersion(grailsVersion);
+            return new GrailsVersion(grailsVersion.trim());
         } catch (Exception e) {
             System.out.println("An invalid Grails Version [" + grailsVersion + "] was specified in gradle.properties");
             e.printStackTrace();

--- a/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
+++ b/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
@@ -215,29 +215,6 @@ class GrailsVersionSpec extends Specification {
         resolved == new GrailsVersion('7.0.11-SNAPSHOT')
     }
 
-    @Unroll
-    def "preferred version - blank grailsVersion in gradle.properties exits with error (value=#description)"() {
-        given:
-        File gradleProperties = tempDir.resolve('gradle.properties').toFile()
-        gradleProperties.text = propertiesContent
-
-        when:
-        int exitCode = SystemStubs.catchSystemExit {
-            SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '8.0.0-SNAPSHOT').execute {
-                GrailsVersion.getPreferredGrailsVersion(gradleProperties)
-            }
-        }
-
-        then: 'a project with a malformed grailsVersion fails fast instead of silently falling through to the env var'
-        exitCode == 1
-
-        where:
-        description      | propertiesContent
-        'empty'          | 'grailsVersion='
-        'whitespace'     | 'grailsVersion=   '
-        'no value, no =' | 'grailsVersion'
-    }
-
     def "preferred version - env var trimmed and whitespace-only treated as unset"() {
         given:
         File missing = tempDir.resolve('does-not-exist.properties').toFile()

--- a/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
+++ b/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
@@ -215,6 +215,29 @@ class GrailsVersionSpec extends Specification {
         resolved == new GrailsVersion('7.0.11-SNAPSHOT')
     }
 
+    @Unroll
+    def "preferred version - blank grailsVersion in gradle.properties exits with error (value=#description)"() {
+        given:
+        File gradleProperties = tempDir.resolve('gradle.properties').toFile()
+        gradleProperties.text = propertiesContent
+
+        when:
+        int exitCode = SystemStubs.catchSystemExit {
+            SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '8.0.0-SNAPSHOT').execute {
+                GrailsVersion.getPreferredGrailsVersion(gradleProperties)
+            }
+        }
+
+        then: 'a project with a malformed grailsVersion fails fast instead of silently falling through to the env var'
+        exitCode == 1
+
+        where:
+        description      | propertiesContent
+        'empty'          | 'grailsVersion='
+        'whitespace'     | 'grailsVersion=   '
+        'no value, no =' | 'grailsVersion'
+    }
+
     def "preferred version - env var trimmed and whitespace-only treated as unset"() {
         given:
         File missing = tempDir.resolve('does-not-exist.properties').toFile()

--- a/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
+++ b/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
@@ -36,7 +36,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, RC').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, 'SNAPSHOT, RC').execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
         }
 
@@ -56,13 +56,13 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, FOO').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, 'SNAPSHOT, FOO').execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
         }
 
         then:
         def ie = thrown(IllegalStateException)
-        ie.message == 'Invalid Value in GRAILS_WRAPPER_ALLOWED_TYPES: FOO'
+        ie.message == "Invalid Value in ${GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV}: FOO"
 
         and:
         0 * mockVersion._
@@ -77,7 +77,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', 'SNAPSHOT, RC').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, 'SNAPSHOT, RC').execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(preferredVersion, mockVersion)
         }
 
@@ -100,7 +100,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, null).execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(preferredVersion, mockVersion)
         }
 
@@ -122,7 +122,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, null).execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
         }
 
@@ -141,7 +141,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, null).execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
         }
 
@@ -160,7 +160,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         Set<GrailsReleaseType> allowedTypes = null
-        SystemStubs.withEnvironmentVariable('GRAILS_WRAPPER_ALLOWED_TYPES', null).execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.GRAILS_WRAPPER_ALLOWED_TYPES_ENV, null).execute {
             allowedTypes = GrailsVersion.getAllowedReleaseTypes(null, mockVersion)
         }
 
@@ -178,7 +178,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         GrailsVersion resolved = null
-        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '8.0.0-SNAPSHOT').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '8.0.0-SNAPSHOT').execute {
             resolved = GrailsVersion.getPreferredGrailsVersion(gradleProperties)
         }
 
@@ -192,7 +192,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         GrailsVersion resolved = null
-        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '7.0.11-SNAPSHOT').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '7.0.11-SNAPSHOT').execute {
             resolved = GrailsVersion.getPreferredGrailsVersion(missing)
         }
 
@@ -207,7 +207,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         GrailsVersion resolved = null
-        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '7.0.11-SNAPSHOT').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '7.0.11-SNAPSHOT').execute {
             resolved = GrailsVersion.getPreferredGrailsVersion(gradleProperties)
         }
 
@@ -221,7 +221,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         GrailsVersion resolved = null
-        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '   ').execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, '   ').execute {
             resolved = GrailsVersion.getPreferredGrailsVersion(missing)
         }
 
@@ -235,7 +235,7 @@ class GrailsVersionSpec extends Specification {
 
         when:
         GrailsVersion resolved = null
-        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', null).execute {
+        SystemStubs.withEnvironmentVariable(GrailsVersion.PREFERRED_GRAILS_VERSION_ENV, null).execute {
             resolved = GrailsVersion.getPreferredGrailsVersion(missing)
         }
 

--- a/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
+++ b/grails-wrapper/src/test/groovy/grails/init/GrailsVersionSpec.groovy
@@ -19,10 +19,16 @@
 package grails.init
 
 import spock.lang.Specification
+import spock.lang.TempDir
 import spock.lang.Unroll
 import uk.org.webcompere.systemstubs.SystemStubs
 
+import java.nio.file.Path
+
 class GrailsVersionSpec extends Specification {
+
+    @TempDir
+    Path tempDir
 
     def "allowed release types - specified valid"() {
         given:
@@ -163,6 +169,78 @@ class GrailsVersionSpec extends Specification {
 
         and: 'only later versions since its not snapshot'
         allowedTypes == [GrailsReleaseType.RELEASE] as LinkedHashSet
+    }
+
+    def "preferred version - gradle.properties with grailsVersion wins over env var"() {
+        given:
+        File gradleProperties = tempDir.resolve('gradle.properties').toFile()
+        gradleProperties.text = 'grailsVersion=7.0.11-SNAPSHOT'
+
+        when:
+        GrailsVersion resolved = null
+        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '8.0.0-SNAPSHOT').execute {
+            resolved = GrailsVersion.getPreferredGrailsVersion(gradleProperties)
+        }
+
+        then:
+        resolved == new GrailsVersion('7.0.11-SNAPSHOT')
+    }
+
+    def "preferred version - env var used when gradle.properties is missing"() {
+        given:
+        File missing = tempDir.resolve('does-not-exist.properties').toFile()
+
+        when:
+        GrailsVersion resolved = null
+        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '7.0.11-SNAPSHOT').execute {
+            resolved = GrailsVersion.getPreferredGrailsVersion(missing)
+        }
+
+        then:
+        resolved == new GrailsVersion('7.0.11-SNAPSHOT')
+    }
+
+    def "preferred version - env var used when gradle.properties has no grailsVersion key"() {
+        given:
+        File gradleProperties = tempDir.resolve('gradle.properties').toFile()
+        gradleProperties.text = 'projectVersion=7.0.11-SNAPSHOT'
+
+        when:
+        GrailsVersion resolved = null
+        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '7.0.11-SNAPSHOT').execute {
+            resolved = GrailsVersion.getPreferredGrailsVersion(gradleProperties)
+        }
+
+        then:
+        resolved == new GrailsVersion('7.0.11-SNAPSHOT')
+    }
+
+    def "preferred version - env var trimmed and whitespace-only treated as unset"() {
+        given:
+        File missing = tempDir.resolve('does-not-exist.properties').toFile()
+
+        when:
+        GrailsVersion resolved = null
+        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', '   ').execute {
+            resolved = GrailsVersion.getPreferredGrailsVersion(missing)
+        }
+
+        then:
+        resolved == null
+    }
+
+    def "preferred version - returns null when neither gradle.properties nor env var is set"() {
+        given:
+        File missing = tempDir.resolve('does-not-exist.properties').toFile()
+
+        when:
+        GrailsVersion resolved = null
+        SystemStubs.withEnvironmentVariable('PREFERRED_GRAILS_VERSION', null).execute {
+            resolved = GrailsVersion.getPreferredGrailsVersion(missing)
+        }
+
+        then:
+        resolved == null
     }
 
     @Unroll


### PR DESCRIPTION
## Summary

The `publish` job's **Verify grails-wrapper** step has failed on every push to `7.0.x` since 8.0.0-SNAPSHOT began being published to the Apache Maven snapshot repo. This PR fixes that, fixes the downstream **Upload Wrapper Zip** path bug it exposes, makes the wrapper's documented `PREFERRED_GRAILS_VERSION` env var actually work (currently dead code), and tidies the wrapper's configuration surface.

## Root cause

With `GRAILS_WRAPPER_ALLOWED_TYPES='SNAPSHOT'` and no pinned version, the wrapper reads `grails-cli`'s root `maven-metadata.xml`, sorts by `GrailsVersion` order, and picks the globally latest SNAPSHOT. Because 8.0.x SNAPSHOTs are now being published from the main development branch, the resolver picks that jar:

```
java.lang.UnsupportedClassVersionError: org/apache/grails/cli/DelegatingShellApplication
  has been compiled by a more recent version of the Java Runtime (class file version 65.0),
  this version of the Java Runtime only recognizes class file versions up to 61.0
```

The wrapper exposes `PREFERRED_GRAILS_VERSION` as the documented way to pin the version (see the `README` "Creating a Grails Application" section), but the env var is dead code in `grails.init.GrailsVersion#getPreferredGrailsVersion` - it is only consulted when `gradle.properties` contains a `grailsVersion` key whose value is literally `null`, which cannot happen with a well-formed properties file. Users following the documented README flow therefore hit the same bytecode-compatibility failure the CI is hitting.

## Changes

### 1. `grails-wrapper/.../GrailsVersion.java` - make `PREFERRED_GRAILS_VERSION` work

Rewrite `getPreferredGrailsVersion` so the precedence matches the documented behaviour:

1. **Inside a Grails project** (a `gradle.properties` containing a `grailsVersion` key) - use that and ignore the env var.
2. **Outside a project** (no `gradle.properties`, or one without `grailsVersion`) - honour `PREFERRED_GRAILS_VERSION`.
3. Otherwise - `null`, let the wrapper resolve the latest from Maven metadata.

Extract a package-private overload that accepts the properties file so the logic is testable without mutating the JVM working directory.

### 2. `grails-wrapper/.../GrailsVersion.java` - named constants for the wrapper config surface

Pin the user-facing configuration strings as public constants so they aren't duplicated as literals across production and tests:

- `PREFERRED_GRAILS_VERSION_ENV` = `"PREFERRED_GRAILS_VERSION"`
- `GRAILS_WRAPPER_ALLOWED_TYPES_ENV` = `"GRAILS_WRAPPER_ALLOWED_TYPES"`
- `GRAILS_VERSION_PROPERTY` = `"grailsVersion"`

Referenced from the production code and all tests. The validation error message now reads `"Invalid Value in " + GRAILS_WRAPPER_ALLOWED_TYPES_ENV + ": ..."` so it stays in sync if the env var is ever renamed.

### 3. `grails-wrapper/.../GrailsVersionSpec.groovy` - coverage

Five new Spock specs exercising the precedence matrix:

- `gradle.properties` with `grailsVersion` wins over env var
- env var used when `gradle.properties` is missing
- env var used when `gradle.properties` has no `grailsVersion` key
- whitespace-only env var treated as unset
- `null` when neither is set

All 20 `:grails-wrapper:test` specs pass (15 existing + 5 new).

### 4. `.github/workflows/gradle.yml` - pin wrapper verification, fix upload path

- Export `PREFERRED_GRAILS_VERSION` (now honoured by the wrapper) derived from the repo's `projectVersion` so the wrapper resolves against this branch's snapshot - branch-portable: 7.0.x → 7.0.x, 7.1.x → 7.1.x, 8.0.x → 8.0.x.
- Promote `GRAILS_WRAPPER_ALLOWED_TYPES` from an inline `export` to step-level `env`.
- Fix the pre-existing Upload Wrapper Zip path bug: the step used `path: tmp/wrapper` relative to the repo root but the zip lands under `build/tmp/wrapper`. Verified on the last successful `publish` (Apr 2):
  ```
  ##[warning]No files were found with the provided path: tmp/wrapper. No artifacts will be uploaded.
  ```
  The artifact has been silently empty for the entire life of this workflow. Fixed to `build/tmp/wrapper`.

## Verification

- `:grails-wrapper:test` passes locally (15 existing + 5 new specs, 20 total).
- CI failure pattern reproducible in every recent push run:
  - https://github.com/apache/grails-core/actions/runs/24496413864/job/71598069598 (Apr 16)
  - https://github.com/apache/grails-core/actions/runs/24487358870/job/71568765789 (Apr 16)
  - https://github.com/apache/grails-core/actions/runs/24227501271/job/70735767232 (Apr 10)
- Last successful `publish` on `7.0.x` was Apr 2 - that run also logged the empty-artifact warning, confirming the upload bug is pre-existing and not introduced by this PR.

## Commits

1. `fix(ci): pin wrapper verification to this branch's snapshot version` - initial CI-only fix writing `gradle.properties`.
2. `Honor PREFERRED_GRAILS_VERSION env var and tidy wrapper CI` - wrapper code fix, tests, and simplify CI to use the env var instead of writing `gradle.properties`. Also fixes matrei's and Copilot's review comments.
3. `Extract wrapper configuration strings as public constants on GrailsVersion` - pure refactor, no behaviour change.