### PR TITLE
Gh 14503 unique discriminator null spec

### DIFF
--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/specs/MultiColumnUniqueConstraintSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/specs/MultiColumnUniqueConstraintSpec.groovy
@@ -23,11 +23,12 @@ import org.apache.grails.data.hibernate5.core.GrailsDataHibernate5TckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.springframework.dao.DataIntegrityViolationException
 import spock.lang.Issue
+import spock.lang.PendingFeature
 
 @Issue('https://github.com/apache/grails-data-mapping/issues/617')
 class MultiColumnUniqueConstraintSpec extends GrailsDataTckSpec<GrailsDataHibernate5TckManager> {
     void setupSpec() {
-        manager.addAllDomainClasses([DomainOne, Task1, TaskLink])
+        manager.addAllDomainClasses([DomainOne, Task1, TaskLink, DomainTwo])
     }
 
     void "test generated unique constraints"() {
@@ -65,6 +66,20 @@ class MultiColumnUniqueConstraintSpec extends GrailsDataTckSpec<GrailsDataHibern
         then: 'DataIntegrityViolationException is thrown'
         thrown DataIntegrityViolationException
     }
+
+    @Issue('https://github.com/apache/grails-core/issues/14503')
+    @PendingFeature(reason = "Validator emits SQL without the discriminator clause when the discriminator is null. See #14503")
+    void "save with null discriminator succeeds when only non-null discriminator rows exist for the same main field"() {
+        given: 'a row with a non-null discriminator already exists for main field "A"'
+        new DomainTwo(name: 'A', discriminator: new Date()).save(flush: true, failOnError: true)
+
+        when: 'a new row is saved with null discriminator for the same main field'
+        DomainTwo saved = new DomainTwo(name: 'A', discriminator: null).save(flush: true)
+
+        then: 'the save passes — (A, null) is a distinct combination from (A, <date>)'
+        saved != null
+        saved.id != null
+    }
 }
 
 @Entity
@@ -92,5 +107,17 @@ class TaskLink {
 
     static constraints = {
         toTask unique: ['fromTask']
+    }
+}
+
+@Entity
+class DomainTwo {
+
+    String name
+    Date discriminator
+
+    static constraints = {
+        name           unique: ['discriminator']
+        discriminator  nullable: true
     }
 }

--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/specs/MultiColumnUniqueConstraintSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/specs/MultiColumnUniqueConstraintSpec.groovy
@@ -23,11 +23,12 @@ import org.apache.grails.data.hibernate7.core.GrailsDataHibernate7TckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.springframework.dao.DataIntegrityViolationException
 import spock.lang.Issue
+import spock.lang.PendingFeature
 
 @Issue('https://github.com/grails/grails-data-mapping/issues/617')
 class MultiColumnUniqueConstraintSpec extends GrailsDataTckSpec<GrailsDataHibernate7TckManager> {
     void setupSpec() {
-        manager.addAllDomainClasses([DomainOne, Task1, TaskLink])
+        manager.addAllDomainClasses([DomainOne, Task1, TaskLink, DomainTwo])
     }
 
     void "test generated unique constraints"() {
@@ -65,6 +66,20 @@ class MultiColumnUniqueConstraintSpec extends GrailsDataTckSpec<GrailsDataHibern
         then: 'DataIntegrityViolationException is thrown'
         thrown DataIntegrityViolationException
     }
+
+    @Issue('https://github.com/apache/grails-core/issues/14503')
+    @PendingFeature(reason = "Validator emits SQL without the discriminator clause when the discriminator is null. See #14503")
+    void "save with null discriminator succeeds when only non-null discriminator rows exist for the same main field"() {
+        given: 'a row with a non-null discriminator already exists for main field "A"'
+        new DomainTwo(name: 'A', discriminator: new Date()).save(flush: true, failOnError: true)
+
+        when: 'a new row is saved with null discriminator for the same main field'
+        DomainTwo saved = new DomainTwo(name: 'A', discriminator: null).save(flush: true)
+
+        then: 'the save passes — (A, null) is a distinct combination from (A, <date>)'
+        saved != null
+        saved.id != null
+    }
 }
 
 @Entity
@@ -92,5 +107,17 @@ class TaskLink {
 
     static constraints = {
         toTask unique: ['fromTask']
+    }
+}
+
+@Entity
+class DomainTwo {
+
+    String name
+    Date discriminator
+
+    static constraints = {
+        name           unique: ['discriminator']
+        discriminator  nullable: true
     }
 }


### PR DESCRIPTION
Follow-up to #14503 per @borinquenkid's request:
*"add a spec to H5 and H7 core modules and mark them as pending and then we
will follow up on the fix"*.

This PR adds the failing scenario as a `@PendingFeature` Spock test in both
`grails-data-hibernate5/core` and `grails-data-hibernate7/core` test modules.
It does **not** propose a fix. The fix approach is still open per
@jdaugherty's "we should discuss this as a team before proposing a fix"
(option 1 — skip-on-null SQL-standard, option 2 — explicit `IS NULL` check,
or configurable).

### What this PR adds

In both modules, `MultiColumnUniqueConstraintSpec.groovy` gains:

- A new `@Entity DomainTwo` with `name unique: ['discriminator']` and
  `discriminator nullable: true`.
- A new `@PendingFeature` test case:
  *"save with null discriminator succeeds when only non-null discriminator
  rows exist for the same main field"*.
- The new domain registered in `manager.addAllDomainClasses(...)`.

### Verification done locally

- `./gradlew :grails-data-hibernate5-core:test --tests "*MultiColumnUniqueConstraintSpec*"`
  → 4 tests, 3 passed, 1 skipped (the new `@PendingFeature`, as expected).
- `./gradlew :grails-data-hibernate7-core:test --tests "*MultiColumnUniqueConstraintSpec*"`
  → same result.
- Sanity check: temporarily removed `@PendingFeature` from the H5 file and
  re-ran. The test FAILED with `Condition not satisfied: saved != null`
  (the `save()` call returns null because the validator rejects the new row
  as a duplicate even though the existing row has a non-null discriminator).
  Restored `@PendingFeature` after confirming.
- Full module test runs (`./gradlew :grails-data-hibernate5-core:test
  :grails-data-hibernate7-core:test`): 2892 tests, 5 failed, 30 skipped.
  All 5 failures are pre-existing environmental issues (testcontainers
  cannot find a Docker environment on this machine):
  `RLikeHibernate7Spec` (3 tests), `GrailsSequenceGeneratorEnumSpec`,
  `HibernateDatastoreIntegrationSpec`. None of the failures touch the
  files modified in this PR. CI with Docker available should report
  these as passing.

When the fix lands and the test starts passing, Spock will throw
`PendingFeatureNotFinished` as a reminder to remove the annotation.

### Note on AI tooling

This contribution was prepared with assistance from Claude (Anthropic).
The reproducer was first verified in an external Grails 7.x application
and the spec was authored, run, and sanity-checked locally before
submission, per the ASF Generative Tooling policy.
