### PR TITLE
fix(grails-datamapping-core): GroovyProxyFactory.getProxiedClass returns Object instead of entity class 

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactory.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactory.groovy
@@ -47,11 +47,13 @@ class GroovyProxyFactory implements ProxyFactory {
     }
 
     @Override
-    @Override
     Class<?> getProxiedClass(Object o) {
-        if (isProxy(o)) {
-            return o.getClass().getSuperclass()
-        }
+        // Proxies created by this factory are real instances of the entity class
+        // with a ProxyInstanceMetaClass attached (see createProxy). The entity
+        // class therefore IS o.getClass() — no superclass walk needed. Walking
+        // up via getSuperclass() would yield java.lang.Object (entity classes
+        // typically extend Object directly), which then fails to resolve in
+        // MappingContext.getPersistentEntity(name) and breaks cascade validation.
         return o.getClass()
     }
 

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactorySpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactorySpec.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.proxy
+
+import org.grails.datastore.mapping.core.Session
+import spock.lang.Specification
+
+class GroovyProxyFactorySpec extends Specification {
+
+    void "getProxiedClass returns the entity class for a proxy created by this factory"() {
+        given:
+        GroovyProxyFactory proxyFactory = new GroovyProxyFactory()
+
+        // Mirror what GroovyProxyFactory.createProxy() does internally — attach a
+        // ProxyInstanceMetaClass to a real instance of the entity class. Avoids the
+        // need to mock EntityPersister (a class, not an interface — would require
+        // byte-buddy or cglib on the test classpath).
+        ProxyEntity proxy = new ProxyEntity()
+        def session = Mock(Session)
+        proxy.metaClass = new ProxyInstanceMetaClass(proxy.metaClass, session, 1L)
+
+        expect: 'isProxy correctly identifies it as a proxy'
+        proxyFactory.isProxy(proxy)
+
+        and: 'getProxiedClass returns the entity class, not its superclass'
+        // GroovyProxyFactory creates "metaclass-only" proxies: the proxy IS a real
+        // instance of the entity class, just with a ProxyInstanceMetaClass attached.
+        // getProxiedClass() must therefore return the entity class itself.
+        // Bug: previously returned proxy.getClass().getSuperclass() (java.lang.Object),
+        // which broke the unique-constraint validator's mappingContext.getPersistentEntity(name)
+        // lookup whenever cascade validation hit a not-yet-unwrapped proxy.
+        proxyFactory.getProxiedClass(proxy) == ProxyEntity
+    }
+
+    void "getProxiedClass returns the entity class for a non-proxy instance"() {
+        given:
+        GroovyProxyFactory proxyFactory = new GroovyProxyFactory()
+        ProxyEntity instance = new ProxyEntity()
+
+        expect:
+        !proxyFactory.isProxy(instance)
+        proxyFactory.getProxiedClass(instance) == ProxyEntity
+    }
+}
+
+class ProxyEntity {
+    Long id
+    String name
+}


### PR DESCRIPTION
# fix(grails-datamapping-core): GroovyProxyFactory.getProxiedClass walks past entity to Object

## Summary

`GroovyProxyFactory.getProxiedClass()` returns `java.lang.Object` (or the entity's actual superclass, whatever that happens to be) for proxies that this same factory created, instead of the proxied entity class. Any caller that feeds the result back into `MappingContext.getPersistentEntity(name)` then receives `null` — at best a confusing failure mode, at worst an NPE on the next dereference (`UniqueConstraint.processValidate` is one such caller — it goes on to invoke `targetEntity.isRoot()` without a null guard).

This PR fixes the contract violation inside the factory itself; it does not depend on how any specific consumer is wired.

## Root cause

`GroovyProxyFactory` and `JavassistProxyFactory` ship a structurally identical `getProxiedClass()`, but the two factories produce **different shapes of proxy**:

| Factory | What `createProxy()` returns | `proxy.getClass()` is | `proxy.getClass().getSuperclass()` is |
|---|---|---|---|
| `JavassistProxyFactory` | runtime subclass `Proxy_$$_javassist extends Entity` | the **proxy** class | the **entity** class — correct |
| `GroovyProxyFactory` | a real `Entity` instance with a `ProxyInstanceMetaClass` attached | the **entity** class | the entity's superclass (usually `java.lang.Object`) — wrong |

The `getSuperclass()` walk is correct for Javassist's runtime-subclass strategy. Copy-pasted into `GroovyProxyFactory`, whose proxies are *not* subclasses of the entity (they are real entity instances with a custom metaclass), the walk steps one level past the entity. The post-walk null check at line 99 catches the inheritance-walk null but never the *initial-lookup* null, so callers that feed the result into `MappingContext.getPersistentEntity(name)` get a silent null back and NPE further down the stack.

The fix is to drop the walk: for the proxies this factory produces, `proxy.getClass()` is already the entity class in both the proxy and non-proxy branches.

```diff
     @Override
-    @Override
     Class<?> getProxiedClass(Object o) {
-        if (isProxy(o)) {
-            return o.getClass().getSuperclass()
-        }
         return o.getClass()
     }
```

(Also drops the duplicate `@Override` annotation that was already on the method — pure cleanup, no behavior change.)

## Test coverage

Adds `grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/proxy/GroovyProxyFactorySpec.groovy` with two cases:

1. **`getProxiedClass` returns the entity class for a proxy created by this factory** — fails on the unmodified code (`getProxiedClass(proxy)` returns `java.lang.Object`), passes after the fix.
2. **`getProxiedClass` returns the entity class for a non-proxy instance** — passes both before and after; regression guard for the non-proxy branch.

The test mirrors what `GroovyProxyFactory.createProxy()` does internally (real entity instance + `ProxyInstanceMetaClass` attached), so it exercises the same proxy shape callers see at runtime.

## Verification

Test totals on the patched code (`groovy-proxy-getproxiedclass-fix` branch off `7.2.x`):

| Suite | Tests | Failures | Skipped |
|---|---|---|---|
| `grails-datamapping-core` (incl. new `GroovyProxyFactorySpec`) | passing | 0 | — |
| `grails-datamapping-core-test` (TCK against the simple in-memory datastore — runs `GroovyProxySpec` for both `useGroovyProxyFactory: true` and `false`) | 474 | 0 | — |
| `grails-datamapping-validation`, `tck`, `support`, `async` | passing | 0 | — |
| `grails-datastore-core` (incl. existing `JavassistProxyFactorySpec`) | passing | 0 | — |
| `grails-datastore-web` | passing | 0 | — |
| `grails-data-mongodb-core` (full cascade + proxy path against real Mongo) | 568 | 0 | 23 |
| `grails-data-mongodb-bson` | 31 | 0 | 0 |
| `grails-data-hibernate5/core` (Javassist path — sanity check that the alternate proxy strategy is unaffected) | 478 | 0 | 28 |

Zero regressions.

## Why this is worth fixing even though `AbstractMappingContext` normally picks `JavassistProxyFactory`

In a normal Grails 7 application the `AbstractMappingContext.getProxyFactory()` picker probes the classpath for `javassist.util.proxy.ProxyFactory` first and uses `JavassistProxyFactory` whenever Javassist is present, so the buggy `GroovyProxyFactory.getProxiedClass()` path doesn't fire in most production setups. It does fire for any consumer that explicitly opts in to `GroovyProxyFactory` — directly (`mappingContext.proxyFactory = new GroovyProxyFactory()`, as the Neo4j and TCK `GroovyProxySpec` tests do) or indirectly via dependency configurations that strip Javassist from the classpath (custom builds that exclude `grails-datastore-core`'s transitive Javassist dep, etc.). For those consumers the bug is currently a latent NPE waiting on cascade validation; fixing the factory removes the trap regardless of how it ends up selected.
