### PR TITLE
fix(sbom): make per-module SBOM and groovydoc output byte-reproducible

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -25,7 +25,6 @@ import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
-import org.cyclonedx.gradle.CyclonedxPlugin
 import org.cyclonedx.gradle.CyclonedxDirectTask
 import org.cyclonedx.model.Component
 import org.cyclonedx.model.ExternalReference
@@ -37,6 +36,7 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.CopySpec
+import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFile
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.provider.Provider
@@ -126,7 +126,7 @@ class SbomPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        project.pluginManager.apply(CyclonedxPlugin)
+        registerCyclonedxDirectBomTask(project)
 
         def sbomOutputLocation = project.layout.buildDirectory.file(
                 project.provider {
@@ -142,6 +142,25 @@ class SbomPlugin implements Plugin<Project> {
 
         // sboms are only published to Grails jar files at this time
         publishSbomForJarProjects(project, sbomOutputLocation)
+    }
+
+    /**
+     * Register only the per-module {@link CyclonedxDirectTask}. We deliberately do not apply
+     * {@code CyclonedxPlugin} because doing so unconditionally also registers the
+     * {@code cyclonedxBom} aggregate task ({@code CyclonedxAggregateTask}), and triggers
+     * Spring Boot 4's {@code CycloneDxPluginAction} to wire that aggregate's output into the
+     * jar at {@code META-INF/sbom/application.cdx.json}. Grails ships per-module SBOMs only
+     * (at {@code META-INF/sbom.json}, see {@link #publishSbomForJarProjects}); the aggregate
+     * SBOM is misleading for library jars and would also need its own reproducibility
+     * post-processing. Registering the direct task ourselves means the aggregate task is
+     * never created in the first place, so there is nothing to disable, exclude, or filter.
+     */
+    private static void registerCyclonedxDirectBomTask(Project project) {
+        project.tasks.register('cyclonedxDirectBom', CyclonedxDirectTask) { CyclonedxDirectTask task ->
+            Provider<Directory> reportDir = project.layout.buildDirectory.dir('reports/cyclonedx-direct')
+            task.xmlOutput.convention(reportDir.map { it.file('bom.xml') })
+            task.jsonOutput.convention(reportDir.map { it.file('bom.json') })
+        }
     }
 
     private static void configureSbomTask(Project project, Provider<RegularFile> sbomOutputLocation) {
@@ -202,6 +221,13 @@ class SbomPlugin implements Plugin<Project> {
 
                 // turn off license text since it's base64 encoded & will inflate the jar sizes
                 includeLicenseText.set(false)
+
+                // Don't auto-inject the build-system externalReference. cyclonedx-gradle-plugin 3.0.0
+                // populates this from CI env vars (e.g. GitHub Actions run URL), which is unknowable
+                // from a local rebuild and would break byte-identical reproducibility between CI and
+                // local builds. Per ASF policy we ship reproducible artifacts and intentionally leave
+                // build info out of the sbom; this is the supported plugin-level off switch for it.
+                includeBuildSystem.set(false)
 
                 // disable xml output
                 xmlOutput.unsetConvention()

--- a/grails-bootstrap/src/main/groovy/grails/codegen/model/FieldDefinition.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/codegen/model/FieldDefinition.groovy
@@ -150,7 +150,20 @@ class FieldDefinition extends AbstractMemberDefinition {
         }
     }
 
-    static Builder builder() {
-        new Builder()
+    /**
+     * Factory for the {@link FieldDefinition.Builder}. The return type is intentionally fully qualified:
+     * {@code PropertyDefinition} declares an inner Builder of the same simple name, and groovydoc resolves
+     * unqualified {@code Builder} references inconsistently between builds (depends on filesystem iteration
+     * order). Keep this qualified to ensure groovydoc renders {@code FieldDefinition.Builder} reproducibly.
+     *
+     * TODO(GROOVY-11954): Revisit and simplify the return type to {@code Builder} once Grails depends on
+     * Groovy 4.0.32+ (also fixed in 5.0.6 and 6.0.0-alpha-1). The upstream fix corrects the shared
+     * short-name resolution cache in {@code SimpleGroovyClassDoc} that causes this non-reproducibility,
+     * so the workaround here will no longer be needed. As of writing, Grails pins {@code groovy.version=4.0.31}
+     * and 4.0.32 has not yet been released to Maven Central. See:
+     * https://issues.apache.org/jira/browse/GROOVY-11954 and https://github.com/apache/groovy/pull/2484.
+     */
+    static FieldDefinition.Builder builder() {
+        new FieldDefinition.Builder()
     }
 }

--- a/grails-bootstrap/src/main/groovy/grails/codegen/model/PropertyDefinition.groovy
+++ b/grails-bootstrap/src/main/groovy/grails/codegen/model/PropertyDefinition.groovy
@@ -113,7 +113,20 @@ class PropertyDefinition extends AbstractMemberDefinition {
         }
     }
 
-    static Builder builder() {
-        new Builder()
+    /**
+     * Factory for the {@link PropertyDefinition.Builder}. The return type is intentionally fully qualified:
+     * {@code FieldDefinition} declares an inner Builder of the same simple name, and groovydoc resolves
+     * unqualified {@code Builder} references inconsistently between builds (depends on filesystem iteration
+     * order). Keep this qualified to ensure groovydoc renders {@code PropertyDefinition.Builder} reproducibly.
+     *
+     * TODO(GROOVY-11954): Revisit and simplify the return type to {@code Builder} once Grails depends on
+     * Groovy 4.0.32+ (also fixed in 5.0.6 and 6.0.0-alpha-1). The upstream fix corrects the shared
+     * short-name resolution cache in {@code SimpleGroovyClassDoc} that causes this non-reproducibility,
+     * so the workaround here will no longer be needed. As of writing, Grails pins {@code groovy.version=4.0.31}
+     * and 4.0.32 has not yet been released to Maven Central. See:
+     * https://issues.apache.org/jira/browse/GROOVY-11954 and https://github.com/apache/groovy/pull/2484.
+     */
+    static PropertyDefinition.Builder builder() {
+        new PropertyDefinition.Builder()
     }
 }


### PR DESCRIPTION
## Summary

Container-based release-vote verification (per `RELEASE.md`) on **v8.0.0-M1** found nine jars not byte-identical between CI-published copies and a fresh local rebuild:

- `grails-async`, `grails-async-core`, `grails-async-gpars`, `grails-async-rxjava{,2,3}`, `grails-bootstrap`, `grails-cache` - differed in their SBOM file(s)
- `grails-bootstrap-javadoc` - differed in 4 HTML files for `FieldDefinition` / `PropertyDefinition`

This PR fixes both root causes at source.

## What changed (and why these two changes are enough)

### 1. `SbomPlugin`: register `CyclonedxDirectTask` ourselves and set `includeBuildSystem = false`

Two related observations:

- **`cyclonedx-gradle-plugin`'s `apply()` always registers BOTH tasks.** Looking at `CyclonedxPlugin.apply()` ([source](https://github.com/CycloneDX/cyclonedx-gradle-plugin/blob/cyclonedx-gradle-plugin-3.0.0/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java)), it unconditionally registers the per-module `cyclonedxDirectBom` and the aggregate `cyclonedxBom` (a `CyclonedxAggregateTask`). When Spring Boot 4 sees the plugin, its `CycloneDxPluginAction` then wires that aggregate's output into the jar at `META-INF/sbom/application.cdx.json` - misleading for library jars and an extra non-reproducible artifact to chase. Grails ships only per-module SBOMs at `META-INF/sbom.json`, so we register `CyclonedxDirectTask` directly and never apply `CyclonedxPlugin`. The aggregate task is never created in the first place; Spring Boot's reaction never fires either since it triggers on plugin-application of `CyclonedxPlugin`. There is nothing to disable, exclude, or filter.

- **`cyclonedx-gradle-plugin` 3.0.0 added a CI-only `build-system` externalReference** populated from GitHub Actions env vars (the run URL), which is unknowable from a local rebuild. The plugin exposes a first-class `includeBuildSystem` property (default `true`); setting it to `false` suppresses the reference at the plugin level. No JSON post-processing for that field, no externalReference filter set.

PR #15614's `projectPath`-into-UUID-seed fix is preserved unchanged.

### 2. `FieldDefinition` / `PropertyDefinition`: qualify the inner `Builder` return types

Both classes declare a static inner `Builder` of the same simple name. Groovydoc's `SimpleGroovyClassDoc` resolves unqualified `Builder` references via a shared short-name cache populated in filesystem iteration order, so the rendered HTML for `FieldDefinition.Builder` and `PropertyDefinition.Builder` differs between filesystems. Qualifying the return types as `static FieldDefinition.Builder builder()` / `static PropertyDefinition.Builder builder()` forces groovydoc to render the correct types reproducibly. Bytecode is unchanged - `groovyc` resolves nested `Builder` via lexical scope at compile time, which is why this was a docs-only bug.

This is the same root cause filed upstream as **[GROOVY-11954](https://issues.apache.org/jira/browse/GROOVY-11954)** and fixed in Groovy 4.0.32, 5.0.6, and 6.0.0-alpha-1 ([apache/groovy#2484](https://github.com/apache/groovy/pull/2484)). Grails pins `groovy.version=4.0.31` and 4.0.32 has not yet been published to Maven Central, so the qualification stays in place for v8.0.0-M1. Each `builder()` carries a `TODO(GROOVY-11954)` note so a future Groovy bump can drop the qualification trivially.

## Diff size

**`+58 / -6` across 3 files.** Everything else from earlier iterations of this PR (the aggregate-task disable, the `META-INF/sbom/**` jar exclude, the `META-INF/sbom/**` runtime-classpath ignore, the `rewriteSbomFile` extraction, the `externalRefTypesToStrip` parameter, the build-system stripping inside the JSON post-processor) became unnecessary once the cyclonedx plugin was no longer being applied and `includeBuildSystem` was used at the plugin level.

## Verification

```
./gradlew :grails-bootstrap:tasks --all | grep -i cyclonedx
# only cyclonedxDirectBom; no cyclonedxBom

./gradlew :grails-bootstrap:jar --rerun-tasks      # build 1
./gradlew :grails-bootstrap:jar --rerun-tasks      # build 2
# both jars: SHA-256 4FE425486AF7E77CC16117D899BFB7042B8292685237FEAAF17259E68FF87620

# SBOM in jar:
#   - present at META-INF/sbom.json
#   - NO META-INF/sbom/application.cdx.json
#   - NO build-system externalReference
#   - deterministic urn:uuid serialNumber
#   - dependencies[*].dependsOn sorted
```

## Test plan

- [x] `./gradlew :build-logic:compileGroovy --rerun-tasks` passes
- [x] `./gradlew :grails-bootstrap:jar --rerun-tasks` passes; jar is byte-reproducible across two runs
- [x] `cyclonedxBom` aggregate task is **not registered** on grails-plugin modules (confirmed via `:grails-bootstrap:tasks --all`)
- [x] Produced jars contain only `META-INF/sbom.json`, no `META-INF/sbom/**`
- [x] No `build-system` externalReference in any sbom.json
- [x] `:grails-bootstrap:test --tests "grails.codegen.model.FieldDefinitionSpec" --tests "grails.codegen.model.PropertyDefinitionSpec"` passes
