### PR TITLE
Set minimum Java Version to 21 for Grails 8.x

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
@@ -31,7 +31,8 @@ import java.util.stream.Collectors;
 public enum JdkVersion {
     JDK_21(21),
     // 25 is an LTS release and will be supported by Spring Framework 6.2.x and Spring Boot 3.5.x
-    JDK_25(25);
+    JDK_25(25),
+    JDK_26(26);
 
     public static final JdkVersion DEFAULT_OPTION = JDK_21;
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/JdkVersion.java
@@ -29,12 +29,11 @@ import java.util.stream.Collectors;
  * @since 6.0.0
  */
 public enum JdkVersion {
-    JDK_17(17),
     JDK_21(21),
     // 25 is an LTS release and will be supported by Spring Framework 6.2.x and Spring Boot 3.5.x
     JDK_25(25);
 
-    public static final JdkVersion DEFAULT_OPTION = JDK_17;
+    public static final JdkVersion DEFAULT_OPTION = JDK_21;
 
     private static final List<Integer> SUPPORTED_JDKS = Arrays.stream(JdkVersion.values()).map(JdkVersion::majorVersion).collect(Collectors.toList());
 

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/spring/SpringBootVirtualThreadsSpec.groovy
@@ -29,9 +29,9 @@ import org.grails.forge.options.TestFramework
 
 class SpringBootVirtualThreadsSpec extends BeanContextSpec implements CommandOutputFixture {
 
-    void "test spring boot virtual threads not enabled for JDK 17, when optional feature selected"() {
+    void "test spring boot virtual threads not enabled for JDK 21, when optional feature selected"() {
         when:
-        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(DevelopmentReloading.DEFAULT_OPTION, JdkVersion.JDK_17))
+        GeneratorContext commandContext = buildGeneratorContext(['spring-boot-virtual-threads'], new Options(DevelopmentReloading.DEFAULT_OPTION, JdkVersion.JDK_21))
 
         then:
         commandContext.configuration.get('spring.threads.virtual.enabled'.toString()) == false


### PR DESCRIPTION
8.0.0-SNAPSHOT is currently showing Java 17 as an option, this removes it.