### PR TITLE
fix: make SBOM and groovydoc output reproducible across CI and local builds

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -25,8 +25,9 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import org.cyclonedx.gradle.CyclonedxPlugin
+import org.cyclonedx.gradle.CyclonedxAggregateTask
 import org.cyclonedx.gradle.CyclonedxDirectTask
+import org.cyclonedx.gradle.CyclonedxPlugin
 import org.cyclonedx.model.Component
 import org.cyclonedx.model.ExternalReference
 import org.cyclonedx.model.License
@@ -147,6 +148,7 @@ class SbomPlugin implements Plugin<Project> {
         )
 
         configureSbomTask(project, sbomOutputLocation)
+        configureAggregateSbomReproducibility(project)
         configureNormalization(project)
         ensureLicensesValidated(project)
 
@@ -228,75 +230,97 @@ class SbomPlugin implements Plugin<Project> {
                 Provider<Boolean> isReproducibleBuildProvider = project.provider { lookupProperty(project, 'isReproducibleBuild') as boolean }
                 Provider<ZonedDateTime> buildDateProvider = project.provider { lookupProperty(project, 'buildDate') as ZonedDateTime }
                 doLast {
-                    // json schema is documented here: https://cyclonedx.org/docs/1.6/json/
-                    def rewriteSbom = { File f ->
-                        def bom = new JsonSlurper().parse(f)
-
-                        // timestamp is not reproducible: https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/292
-                        // Use a fixed epoch when SOURCE_DATE_EPOCH is not set so the SBOM is identical between
-                        // builds. This prevents the non-reproducible timestamp from changing the jar checksum
-                        // and cascading cache misses through the compile classpath of downstream projects.
-                        ZonedDateTime sbomTimestamp = isReproducibleBuildProvider.get() ?
-                                buildDateProvider.get() :
-                                Instant.EPOCH.atZone(ZoneOffset.UTC)
-                        bom['metadata']['timestamp'] = DateTimeFormatter.ISO_INSTANT.format(sbomTimestamp.truncatedTo(ChronoUnit.SECONDS))
-
-                        // components[*]
-                        def comps = (bom instanceof Map && bom.components instanceof List) ? bom.components : []
-                        comps.each { c ->
-                            // .licenses => choose a license that is compatible with ASF policy if multiple licensed
-                            if (c instanceof Map && c.licenses instanceof List && !(c.licenses as List).empty) {
-                                def chosen = pickLicense(logger, projectName, c['bom-ref'] as String, c.licenses as List)
-                                if (chosen != null) {
-                                    c.licenses = [chosen]
-                                }
-                            }
-
-                            // .hashes => project hashes are only generated if the jar file has been created,
-                            // which with a parallel build may not have occurred, so for any dependency that is a
-                            // project we exclude them
-                            if (c instanceof Map && c.hashes instanceof List && !(c.hashes as List).empty) {
-                                def componentPath = c['bom-ref'] as String
-                                if (componentPath.contains('?project_path=')) {
-                                    c.remove('hashes')
-                                }
-                            }
-                        }
-
-                        // dependencies[*].dependsOn is not reproducible, so sort it
-                        def dependencies = (bom instanceof Map && bom.dependencies instanceof List) ? bom.dependencies : []
-                        dependencies.each { d ->
-                            if (d instanceof Map && d.dependsOn instanceof List && !(d.dependsOn as List).empty) {
-                                d.dependsOn = (d.dependsOn as List).sort()
-                            }
-                        }
-
-                        // force the serialNumber to be reproducible by clearing it & recalculating.
-                        // Mix the projectPath into the UUID seed so two modules whose post-processed
-                        // BOM JSON happens to be identical (for example, empty BOM platforms with no
-                        // runtime dependencies, or modules whose metadata.component is filled in
-                        // identically by the CycloneDX plugin) still receive distinct serialNumbers
-                        // as required by the CycloneDX specification. Including projectPath preserves
-                        // reproducibility because the same project path + same content always yields
-                        // the same UUID across rebuilds. This guards against collisions introduced by
-                        // CycloneDX 3.0.0 / Gradle 9 metadata changes.
-                        // See: https://cyclonedx.org/docs/1.6/json/#serialNumber
-                        bom['serialNumber'] = ''
-                        def withoutSerial = JsonOutput.prettyPrint(JsonOutput.toJson(bom))
-                        def uuidSeed = "${projectPath}\n${withoutSerial}"
-                        def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8))
-                        bom['serialNumber'] = "urn:uuid:$uuid".toString()
-
-                        f.setText(JsonOutput.prettyPrint(JsonOutput.toJson(bom)), StandardCharsets.UTF_8.name())
-
-                        logger.info('Rewrote JSON SBOM ({}) to pick preferred license', projectPath)
+                    ZonedDateTime sbomTimestamp = isReproducibleBuildProvider.get() ?
+                            buildDateProvider.get() :
+                            Instant.EPOCH.atZone(ZoneOffset.UTC)
+                    sbomOutputLocation.get().with {
+                        rewriteSbomFile(it.asFile, logger, projectName, projectPath, sbomTimestamp,
+                                ['build-system'] as Set<String>)
                     }
-
-                    sbomOutputLocation.get().with { rewriteSbom(it.asFile) }
                 }
 
             }
         }
+    }
+
+    private static void configureAggregateSbomReproducibility(Project project) {
+        project.tasks.withType(CyclonedxAggregateTask).configureEach { CyclonedxAggregateTask task ->
+            String projectName = project.name
+            String projectPath = project.path
+            Provider<Boolean> isReproducibleBuildProvider = project.provider { lookupProperty(project, 'isReproducibleBuild') as boolean }
+            Provider<ZonedDateTime> buildDateProvider = project.provider { lookupProperty(project, 'buildDate') as ZonedDateTime }
+            task.doLast {
+                if (!task.jsonOutput.isPresent()) {
+                    return
+                }
+                ZonedDateTime sbomTimestamp = isReproducibleBuildProvider.get() ?
+                        buildDateProvider.get() :
+                        Instant.EPOCH.atZone(ZoneOffset.UTC)
+                rewriteSbomFile(task.jsonOutput.get().asFile, task.logger, projectName, projectPath,
+                        sbomTimestamp, ['build-system', 'vcs'] as Set<String>)
+            }
+        }
+    }
+
+    @CompileDynamic
+    private static void rewriteSbomFile(
+            File f,
+            org.gradle.api.logging.Logger logger,
+            String projectName,
+            String projectPath,
+            ZonedDateTime sbomTimestamp,
+            Set<String> externalRefTypesToStrip) {
+        def bom = new JsonSlurper().parse(f)
+
+        bom['metadata']['timestamp'] = DateTimeFormatter.ISO_INSTANT.format(sbomTimestamp.truncatedTo(ChronoUnit.SECONDS))
+
+        def comps = (bom instanceof Map && bom.components instanceof List) ? bom.components : []
+        comps.each { c ->
+            if (c instanceof Map && c.licenses instanceof List && !(c.licenses as List).empty) {
+                def chosen = pickLicense(logger, projectName, c['bom-ref'] as String, c.licenses as List)
+                if (chosen != null) {
+                    c.licenses = [chosen]
+                }
+            }
+
+            if (c instanceof Map && c.hashes instanceof List && !(c.hashes as List).empty) {
+                def componentPath = c['bom-ref'] as String
+                if (componentPath.contains('?project_path=')) {
+                    c.remove('hashes')
+                }
+            }
+        }
+
+        def dependencies = (bom instanceof Map && bom.dependencies instanceof List) ? bom.dependencies : []
+        dependencies.each { d ->
+            if (d instanceof Map && d.dependsOn instanceof List && !(d.dependsOn as List).empty) {
+                d.dependsOn = (d.dependsOn as List).sort()
+            }
+        }
+
+        def componentMeta = (bom instanceof Map && bom.metadata instanceof Map) ? bom.metadata.component : null
+        if (componentMeta instanceof Map && componentMeta.externalReferences instanceof List) {
+            componentMeta.externalReferences = (componentMeta.externalReferences as List).findAll { ref ->
+                !(ref instanceof Map) || !externalRefTypesToStrip.contains(ref['type'] as String)
+            }
+        }
+
+        // Mix projectPath into the UUID seed so two modules whose post-processed BOM JSON
+        // happens to be identical (for example, empty BOM platforms with no runtime
+        // dependencies, or modules whose metadata.component is filled in identically by the
+        // CycloneDX plugin) still receive distinct serialNumbers as required by the CycloneDX
+        // specification. Including projectPath preserves reproducibility because the same
+        // project path + same content always yields the same UUID across rebuilds. See
+        // https://cyclonedx.org/docs/1.6/json/#serialNumber and PR #15614.
+        bom['serialNumber'] = ''
+        def withoutSerial = JsonOutput.prettyPrint(JsonOutput.toJson(bom))
+        def uuidSeed = "${projectPath}\n${withoutSerial}"
+        def uuid = UUID.nameUUIDFromBytes(uuidSeed.getBytes(StandardCharsets.UTF_8))
+        bom['serialNumber'] = "urn:uuid:$uuid".toString()
+
+        f.setText(JsonOutput.prettyPrint(JsonOutput.toJson(bom)), StandardCharsets.UTF_8.name())
+
+        logger.info('Rewrote JSON SBOM ({}) for reproducibility', projectPath)
     }
 
     private static void configureNormalization(Project project) {

--- a/grails-bootstrap/src/main/groovy/grails/codegen/model/FieldDefinition.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/codegen/model/FieldDefinition.groovy
@@ -150,7 +150,7 @@ class FieldDefinition extends AbstractMemberDefinition {
         }
     }
 
-    static Builder builder() {
-        new Builder()
+    static FieldDefinition.Builder builder() {
+        new FieldDefinition.Builder()
     }
 }

--- a/grails-bootstrap/src/main/groovy/grails/codegen/model/PropertyDefinition.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/codegen/model/PropertyDefinition.groovy
@@ -113,7 +113,7 @@ class PropertyDefinition extends AbstractMemberDefinition {
         }
     }
 
-    static Builder builder() {
-        new Builder()
+    static PropertyDefinition.Builder builder() {
+        new PropertyDefinition.Builder()
     }
 }


### PR DESCRIPTION
## Summary

The container-based release-vote verification described in `RELEASE.md` fails on **v8.0.0-M1** because nine jars are not byte-identical between the CI-published copies and a fresh local rebuild from the source distribution. The SbomPlugin's existing deterministic `serialNumber` logic and the project's existing reproducibility infrastructure are correct, but three independent root causes upstream of them break reproducibility for these specific files.

This PR addresses all three.

### Affected jars (verified via `verify.sh v8.0.0-M1`)

| Jar | What differs | Fix in this PR |
|---|---|---|
| `grails-async`, `grails-async-core`, `grails-async-gpars`, `grails-async-rxjava{,2,3}`, `grails-bootstrap` | `META-INF/sbom.json` | Fix #1 |
| `grails-cache` | `META-INF/sbom.json` and `META-INF/sbom/application.cdx.json` | Fix #1 + Fix #2 |
| `grails-bootstrap-javadoc` | 4 HTML files for `FieldDefinition`/`PropertyDefinition` | Fix #3 |

## Root causes and fixes

### 1. `SbomPlugin` direct task: strip the auto-injected `build-system` externalReference

`cyclonedx-gradle-plugin` v3.0.0 auto-injects a `build-system` externalReference pointing at `https://github.com/apache/grails-core/actions/runs/<run_id>` when `GITHUB_ACTIONS` env vars are present. This URL is unknowable from source, so its presence breaks the deterministic `serialNumber` hash that `SbomPlugin` already computes from the BOM content. Stripping this reference before the hash recompute makes `META-INF/sbom.json` byte-identical between CI and local rebuilds.

### 2. `SbomPlugin` aggregate task: apply the same reproducibility transforms

Spring Boot 4 (`CycloneDxPluginAction`) wires the cyclonedx-gradle-plugin aggregate task (`CyclonedxAggregateTask`, default name `cyclonedxBom`) into Grails-plugin jars, packaging its output at `META-INF/sbom/application.cdx.json`. `SbomPlugin` previously only configured the direct task (`CyclonedxDirectTask`), so the aggregate SBOM had:
- a random `serialNumber` UUID
- an `Instant.now()` timestamp that ignored `SOURCE_DATE_EPOCH`
- CI auto-detected externalReferences (`build-system` and `vcs`)

The rewrite logic is extracted into a shared `rewriteSbomFile` helper applied to both task types via `configureSbomTask` and a new `configureAggregateSbomReproducibility` method. The aggregate strip set covers both `build-system` AND `vcs` because the aggregate task has no explicit `externalReferences` configuration to fall back on (unlike the direct task which sets four explicit refs).

### 3. `FieldDefinition` / `PropertyDefinition`: qualify `Builder` return types for groovydoc

Both classes declare a static inner `Builder` class with the same simple name, and both extend `AbstractMemberDefinition`. The `static Builder builder()` factory method previously used the unqualified return type `Builder`. When **groovydoc** walks the class graph, it resolves that simple name based on file system iteration order. Different filesystems produce different (and incorrect) HTML:
- One ordering: every `Builder` reference renders as `PropertyDefinition.Builder` (so `FieldDefinition.html` is wrong)
- Other ordering: every `Builder` reference renders as `FieldDefinition.Builder` (so `PropertyDefinition.html` is wrong)

This is **not a Gradle 9 issue** (Gradle 9's reproducibility fixes target `AbstractArchiveTask`, not the groovydoc tool's name resolution), and `noTimestamp = true` is already configured in `GroovydocEnhancerPlugin` so the difference is content, not metadata. Qualifying the return types as `static FieldDefinition.Builder builder()` and `static PropertyDefinition.Builder builder()` forces groovydoc to render the correct (and consistent) types regardless of iteration order.

**Compiled bytecode is unchanged** because the nested `Builder` classes already resolved correctly via lexical scope at the `groovyc` stage.

## Verification

Built `grails-async-core`, `grails-bootstrap`, and `grails-cache` twice with the same `SOURCE_DATE_EPOCH` and confirmed:

```
✅ grails-async-core: byte-identical between runs
✅ grails-bootstrap : byte-identical between runs
✅ grails-cache     : byte-identical between runs (sbom.json AND application.cdx.json)
✅ no build-system externalReference in any sbom.json
✅ no build-system or vcs externalReference in application.cdx.json
✅ deterministic urn:uuid serialNumber format
```

Existing `FieldDefinitionSpec` and `PropertyDefinitionSpec` test suites continue to pass because the bytecode-level `builder()` return type is unchanged.

End-to-end CI-vs-local validation will happen on this PR's CI build: once merged and a release is cut, `verify.sh v<next_release>` should pass on the previously-failing 9 jars.

## Test plan

- [x] `./gradlew :grails-bootstrap:test --tests "grails.codegen.model.FieldDefinitionSpec" --tests "grails.codegen.model.PropertyDefinitionSpec"` passes
- [x] `./gradlew :grails-bootstrap:codeStyle` passes
- [x] `./gradlew :build-logic:compileGroovy` (in `build-logic/`) passes
- [x] `:grails-async-core:cyclonedxDirectBom`, `:grails-bootstrap:cyclonedxDirectBom`, `:grails-cache:cyclonedxDirectBom` produce byte-identical output across two consecutive runs with the same `SOURCE_DATE_EPOCH`
- [x] `:grails-cache:cyclonedxBom` (aggregate) produces byte-identical output across two runs

## Notes for reviewers

- The aggregate task strip set (`['build-system', 'vcs']`) is intentionally broader than the direct task's (`['build-system']`). The direct task explicitly sets a known-good `vcs` reference at `SbomPlugin.groovy:191-193`, so we only need to strip the auto-injected `build-system`. The aggregate task has no such explicit config, so any externalReferences it has come from CI/`.git` auto-detection that won't reproduce locally.

- Build-logic does not currently have a `codeStyle` task or unit-test infrastructure for plugins; the verification was done via behavioral integration build. If you'd like to add `SbomPluginSpec` coverage in this PR, happy to extend - just say the word.

- For the groovydoc fix, an alternative approach would be renaming one of the inner `Builder` classes (`FieldDefinitionBuilder` / `PropertyDefinitionBuilder`) to remove the simple-name collision entirely. That's an API-breaking change so I went with the non-breaking qualification approach. If you'd prefer the rename, happy to switch.