### PR TITLE
build - do not include merge PRs from releases in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -127,6 +127,8 @@ categories:
   - title: '⏪ Reverts'
     labels:
       - 'revert'
+exclude-labels:
+  - 'skip-changelog'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 filter-by-commitish: true
 version-resolver:

--- a/.github/workflows/release-close.yml
+++ b/.github/workflows/release-close.yml
@@ -47,6 +47,7 @@ jobs:
       - name: "⚙️ Run post-release"
         uses: apache/grails-github-actions/post-release@asf
         env:
+          PR_LABELS: skip-changelog
           RELEASE_SCRIPT_PATH: '.github/scripts/setSnapshotGrailsVersion.sh'
       - name: "🌎 MANUAL - Create Blog Post"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -644,6 +644,7 @@ jobs:
       - name: "⚙️ Run post-release"
         uses: apache/grails-github-actions/post-release@asf
         env:
+          PR_LABELS: skip-changelog
           RELEASE_SCRIPT_PATH: '.github/scripts/setSnapshotGrailsVersion.sh'
       - name: "🌎 MANUAL - Create Blog Post"
         run: |


### PR DESCRIPTION
Per previous discussion, this PR configures the release drafter action to ignore PR's labeled with 'skip-changelog' and it sets the close release PRs to have this label.