### PR TITLE
Restore micronaut-jackson-databind for grails-forge-web-netty JSON runtime

### DIFF
--- a/grails-forge/grails-forge-web-netty/build.gradle
+++ b/grails-forge/grails-forge-web-netty/build.gradle
@@ -32,7 +32,20 @@ dependencies {
     implementation 'io.micronaut.gcp:micronaut-gcp-http-client'
 
     runtimeOnly 'ch.qos.logback:logback-classic'
-    runtimeOnly 'io.micronaut.serde:micronaut-serde-jackson'
+    // Forge's grails-forge-api DTO classes (VersionDTO, ApplicationTypeDTO,
+    // FeatureDTO, SelectOptionsDTO, Linkable, ...) are annotated with
+    // @Introspected only. micronaut-serde-jackson requires @Serdeable on
+    // each serializable type and rejects @Introspected-only classes at
+    // runtime, which surfaces in the deployed native image as
+    //   "Internal Server Error: Error encoding object [VersionDTO@..] to
+    //    JSON: No serializable introspection present for type VersionDTO."
+    // and breaks every JSON endpoint behind start.grails.org / next.grails.org
+    // / prev-snapshot.grails.org. The rest of the forge stack (forge-api,
+    // forge-core, analytics-postgres) still depends on
+    // io.micronaut:micronaut-jackson-databind, so keep the netty service on
+    // the same JSON runtime to match. If forge ever migrates to Serde end-
+    // to-end, every DTO needs @Serdeable / @SerdeImport at the same time.
+    runtimeOnly 'io.micronaut:micronaut-jackson-databind'
 
     testImplementation 'io.micronaut:micronaut-http-client'
     testImplementation 'io.micronaut.test:micronaut-test-spock'


### PR DESCRIPTION
## Summary

PRs #15646 / #15647 / #15648 fixed the broken `dockerBuildNative` and Cloud Run startup paths so the Forge deploy workflows ([prev-snapshot run 25579824416](https://github.com/apache/grails-core/actions/runs/25579824416), [next run 25579825356](https://github.com/apache/grails-core/actions/runs/25579825356)) finished green and the `next.grails.org` (8.0.0-M1) and `prev-snapshot.grails.org` (8.0-SNAPSHOT) Cloud Run revisions went live.

`start.grails.org` still does not list 8.0.0-M1 / 8.0-SNAPSHOT in the Grails Version selector, though, because the freshly deployed backends both return HTTP 500 on every JSON endpoint:

```
$ curl -i -H 'Origin: https://start.grails.org' https://next.grails.org/versions
HTTP/1.1 500 Internal Server Error
Content-Type: application/json
...
{"_embedded":{"errors":[{"message":"Internal Server Error: Error encoding object
 [org.grails.forge.api.VersionDTO@4a8eebd4] to JSON: No serializable introspection
 present for type VersionDTO. Consider adding Serdeable.Serializable annotate to
 type VersionDTO. Alternatively if you are not in control of the project's source
 code, you can use @SerdeImport(VersionDTO.class) to enable serialization of this
 type."}]},"message":"Internal Server Error"}
```

The frontend's [`grails-version-feed.json`](https://start.grails.org/grails-version-feed.json) explicitly fans out to `latest.grails.org`, `snapshot.grails.org`, `next.grails.org`, `prev.grails.org`, and `prev-snapshot.grails.org`. The first three are 7.1.x release builds and return 200; the latter two are our new 8.0.x builds and return 500, so the version selector skips them and the only Grails versions visible at `start.grails.org` today are `7.1.1`, `7.1.2-SNAPSHOT`, `7.0.11`. The browser additionally reports CORS errors on those 500 responses because Micronaut's error path bypasses the CORS filter (separate hardening, out of scope for this PR).

## Root cause

PR #15365 review feedback ([commit `e1f3013070`](https://github.com/apache/grails-core/commit/e1f3013070)) swapped the runtime JSON dependency in `grails-forge-web-netty/build.gradle`:

```
-    runtimeOnly 'io.micronaut:micronaut-jackson-databind'
+    runtimeOnly 'io.micronaut.serde:micronaut-serde-jackson'
```

with the rationale that "the forge stack is a Micronaut 4 serde-jackson application; the legacy jackson-databind runtime was a copy-paste from an earlier generator template." That is **not yet** true: every DTO returned by the Forge controllers (`VersionDTO`, `ApplicationTypeDTO`, `FeatureDTO`, `FeatureList`, `SelectOptionsDTO`, `GormImplDTO`, `JdkVersionDTO`, `LanguageDTO`, `ServletImplDTO`, `DevelopmentReloadingDTO`, `GitHubCreateDTO`, `PreviewDTO`, `ApplicationTypeList`, `LinkDTO`, the abstract `Linkable` parent, ...) carries `@Introspected` only - none of them are `@Serdeable` or registered via `@SerdeImport`. Micronaut Serde correctly rejects `@Introspected`-only classes at runtime; Micronaut Jackson Databind serialises them via Jackson + bean introspection. The mismatch turns every JSON endpoint behind `next.grails.org` and `prev-snapshot.grails.org` into a 500.

The other Forge modules - `forge-api` tests, `forge-core`, `analytics-postgres` - all still use `micronaut-jackson-databind`; `web-netty` was the only inconsistency.

## Fix

Restore `runtimeOnly 'io.micronaut:micronaut-jackson-databind'` in `grails-forge-web-netty/build.gradle` so the JSON runtime matches the rest of the forge stack and the existing `@Introspected` DTOs serialise. A proper end-to-end Serde migration belongs in a separate PR that also annotates every Forge DTO with `@Serdeable` / `@SerdeImport` at the same time.

## Verification

Reproduced locally on Docker 29.3.0 with the same Java 21 GraalVM Community 21.0.2-ol9 native-image container the deploy workflows use, then rebuilt with the fix:

```
$ docker run -d --name web-netty-local -p 18080:8080 \
    -e MICRONAUT_SERVER_PORT=8080 \
    -e CORS_ALLOWED_ORIGIN=https://start.grails.org \
    grails-forge-local:web-netty

$ curl -i -H 'Origin: https://start.grails.org' http://localhost:18080/versions
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://start.grails.org
Vary: Origin
Access-Control-Allow-Credentials: true
content-type: application/json
...
{"_links":{"self":{"href":"http://.../versions","templated":false}},
 "versions":{...,"grails.version":"8.0.0-M1",...,"groovy.version":"4.0.31",
             "spring-boot.version":"4.0.5",...}}

$ curl -i -H 'Origin: https://start.grails.org' http://localhost:18080/select-options
HTTP/1.1 200 OK
Access-Control-Allow-Origin: https://start.grails.org
...
```

Endpoints serve JSON cleanly with the CORS allow-origin header. Once `next.grails.org` and `prev-snapshot.grails.org` are redeployed from this commit, the start.grails.org Grails Version selector will pick up 8.0.0-M1 and 8.0-SNAPSHOT.
