### PR TITLE
Make capturing Liquibase log output more reliable

### DIFF
--- a/grails-data-hibernate5/dbmigration/build.gradle
+++ b/grails-data-hibernate5/dbmigration/build.gradle
@@ -74,6 +74,14 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation 'com.h2database:h2'
+
+    // Liquibase uses JUL for logging -> redirect it to SLF4J to reliably capture its output
+    testRuntimeOnly 'org.slf4j:jul-to-slf4j'
+    testRuntimeOnly 'org.slf4j:slf4j-simple'
+}
+
+tasks.named('test', Test) {
+    systemProperty("java.util.logging.config.file", "src/test/resources/logging.properties")
 }
 
 tasks.named('jar', Jar) {

--- a/grails-data-hibernate5/dbmigration/src/test/resources/logging.properties
+++ b/grails-data-hibernate5/dbmigration/src/test/resources/logging.properties
@@ -1,0 +1,1 @@
+handlers = org.slf4j.bridge.SLF4JBridgeHandler

--- a/grails-data-hibernate5/dbmigration/src/test/resources/logging.properties
+++ b/grails-data-hibernate5/dbmigration/src/test/resources/logging.properties
@@ -1,1 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 handlers = org.slf4j.bridge.SLF4JBridgeHandler


### PR DESCRIPTION
## Description

Tests like `GroovyChangeLogSpec` capture output written to `System.out` and `System.err` and make assertions against it. By default, Liquibase uses `java.util.logging` (JUL) for logging. JUL's `ConsoleHandler` stores a reference to `System.err` when it's initialized. When that happens is outside the control of the test class. If there is code present that initializes JUL early (e.g. TestLens instrumentation), this happens *before* it is replaced by `OutputCaptureExtension`. This leads to logging output not being captured by the extension and tests failing as a consequence.

This commit redirects JUL to SLF4J by adding `org.slf4j:jul-to-slf4j` as dependency, and configuring JUL to use it via the `logging.properties` file and the corresponding `java.util.logging.config.file` system property. Moreover, `org.slf4j:slf4j-simple` is added so logging output is written to `System.err`. This logging implementation does not store a reference on the value of `System.err` when it's initialized and so avoids the problem described above.

Closes #15661.

## Contributor Checklist

Please review the following checklist before submitting your pull request. Pull requests that do not meet these requirements may be closed without review.

### Issue and Scope

- [ ] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. If no approved issue exists, please give background on why this change is necessary.  Tickets are preferred for release change log history.
- [x] This PR addresses the **complete scope** of the linked issue. Partial implementations or unfinished work should not be submitted for review.
- [x] This PR contains a **single, focused change**. Unrelated changes should be submitted as separate pull requests.
- [x] This PR targets the **correct branch** for the type of change:
    - **Patch release branches** (e.g., `7.0.x`): Bug fixes only. No new features or API changes.
    - **Minor release branches** (e.g., `7.1.x`): New features are welcome, but breaking existing APIs must be avoided.
    - **Major release branches** (e.g., `8.0.x`): Reserved for major changes. Breaking API changes are permitted.

### Code Quality

- [x] I have **added or updated tests** that cover the changes introduced in this PR. All code contributions are expected to include appropriate test coverage.
- [X] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`.
- [X] My code follows the project's **code style** guidelines. I have run `./gradlew codeStyle` and resolved any violations. See [Code Style](../CONTRIBUTING.md#code-style) for details.
- [x] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring unless it was **explicitly approved** in the linked issue. Unsolicited reformatting will not be accepted.
- [x] If generative AI tooling was used in preparing this contribution, a quality model was used to ensure contributions are **consistent with the project's quality standards**.

### Licensing and Attribution

- [x] All contributed code is provided under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), and new source files include the appropriate **Apache license header**.
- [x] I have the necessary rights to submit this contribution and confirm it is my own original work (see [Legal Notice](../CONTRIBUTING.md#i-want-to-contribute)).
- [x] If generative AI tooling was used in preparing this contribution, I have followed the [Apache Software Foundation's policy on generative tooling](https://www.apache.org/legal/generative-tooling.html) and have properly attributed its use.

### Documentation

- [x] If this PR introduces user-facing changes, I have included or updated the relevant documentation.
- [x] If this PR adds a new feature, I have updated the **What's New** section of the Grails Guide.
- [x] If this PR introduces breaking changes or changes that require user action during an upgrade, I have updated the **Upgrade Notes** for the corresponding version in the Grails Guide.
- [x] The PR description clearly explains **what** was changed and **why**.

---

> **First-time contributors:** Please read our [Contributing Guide](../CONTRIBUTING.md) before submitting.
> Pull requests that appear to be auto-generated, incomplete, or unrelated to an approved issue may be
> closed to help maintainers focus on reviewed and planned work. We appreciate your understanding.
