### PR TITLE
Parameterize the @Scaffold service superclass so scaffolded service methods aren't type-erased

### DIFF
--- a/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -92,11 +92,15 @@ class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
                 if (!domainClass) {
                     GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @Scaffold does not have domain class set.", true)
                 }
-                // Parameterize the superclass (GormService<Domain>) so inherited get()/list()/save()
+                // Parameterize the superclass (e.g. GormService<Domain>) so inherited get()/list()/save()
                 // resolve to the domain type under static compilation, not the GormEntity upper bound.
                 ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
                 parameterizedSuper.setGenericsTypes(
                     [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
+                // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
+                // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
+                // written raw. Required - do not remove.
+                classNode.setUsingGenerics(true)
                 classNode.setSuperClass(parameterizedSuper)
                 def readOnlyExpression = (ConstantExpression) annotationNode.getMember('readOnly')
                 new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean() ?: false)

--- a/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -24,6 +24,7 @@ import java.util.regex.Pattern
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.GenericsType
 import org.codehaus.groovy.ast.expr.ClassExpression
 import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.classgen.GeneratorContext
@@ -91,7 +92,12 @@ class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
                 if (!domainClass) {
                     GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @Scaffold does not have domain class set.", true)
                 }
-                classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                // Parameterize the superclass (GormService<Domain>) so inherited get()/list()/save()
+                // resolve to the domain type under static compilation, not the GormEntity upper bound.
+                ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
+                parameterizedSuper.setGenericsTypes(
+                    [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
+                classNode.setSuperClass(parameterizedSuper)
                 def readOnlyExpression = (ConstantExpression) annotationNode.getMember('readOnly')
                 new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean() ?: false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {

--- a/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjectorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjectorSpec.groovy
@@ -1,0 +1,159 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.compiler.scaffolding
+
+import java.lang.reflect.ParameterizedType
+
+import grails.compiler.ast.ClassInjector
+import grails.plugin.scaffolding.GormService
+import org.grails.compiler.injection.GrailsAwareClassLoader
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ScaffoldingServiceInjectorSpec extends Specification {
+
+    private static final String DOMAIN_SRC = '''
+package com.example
+import org.grails.datastore.gorm.GormEntity
+class Widget implements GormEntity<Widget> {
+    String name
+}
+'''
+
+    @TempDir
+    File tmpDir
+
+    GrailsAwareClassLoader gcl
+
+    def setup() {
+        gcl = new GrailsAwareClassLoader()
+        gcl.classInjectors = [new ScaffoldingServiceInjector()] as ClassInjector[]
+        gcl.parseClass(DOMAIN_SRC)
+    }
+
+    /**
+     * The ScaffoldingServiceInjector only runs for sources whose URL matches the
+     * grails-app/services/**Service.groovy pattern, and the compiler only resolves that
+     * URL when the file actually exists on disk - so the service must be written to a real file.
+     */
+    private Class<?> parseScaffoldService(String simpleName, String source) {
+        def serviceDir = new File(tmpDir, 'grails-app/services/com/example')
+        serviceDir.mkdirs()
+        def serviceFile = new File(serviceDir, "${simpleName}.groovy")
+        serviceFile.text = source
+        gcl.parseClass(serviceFile)
+    }
+
+    void 'the @Scaffold(Domain) superclass is parameterized as GormService<Domain> rather than raw'() {
+        when:
+        def serviceClass = parseScaffoldService('WidgetService', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(Widget)
+class WidgetService {
+}
+''')
+
+        then: 'the generic superclass carries the domain type argument, not an erased raw type'
+        serviceClass.genericSuperclass instanceof ParameterizedType
+
+        and:
+        ParameterizedType parameterized = serviceClass.genericSuperclass as ParameterizedType
+        parameterized.rawType == GormService
+        parameterized.actualTypeArguments.length == 1
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'the @Scaffold(GormService<Domain>) generic form is parameterized as GormService<Domain>'() {
+        when:
+        def serviceClass = parseScaffoldService('WidgetService', '''
+package com.example
+import grails.plugin.scaffolding.GormService
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(GormService<Widget>)
+class WidgetService {
+}
+''')
+
+        then:
+        ParameterizedType parameterized = serviceClass.genericSuperclass as ParameterizedType
+        parameterized.rawType == GormService
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'a custom scaffold base is preserved and parameterized as CustomBase<Domain>'() {
+        given: 'a custom GormService subclass used as the scaffold base'
+        gcl.parseClass('''
+package com.example
+import grails.plugin.scaffolding.GormService
+import org.grails.datastore.gorm.GormEntity
+class WidgetRepository<T extends GormEntity<T>> extends GormService<T> {
+    WidgetRepository(Class<T> resource, boolean readOnly) {
+        super(resource, readOnly)
+    }
+}
+''')
+
+        when:
+        def serviceClass = parseScaffoldService('WidgetService', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(WidgetRepository<Widget>)
+class WidgetService {
+}
+''')
+
+        then: 'the declared custom base is kept (not collapsed to GormService) and carries the domain type argument'
+        ParameterizedType parameterized = serviceClass.genericSuperclass as ParameterizedType
+        parameterized.rawType.name == 'com.example.WidgetRepository'
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'the parameterized superclass narrows inherited get()/list()/save() to the domain type under static compilation'() {
+        given:
+        parseScaffoldService('WidgetService', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(Widget)
+class WidgetService {
+}
+''')
+
+        when: 'a statically-compiled caller assigns the scaffold-service results to the concrete domain type'
+        def caller = gcl.parseClass('''
+package com.example
+import groovy.transform.CompileStatic
+@CompileStatic
+class WidgetCaller {
+    static List<Widget> useService(WidgetService service) {
+        Widget single = service.get(1L)
+        List<Widget> many = service.list([:])
+        Widget saved = service.save(new Widget())
+        many
+    }
+}
+''')
+
+        then: '''static compilation succeeds without casts: the type checker resolves get():T, list():List<T>
+                  and save(T):T through the GormService<Widget> superclass. With the prior raw superclass these
+                  erased to GormEntity and the Widget assignments would have failed to compile.'''
+        caller != null
+        caller.getDeclaredMethod('useService', gcl.loadClass('com.example.WidgetService')) != null
+    }
+}


### PR DESCRIPTION
## Problem

A scaffolded service declared with a parameterized base, e.g. `@Scaffold(GormMongoService<Book>)`, is given the **raw** type `GormService`/`GormMongoService` as its superclass — the `<Book>` type argument is dropped. So every inherited generic method (`get():T`, `list():List<T>`, `save(T):T`, …) resolves to the `GormEntity` upper bound rather than the concrete domain type.

Under `@GrailsCompileStatic`/`@CompileStatic` this forces a cast at every call site:

```groovy
Book b         = bookService.get(id)      // Cannot assign value of type GormEntity to variable of type Book
List<Book> all = bookService.list(params) // List<GormEntity>
```

## Root cause

In `ScaffoldingServiceInjector.performInjectionOnAnnotatedClass`:

```groovy
superClassNode = valueClassNode.getPlainNodeReference()                    // strips the <Book> generic
...
classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
```

`getPlainNodeReference()` removes the generics, so the following `nonGeneric(raw, domain)` is a no-op: `replaceGenericsPlaceholders` early-returns the plain node because the type is no longer using generics. The domain type is known but never applied to the superclass.

## Fix

Set the superclass to a parameterized `GormService<Domain>`:

```groovy
ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
parameterizedSuper.setGenericsTypes(
    [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
classNode.setSuperClass(parameterizedSuper)
```

## Impact

Inherited scaffold-service methods now resolve to the domain type with no casts under static compilation:

```groovy
Book b         = bookService.get(id)      // ✅ Book
List<Book> all = bookService.list(params) // ✅ List<Book>
```

Generics are compile-time only, so there is no runtime behavior change. Verified against a real app's `@Scaffold(GormMongoService<T>)` services — `get()`/`list()` compile to the domain type under `@GrailsCompileStatic` with zero casts (previously every such call required a cast or `@CompileDynamic`).
