### PR TITLE
docs: fix typos in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -136,7 +136,7 @@ Example:
 ```
 
 ### Manual Verification: Reproducible Jar Files
-After all jar files are verified to be signed by a valid Grails key, we need to build a local copy to ensure the file was built with the right code base. The `very-reproducible.sh` script handles this check, but if the bootstrap needs to be manually bootstrapped, perform the following step: 
+After all jar files are verified to be signed by a valid Grails key, we need to build a local copy to ensure the file was built with the right code base. The `verify-reproducible.sh` script handles this check, but if the bootstrap needs to be manually bootstrapped, perform the following step: 
 
     gradle -p gradle-bootstrap
 
@@ -288,7 +288,7 @@ an example call to the checked in script to move the distributions.
 After moving the distributions, you will receive an email from the ASF reporter. Click the link in the email to mark the
 release as published or go to https://reporter.apache.org/addrelease.html?grails. The `release` job in the `Release` workflow has a step to remind you of this.
 
-For example, if the release is out of core with version `7.0.0-M4`, then the release name with be `CORE-7.0.0-M4`. Enter
+For example, if the release is out of core with version `7.0.0-M4`, then the release name will be `CORE-7.0.0-M4`. Enter
 the date you moved the distribution artifacts and report the release.
 
 ### Deploy the release to Grails Forge
@@ -383,7 +383,7 @@ Setup the key for validity:
 # Appendix: Verification from a Container
 
 The Grails image is officially built on linux in a GitHub action using an Ubuntu container. To run a linux container
-locally, you can use the following command (substitute `<git-tag-of-release` with the tag name):
+locally, you can use the following command (substitute `<git-tag-of-release>` with the tag name):
 
 **macOS/Linux**
 ```bash


### PR DESCRIPTION
## Summary

Three small typo fixes in `RELEASE.md`. No version examples are touched - per reviewer feedback, the file should not track the current release version, so the existing `v7.0.0-M4` / `7.0.x` examples are left as illustrative tags.

## Changes

- `Manual Verification: Reproducible Jar Files` referenced a non-existent script `very-reproducible.sh`. Corrected to the actual `verify-reproducible.sh`.
- `Update ASF Reporter` had a small typo: `with be` -> `will be`.
- `Appendix: Verification from a Container` had an unbalanced backtick in `` `<git-tag-of-release` ``. Closed the placeholder.

## History

This PR previously also bumped every worked example from `v7.0.0-M4` / `7.0.x` to `v8.0.0-M1` / `8.0.x` and changed the manual gradle-bootstrap example from `gradle -p gradle-bootstrap` to `cd gradle-bootstrap && gradle`. Both have been reverted on @jdaugherty's review:

- RELEASE.md is not a per-release document, so the example tag stays as `v7.0.0-M4`.
- `gradle -p gradle-bootstrap` and `cd gradle-bootstrap && gradle` are functionally identical (`-p` is the standard `--project-dir`), so the doc form does not need to change.
