### PR TITLE
fix(deps): Bump Spring Boot to 4.1.0-RC1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@ ext {
             'jna.version'                   : '5.18.1',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '4.0.6',
+            'spring-boot.version'           : '4.1.0-RC1',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly
@@ -86,7 +86,7 @@ ext {
             'jakarta-validation.version': '3.1.1',
             'jquery.version'                : '3.7.1',
             'junit.version'                 : '6.0.3',
-            'mongodb.version'               : '5.6.5',
+            'mongodb.version'               : '5.7.0-beta1',
             'rxjava.version'                : '1.3.8',
             'rxjava2.version'               : '2.2.21',
             'rxjava3.version'               : '3.1.12',


### PR DESCRIPTION
## Summary

Bumps Spring Boot from `4.0.6` to `4.1.0-RC1` (released to Maven Central).

The change is two lines in `dependencies.gradle`:

- `spring-boot.version`: `4.0.6` -> `4.1.0-RC1`
- `mongodb.version`: `5.6.5` -> `5.7.0-beta1`

The MongoDB driver bump is required: the Spring Boot 4.1.0-RC1 dependency BOM now manages `org.mongodb` at `5.7.0-beta1`, so `validateDependencyVersions` fails unless Grails' pin is aligned to match. This mirrors the prior alignment done when Spring Boot was bumped to 4.0.6 (commit `5d454365ae`, "Align mongodb.version with Spring Boot 4.0.6 (5.6.5)").


