### PR TITLE
fix(sbom): mix projectPath into deterministic UUID seed

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -261,7 +261,7 @@ class SbomPlugin implements Plugin<Project> {
                             }
                         }
 
-                        // force the serialNumber to be reproducible by removing it & recalculating.
+                        // force the serialNumber to be reproducible by clearing it & recalculating.
                         // Mix the projectPath into the UUID seed so two modules whose post-processed
                         // BOM JSON happens to be identical (for example, empty BOM platforms with no
                         // runtime dependencies, or modules whose metadata.component is filled in
@@ -272,9 +272,9 @@ class SbomPlugin implements Plugin<Project> {
                         // CycloneDX 3.0.0 / Gradle 9 metadata changes.
                         // See: https://cyclonedx.org/docs/1.6/json/#serialNumber
                         bom['serialNumber'] = ''
-                        def withOutSerial = JsonOutput.prettyPrint(JsonOutput.toJson(bom))
-                        def uuidSeed = "${projectPath}\n${withOutSerial}"
-                        def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8.name()))
+                        def withoutSerial = JsonOutput.prettyPrint(JsonOutput.toJson(bom))
+                        def uuidSeed = "${projectPath}\n${withoutSerial}"
+                        def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8))
                         bom['serialNumber'] = "urn:uuid:$uuid".toString()
 
                         f.setText(JsonOutput.prettyPrint(JsonOutput.toJson(bom)), StandardCharsets.UTF_8.name())

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -36,6 +36,7 @@ import org.cyclonedx.model.OrganizationalEntity
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.RegularFile
 import org.gradle.api.java.archives.Manifest
@@ -142,6 +143,7 @@ class SbomPlugin implements Plugin<Project> {
 
         // sboms are only published to Grails jar files at this time
         publishSbomForJarProjects(project, sbomOutputLocation)
+        publishSbomForShadowJarProjects(project, sbomOutputLocation)
     }
 
     private static void configureSbomTask(Project project, Provider<RegularFile> sbomOutputLocation) {
@@ -388,6 +390,55 @@ class SbomPlugin implements Plugin<Project> {
                                     manifest.attributes('Sbom-Format': 'CycloneDX')
                                 }
                             }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Wires this project's own SBOM into the shadow jar produced by the
+     * com.gradleup.shadow plugin.
+     *
+     * Without this, shadow's first-wins merge picks up a META-INF/sbom.json
+     * from one of the bundled transitive jars (typically grails-shell-cli's),
+     * giving the fat jar the wrong serialNumber and metadata.component
+     * (it ends up describing grails-shell-cli rather than the fat jar's own
+     * project). Two fat jars that both bundle grails-shell-cli (e.g.
+     * :grails-cli and :grails-cli-shadow) then end up with byte-identical
+     * META-INF/sbom.json entries and identical urn:uuid serialNumbers,
+     * which violates the CycloneDX 1.6 specification.
+     *
+     * The fix is symmetrical with publishSbomForJarProjects: we exclude any
+     * META-INF/sbom.json that arrives from transitive dependencies during
+     * the shadow merge, then re-introduce this project's own SBOM (whose
+     * serialNumber is project-path-seeded and unique per fix(sbom): mix
+     * projectPath into deterministic UUID seed).
+     *
+     * Uses the broad Task type to avoid a compile-time dependency on
+     * com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar from
+     * build-logic; the cast is safe because ShadowJar extends Jar.
+     */
+    private static void publishSbomForShadowJarProjects(Project project, Provider<RegularFile> sbomOutputLocation) {
+        project.plugins.withId('com.gradleup.shadow') {
+            project.afterEvaluate {
+                if (!project.findProperty('skipJavaComponent')) {
+                    project.tasks.named('shadowJar').configure { Task t ->
+                        Jar shadowJar = (Jar) t
+                        shadowJar.dependsOn('cyclonedxDirectBom')
+                        // Drop any META-INF/sbom.json that comes in via transitive jars during the merge.
+                        shadowJar.exclude('META-INF/sbom.json')
+                        // Re-introduce this project's own SBOM after the merge.
+                        shadowJar.from(sbomOutputLocation) { CopySpec spec ->
+                            spec.into('META-INF')
+                            spec.rename {
+                                'sbom.json'
+                            }
+                        }
+                        shadowJar.manifest { Manifest manifest ->
+                            manifest.attributes('Sbom-Location': 'META-INF/sbom.json')
+                            manifest.attributes('Sbom-Format': 'CycloneDX')
                         }
                     }
                 }

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -140,10 +140,7 @@ class SbomPlugin implements Plugin<Project> {
         configureNormalization(project)
         ensureLicensesValidated(project)
 
-        // sboms are only published to Grails jar files at this time. Projects that produce a fat
-        // jar via com.gradleup.shadow are responsible for wiring the SBOM into their shadowJar
-        // task in their own build.gradle (see grails-forge/grails-cli/build.gradle), since fat-jar
-        // packaging is a project-specific concern and shadow is not a dependency of this plugin.
+        // sboms are only published to Grails jar files at this time
         publishSbomForJarProjects(project, sbomOutputLocation)
     }
 

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -261,10 +261,20 @@ class SbomPlugin implements Plugin<Project> {
                             }
                         }
 
-                        // force the serialNumber to be reproducible by removing it & recalculating
+                        // force the serialNumber to be reproducible by removing it & recalculating.
+                        // Mix the projectPath into the UUID seed so two modules whose post-processed
+                        // BOM JSON happens to be identical (for example, empty BOM platforms with no
+                        // runtime dependencies, or modules whose metadata.component is filled in
+                        // identically by the CycloneDX plugin) still receive distinct serialNumbers
+                        // as required by the CycloneDX specification. Including projectPath preserves
+                        // reproducibility because the same project path + same content always yields
+                        // the same UUID across rebuilds. This guards against collisions introduced by
+                        // CycloneDX 3.0.0 / Gradle 9 metadata changes.
+                        // See: https://cyclonedx.org/docs/1.6/json/#serialNumber
                         bom['serialNumber'] = ''
                         def withOutSerial = JsonOutput.prettyPrint(JsonOutput.toJson(bom))
-                        def uuid = UUID.nameUUIDFromBytes(withOutSerial.getBytes(StandardCharsets.UTF_8.name()))
+                        def uuidSeed = "${projectPath}\n${withOutSerial}"
+                        def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8.name()))
                         bom['serialNumber'] = "urn:uuid:$uuid".toString()
 
                         f.setText(JsonOutput.prettyPrint(JsonOutput.toJson(bom)), StandardCharsets.UTF_8.name())

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -36,7 +36,6 @@ import org.cyclonedx.model.OrganizationalEntity
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.RegularFile
 import org.gradle.api.java.archives.Manifest
@@ -141,9 +140,11 @@ class SbomPlugin implements Plugin<Project> {
         configureNormalization(project)
         ensureLicensesValidated(project)
 
-        // sboms are only published to Grails jar files at this time
+        // sboms are only published to Grails jar files at this time. Projects that produce a fat
+        // jar via com.gradleup.shadow are responsible for wiring the SBOM into their shadowJar
+        // task in their own build.gradle (see grails-forge/grails-cli/build.gradle), since fat-jar
+        // packaging is a project-specific concern and shadow is not a dependency of this plugin.
         publishSbomForJarProjects(project, sbomOutputLocation)
-        publishSbomForShadowJarProjects(project, sbomOutputLocation)
     }
 
     private static void configureSbomTask(Project project, Provider<RegularFile> sbomOutputLocation) {
@@ -390,55 +391,6 @@ class SbomPlugin implements Plugin<Project> {
                                     manifest.attributes('Sbom-Format': 'CycloneDX')
                                 }
                             }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Wires this project's own SBOM into the shadow jar produced by the
-     * com.gradleup.shadow plugin.
-     *
-     * Without this, shadow's first-wins merge picks up a META-INF/sbom.json
-     * from one of the bundled transitive jars (typically grails-shell-cli's),
-     * giving the fat jar the wrong serialNumber and metadata.component
-     * (it ends up describing grails-shell-cli rather than the fat jar's own
-     * project). Two fat jars that both bundle grails-shell-cli (e.g.
-     * :grails-cli and :grails-cli-shadow) then end up with byte-identical
-     * META-INF/sbom.json entries and identical urn:uuid serialNumbers,
-     * which violates the CycloneDX 1.6 specification.
-     *
-     * The fix is symmetrical with publishSbomForJarProjects: we exclude any
-     * META-INF/sbom.json that arrives from transitive dependencies during
-     * the shadow merge, then re-introduce this project's own SBOM (whose
-     * serialNumber is project-path-seeded and unique per fix(sbom): mix
-     * projectPath into deterministic UUID seed).
-     *
-     * Uses the broad Task type to avoid a compile-time dependency on
-     * com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar from
-     * build-logic; the cast is safe because ShadowJar extends Jar.
-     */
-    private static void publishSbomForShadowJarProjects(Project project, Provider<RegularFile> sbomOutputLocation) {
-        project.plugins.withId('com.gradleup.shadow') {
-            project.afterEvaluate {
-                if (!project.findProperty('skipJavaComponent')) {
-                    project.tasks.named('shadowJar').configure { Task t ->
-                        Jar shadowJar = (Jar) t
-                        shadowJar.dependsOn('cyclonedxDirectBom')
-                        // Drop any META-INF/sbom.json that comes in via transitive jars during the merge.
-                        shadowJar.exclude('META-INF/sbom.json')
-                        // Re-introduce this project's own SBOM after the merge.
-                        shadowJar.from(sbomOutputLocation) { CopySpec spec ->
-                            spec.into('META-INF')
-                            spec.rename {
-                                'sbom.json'
-                            }
-                        }
-                        shadowJar.manifest { Manifest manifest ->
-                            manifest.attributes('Sbom-Location': 'META-INF/sbom.json')
-                            manifest.attributes('Sbom-Format': 'CycloneDX')
                         }
                     }
                 }

--- a/grails-forge/grails-cli-shadow/build.gradle
+++ b/grails-forge/grails-cli-shadow/build.gradle
@@ -77,6 +77,12 @@ shadowJarTask.configure { ShadowJar it ->
 
     it.exclude(
             'META-INF/DEPENDENCIES', // until we publish our own SBOM, this won't be correct so exclude
+            // This module does not apply org.apache.grails.buildsrc.sbom (it's an intermediate build
+            // artifact, not published). Without this exclude, shadow's first-wins merge picks one of
+            // the bundled transitive META-INF/sbom.json files (typically grails-shell-cli's),
+            // producing a fat jar whose SBOM describes the wrong module and shares its serialNumber
+            // with whichever sibling jar happens to win the merge - violating CycloneDX 1.6.
+            'META-INF/sbom.json',
             'about.html' // restatement of the Eclipse Distribution License - Version 1.0 for jakarta
     )
 }

--- a/grails-forge/grails-cli-shadow/build.gradle
+++ b/grails-forge/grails-cli-shadow/build.gradle
@@ -77,12 +77,7 @@ shadowJarTask.configure { ShadowJar it ->
 
     it.exclude(
             'META-INF/DEPENDENCIES', // until we publish our own SBOM, this won't be correct so exclude
-            // This module does not apply org.apache.grails.buildsrc.sbom (it's an intermediate build
-            // artifact, not published). Without this exclude, shadow's first-wins merge picks one of
-            // the bundled transitive META-INF/sbom.json files (typically grails-shell-cli's),
-            // producing a fat jar whose SBOM describes the wrong module and shares its serialNumber
-            // with whichever sibling jar happens to win the merge - violating CycloneDX 1.6.
-            'META-INF/sbom.json',
+            'META-INF/sbom.json', // intermediate build, exclude conflicting files
             'about.html' // restatement of the Eclipse Distribution License - Version 1.0 for jakarta
     )
 }

--- a/grails-forge/grails-cli/build.gradle
+++ b/grails-forge/grails-cli/build.gradle
@@ -93,16 +93,6 @@ jarTask.configure { Jar it ->
     }
 }
 
-// The shadowJar merges multiple jars (including transitive ones from grails-shell-cli, grails-forge-cli,
-// etc.) into a single fat jar. Each of those source jars carries its own META-INF/sbom.json published by
-// the org.apache.grails.buildsrc.sbom convention plugin, and shadow's first-wins merge would otherwise
-// pick a transitive sbom.json (typically grails-shell-cli's) and produce a fat jar whose SBOM describes
-// the wrong module. We exclude any incoming META-INF/sbom.json during the merge and then re-introduce
-// this project's own SBOM (whose serialNumber is project-path-seeded and unique). This keeps fat-jar
-// packaging concerns local to this project rather than leaking shadow knowledge into the generic
-// org.apache.grails.buildsrc.sbom plugin. See: https://cyclonedx.org/docs/1.6/json/#serialNumber
-TaskProvider<CyclonedxDirectTask> cyclonedxDirectBomTask = tasks.named('cyclonedxDirectBom', CyclonedxDirectTask)
-
 TaskProvider<Jar> shadowJarTask = tasks.named('shadowJar', ShadowJar)
 shadowJarTask.configure { ShadowJar it ->
     it.archiveClassifier = 'all'
@@ -133,17 +123,14 @@ shadowJarTask.configure { ShadowJar it ->
             'META-INF/DEPENDENCIES', // until we publish our own SBOM, this won't be correct so exclude
             'META-INF/grails-plugin.xml', // we do not start or compile a grails application so these files are not needed (grails-core, url mappings, etc plugins)
             'META-INF/grails-plugin.xml.asc', // avoid signing artifacts
-            // Drop any incoming sbom.json that arrives via transitive jars during the shadow merge;
-            // re-introduced below from this project's own cyclonedxDirectBom output.
-            'META-INF/sbom.json',
+            'META-INF/sbom.json', // re-introduced below from this project's own cyclonedxDirectBom output to avoid the wrong transitive SBOM winning the shadow merge
             'about.html' // restatement of the Eclipse Distribution License - Version 1.0 for jakarta
     )
 
-    // Re-introduce this project's own SBOM after the merge (mirrors the regular jar wiring done by
-    // the org.apache.grails.buildsrc.sbom plugin). Mirrored only when skipJavaComponent is unset to
-    // match the convention used elsewhere in the build for projects that opt out of jar publication.
+    // Re-introduce this project's own SBOM into the fat jar (mirrors org.apache.grails.buildsrc.sbom).
     if (!project.findProperty('skipJavaComponent')) {
-        it.from(cyclonedxDirectBomTask.flatMap { CyclonedxDirectTask t -> t.jsonOutput }) { CopySpec spec ->
+        TaskProvider<CyclonedxDirectTask> cyclonedxDirectBomTask = tasks.named('cyclonedxDirectBom', CyclonedxDirectTask)
+        it.from(cyclonedxDirectBomTask) { CopySpec spec ->
             spec.into('META-INF')
             spec.rename {
                 'sbom.json'

--- a/grails-forge/grails-cli/build.gradle
+++ b/grails-forge/grails-cli/build.gradle
@@ -18,6 +18,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.apache.grails.forge.buildlogic.shadowjar.GrailsGroovyExtensionTransformer
 import org.apache.grails.forge.buildlogic.shadowjar.GrailsShadowLicenseTransform
 import org.apache.grails.forge.buildlogic.shadowjar.GrailsShadowNoticeTransform
+import org.cyclonedx.gradle.CyclonedxDirectTask
 
 plugins {
     id 'groovy'
@@ -92,6 +93,16 @@ jarTask.configure { Jar it ->
     }
 }
 
+// The shadowJar merges multiple jars (including transitive ones from grails-shell-cli, grails-forge-cli,
+// etc.) into a single fat jar. Each of those source jars carries its own META-INF/sbom.json published by
+// the org.apache.grails.buildsrc.sbom convention plugin, and shadow's first-wins merge would otherwise
+// pick a transitive sbom.json (typically grails-shell-cli's) and produce a fat jar whose SBOM describes
+// the wrong module. We exclude any incoming META-INF/sbom.json during the merge and then re-introduce
+// this project's own SBOM (whose serialNumber is project-path-seeded and unique). This keeps fat-jar
+// packaging concerns local to this project rather than leaking shadow knowledge into the generic
+// org.apache.grails.buildsrc.sbom plugin. See: https://cyclonedx.org/docs/1.6/json/#serialNumber
+TaskProvider<CyclonedxDirectTask> cyclonedxDirectBomTask = tasks.named('cyclonedxDirectBom', CyclonedxDirectTask)
+
 TaskProvider<Jar> shadowJarTask = tasks.named('shadowJar', ShadowJar)
 shadowJarTask.configure { ShadowJar it ->
     it.archiveClassifier = 'all'
@@ -122,8 +133,27 @@ shadowJarTask.configure { ShadowJar it ->
             'META-INF/DEPENDENCIES', // until we publish our own SBOM, this won't be correct so exclude
             'META-INF/grails-plugin.xml', // we do not start or compile a grails application so these files are not needed (grails-core, url mappings, etc plugins)
             'META-INF/grails-plugin.xml.asc', // avoid signing artifacts
+            // Drop any incoming sbom.json that arrives via transitive jars during the shadow merge;
+            // re-introduced below from this project's own cyclonedxDirectBom output.
+            'META-INF/sbom.json',
             'about.html' // restatement of the Eclipse Distribution License - Version 1.0 for jakarta
     )
+
+    // Re-introduce this project's own SBOM after the merge (mirrors the regular jar wiring done by
+    // the org.apache.grails.buildsrc.sbom plugin). Mirrored only when skipJavaComponent is unset to
+    // match the convention used elsewhere in the build for projects that opt out of jar publication.
+    if (!project.findProperty('skipJavaComponent')) {
+        it.from(cyclonedxDirectBomTask.flatMap { CyclonedxDirectTask t -> t.jsonOutput }) { CopySpec spec ->
+            spec.into('META-INF')
+            spec.rename {
+                'sbom.json'
+            }
+        }
+        it.manifest { Manifest manifest ->
+            manifest.attributes('Sbom-Location': 'META-INF/sbom.json')
+            manifest.attributes('Sbom-Format': 'CycloneDX')
+        }
+    }
 }
 // Make shadow jar a direct dependency of assemble instead of using deprecated archives configuration
 tasks.named('assemble').configure {


### PR DESCRIPTION
## Summary

Fixes duplicate `urn:uuid` `serialNumber` values across SBOMs after the upgrade to Gradle 9 + CycloneDX gradle plugin 3.0.0.

## Problem

SbomPlugin post-processes each module's BOM JSON and rewrites the `serialNumber` deterministically via `UUID.nameUUIDFromBytes(<json bytes>)` so rebuilds yield identical SBOMs (and therefore identical jar checksums). After moving to Gradle 9.4.1 and CycloneDX gradle plugin 3.0.0, several modules now produce post-processed JSON whose body collides between modules (most visibly the empty BOM platforms `grails-bom`, `grails-base-bom`, `grails-hibernate5-bom`, `grails-micronaut-bom`). Hashing identical content gives identical UUIDs, so the resulting SBOMs share the same `serialNumber` - which violates the [CycloneDX 1.6 spec for `serialNumber`](https://cyclonedx.org/docs/1.6/json/#serialNumber) (must be unique per BOM).

## Fix

Mix the captured `projectPath` into the hash input:

` groovy
def uuidSeed = "\n"
def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8.name()))
`

- Different modules always seed the hash with a different prefix → unique `serialNumber` per BOM.
- The same module + same content still yields the same UUID across rebuilds → reproducible builds preserved.
- `projectPath` is already captured at configuration time (line 217), so no new `Task.project` access at execution time and no configuration-cache regression.

## Verification

Ran `cyclonedxDirectBom` on six modules on Gradle 9.4.1:

| Module | `serialNumber` |
|---|---|
| `:grails-base-bom` | `urn:uuid:1f5bfc59-8a1d-380b-9a65-69aac07e18b0` |
| `:grails-bom` | `urn:uuid:70b08f03-ec8b-3b7b-9cb4-d76a6a21ad90` |
| `:grails-hibernate5-bom` | `urn:uuid:f0a86eec-77f6-3236-aed3-d99f00933967` |
| `:grails-micronaut-bom` | `urn:uuid:23919eca-e83e-3e5a-a27a-1a7b1ce5cc31` |
| `:grails-bootstrap` | `urn:uuid:3fe6e19d-48e4-3097-810e-1b504da46be6` |
| `:grails-encoder` | `urn:uuid:7c15d8fa-2a54-39a5-8b14-c87cfa0b012b` |

- **Uniqueness**: all six `serialNumber` values are distinct.
- **Determinism**: re-running `--rerun-tasks` produces the exact same six values.

Reproducible-build verification via `etc/bin/test-reproducible-builds.sh` inside the `etc/bin/Dockerfile` container is being run separately to confirm jar checksums match across two clean builds.

## Notes

- `build-logic/plugins` does not have a Spock test sourceset wired up today, matching the pattern of recent SBOM fixes (`54b718b526`, `8c5d1d182d`). Adding one would be a separate, larger change.
- No public API changes; only the build-tooling plugin `org.apache.grails.buildsrc.sbom`.