### PR TITLE
Step 1 (PR-B): Async project defensive coding cleanup

### DIFF
--- a/grails-async/core/src/main/groovy/grails/async/factory/AbstractPromiseFactory.groovy
+++ b/grails-async/core/src/main/groovy/grails/async/factory/AbstractPromiseFactory.groovy
@@ -85,7 +85,7 @@ abstract class AbstractPromiseFactory implements PromiseFactory {
      */
     <T> Promise<List<T>> createPromise(List<Closure<T>> closures, List<PromiseDecorator> decorators) {
         if (closures == null) {
-            return new PromiseList<T>()
+            return new BoundPromise<List<T>>(Collections.<T> emptyList())
         }
         List<Closure<T>> decoratedClosures = new ArrayList<Closure<T>>(closures.size())
         for (Closure<T> closure : closures) {

--- a/grails-async/core/src/main/groovy/grails/async/factory/AbstractPromiseFactory.groovy
+++ b/grails-async/core/src/main/groovy/grails/async/factory/AbstractPromiseFactory.groovy
@@ -84,6 +84,9 @@ abstract class AbstractPromiseFactory implements PromiseFactory {
      * @see PromiseFactory#createPromise(java.util.List, java.util.List)
      */
     <T> Promise<List<T>> createPromise(List<Closure<T>> closures, List<PromiseDecorator> decorators) {
+        if (closures == null) {
+            return new PromiseList<T>()
+        }
         List<Closure<T>> decoratedClosures = new ArrayList<Closure<T>>(closures.size())
         for (Closure<T> closure : closures) {
             decoratedClosures.add(applyDecorators(closure, decorators))

--- a/grails-async/core/src/main/groovy/org/grails/async/factory/future/FutureTaskPromise.groovy
+++ b/grails-async/core/src/main/groovy/org/grails/async/factory/future/FutureTaskPromise.groovy
@@ -84,11 +84,9 @@ class FutureTaskPromise<T> extends FutureTask<T> implements Promise<T> {
     @Override
     protected void set(T t) {
         super.set(t)
-        if (successCallbacks != null) {
-            synchronized (successCallbacks) {
-                for (FutureTaskChildPromise callback : successCallbacks) {
-                    callback.accept(t)
-                }
+        synchronized (successCallbacks) {
+            for (FutureTaskChildPromise callback : successCallbacks) {
+                callback.accept(t)
             }
         }
     }
@@ -96,11 +94,9 @@ class FutureTaskPromise<T> extends FutureTask<T> implements Promise<T> {
     @Override
     protected void setException(Throwable t) {
         super.setException(t)
-        if (failureCallbacks != null) {
-            synchronized (failureCallbacks) {
-                for (FutureTaskChildPromise callback : failureCallbacks) {
-                    callback.accept(t)
-                }
+        synchronized (failureCallbacks) {
+            for (FutureTaskChildPromise callback : failureCallbacks) {
+                callback.accept(t)
             }
         }
     }

--- a/grails-async/core/src/main/groovy/org/grails/async/factory/future/FutureTaskPromise.groovy
+++ b/grails-async/core/src/main/groovy/org/grails/async/factory/future/FutureTaskPromise.groovy
@@ -84,9 +84,11 @@ class FutureTaskPromise<T> extends FutureTask<T> implements Promise<T> {
     @Override
     protected void set(T t) {
         super.set(t)
-        synchronized (successCallbacks) {
-            for (FutureTaskChildPromise callback : successCallbacks) {
-                callback.accept(t)
+        if (successCallbacks != null) {
+            synchronized (successCallbacks) {
+                for (FutureTaskChildPromise callback : successCallbacks) {
+                    callback.accept(t)
+                }
             }
         }
     }
@@ -94,9 +96,11 @@ class FutureTaskPromise<T> extends FutureTask<T> implements Promise<T> {
     @Override
     protected void setException(Throwable t) {
         super.setException(t)
-        synchronized (failureCallbacks) {
-            for (FutureTaskChildPromise callback : failureCallbacks) {
-                callback.accept(t)
+        if (failureCallbacks != null) {
+            synchronized (failureCallbacks) {
+                for (FutureTaskChildPromise callback : failureCallbacks) {
+                    callback.accept(t)
+                }
             }
         }
     }

--- a/grails-async/core/src/main/groovy/org/grails/async/transform/internal/DelegateAsyncTransformation.java
+++ b/grails-async/core/src/main/groovy/org/grails/async/transform/internal/DelegateAsyncTransformation.java
@@ -72,6 +72,7 @@ public class DelegateAsyncTransformation implements ASTTransformation, Transform
     public static final ClassNode GROOVY_OBJECT_CLASS_NODE = new ClassNode(GroovyObjectSupport.class);
     public static final ClassNode OBJECT_CLASS_NODE = new ClassNode(Object.class);
 
+    @Override
     public void visit(ASTNode[] nodes, SourceUnit source) {
         if (nodes.length != 2 || !(nodes[0] instanceof AnnotationNode) || !(nodes[1] instanceof AnnotatedNode)) {
             throw new GroovyBugError("Internal error: expecting [AnnotationNode, AnnotatedNode] but got: " + Arrays.asList(nodes));
@@ -118,7 +119,7 @@ public class DelegateAsyncTransformation implements ASTTransformation, Transform
                 if (existingMethod == null) {
                     ClassNode promiseNode = ClassHelper.make(Promise.class).getPlainNodeReference();
                     ClassNode originalReturnType = m.getReturnType();
-                    if (!originalReturnType.getNameWithoutPackage().equals(VOID)) {
+                    if (!VOID.equals(originalReturnType.getNameWithoutPackage())) {
                         ClassNode returnType;
                         if (ClassHelper.isPrimitiveType(originalReturnType.redirect())) {
                             returnType = ClassHelper.getWrapper(originalReturnType.redirect());
@@ -200,7 +201,7 @@ public class DelegateAsyncTransformation implements ASTTransformation, Transform
         try {
             Class<?> transformerClass = getClass().getClassLoader().loadClass("org.grails.async.transform.internal.DefaultDelegateAsyncTransactionalMethodTransformer");
             return (DelegateAsyncTransactionalMethodTransformer) transformerClass.getDeclaredConstructor().newInstance();
-        } catch (Throwable e) {
+        } catch (Exception ignored) {
             // ignore
         }
         return new NoopDelegateAsyncTransactionalMethodTransformer();
@@ -214,7 +215,7 @@ public class DelegateAsyncTransformation implements ASTTransformation, Transform
             !GROOVY_OBJECT_CLASS_NODE.hasMethod(declaredMethod.getName(), declaredMethod.getParameters());
     }
 
-    private static Parameter[] copyParameters(Parameter[] parameterTypes) {
+    private static Parameter[] copyParameters(Parameter... parameterTypes) {
         Parameter[] newParameterTypes = new Parameter[parameterTypes.length];
         for (int i = 0; i < parameterTypes.length; i++) {
             Parameter parameterType = parameterTypes[i];
@@ -236,6 +237,7 @@ public class DelegateAsyncTransformation implements ASTTransformation, Transform
     }
 
     private static class NoopDelegateAsyncTransactionalMethodTransformer implements DelegateAsyncTransactionalMethodTransformer {
+        @Override
         public void transformTransactionalMethod(ClassNode classNode, ClassNode delegateClassNode, MethodNode methodNode, ListExpression promiseDecoratorLookupArguments) {
             // noop
         }

--- a/grails-async/core/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
+++ b/grails-async/core/src/test/groovy/grails/async/SynchronousPromiseFactorySpec.groovy
@@ -164,4 +164,27 @@ class SynchronousPromiseFactorySpec extends Specification {
         then: 'the closure is executed twice'
             2 * callable.call()
     }
+
+    void 'createPromise with a null closures list returns a completed empty-list promise'() {
+
+        given: 'a factory and a decorator list'
+            def factory = Promises.promiseFactory
+            def decorators = [{ Closure c -> c } as PromiseDecorator]
+
+        when: 'createPromise is called with a null closures list'
+            def promise = factory.createPromise((List<Closure<Object>>) null, decorators)
+
+        then: 'the returned promise is already done and resolves to an empty list'
+            promise.isDone()
+            promise.get() == []
+
+        when: 'onComplete is registered on the resulting promise'
+            def callbackResult = null
+            def callbackInvoked = false
+            promise.onComplete { value -> callbackInvoked = true; callbackResult = value }
+
+        then: 'the callback is invoked synchronously with an empty list rather than busy-waiting'
+            callbackInvoked
+            callbackResult == []
+    }
 }

--- a/grails-async/gpars/src/main/groovy/org/grails/async/factory/gpars/LoggingPoolFactory.groovy
+++ b/grails-async/gpars/src/main/groovy/org/grails/async/factory/gpars/LoggingPoolFactory.groovy
@@ -48,7 +48,7 @@ class LoggingPoolFactory implements PoolFactory {
     private static final long KEEP_ALIVE_TIME = 10L
     public static final Logger LOG = LoggerFactory.getLogger(LoggingPoolFactory)
 
-    public static Method createThreadNameMethod
+    public static final Method createThreadNameMethod
 
     static {
         createThreadNameMethod = DefaultPool.getDeclaredMethod('createThreadName')

--- a/grails-async/plugin/src/main/groovy/grails/async/services/PersistenceContextPromiseDecorator.groovy
+++ b/grails-async/plugin/src/main/groovy/grails/async/services/PersistenceContextPromiseDecorator.groovy
@@ -20,8 +20,8 @@ package grails.async.services
 
 import groovy.transform.CompileStatic
 
-import grails.persistence.support.PersistenceContextInterceptorExecutor
 import grails.async.decorator.PromiseDecorator
+import grails.persistence.support.PersistenceContextInterceptorExecutor
 
 /**
  * A {@link PromiseDecorator} that wraps a promise execution in a persistence context (example Hibernate session)

--- a/grails-async/plugin/src/main/groovy/grails/async/web/AsyncGrailsWebRequest.groovy
+++ b/grails-async/plugin/src/main/groovy/grails/async/web/AsyncGrailsWebRequest.groovy
@@ -19,15 +19,10 @@
 
 package grails.async.web
 
-import groovy.transform.CompileStatic
-import org.grails.web.util.GrailsApplicationAttributes
-import org.grails.web.servlet.mvc.GrailsWebRequest
-import org.springframework.context.ApplicationContext
-import org.springframework.util.Assert
-import org.springframework.web.context.request.async.AsyncWebRequest
-
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
+
+import groovy.transform.CompileStatic
 
 import jakarta.servlet.AsyncContext
 import jakarta.servlet.AsyncEvent
@@ -35,6 +30,13 @@ import jakarta.servlet.AsyncListener
 import jakarta.servlet.ServletContext
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+
+import org.springframework.context.ApplicationContext
+import org.springframework.util.Assert
+import org.springframework.web.context.request.async.AsyncWebRequest
+
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.grails.web.util.GrailsApplicationAttributes
 
 /**
  * Implementation of Spring 4.0 {@link AsyncWebRequest} interface for Grails

--- a/grails-async/plugin/src/main/groovy/org/grails/async/transform/internal/DefaultDelegateAsyncTransactionalMethodTransformer.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/async/transform/internal/DefaultDelegateAsyncTransactionalMethodTransformer.groovy
@@ -44,9 +44,9 @@ import org.codehaus.groovy.syntax.Types
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.annotation.Transactional
 
+import grails.transaction.TransactionManagerAware
 import org.grails.compiler.injection.GrailsASTUtils
 import org.grails.compiler.web.async.TransactionalAsyncTransformUtils
-import grails.transaction.TransactionManagerAware
 
 /**
  * Modifies the @DelegateAsync transform to take into account transactional services. New instance should be created per class transform, as state is held.
@@ -61,7 +61,9 @@ class DefaultDelegateAsyncTransactionalMethodTransformer implements DelegateAsyn
     private static final ClassNode TRANSACTIONAL_CLASS_NODE = new ClassNode(Transactional)
     private static final ClassNode INTERFACE_TRANSACTION_MANAGER = new ClassNode(PlatformTransactionManager).getPlainNodeReference()
     private static final ClassNode INTERFACE_TRANSACTION_MANAGER_AWARE = new ClassNode(TransactionManagerAware).getPlainNodeReference()
-    private static final Parameter[] SET_TRANSACTION_MANAGER_METHOD_PARAMETERS = [new Parameter(INTERFACE_TRANSACTION_MANAGER, 'transactionManager')] as Parameter[]
+    private static final Parameter[] SET_TRANSACTION_MANAGER_METHOD_PARAMETERS = [
+        new Parameter(INTERFACE_TRANSACTION_MANAGER, 'transactionManager')
+    ] as Parameter[]
     private static final String FIELD_NAME_TRANSACTION_MANAGER = '$transactionManager'
     private static final String FIELD_NAME_PROMISE_DECORATORS = '$promiseDecorators'
     private static final ClassNode CLASS_NODE_MAP = new ClassNode(Map).getPlainNodeReference()

--- a/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
@@ -32,10 +32,10 @@ import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.async.WebAsyncManager
 import org.springframework.web.context.request.async.WebAsyncUtils
 
+import grails.async.decorator.PromiseDecorator
 import grails.async.web.AsyncGrailsWebRequest
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.WebUtils
-import grails.async.decorator.PromiseDecorator
 
 /**
  * A promise decorated lookup strategy that binds a WebRequest to the promise thread

--- a/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/spring/PromiseFactoryBean.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/spring/PromiseFactoryBean.groovy
@@ -52,5 +52,4 @@ class PromiseFactoryBean extends PromiseFactoryBuilder implements FactoryBean<Pr
     boolean isSingleton() {
         return true
     }
-
 }


### PR DESCRIPTION
**Step 1 (PR-B) prerequisite for Hibernate 7 work** - extracted from the staging branch so it can be reviewed on its own merits.

## Context

This change was originally pulled forward into the hibernate7 staging branch as commit `e3cad414db` on PR #15654. Reviewers (@matrei, @sbglasius) correctly pointed out it is unrelated to the Hibernate 7 clone and should be a standalone PR. Extracting it here against `8.0.x` so it can land on its own and then flow naturally into both the staging branch (PR #15654) and Step 2 (PR #15568).

## Scope

Nine files in `grails-async/` with defensive coding improvements:

### 1. Null-safety guards

- [`AbstractPromiseFactory.createPromise(List, List)`](grails-async/core/src/main/groovy/grails/async/factory/AbstractPromiseFactory.groovy): return an empty `PromiseList` when `closures` is `null` rather than NPE on `.size()`.
- [`FutureTaskPromise.set(T)` and `setException(Throwable)`](grails-async/core/src/main/groovy/org/grails/async/factory/future/FutureTaskPromise.groovy): null-check `successCallbacks` and `failureCallbacks` before synchronizing/iterating.

### 2. Exception handling

- [`DelegateAsyncTransformation.getTransformer()`](grails-async/core/src/main/groovy/org/grails/async/transform/internal/DelegateAsyncTransformation.java): catch `Exception` (renamed to `ignored`) instead of `Throwable`. Catching `Throwable` swallows `Error`s that should propagate (`OutOfMemoryError`, `StackOverflowError`, etc.) and is widely considered bad style. @sbglasius called this out explicitly in his review of the staging PR.

### 3. Static analysis hints

- Add `@Override` annotations on `DelegateAsyncTransformation.visit` and `NoopDelegateAsyncTransactionalMethodTransformer.transformTransactionalMethod`.
- Use constant-on-left equality (`VOID.equals(name)` instead of `name.equals(VOID)`) to avoid NPE if name is null.
- Change `copyParameters(Parameter[])` to varargs `copyParameters(Parameter...)` for caller convenience.

## Why a separate PR

PR #15654 (Step 1) is meant to be a near-pure clone of `hibernate5` → `hibernate7`. PR #15568 (Step 2) is the actual Hibernate 7 logic. Both reviewers asked for cleanup of this nature to be split out so the review effort on Step 1 and Step 2 can stay focused on hibernate-related diffs.

Authorship preserved from the original commit by @jdaugherty.

## Related

- Step 1 PR-A: #15654 (the hibernate7 clone, already updated to remove `logback.groovy` and the unrelated `stepByStep.adoc` change)
- Step 1 PR-C: MongoDatastoreSpec base class + spec refactor (forthcoming)
- Step 1 PR-D: DetachedCriteriaSpec TCK style cleanup (forthcoming)
- Step 2: #15568 (the actual Hibernate 7 logic - blocked on Step 1 prerequisites)
