### PR TITLE
fix: enforce LF line endings for shell scripts, gradlew, KEYS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Git auto-detects text vs binary; text files are stored as LF in the index.
+* text=auto
+
+# Files that MUST be LF on every platform.
+# Shell scripts, the Gradle wrapper launcher, the published KEYS file, and the
+# Dockerfile all run on Linux during release verification. CRLF in any of them
+# breaks the verification flow (kernel rejects scripts with bash\r shebangs and
+# verify-keys.sh fails the byte-for-byte SVN comparison).
+*.sh           text eol=lf
+gradlew        text eol=lf
+KEYS           text eol=lf
+Dockerfile     text eol=lf
+*.properties   text eol=lf
+
+# Files that MUST be CRLF (Windows scripts).
+*.bat          text eol=crlf
+*.cmd          text eol=crlf
+gradlew.bat    text eol=crlf
+
+# Common binary types - never normalize.
+*.jar          binary
+*.zip          binary
+*.gz           binary
+*.tgz          binary
+*.7z           binary
+*.png          binary
+*.jpg          binary
+*.jpeg         binary
+*.gif          binary
+*.ico          binary
+*.pdf          binary
+*.p12          binary
+*.gpg          binary
+*.keystore     binary
+*.class        binary
+*.so           binary
+*.dylib        binary
+*.dll          binary

--- a/etc/bin/Dockerfile
+++ b/etc/bin/Dockerfile
@@ -38,6 +38,15 @@ ADD --chown=groovy gradlew /home/groovy/scripts
 ADD --chown=groovy KEYS /home/groovy/scripts
 ADD --chown=groovy gradle/wrapper/gradle-wrapper.jar /home/groovy/scripts/gradle/wrapper
 ADD --chown=groovy gradle/wrapper/gradle-wrapper.properties /home/groovy/scripts/gradle/wrapper
+
+# Defensive line-ending normalization. The repository's .gitattributes pins
+# shell scripts, gradlew, KEYS, and the Dockerfile to LF on every platform, but
+# committers with a pre-existing local checkout under core.autocrlf=true may
+# still feed CRLF into the build context. Linux refuses scripts with bash\r
+# shebangs and verify-keys.sh would fail the byte-for-byte SVN comparison.
+# Strip CRs from any text file that must be LF on Linux.
+RUN find /home/groovy/scripts -type f \( -name '*.sh' -o -name 'gradlew' -o -name 'KEYS' -o -name '*.properties' \) -exec sed -i 's/\r$//' {} \;
+
 ENV PATH="/home/groovy/scripts:/home/groovy/scripts/etc/bin:$PATH"
 ENV CI=true
 ENV LANG=C.UTF-8


### PR DESCRIPTION
## Summary

7.0.x companion to apache/grails-core#15620. Pin the line endings of shell scripts, `gradlew`, `KEYS`, and the Dockerfile to LF on every platform, and add a defensive `sed` strip step in `etc/bin/Dockerfile`, so the release verification container is reproducible from a Windows committer's checkout.

## Why

There is no `.gitattributes` in the repo today. With Git for Windows' default `core.autocrlf=true`, every Windows checkout converts these files from LF to CRLF in the working tree. The Dockerfile's `ADD` then preserves the CRLF into the image, which produces three independent failures during release verification:

1. The Linux kernel refuses to execute scripts with `bash\r` in the shebang, so `gradlew` and every `verify-*.sh` script fail with `cannot execute: required file not found` / `/usr/bin/env: 'bash\r': No such file or directory`.
2. `verify-keys.sh` shasum-512s the in-tree `KEYS` file and compares against the canonical copy at `https://dist.apache.org/repos/dist/release/grails/KEYS`. The two byte-streams differ by exactly one `\r` per line (52 bytes total) and the comparison fails even though the content is byte-identical after normalization.
3. By extension, `verify.sh` aborts at its first step (`verify-keys.sh`) on any Windows committer's machine. The container documented in `RELEASE.md` is unusable as-is.

CI on `ubuntu-latest` and any Linux/macOS verifier are unaffected. The bug is only visible to a Windows committer because git's checkout-time conversion is the layer that introduces the corruption.

The line-ending bug exists identically on 7.0.x: `etc/bin/Dockerfile` and the `verify-*.sh` scripts are byte-for-byte the same as on 8.0.x (the only Dockerfile delta between branches is the JDK version - `17.0.18` here vs `21.0.7` on 8.0.x), and 7.0.x has the same identical missing-`.gitattributes` situation.

## Why fix this at the `.gitattributes` layer

`.gitattributes` is the only mechanism in the repo that operates at git's working-tree write path. Other code-style mechanisms either don't run at the right time or don't cover the right files:

| Tool | Audits `*.sh` / `gradlew` / `KEYS`? | Runs at checkout? |
|---|---|---|
| `.editorconfig` (existing - groovy/java only) | No | No (editor-time) |
| Checkstyle / `codeStyle` task | No (Java/Groovy only) | No (build-time) |
| CodeNarc | No (Groovy only; LineEnding rule not enabled) | No (build-time) |
| `.gitattributes` (this PR) | Yes | **Yes** |

## Changes

### `.gitattributes` (new)

- `* text=auto` - sane default; git auto-detects text vs binary, stores text as LF in the index
- `*.sh`, `gradlew`, `KEYS`, `Dockerfile`, `*.properties` -> `text eol=lf` (must be LF on Linux verifier and CI)
- `*.bat`, `*.cmd`, `gradlew.bat` -> `text eol=crlf` (must be CRLF on Windows)
- Common binary types (`*.jar`, `*.zip`, `*.png`, `*.pdf`, `*.gpg`, `*.keystore`, ...) marked `binary` so git never normalizes them

### `etc/bin/Dockerfile`

Add a `RUN sed -i 's/\r$//'` step after the `ADD` lines, scoped to `*.sh`, `gradlew`, `KEYS`, and `*.properties`. This is belt-and-braces: even if a committer's working tree still has CRLF (because their local checkout predates this PR and they have not re-checked-out / renormalized), the image they build will still be correct.

## Index impact

Verified ahead of time on the 7.0.x worktree:

`
$ git ls-files --eol gradlew etc/bin/verify.sh KEYS gradlew.bat etc/bin/Dockerfile
i/lf    w/lf    attr/text eol=lf       KEYS
i/lf    w/lf    attr/text eol=lf       etc/bin/Dockerfile
i/lf    w/lf    attr/text eol=lf       etc/bin/verify.sh
i/lf    w/lf    attr/text eol=lf       gradlew
i/crlf  w/crlf  attr/text eol=crlf     gradlew.bat
`

Every affected file is **already LF in the index**. This PR therefore does not require `git add --renormalize .` and does not produce any blob churn - it only changes what `git checkout` writes to disk on the next checkout, and pins the contract going forward.

## Related

- Companion PR: apache/grails-core#15620 (same fix on `8.0.x`).

With both PRs merged, the container verification flow is reproducible on every platform for both the 7.0.x maintenance line and the 8.0.x development line.