### PR TITLE
Pin SiteMesh 3 to 3.2.3 release and drop snapshot repo resolution

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsRepoSettingsPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsRepoSettingsPlugin.groovy
@@ -47,7 +47,6 @@ class GrailsRepoSettingsPlugin implements Plugin<Settings> {
                     url = 'https://central.sonatype.com/repository/maven-snapshots'
                     content {
                         it.includeVersionByRegex('cloud[.]wondrify.*', '.*', '.*-SNAPSHOT')
-                        it.includeVersionByRegex('org[.]sitemesh.*', '.*', '.*-SNAPSHOT')
                     }
                     mavenContent {
                         it.snapshotsOnly()
@@ -92,7 +91,6 @@ class GrailsRepoSettingsPlugin implements Plugin<Settings> {
                     url = 'https://central.sonatype.com/repository/maven-snapshots'
                     content {
                         it.includeVersionByRegex('cloud[.]wondrify.*', '.*', '.*-SNAPSHOT')
-                        it.includeVersionByRegex('org[.]sitemesh.*', '.*', '.*-SNAPSHOT')
                     }
                     mavenContent {
                         it.snapshotsOnly()

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsRepoSettingsPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GrailsRepoSettingsPlugin.groovy
@@ -47,6 +47,7 @@ class GrailsRepoSettingsPlugin implements Plugin<Settings> {
                     url = 'https://central.sonatype.com/repository/maven-snapshots'
                     content {
                         it.includeVersionByRegex('cloud[.]wondrify.*', '.*', '.*-SNAPSHOT')
+                        it.includeVersionByRegex('org[.]sitemesh.*', '.*', '.*-SNAPSHOT')
                     }
                     mavenContent {
                         it.snapshotsOnly()
@@ -91,6 +92,7 @@ class GrailsRepoSettingsPlugin implements Plugin<Settings> {
                     url = 'https://central.sonatype.com/repository/maven-snapshots'
                     content {
                         it.includeVersionByRegex('cloud[.]wondrify.*', '.*', '.*-SNAPSHOT')
+                        it.includeVersionByRegex('org[.]sitemesh.*', '.*', '.*-SNAPSHOT')
                     }
                     mavenContent {
                         it.snapshotsOnly()

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -91,8 +91,8 @@ ext {
             'selenium.version'              : '4.38.0',
             'spock.version'                 : '2.3-groovy-4.0',
             'sitemesh.version'              : '2.6.0',
-            'starter-sitemesh.version'      : '3.2.3-SNAPSHOT',
-            'spring-webmvc-sitemesh.version': '3.2.3-SNAPSHOT',
+            'starter-sitemesh.version'      : '3.2.3',
+            'spring-webmvc-sitemesh.version': '3.2.3',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly


### PR DESCRIPTION
## What

SiteMesh `3.2.3` is now published to Maven Central, so the SiteMesh 3 dependencies no longer need to resolve from the Sonatype `maven-snapshots` repository.

## Changes

- **`dependencies.gradle`**: bump `starter-sitemesh.version` and `spring-webmvc-sitemesh.version` from `3.2.3-SNAPSHOT` to `3.2.3`.
- **`GrailsRepoSettingsPlugin`**: remove the `org.sitemesh` snapshot `includeVersionByRegex` from the `central.sonatype.com/repository/maven-snapshots` repository (both the `pluginManagement` and `dependencyResolutionManagement` blocks). The `cloud.wondrify` (asset-pipeline) snapshot include is retained.

## Notes

- SiteMesh 2 (`opensymphony:sitemesh:2.6.0`, used by `grails-layout`) is unaffected.
- Verified both release artifacts exist on Maven Central:
  - `org.sitemesh:spring-boot-starter-sitemesh:3.2.3`
  - `org.sitemesh:spring-webmvc-sitemesh:3.2.3`
- This also unblocks the `validateNoSnapshotDependencies` release checks for SiteMesh.