### PR TITLE
Register CriteriaTypeCheckingExtension in @GrailsCompileStatic and cover createCriteria().<terminal>{} closures

### DIFF
--- a/grails-core/src/main/groovy/grails/compiler/GrailsCompileStatic.groovy
+++ b/grails-core/src/main/groovy/grails/compiler/GrailsCompileStatic.groovy
@@ -33,5 +33,6 @@ import groovy.transform.CompileStatic
                            'org.grails.compiler.WhereQueryTypeCheckingExtension',
                            'org.grails.compiler.DynamicFinderTypeCheckingExtension',
                            'org.grails.compiler.DomainMappingTypeCheckingExtension',
+                           'org.grails.compiler.CriteriaTypeCheckingExtension',
                            'org.grails.compiler.RelationshipManagementMethodTypeCheckingExtension'])
 @interface GrailsCompileStatic {}

--- a/grails-core/src/main/groovy/org/grails/compiler/CriteriaTypeCheckingExtension.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/CriteriaTypeCheckingExtension.groovy
@@ -63,10 +63,28 @@ class CriteriaTypeCheckingExtension extends TypeCheckingDSL {
         null
     }
 
+    private static final List<String> CRITERIA_TERMINALS =
+        ['list', 'listDistinct', 'get', 'count', 'scroll']
+
     protected boolean isCriteriaCall(MethodCall call) {
-        call instanceof MethodCallExpression &&
-            call.objectExpression instanceof ClassExpression &&
-            GrailsASTUtils.isDomainClass(call.objectExpression.type, null) &&
-            (call.method.value == 'withCriteria' || call.method.value == 'createCriteria')
+        if (!(call instanceof MethodCallExpression)) {
+            return false
+        }
+        // Domain.withCriteria { } / Domain.createCriteria() — the criteria closure is the direct argument.
+        if (call.objectExpression instanceof ClassExpression &&
+                GrailsASTUtils.isDomainClass(call.objectExpression.type, null) &&
+                (call.method.value == 'withCriteria' || call.method.value == 'createCriteria')) {
+            return true
+        }
+        // Domain.createCriteria().list/get/count/... { } — the closure is the argument to the terminal
+        // call chained on the builder, so its body must be type-checked in a criteria scope too.
+        if (call.method.value in CRITERIA_TERMINALS &&
+                call.objectExpression instanceof MethodCallExpression &&
+                call.objectExpression.method.value == 'createCriteria' &&
+                call.objectExpression.objectExpression instanceof ClassExpression &&
+                GrailsASTUtils.isDomainClass(call.objectExpression.objectExpression.type, null)) {
+            return true
+        }
+        false
     }
 }


### PR DESCRIPTION
## What

`CriteriaTypeCheckingExtension` exists in grails-core but is **not registered** in `@GrailsCompileStatic`'s extension list, and it only recognizes the `Domain.withCriteria { … }` form (closure as the direct argument). The far more common `Domain.createCriteria().list/get/count { … }` chain — where the closure is the argument to the *terminal* call on the builder — is never entered, so its `eq`/`order`/`projections`/etc. calls fail static type checking.

The result: every `createCriteria()…{}` site under static compilation has to be marked `@CompileDynamic`, even when the only dynamic part is the criteria builder DSL.

## Change

1. Extend `isCriteriaCall` to also open a criteria scope when the call is a terminal (`list`, `listDistinct`, `get`, `count`, `scroll`) chained directly on `Domain.createCriteria()`.
2. Add `org.grails.compiler.CriteriaTypeCheckingExtension` to the `@CompileStatic(extensions=[…])` list on `@GrailsCompileStatic`.

With both in place, criteria-builder closures type-check under `@GrailsCompileStatic` and no longer require `@CompileDynamic`.

## Scope / limits

The extension makes the *direct children* of the criteria closure dynamic. Deeply nested builder closures (e.g. `projections { property '…' }`) and post-processing that indexes the projection result (`withCriteria { … }[0]`) still need `@CompileDynamic` — those are out of scope here.

## Testing

Verified against a multi-module Grails 7.2 app: `createCriteria().list(params){ eq(...) }` and `createCriteria().get { ilike(...); maxResults(1) }` compile cleanly under `@GrailsCompileStatic` with the extension registered, where they previously required `@CompileDynamic`.