### PR TITLE
Add flyway-database-postgresql for grails-forge-analytics-postgres native deploy

### DIFF
--- a/grails-forge/grails-forge-analytics-postgres/build.gradle
+++ b/grails-forge/grails-forge-analytics-postgres/build.gradle
@@ -36,9 +36,16 @@ dependencies {
     implementation 'io.micronaut.data:micronaut-data-jdbc'
     implementation 'io.micronaut.flyway:micronaut-flyway'
     implementation 'io.micronaut.sql:micronaut-jdbc-hikari'
-    implementation "org.postgresql:postgresql:$postgresqlVersion"
+    implementation "org.postgresql:postgresql"
 
-    runtimeOnly "ch.qos.logback:logback-classic:$logbackClassicVersion"
+    // Flyway 10.x split the PostgreSQL DatabaseType implementation out of
+    // flyway-core into a dedicated module. Without it, Flyway's
+    // ServiceLoader<DatabaseType> lookup fails at runtime with
+    // "FlywayException: Unsupported Database: PostgreSQL <ver>" and the
+    // analytics service crashes during datasource initialization on
+    // Cloud Run, causing the deploy revision to fail its startup probe.
+    runtimeOnly 'org.flywaydb:flyway-database-postgresql'
+    runtimeOnly "ch.qos.logback:logback-classic"
     runtimeOnly 'io.micronaut:micronaut-jackson-databind'
 
     testCompileOnly 'io.micronaut:micronaut-inject-groovy'


### PR DESCRIPTION
## Summary

After PR #15647 unblocked `dockerBuildNative` for `grails-forge-analytics-postgres` and the resulting native binary built and pushed cleanly, the Cloud Run revision still failed its startup probe ([run 25578314349](https://github.com/apache/grails-core/actions/runs/25578314349) / [run 25578315293](https://github.com/apache/grails-core/actions/runs/25578315293)):

```
ERROR: (gcloud.run.deploy) The user-provided container failed to start and listen on the port
defined provided by the PORT=8080 environment variable within the allocated timeout.
```

That makes 8.0.x's `Deploy to Google Cloud Run` (the web-netty one) green again, but `Deploy analytics to Google Cloud Run` red - this is the third-and-final blocker on the broken Forge deploy pipeline.

## Root cause

Reproducing the analytics native binary locally on Docker against a `postgres:15.3` sidecar showed it crashing during datasource initialization, well before binding to `:8080`:

```
HikariPool-1 - Start completed.
Running migrations for database with qualifier [default]
ERROR io.micronaut.runtime.Micronaut - Error starting Micronaut server:
  Bean definition [javax.sql.DataSource] could not be loaded:
  Unsupported Database: PostgreSQL 15.3
Caused by: org.flywaydb.core.api.FlywayException: Unsupported Database: PostgreSQL 15.3
    at org.flywaydb.core.internal.database.DatabaseTypeRegister
        .getDatabaseTypeForConnection(DatabaseTypeRegister.java:131)
```

Flyway 10.x [split](https://documentation.red-gate.com/fd/major-changes-required-for-flyway-database-postgresql-in-flyway-10-225772349.html) the per-database `DatabaseType` SPI implementations out of `flyway-core` into dedicated modules. After the May-2026 adoption of `micronaut-platform` ([commit `b406076e87`](https://github.com/apache/grails-core/commit/b406076e87)) pinned us to `flyway-core:10.22.0`, the analytics service no longer had a PostgreSQL `DatabaseType` on the runtime classpath, so Flyway's `ServiceLoader<org.flywaydb.core.internal.database.DatabaseType>` returned an empty match for the postgres connection, threw `Unsupported Database`, and the Micronaut bootstrap aborted before the HTTP server could bind.

Previously this was masked by the earlier `dockerBuildNative` failures - the build never produced an image to deploy, so we never saw the runtime error.

## Fix

Add `runtimeOnly 'org.flywaydb:flyway-database-postgresql'` to [`grails-forge-analytics-postgres/build.gradle`](https://github.com/apache/grails-core/blob/8.0.x/grails-forge/grails-forge-analytics-postgres/build.gradle). `micronaut-flyway-bom:7.9.2` already manages the matching `org.flywaydb:flyway-database-postgresql:10.22.0` artifact, so no explicit version pin is needed:

```
+--- io.micronaut.flyway:micronaut-flyway-bom:7.9.2
|    +--- org.flywaydb:flyway-database-postgresql:10.22.0 (c)
|    +--- io.micronaut.flyway:micronaut-flyway:7.9.2 (c)
|    \--- org.flywaydb:flyway-core:10.22.0 (c)
```

## Verification

Local repro on Docker 29.3.0 (post-fix image rebuilt with the same `21.0.2-ol9` GraalVM Community native-image container the deploy workflows use):

```
$ docker run -d --name analytics-pg -p 15432:5432 -e POSTGRES_USER=dbuser \
    -e POSTGRES_PASSWORD=theSecretPassword -e POSTGRES_DB=postgres postgres:15.3
$ docker run -d --name analytics-app -p 18082:8080 \
    --add-host=host.docker.internal:host-gateway \
    -e MICRONAUT_SERVER_PORT=8080 \
    -e DATASOURCES_DEFAULT_URL=jdbc:postgresql://host.docker.internal:15432/postgres \
    -e DATASOURCES_DEFAULT_USERNAME=dbuser \
    -e DATASOURCES_DEFAULT_PASSWORD=theSecretPassword \
    grails-forge-local:analytics
```

```
HikariPool-1 - Start completed.
Flyway - Database: jdbc:postgresql://...:5432/postgres (PostgreSQL 15.3)
Flyway - Creating Schema History table "public"."flyway_schema_history" ...
Flyway - Schema "public" is up to date. No migration necessary.
io.micronaut.runtime.Micronaut - Startup completed in 193ms.
  Server Running: http://...:8080
```

Native binary now binds to `:8080` within the Cloud Run startup-probe window. The Cloud Run-side service config (Cloud SQL connection name, secrets, env vars) is unchanged from prior successful deploys (most recent: 2026-04-16 [run 24524756128](https://github.com/apache/grails-core/actions/runs/24524756128)).
