### PR TITLE
7.1.x FIX: Rank URL mapping specificity by literal token count before wildcard captures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -59,7 +59,7 @@ micronautPlatformVersion=4.9.4
 
 # Libraries only specific to test apps, these should not be exposed
 ersatzVersion=4.0.1
-grailsSpringSecurityVersion=7.0.2-SNAPSHOT
+grailsSpringSecurityVersion=7.0.3-SNAPSHOT
 jbossTransactionApiVersion=2.0.0.Final
 # Note: we do not import the micronaut bom in our tests to avoid spring version mismatches
 micronautHttpClientVersion=4.9.9

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
@@ -230,20 +230,35 @@ abstract class AbstractGrailsControllerUrlMappings implements UrlMappings {
             // else: wildcard-captured values didn't match a registered controller/action — skip
         }
         // When wildcard validation is enabled, promote validated wildcard matches
-        // (e.g., $action? resolving to a real action) only when they have strictly fewer
-        // non-routing URL captures — meaning they matched a more specific URL pattern.
+        // (e.g., $action? resolving to a real action) only when they are strictly more specific.
+        // Specificity is determined first by literal URL token count (more literals = more specific),
+        // then by non-routing param count (fewer free captures = more specific).
+        // A route with more literal path segments always beats one with fewer, regardless of
+        // whether either has wildcard captures ($action/$controller/$namespace).
         // Same wildcard status: preserve URL matcher's original order (stable sort).
         // When validation is disabled, preserve original URL matcher order entirely.
         if (validateWildcardMappings) {
             matches.sort(true) { a, b ->
                 if (a.hasWildcardCaptures() == b.hasWildcardCaptures()) return 0
-                int diff = nonRoutingParamCount(a) - nonRoutingParamCount(b)
-                if (a.hasWildcardCaptures() && diff < 0) return -1
-                if (b.hasWildcardCaptures() && diff < 0) return 1
+                // Primary: more literal URL tokens wins
+                int literalDiff = literalTokenCount(b) - literalTokenCount(a)
+                if (literalDiff != 0) return literalDiff
+                // Secondary: fewer non-routing captures wins (promotes more specific wildcard routes)
+                int paramDiff = nonRoutingParamCount(a) - nonRoutingParamCount(b)
+                if (a.hasWildcardCaptures() && paramDiff < 0) return -1
+                if (b.hasWildcardCaptures() && paramDiff < 0) return 1
                 0  // preserve original order
             }
         }
         matches as UrlMappingInfo[]
+    }
+
+    private static final String CAPTURED_WILDCARD = '(*)'
+    private static final String CAPTURED_DOUBLE_WILDCARD = '(**)'
+
+    private static int literalTokenCount(UrlMappingInfo info) {
+        String[] tokens = info.urlData?.tokens
+        tokens == null ? 0 : (int) tokens.count { String t -> t != CAPTURED_WILDCARD && t != CAPTURED_DOUBLE_WILDCARD && !t.startsWith('(') }
     }
 
     private static int nonRoutingParamCount(UrlMappingInfo info) {

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/mvc/AbstractGrailsControllerUrlMappings.groovy
@@ -253,12 +253,9 @@ abstract class AbstractGrailsControllerUrlMappings implements UrlMappings {
         matches as UrlMappingInfo[]
     }
 
-    private static final String CAPTURED_WILDCARD = '(*)'
-    private static final String CAPTURED_DOUBLE_WILDCARD = '(**)'
-
     private static int literalTokenCount(UrlMappingInfo info) {
         String[] tokens = info.urlData?.tokens
-        tokens == null ? 0 : (int) tokens.count { String t -> t != CAPTURED_WILDCARD && t != CAPTURED_DOUBLE_WILDCARD && !t.startsWith('(') }
+        tokens == null ? 0 : (int) tokens.count { String t -> !t.contains('*') }
     }
 
     private static int nonRoutingParamCount(UrlMappingInfo info) {

--- a/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/WildcardActionValidationSpec.groovy
+++ b/grails-web-url-mappings/src/test/groovy/org/grails/web/mapping/mvc/WildcardActionValidationSpec.groovy
@@ -152,6 +152,35 @@ class WildcardActionValidationSpec extends AbstractUrlMappingsSpec {
         }
     }
 
+    void 'literal segment in path beats generic $id/$action/$imageId wildcard pattern declared earlier'() {
+        when: 'a URL whose second segment is the literal "list" matches both a hardcoded list route and a generic /$id/$action/$imageId wildcard'
+        def mappingInfo = evaluateRequestFor('/articles/list/gallery/spring', {
+            "/articles/$id/$action(.$format)?"(controller: 'topic')
+            "/articles/$id/$action/$imageId(.$format)?"(controller: 'topic')
+            "/articles/list/$stage/$sort?(.$format)?"(controller: 'topic', action: 'home')
+        }, TopicController)
+
+        then: 'the route with the literal "list" segment wins because it is more specific'
+        with(mappingInfo) {
+            controllerName == 'topic'
+            actionName == 'home'
+        }
+    }
+
+    void 'literal segment in path beats generic $id/$action/$imageId wildcard even when wildcard is declared first'() {
+        when: 'the generic /$id/$action/$imageId pattern is declared before the literal-segment route'
+        def mappingInfo = evaluateRequestFor('/articles/list/gallery/spring', {
+            "/articles/$id/$action/$imageId(.$format)?"(controller: 'topic')
+            "/articles/list/$stage/$sort?(.$format)?"(controller: 'topic', action: 'home')
+        }, TopicController)
+
+        then: 'the literal segment route still wins regardless of declaration order'
+        with(mappingInfo) {
+            controllerName == 'topic'
+            actionName == 'home'
+        }
+    }
+
     void 'prefers literal path mappings over wildcard controller matches'() {
         when: 'a literal path mapping and a wildcard controller mapping can both match the request'
         def mappingInfo = evaluateRequestFor('/community', {
@@ -342,3 +371,4 @@ class TopicController {
     def save() {}
     def show() {}
 }
+


### PR DESCRIPTION
When wildcard validation is enabled, AbstractGrailsControllerUrlMappings now sorts validated wildcard matches first by literal URL-token count (more literals = more specific) and only then by non-routing capture count. Previously a generic pattern like /$id/$action/$imageId could win over a more specific route such as /list/$stage/$sort because both had the same wildcard-capture status, causing the wrong controller/action to be resolved regardless of declaration order. Adds two WildcardActionValidationSpec cases covering both declaration orders. 

https://github.com/apache/grails-core/pull/15525
https://github.com/apache/grails-core/pull/15542