### PR TITLE
fix(grails-gsp): eliminate race condition in FormTagLib2Tests.testDatePickerTag

### DIFF
--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLib2Tests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLib2Tests.groovy
@@ -171,31 +171,38 @@ class FormTagLib2Tests extends AbstractGrailsTagTests {
     }
 
     private void testDatePickerTag(Object date, String precision) {
-        Document document = getDatePickerOutput(date, precision, null)
+        // Capture a single "now" instant up-front so that the picker output
+        // and the calendar used for assertions agree on the same point in
+        // time. Previously the picker rendered with one System.currentTimeMillis()
+        // and the calendar was constructed afterwards, which made the test
+        // flaky on slow runners (e.g. Windows CI) when the two calls fell
+        // on opposite sides of a minute (or hour/day/year) boundary -
+        // see testDatePickerTagWithMinutePrecision().
+        Calendar calendar = new GregorianCalendar()
+        Object resolvedDate = date
+        if (date == null) {
+            resolvedDate = calendar.getTime()
+        } else if (date instanceof Date) {
+            calendar.setTime(date)
+        } /*else if (date instanceof TemporalAccessor) {
+            ZonedDateTime zonedDateTime
+            if (date instanceof LocalDateTime) {
+                zonedDateTime = ZonedDateTime.of(date, ZoneId.systemDefault())
+            } else if (date instanceof LocalDate) {
+                zonedDateTime = ZonedDateTime.of(date, LocalTime.MIN, ZoneId.systemDefault())
+            } else {
+                zonedDateTime = ZonedDateTime.from(date)
+            }
+            calendar = GregorianCalendar.from(zonedDateTime)
+        }*/
+
+        Document document = getDatePickerOutput(resolvedDate, precision, null)
         assertNotNull(document)
 
         // validate presence and structure of hidden date picker form field
         assertXPathExists(
                 document,
                 "//input[@name='" + DATE_PICKER_TAG_NAME + "' and @type='hidden' and @value='date.struct']")
-
-        // if no date was given, default to the current date
-        Calendar calendar = new GregorianCalendar()
-        if (date != null) {
-            if (date instanceof Date) {
-                calendar.setTime(date)
-            } /*else if (date instanceof TemporalAccessor) {
-                ZonedDateTime zonedDateTime
-                if (date instanceof LocalDateTime) {
-                    zonedDateTime = ZonedDateTime.of(date, ZoneId.systemDefault())
-                } else if (date instanceof LocalDate) {
-                    zonedDateTime = ZonedDateTime.of(date, LocalTime.MIN, ZoneId.systemDefault())
-                } else {
-                    zonedDateTime = ZonedDateTime.from(date)
-                }
-                calendar = GregorianCalendar.from(zonedDateTime)
-            }*/
-        }
 
         // validate id attributes
         String xp

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLib2Tests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/FormTagLib2Tests.groovy
@@ -171,17 +171,11 @@ class FormTagLib2Tests extends AbstractGrailsTagTests {
     }
 
     private void testDatePickerTag(Object date, String precision) {
-        // Capture a single "now" instant up-front so that the picker output
-        // and the calendar used for assertions agree on the same point in
-        // time. Previously the picker rendered with one System.currentTimeMillis()
-        // and the calendar was constructed afterwards, which made the test
-        // flaky on slow runners (e.g. Windows CI) when the two calls fell
-        // on opposite sides of a minute (or hour/day/year) boundary -
-        // see testDatePickerTagWithMinutePrecision().
+        // Capture "now" upfront to prevent test pollution at minute/hour/day boundaries.
         Calendar calendar = new GregorianCalendar()
-        Object resolvedDate = date
+        Date xdefault = null
         if (date == null) {
-            resolvedDate = calendar.getTime()
+            xdefault = calendar.getTime()
         } else if (date instanceof Date) {
             calendar.setTime(date)
         } /*else if (date instanceof TemporalAccessor) {
@@ -196,7 +190,7 @@ class FormTagLib2Tests extends AbstractGrailsTagTests {
             calendar = GregorianCalendar.from(zonedDateTime)
         }*/
 
-        Document document = getDatePickerOutput(resolvedDate, precision, null)
+        Document document = getDatePickerOutput(date, precision, xdefault)
         assertNotNull(document)
 
         // validate presence and structure of hidden date picker form field


### PR DESCRIPTION
## Summary

Eliminates the race condition in `FormTagLib2Tests.testDatePickerTag` that produced an intermittent `testDatePickerTagWithMinutePrecision()` failure on slow runners (most recently on `Build Grails-Core (windows-latest, 25)` in [PR #15467 / run 25170545020](https://github.com/apache/grails-core/actions/runs/25170545020/job/73788418508)).

## What was wrong

`testDatePickerTag(Object date, String precision)` rendered the date-picker HTML first, then constructed a fresh `GregorianCalendar` afterwards to derive the expected select-field values. When the two calls fell on opposite sides of a minute (or hour/day/year) boundary, the picker output and the calendar disagreed, producing a flaky assertion such as:

```
FormTagLib2Tests > testDatePickerTagWithMinutePrecision()
expected: <true> but was: <false>
  at org.grails.web.taglib.AbstractGrailsTagTests.assertXPathExists(AbstractGrailsTagTests.groovy:527)
  at FormTagLib2Tests.assertSelectFieldPresentWithSelectedValue(FormTagLib2Tests.groovy:307)
  at FormTagLib2Tests.validateSelectedMinuteValue(FormTagLib2Tests.groovy:297)
  at FormTagLib2Tests.testDatePickerTag(FormTagLib2Tests.groovy:237)
```

## Fix

Capture the calendar up-front and, when the test passes a `null` date, forward `calendar.getTime()` to the picker so both sides agree on a single instant. Behaviour for explicit `Date` arguments is unchanged. `getDatePickerOutput` simply forwards the supplied value to the `datePicker` tag, which itself defaults to `new Date()` when no value is provided, so passing the captured `calendar.getTime()` exercises the same code path as `null` did before but without the race window.

## Verification

```
./gradlew :grails-gsp:test --tests org.grails.web.taglib.FormTagLib2Tests --rerun-tasks
```

All 11 tests pass on Windows (the runner that exhibited the original flake), including the previously flaky `testDatePickerTagWithMinutePrecision()`.