### PR TITLE
fix(ci): restore executable bit on grailsw before verify

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -474,6 +474,9 @@ jobs:
           # globally latest SNAPSHOT in the Apache repo, which may be compiled
           # for a newer Java runtime than this job's JDK.
           export PREFERRED_GRAILS_VERSION=$(grep '^projectVersion=' gradle.properties | cut -d'=' -f2)
+          # actions/download-artifact does not preserve the executable bit, so
+          # restore it before invoking the wrapper script (see actions/upload-artifact#38).
+          chmod +x ./wrapper/grailsw
           ./wrapper/grailsw --version
   docs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'


### PR DESCRIPTION
## Summary

The `Verify grails-wrapper` job on `7.0.x` has been failing on every push since #15602 was merged.
Example failure: https://github.com/apache/grails-core/actions/runs/24933507519/job/73020232978

`
/home/runner/work/_temp/...sh: line 5: ./wrapper/grailsw: Permission denied
##[error]Process completed with exit code 126.
`

## Root Cause

The `verifyWrapper` job downloads the wrapper distribution as a GitHub Actions artifact (`apache-grails-wrapper-SNAPSHOT-bin`) produced by the `publish` job and then invokes `./wrapper/grailsw`. The build itself sets `permissions.unix(0755)` on `grailsw` (see `grails-wrapper/build.gradle`), so the source side is correct — but `actions/download-artifact` does not reliably preserve the Unix executable bit on the downloading runner. The script comes back without `+x` and fails with `Permission denied` (exit code `126`). This is a known limitation of GitHub artifact transport (see [actions/upload-artifact#38](https://github.com/actions/upload-artifact/issues/38)).

## Fix

Restore the executable bit with `chmod +x ./wrapper/grailsw` immediately before invocation. Three-line change inside the `Verify grails-wrapper` step.

## Scope

- `7.0.x` only. `7.1.x` is not affected because its `Verify grails-wrapper` step runs in the same job that builds the wrapper and re-extracts the distZip via `unzip`, which preserves Unix mode bits.
- No source/test changes; CI workflow only.

## Verification Plan

Once the draft is marked ready and merged to `7.0.x`, the next push-triggered run of `CI` should show `Verify grails-wrapper` completing successfully and printing the wrapper version. No new tests are appropriate — this exercises the actual wrapper artifact end-to-end on the CI runner.