### PR TITLE
AGENTS.md: link the project's security model for agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,11 @@ See `CONTRIBUTING.md` for full details.
 
 Please see the page of the [ASF Security Team](https://www.apache.org/security/) for further information and contact information.
 
+Security model: [SECURITY.md](./SECURITY.md) → [THREAT_MODEL.md](./THREAT_MODEL.md). Agents that
+scan this repository should consult `SECURITY.md` and the linked `THREAT_MODEL.md` for the project's
+threat model — in-scope / out-of-scope declarations, the security properties claimed and disclaimed,
+and known non-findings — before reporting issues.
+
 ## Resources
 
 - **Grails 7 Guide**: https://grails.apache.org/docs/latest/guide/single.html


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds a "Security model" pointer to the *Reporting Vulnerabilities* section of `AGENTS.md` so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md → THREAT_MODEL.md` chain. `SECURITY.md` and `THREAT_MODEL.md` already exist on this branch; `AGENTS.md` currently points only at the generic ASF Security Team page, so the chain doesn't start from there. This PR adds only that link — no model content changes.

Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting. Such scans refuse to run if the model isn't mechanically discoverable by that path (refusing upfront beats wasting reviewer cycles on a noise-heavy run against a model the agent never found). Discoverability is the one hard gate; everything else is suggestion.

Questions / pushback welcome — happy to move the line or adjust wording to match house style.
