### PR TITLE
fix(deps): Bump Spring Boot to 4.0.6

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -86,7 +86,7 @@ ext {
             'jakarta-validation.version': '3.1.1',
             'jquery.version'                : '3.7.1',
             'junit.version'                 : '6.0.3',
-            'mongodb.version'               : '5.6.4',
+            'mongodb.version'               : '5.6.5',
             'rxjava.version'                : '1.3.8',
             'rxjava2.version'               : '2.2.21',
             'rxjava3.version'               : '3.1.12',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@ ext {
             'jna.version'                   : '5.18.1',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '4.0.5',
+            'spring-boot.version'           : '4.0.6',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly

--- a/grails-bom/micronaut/build.gradle
+++ b/grails-bom/micronaut/build.gradle
@@ -76,9 +76,13 @@ dependencies {
     // managed versions transitively and don't need to declare the platform themselves.
     // Exclude Groovy since we declare the required version explicitly below via customBomDependencies.
     // Exclude Spock since the base BOM manages that version.
+    // Exclude Jackson 3 (tools.jackson) since spring-boot-dependencies manages that version,
+    // and Micronaut can lag behind Spring Boot's patch bumps (e.g. SB 4.0.6 ships
+    // jackson-bom 3.1.2 while micronaut-platform 5.0.0-M2 still pins 3.1.0).
     api(platform("io.micronaut.platform:micronaut-platform:$micronautPlatformVersion")) {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'
+        exclude group: 'tools.jackson'
     }
 
     constraints {


### PR DESCRIPTION
Bumps `spring-boot.version` from 4.0.5 to 4.0.6 in `dependencies.gradle`.

Release notes: https://github.com/spring-projects/spring-boot/releases/tag/v4.0.6

## Dependency-version fallout (a.k.a. why this PR has three commits)

The `validateDependencyVersions` CI job caught two transitive-version conflicts introduced by the SB 4.0.5 → 4.0.6 bump. Both are upstream BOM drift, not anything broken in our build - but our pins (and the Micronaut platform's pins) had to be reconciled so the validator sees a single source of truth.

### 1. MongoDB driver 5.6.4 → 5.6.5

Spring Boot 4.0.6 bumps its managed `mongodb.version` from 5.6.4 to 5.6.5. Our `dependencies.gradle` was still pinning 5.6.4, so the higher SB version won during transitive resolution and the validator flagged every grails-data-mongodb module and mongodb test example:

```
org.mongodb:bson                - resolved 5.6.5, expected 5.6.4
org.mongodb:mongodb-driver-core - resolved 5.6.5, expected 5.6.4
org.mongodb:mongodb-driver-sync - resolved 5.6.5, expected 5.6.4
org.mongodb:bson-record-codec   - resolved 5.6.5, expected 5.6.4
```

Affected projects: `grails-data-mongodb`, `-bson`, `-core`, `-ext`, `-spring-boot`, `-gson-templates`, `-docs`, plus the `grails-test-examples-mongodb-*` set.

**Fix:** Bump `mongodb.version` to `5.6.5` in `dependencies.gradle` so our pin matches what Spring Boot 4.0.6 manages.

### 2. Jackson 3 BOM: SB 4.0.6 ships 3.1.2, Micronaut platform still pins 3.1.0

Spring Boot 4.0.6 also bumps `tools.jackson:jackson-bom` from 3.1.0 to 3.1.2. `io.micronaut.platform:micronaut-platform:5.0.0-M2` has not caught up yet and still pins 3.1.0. Both platforms are imported into `grails-micronaut-bom`, so:

- The validator's probe (using `platform(:grails-micronaut-bom)`) sees Micronaut's 3.1.0.
- Real project resolution under `enforcedPlatform(:grails-micronaut-bom)` picks Spring Boot's higher 3.1.2.

Result: `grails-test-examples-micronaut` failed validation:

```
tools.jackson:jackson-bom - resolved 3.1.2, expected 3.1.0
```

**Fix:** Apply the same exclusion pattern already used for Groovy and Spock in `grails-bom/micronaut/build.gradle` - exclude `tools.jackson` from the Micronaut platform import so `spring-boot-dependencies` is the single source of truth for Jackson 3. The probe and actual resolution now agree on 3.1.2, and consumers stay aligned with the Jackson version Spring Boot tests against.
