### PR TITLE
Add `settings.gradle` file to wrapper Forge verification app

### DIFF
--- a/etc/bin/verify-wrapper-distribution.sh
+++ b/etc/bin/verify-wrapper-distribution.sh
@@ -90,7 +90,7 @@ echo "Checking wrapper shell command ..."
 ./grailsw -t shell create-app ShellApp
 echo "✅ Generated Shell App"
 echo "Checking forge command"
-./grailsw -t forge create-app -x -g mongodb ForgeApp
+./grailsw -t forge create-app -x -g mongodb -f gradle-settings-file ForgeApp
 echo "✅ Generated Forge App"
 
 echo "✅✅✅ All wrapper binary distribution checks passed successfully for Apache Grails ${VERSION}."


### PR DESCRIPTION
Enables running inside `grails-core/download`.
This was previously added to the cli verification script.

Related: gh-15546