### PR TITLE
Fix profile resolution when GRAILS_REPO_URL points at a BOM-incomplete repo (e.g. Apache staging)

### DIFF
--- a/grails-bom/base/build.gradle
+++ b/grails-bom/base/build.gradle
@@ -93,7 +93,7 @@ dependencies {
                 continue
             }
 
-            boolean publishedProject = subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish-profile') || subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish')
+            boolean publishedProject = subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish-profile') || subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-publish') || subproject.pluginManager.hasPlugin('org.apache.grails.gradle.grails-profile')
             if (!publishedProject) {
                 continue
             }

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepository.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepository.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import org.eclipse.aether.artifact.Artifact
 import org.eclipse.aether.artifact.DefaultArtifact
 
+import grails.util.Environment
 import org.grails.cli.GrailsCli
 import org.grails.cli.profile.AbstractProfile
 import org.grails.cli.profile.Command
@@ -81,14 +82,28 @@ abstract class AbstractJarProfileRepository implements ProfileRepository {
         }
 
         String groupId = DEFAULT_PROFILE_GROUPID
-        String version = null
+        // Default to the running Grails version. Profiles are released in lock-step with
+        // grails-core since the move to the apache/grails-core monorepo, so the CLI version
+        // is the correct profile version. This guarantees resolution succeeds even when the
+        // BOM declared in dependency management does not list the profile coordinates (e.g.
+        // when GRAILS_REPO_URL points at an Apache staging repository before promotion, or
+        // any repository whose BOM omits org.apache.grails.profiles entries). The Aether
+        // resolver in MavenResolverGrapeEngine still falls back to the BOM-managed version
+        // only when the requested version is null, so we override that path here.
+        String version = Environment.grailsVersion
 
         Map<String, Map> defaultValues = GrailsCli.getSetting('grails.profiles', Map, [:])
         defaultValues.remove('repositories')
         def data = defaultValues.get(profileName)
         if (data instanceof Map) {
-            groupId = data.get('groupId')
-            version = data.get('version')
+            String configuredGroupId = data.get('groupId') as String
+            if (configuredGroupId) {
+                groupId = configuredGroupId
+            }
+            String configuredVersion = data.get('version') as String
+            if (configuredVersion) {
+                version = configuredVersion
+            }
         }
 
         return new DefaultArtifact(groupId, profileName, null, version)

--- a/grails-shell-cli/src/test/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepositorySpec.groovy
+++ b/grails-shell-cli/src/test/groovy/org/grails/cli/profile/repository/AbstractJarProfileRepositorySpec.groovy
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.cli.profile.repository
+
+import grails.util.Environment
+import org.eclipse.aether.artifact.Artifact
+import spock.lang.Specification
+
+/**
+ * Regression tests for {@link AbstractJarProfileRepository#getProfileArtifact}.
+ *
+ * <p>These tests guard against the version-resolution failure observed when the Grails
+ * CLI is invoked with {@code GRAILS_REPO_URL} pointing at an Apache staging repository
+ * whose published BOM does not declare {@code org.apache.grails.profiles:*} coordinates.
+ * Prior to the fix, {@code getProfileArtifact} returned an {@link Artifact} with a
+ * {@code null} version, the BOM-managed version fallback in
+ * {@code MavenResolverGrapeEngine.createArtifact} also returned {@code null}, and Aether
+ * surfaced a "Could not find artifact org.apache.grails.profiles:web:jar:" error
+ * (with an empty version) against {@code grails-override-repo}.
+ */
+class AbstractJarProfileRepositorySpec extends Specification {
+
+    private static AbstractJarProfileRepository newRepository() {
+        new StaticJarProfileRepository(Thread.currentThread().contextClassLoader, new URL[0])
+    }
+
+    void "getProfileArtifact defaults to the running Grails version when no settings are configured"() {
+        given: 'a profile repository with no grails.profiles settings'
+        def repo = newRepository()
+
+        when: 'a bare profile name is resolved'
+        Artifact art = repo.getProfileArtifact('web')
+
+        then: 'the artifact has the default group, the requested artifact id, and the running Grails version'
+        art.groupId == 'org.apache.grails.profiles'
+        art.artifactId == 'web'
+        art.version == Environment.grailsVersion
+        art.version != null
+        !art.version.isEmpty()
+    }
+
+    void "getProfileArtifact preserves an explicit GAV passed by the caller"() {
+        given:
+        def repo = newRepository()
+
+        when:
+        Artifact art = repo.getProfileArtifact('com.acme.profiles:custom-web:9.9.9')
+
+        then:
+        art.groupId == 'com.acme.profiles'
+        art.artifactId == 'custom-web'
+        art.version == '9.9.9'
+    }
+}


### PR DESCRIPTION
## Summary

Fixes profile resolution failure in the Grails CLI when `GRAILS_REPO_URL` points at an Apache staging repository (or any repository whose published BOM does not declare `org.apache.grails.profiles:*` coordinates).

This was hit by the **7.0.11 release manager** during the staging vote, with the release wrapper failing as:

```
Updated wrapper to version: 7.0.11
Grails repo url override detected, including repo: https://repository.apache.org/content/groups/staging
Resolving dependencies...
| Error Error occurred running Grails CLI: Could not find artifact org.apache.grails.profiles:web:jar: in grails-override-repo (https://repository.apache.org/content/groups/staging)
```

Note the **empty version** after `web:jar:`.

## Root cause

Two defects combine to produce the empty-version request:

1. `AbstractJarProfileRepository.getProfileArtifact` defaults the profile version to `null` and only fills it from user-supplied `grails.profiles` settings, which are absent in a clean release-manager test environment. The downstream `MavenResolverGrapeEngine.createArtifact` (line 170) then attempts to recover a BOM-managed version, but that fallback also returns `null` because of (2).
2. The published `grails-bom` / `grails-base-bom` `<dependencyManagement>` does not list any `org.apache.grails.profiles:*` coordinates. Profile subprojects apply `org.apache.grails.gradle.grails-profile`, which is not in the `publishedProject` filter in `grails-bom/base/build.gradle`.

## Fix

* **Default the profile artifact version to `Environment.grailsVersion`** in `AbstractJarProfileRepository`. Profiles are released in lock-step with grails-core since the monorepo move, so the CLI version is the correct profile version. User-supplied `grails.profiles` settings still override per profile.
* **Include the `grails-profile` plugin in the BOM's `publishedProject` filter** so the published `grails-bom` and `grails-base-bom` POMs declare profile coordinates in `<dependencyManagement>`. The default / hibernate5 / micronaut BOMs inherit constraints via `api platform(project(':grails-base-bom'))`, so a single edit propagates.
* **Add `AbstractJarProfileRepositorySpec`** with regression coverage for the version-default and explicit-GAV paths so this cannot recur silently.

## Verification

* `./gradlew :grails-shell-cli:compileGroovy :grails-shell-cli:compileTestGroovy` BUILD SUCCESSFUL
* `./gradlew :grails-shell-cli:test --tests "org.grails.cli.profile.repository.AbstractJarProfileRepositorySpec"` -> both specs **PASSED**
* `./gradlew :grails-base-bom:generatePomFileForMavenPublication` -> generated `pom-default.xml` `<dependencyManagement>` now declares all 7 profile coordinates: `org.apache.grails.profiles:{base,plugin,profile,rest-api,rest-api-plugin,web,web-plugin}`.
* Independent control: a separate Gradle-based 7.0.11 staging consumer build (`curl https://latest.grails.org/create/WEB/myapp`, `grailsVersion=7.0.11`, staging repo added to `build.gradle`) resolves all `org.apache.grails:*` artifacts at 7.0.11 and `./gradlew assemble` succeeds. Only the CLI/wrapper code path was affected by the bug fixed here, which matches expectations.

## Release note (suggested)

> Fixes a regression in the Grails CLI where `grails create-app` fails to resolve the `web` profile when `GRAILS_REPO_URL` points at a repository whose BOM does not declare `org.apache.grails.profiles:*` coordinates (e.g. an Apache staging repository before promotion). The CLI now falls back to the running Grails version for profile resolution, and the published BOM now declares profile coordinates so the existing dependency-management fallback also works.

## Notes for the release process

7.0.11 staging should be **dropped** and the release re-cut once this is merged - the CLI/wrapper path is unusable as-is for anyone testing 7.0.11 against the staged artifacts.

Assisted-by: claude-code:claude-opus-4