### PR TITLE
docs: fix plugin reference links in Application Properties

### DIFF
--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -479,8 +479,8 @@ generateConfigReference.configure { Task it ->
             writer.writeLine('')
             writer.writeLine('The following plugin documentation covers configuration properties that are not listed above:')
             writer.writeLine('')
-            writer.writeLine('- https://apache.github.io/grails-spring-security/snapshot/core-plugin/guide/index.html#_configuration_properties[Spring Security Core Configuration Properties]')
-            writer.writeLine('- https://wondrify.github.io/asset-pipeline/[Asset Pipeline Configuration Properties]')
+            writer.writeLine('- https://apache.github.io/grails-spring-security/snapshot/guide/index.html#configuration-properties[Spring Security Core Configuration Properties]')
+            writer.writeLine('- https://wondrify.github.io/asset-pipeline/#configuration-properties[Asset Pipeline Configuration Properties]')
             writer.writeLine('')
         }
 


### PR DESCRIPTION
## Description

Fix the two broken plugin reference links rendered at the bottom of the [Application Properties reference page](https://grails.apache.org/docs/snapshot/ref/Configuration/Application%20Properties.html), under "Plugin References". Both links currently 404 / land on a page without the expected anchor.

These links are emitted dynamically by `generateConfigReference` in `grails-doc/build.gradle` (added in #15426). This PR updates the two `writer.writeLine` calls only - no other behavior change.

### Spring Security Core

- Before: `https://apache.github.io/grails-spring-security/snapshot/core-plugin/guide/index.html#_configuration_properties` (404 - the per-plugin `core-plugin/` path no longer exists)
- After: `https://apache.github.io/grails-spring-security/snapshot/guide/index.html#configuration-properties` (combined Spring Security plugin reference, section 4.22)

### Asset Pipeline

- Before: `https://wondrify.github.io/asset-pipeline/` (lands at the top of the guide)
- After: `https://wondrify.github.io/asset-pipeline/#configuration-properties` (deep-links to the Configuration Properties section)

I verified both anchors exist in the rendered upstream HTML.

## Contributor Checklist

### Issue and Scope

- [x] This PR contains a **single, focused change**.
- [x] This PR targets the **correct branch**: `7.0.x` (patch branch, doc-only fix - no API or behavior change).

### Code Quality

- [x] Doc-only change in a Gradle build script string literal; no source code or test surface affected.
- [x] No mass reformatting or unrelated changes.

### Licensing and Attribution

- [x] No new files; existing Apache 2.0 header on `grails-doc/build.gradle` is unchanged.

### Documentation

- [x] This **is** the documentation fix - the page rendered to users now has working links.