### PR TITLE
Make domain properties nullable by default (Grails 8)

### DIFF
--- a/grails-core/src/main/groovy/grails/config/Settings.groovy
+++ b/grails-core/src/main/groovy/grails/config/Settings.groovy
@@ -152,6 +152,11 @@ interface Settings {
     String GORM_DEFAULT_CONSTRAINTS = 'grails.gorm.default.constraints'
 
     /**
+     * Whether an unconstrained persistent property is nullable by default
+     */
+    String GORM_DEFAULT_NULLABLE = 'grails.gorm.default.nullable'
+
+    /**
      * Whether to autowire instances
      */
     String GORM_AUTOWIRE_INSTANCES = 'grails.gorm.autowire'

--- a/grails-core/src/main/groovy/org/grails/validation/ConstraintEvalUtils.groovy
+++ b/grails-core/src/main/groovy/org/grails/validation/ConstraintEvalUtils.groovy
@@ -61,6 +61,14 @@ class ConstraintEvalUtils {
         return defaultConstraintsMap
     }
 
+    /**
+     * Whether an unconstrained persistent property is nullable by default (Grails 8).
+     * Set {@code grails.gorm.default.nullable = false} to restore the legacy required-by-default behaviour.
+     */
+    static boolean getDefaultNullable(Config config) {
+        config.getProperty(Settings.GORM_DEFAULT_NULLABLE, Boolean, true)
+    }
+
     static void clearDefaultConstraints() {
         defaultConstraintsMap =  null
         configId = null

--- a/grails-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/grails-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -223,6 +223,12 @@
             "defaultValue": {}
         },
         {
+            "name": "grails.gorm.default.nullable",
+            "type": "java.lang.Boolean",
+            "description": "Whether an unconstrained persistent property is nullable by default (Grails 8). Set to false to restore the legacy required-by-default behaviour.",
+            "defaultValue": true
+        },
+        {
             "name": "grails.gorm.custom.types",
             "type": "java.util.Map<java.lang.String,java.lang.Object>",
             "description": "Map of custom GORM types.",

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/SaveWithExistingValidationErrorSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/SaveWithExistingValidationErrorSpec.groovy
@@ -66,5 +66,6 @@ class ObjectB {
     String name
 
     static constraints = {
+        name nullable: false
     }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/entities/Contract.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/entities/Contract.groovy
@@ -28,4 +28,8 @@ import grails.gorm.annotation.Entity
 class Contract {
     BigDecimal salary
     static belongsTo = [player: Player]
+
+    static constraints = {
+        player nullable: false
+    }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/validation/CascadeValidationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/validation/CascadeValidationSpec.groovy
@@ -61,6 +61,9 @@ class Business {
             people: Person
     ]
 
+    static constraints = {
+        name nullable: false
+    }
 }
 @Entity
 abstract class Person {

--- a/grails-data-hibernate5/grails-plugin/src/test/groovy/grails/test/mixin/hibernate/HibernateSpecSpec.groovy
+++ b/grails-data-hibernate5/grails-plugin/src/test/groovy/grails/test/mixin/hibernate/HibernateSpecSpec.groovy
@@ -73,7 +73,7 @@ class Person {
     Integer age
     String phone
     static constraints = {
-        age min: 18, max: 65
+        age min: 18, max: 65, nullable: false
         name blank: false
         phone nullable: true
     }

--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/SaveWithExistingValidationErrorSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/SaveWithExistingValidationErrorSpec.groovy
@@ -66,5 +66,6 @@ class ObjectB {
     String name
 
     static constraints = {
+        name nullable: false
     }
 }

--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/entities/Contract.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/entities/Contract.groovy
@@ -28,4 +28,8 @@ import grails.gorm.annotation.Entity
 class Contract {
     BigDecimal salary
     static belongsTo = [player: Player]
+
+    static constraints = {
+        player nullable: false
+    }
 }

--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/validation/CascadeValidationSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/validation/CascadeValidationSpec.groovy
@@ -61,6 +61,9 @@ class Business {
             people: Person
     ]
 
+    static constraints = {
+        name nullable: false
+    }
 }
 @Entity
 abstract class Person {

--- a/grails-data-hibernate7/grails-plugin/src/test/groovy/grails/test/mixin/hibernate/HibernateSpecSpec.groovy
+++ b/grails-data-hibernate7/grails-plugin/src/test/groovy/grails/test/mixin/hibernate/HibernateSpecSpec.groovy
@@ -73,7 +73,7 @@ class Person {
     Integer age
     String phone
     static constraints = {
-        age min: 18, max: 65
+        age min: 18, max: 65, nullable: false
         name blank: false
         phone nullable: true
     }

--- a/grails-data-mongodb/core/src/test/groovy/grails/gorm/tests/Plant.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/grails/gorm/tests/Plant.groovy
@@ -28,6 +28,10 @@ class Plant implements Serializable, MongoEntity<Plant> {
     boolean goesInPatch
     String name
 
+    static constraints = {
+        name nullable: false
+    }
+
     static mapping = {
         name index:true
         goesInPatch index:true

--- a/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
@@ -226,7 +226,7 @@ class Person implements MongoEntity<Person> {
     Birthday birthday
 
     static constraints = {
-        name blank: false
+        name blank: false, nullable: false
         birthday nullable: true
     }
 }

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/FindOrCreateWhereSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/gorm/mongo/FindOrCreateWhereSpec.groovy
@@ -18,6 +18,7 @@
  */
 package org.grails.datastore.gorm.mongo
 
+import grails.gorm.tests.Person
 import grails.gorm.tests.Pet
 import org.apache.grails.data.mongo.core.GrailsDataMongoTckManager
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec

--- a/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/CircularCascadeSpec.groovy
+++ b/grails-datamapping-core-test/src/test/groovy/grails/gorm/tests/CircularCascadeSpec.groovy
@@ -133,10 +133,18 @@ class SportValidate {
 class TeamValidate {
 
     String name
+
+    static constraints = {
+        name nullable: false
+    }
 }
 
 @Entity
 class ArenaValidate {
 
     String name
+
+    static constraints = {
+        name nullable: false
+    }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithListArgBeforeValidate.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithListArgBeforeValidate.groovy
@@ -36,6 +36,6 @@ class ClassWithListArgBeforeValidate implements Serializable {
     }
 
     static constraints = {
-        name(blank: false)
+        name(blank: false, nullable: false)
     }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithNoArgBeforeValidate.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithNoArgBeforeValidate.groovy
@@ -34,6 +34,6 @@ class ClassWithNoArgBeforeValidate implements Serializable {
     }
 
     static constraints = {
-        name(blank: false)
+        name(blank: false, nullable: false)
     }
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithOverloadedBeforeValidate.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/domains/ClassWithOverloadedBeforeValidate.groovy
@@ -41,6 +41,6 @@ class ClassWithOverloadedBeforeValidate implements Serializable {
     }
 
     static constraints = {
-        name(blank: false)
+        name(blank: false, nullable: false)
     }
 }

--- a/grails-datamapping-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
+++ b/grails-datamapping-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
@@ -72,6 +72,7 @@ public class DefaultConstraintEvaluator implements ConstraintsEvaluator {
     protected final MappingContext mappingContext;
     protected final Map<String, Object> defaultConstraints;
     protected final boolean cacheAutoTimestampAnnotations;
+    protected final boolean defaultNullable;
 
     public DefaultConstraintEvaluator() {
         this(new DefaultConstraintRegistry(new StaticMessageSource()), new KeyValueMappingContext("default"), Collections.<String, Object>emptyMap(), true);
@@ -98,10 +99,15 @@ public class DefaultConstraintEvaluator implements ConstraintsEvaluator {
     }
 
     public DefaultConstraintEvaluator(ConstraintRegistry constraintRegistry, MappingContext mappingContext, Map<String, Object> defaultConstraints, boolean cacheAutoTimestampAnnotations) {
+        this(constraintRegistry, mappingContext, defaultConstraints, cacheAutoTimestampAnnotations, true);
+    }
+
+    public DefaultConstraintEvaluator(ConstraintRegistry constraintRegistry, MappingContext mappingContext, Map<String, Object> defaultConstraints, boolean cacheAutoTimestampAnnotations, boolean defaultNullable) {
         this.constraintRegistry = constraintRegistry;
         this.mappingContext = mappingContext;
         this.defaultConstraints = defaultConstraints;
         this.cacheAutoTimestampAnnotations = cacheAutoTimestampAnnotations;
+        this.defaultNullable = defaultNullable;
     }
 
     @Override
@@ -270,7 +276,14 @@ public class DefaultConstraintEvaluator implements ConstraintsEvaluator {
     }
 
     protected void applyDefaultNullableConstraint(PersistentProperty p, ConstrainedProperty cp) {
-        applyDefaultNullableConstraint(cp, false);
+        // Grails 8: persistent properties are nullable by default, aligning Grails with the rest of
+        // the JVM persistence/validation ecosystem (JPA/Hibernate, Spring Data, Micronaut Data and
+        // Jakarta Bean Validation are all "nullable unless you say otherwise"). To restore the
+        // legacy required-by-default behavior, either set the boolean flag:
+        //     grails.gorm.default.nullable = false
+        // or apply a wildcard default constraint:
+        //     grails.gorm.default.constraints = { '*'(nullable: false) }
+        applyDefaultNullableConstraint(cp, defaultNullable);
     }
 
     protected void applyDefaultNullableConstraint(ConstrainedProperty cp, boolean defaultNullable) {

--- a/grails-datamapping-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/registry/DefaultValidatorRegistry.groovy
+++ b/grails-datamapping-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/registry/DefaultValidatorRegistry.groovy
@@ -60,7 +60,8 @@ class DefaultValidatorRegistry implements ValidatorRegistry, ConstraintRegistry,
         // Default to true if not explicitly configured
         boolean cacheAnnotations = connectionSourceSettings.cacheAutoTimestampAnnotations != null ?
             connectionSourceSettings.cacheAutoTimestampAnnotations : true
-        this.constraintsEvaluator = new DefaultConstraintEvaluator(constraintRegistry, mappingContext, defaultConstraintsMap, cacheAnnotations)
+        boolean defaultNullable = connectionSourceSettings.default.nullable
+        this.constraintsEvaluator = new DefaultConstraintEvaluator(constraintRegistry, mappingContext, defaultConstraintsMap, cacheAnnotations, defaultNullable)
         this.mappingContext = mappingContext
     }
 

--- a/grails-datamapping-validation/src/test/groovy/grails/gorm/validation/NullableByDefaultSpec.groovy
+++ b/grails-datamapping-validation/src/test/groovy/grails/gorm/validation/NullableByDefaultSpec.groovy
@@ -1,0 +1,121 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.validation
+
+import org.grails.datastore.gorm.validation.constraints.registry.DefaultValidatorRegistry
+import org.grails.datastore.mapping.core.connections.ConnectionSourceSettings
+import org.grails.datastore.mapping.keyvalue.mapping.config.GormKeyValueMappingFactory
+import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.datastore.mapping.model.config.GormMappingConfigurationStrategy
+import org.grails.datastore.mapping.validation.ValidationErrors
+import org.grails.datastore.mapping.validation.ValidatorRegistry
+import org.springframework.validation.Errors
+import org.springframework.validation.Validator
+import spock.lang.Shared
+import spock.lang.Specification
+
+import jakarta.persistence.Entity
+
+/**
+ * Demonstrates the Grails 8 default: an unconstrained persistent property is nullable by default,
+ * aligning Grails with the rest of the JVM persistence/validation ecosystem. This spec deliberately
+ * does NOT opt out (no {@code grails.gorm.default.constraints} override), so it exercises the real
+ * framework default applied by {@code DefaultConstraintEvaluator}.
+ */
+class NullableByDefaultSpec extends Specification {
+
+    @Shared Validator widgetValidator
+
+    void setupSpec() {
+        MappingContext mappingContext = new KeyValueMappingContext("test")
+        mappingContext.mappingFactory = new GormKeyValueMappingFactory("test")
+        mappingContext.syntaxStrategy = new GormMappingConfigurationStrategy(mappingContext.mappingFactory)
+
+        PersistentEntity widgetEntity = mappingContext.addPersistentEntity(Widget)
+
+        ValidatorRegistry registry = new DefaultValidatorRegistry(mappingContext, new ConnectionSourceSettings())
+        widgetValidator = registry.getValidator(widgetEntity)
+    }
+
+    void "an unconstrained property is nullable by default"() {
+        given: "a widget whose only populated property is the explicitly-required one"
+        Widget widget = new Widget(requiredName: 'gizmo')
+        Errors errors = new ValidationErrors(widget)
+
+        when:
+        widgetValidator.validate(widget, errors)
+
+        then: "the unconstrained properties are valid while null - they are nullable by default"
+        !errors.hasErrors()
+        !errors.getFieldError('description')
+        !errors.getFieldError('quantity')
+    }
+
+    void "a property with an explicit nullable: false constraint is still required"() {
+        given: "a widget missing the explicitly-required property"
+        Widget widget = new Widget()
+        Errors errors = new ValidationErrors(widget)
+
+        when:
+        widgetValidator.validate(widget, errors)
+
+        then: "only the explicitly-required property is rejected; the unconstrained ones are not"
+        errors.hasErrors()
+        errors.getFieldError('requiredName')?.code == 'nullable'
+        !errors.getFieldError('description')
+        !errors.getFieldError('quantity')
+    }
+
+    void "grails.gorm.default.nullable = false restores required-by-default"() {
+        given: "a validator built with the YAML-friendly flag disabled"
+        MappingContext mappingContext = new KeyValueMappingContext("test")
+        mappingContext.mappingFactory = new GormKeyValueMappingFactory("test")
+        mappingContext.syntaxStrategy = new GormMappingConfigurationStrategy(mappingContext.mappingFactory)
+        PersistentEntity widgetEntity = mappingContext.addPersistentEntity(Widget)
+
+        ConnectionSourceSettings settings = new ConnectionSourceSettings()
+        settings.default.nullable = false
+        Validator validator = new DefaultValidatorRegistry(mappingContext, settings).getValidator(widgetEntity)
+
+        and: "a widget whose unconstrained properties are null"
+        Widget widget = new Widget(requiredName: 'gizmo')
+        Errors errors = new ValidationErrors(widget)
+
+        when:
+        validator.validate(widget, errors)
+
+        then: "the unconstrained properties are required again - the flag restored legacy behaviour"
+        errors.hasErrors()
+        errors.getFieldError('description')?.code == 'nullable'
+        errors.getFieldError('quantity')?.code == 'nullable'
+    }
+}
+
+@Entity
+class Widget {
+    String description
+    Integer quantity
+    String requiredName
+
+    static constraints = {
+        requiredName nullable: false
+    }
+}

--- a/grails-datamapping-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
+++ b/grails-datamapping-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
@@ -200,6 +200,8 @@ class Author {
     ]
 
     static constraints = {
+        name(nullable: false)   // explicit now that properties are nullable by default — this spec
+                                // uses the null-name error to detect that root beforeValidate didn't run
         publisher(nullable: true)
         ownedPublisher(nullable: true)
         defaultPublisher(nullable: true)

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Settings.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Settings.java
@@ -55,6 +55,10 @@ public interface Settings {
      */
     String SETTING_DEFAULT_CONSTRAINTS = PREFIX + '.' + "default.constraints";
     /**
+     * Whether an unconstrained persistent property is nullable by default (Grails 8 default: true)
+     */
+    String SETTING_DEFAULT_NULLABLE = PREFIX + '.' + "default.nullable";
+    /**
      * The custom types
      */
     String SETTING_CUSTOM_TYPES = PREFIX + '.' + "custom.types";

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Settings.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Settings.java
@@ -55,10 +55,6 @@ public interface Settings {
      */
     String SETTING_DEFAULT_CONSTRAINTS = PREFIX + '.' + "default.constraints";
     /**
-     * Whether an unconstrained persistent property is nullable by default (Grails 8 default: true)
-     */
-    String SETTING_DEFAULT_NULLABLE = PREFIX + '.' + "default.nullable";
-    /**
      * The custom types
      */
     String SETTING_CUSTOM_TYPES = PREFIX + '.' + "custom.types";

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/connections/ConnectionSourceSettings.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/connections/ConnectionSourceSettings.groovy
@@ -124,6 +124,12 @@ class ConnectionSourceSettings implements Settings {
          * The default constraints
          */
         Closure constraints
+
+        /**
+         * Whether an unconstrained persistent property is nullable by default (Grails 8 default: true).
+         * Set {@code grails.gorm.default.nullable = false} to restore the legacy required-by-default behaviour.
+         */
+        boolean nullable = true
     }
 
     /**

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -680,7 +680,51 @@ If your application contributed `HttpMessageConverter` beans through this class,
 Spring Framework 7 deprecated `org.springframework.lang.Nullable` and `org.springframework.lang.NonNull` in favor of the JSpecify annotations (`org.jspecify.annotations.Nullable`, `org.jspecify.annotations.NonNull`).
 The Spring annotations still work, so this is non-blocking, but new code should prefer the JSpecify equivalents.
 
-==== 20. Tag Library Test Cleanup Changes
+==== 20. GORM Properties Are Nullable by Default
+
+Grails 8 changes the validation default so that an *unconstrained persistent (domain) property is nullable by default* rather than required.
+This aligns Grails with the rest of the JVM persistence/validation ecosystem (JPA/Hibernate, Spring Data, Micronaut Data and Jakarta Bean Validation), all of which treat an unconstrained property as valid when `null`.
+
+Previously every domain property without an explicit constraint had an implicit `nullable: false` applied, so `save()` failed validation when the property was `null`.
+From Grails 8 such a property is optional unless you declare otherwise:
+
+[source,groovy]
+----
+class Book {
+    String title    // Grails 7: required, Grails 8: nullable
+
+    static constraints = {
+        title nullable: false   // declare explicitly to keep it required
+    }
+}
+----
+
+This is a *validation-layer* change only.
+Column/DDL nullability is governed separately by the mapping layer and is unaffected.
+Command objects are also unaffected: `Validateable` command-object fields remain required by default.
+
+To restore the legacy required-by-default behaviour for an entire application, set the new `grails.gorm.default.nullable` property to `false`:
+
+[source,yaml]
+.application.yml
+----
+grails:
+    gorm:
+        default:
+            nullable: false
+----
+
+The existing `grails.gorm.default.constraints` wildcard form also works:
+
+[source,groovy]
+.application.groovy
+----
+grails.gorm.default.constraints = {
+    '*'(nullable: false)
+}
+----
+
+==== 21. Tag Library Test Cleanup Changes
 
 Grails 8 removes the `purgeTagLibMetaClass` test hook used by some web and TagLib unit tests.
 TagLib metaclass cleanup now happens automatically as part of the web test infrastructure, so test specs should delete any custom `purgeTagLibMetaClass` property or getter.
@@ -706,7 +750,7 @@ class MyTagLibSpec extends Specification implements TagLibUnitTest<MyTagLib> {
 }
 ----
 
-==== 21. Method-based TagLib Handlers
+==== 22. Method-based TagLib Handlers
 
 Grails 8 introduces method-based tag handler syntax as the recommended way to define tags. Closure-based handlers are still supported for backward compatibility.
 
@@ -843,7 +887,7 @@ tasks.withType(GroovyCompile).configureEach {
 
 Without these flags, `Parameter.getName()` returns synthetic names such as `arg0`, the attribute lookup misses, and the call surfaces as `MissingMethodException` at runtime. The `@Tag`-annotated method itself produces no compile-time warning, because preservation is a property of the build, not of the source file.
 
-==== 22. Known Plugin Incompatibilities
+==== 23. Known Plugin Incompatibilities
 
 Some third-party plugins have not yet been updated for Spring Boot 4 / Spring Framework 7 compatibility.
 The following are known blockers at this time:

--- a/grails-doc/src/en/guide/validation/constraints.adoc
+++ b/grails-doc/src/en/guide/validation/constraints.adoc
@@ -51,7 +51,7 @@ class User {
 
 In this example we've declared that the `login` property must be between 5 and 15 characters long, it cannot be blank and must be unique. We've also applied other constraints to the `password`, `email` and `age` properties.
 
-NOTE: By default, all domain class properties are not nullable (i.e. they have an implicit `nullable: false` constraint).
+NOTE: As of Grails 8, domain class properties are *nullable by default*: an unconstrained property is optional unless you declare `nullable: false` (prior to Grails 8 the default was the opposite — an implicit `nullable: false` was applied to every property). To restore the legacy required-by-default behaviour application-wide, set `grails.gorm.default.nullable = false`.
 
 A complete reference for the available constraints can be found in the Quick Reference section under the Constraints heading.
 

--- a/grails-doc/src/en/ref/Constraints/nullable.adoc
+++ b/grails-doc/src/en/ref/Constraints/nullable.adoc
@@ -25,7 +25,26 @@ under the License.
 === Purpose
 
 
-Allows a property to be set to `null`. By default Grails does not allow `null` values for properties.
+Allows a property to be set to `null`.
+
+NOTE: As of Grails 8, an unconstrained persistent property is *nullable by default*, aligning Grails with the rest of the JVM persistence/validation ecosystem (JPA/Hibernate, Spring Data, Micronaut Data and Jakarta Bean Validation). Declare `nullable: false` to make a property required. To restore the legacy required-by-default behaviour for an application, set `grails.gorm.default.nullable` to `false`:
+
+[source,yaml]
+.grails-app/conf/application.yml
+----
+grails:
+    gorm:
+        default:
+            nullable: false
+----
+
+The equivalent in `grails-app/conf/application.groovy`:
+
+[source,groovy]
+.grails-app/conf/application.groovy
+----
+grails.gorm.default.nullable = false
+----
 
 
 === Examples

--- a/grails-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -29,6 +29,7 @@ import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluato
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
+import org.grails.datastore.mapping.config.Settings
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.validation.ConstraintEvalUtils
 
@@ -50,7 +51,10 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
     ConstraintsEvaluator getObject() throws Exception {
         ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
 
-        new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext, ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config))
+        boolean cacheAutoTimestampAnnotations = grailsApplication.config.getProperty(Settings.SETTING_AUTO_TIMESTAMP_CACHE_ANNOTATIONS, Boolean, true)
+        boolean defaultNullable = grailsApplication.config.getProperty(Settings.SETTING_DEFAULT_NULLABLE, Boolean, true)
+        new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext,
+                ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config), cacheAutoTimestampAnnotations, defaultNullable)
     }
 
     @Override

--- a/grails-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
+++ b/grails-domain-class/src/main/groovy/org/grails/plugins/domain/support/DefaultConstraintEvaluatorFactoryBean.groovy
@@ -29,7 +29,6 @@ import org.grails.datastore.gorm.validation.constraints.eval.ConstraintsEvaluato
 import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
 import org.grails.datastore.gorm.validation.constraints.registry.ConstraintRegistry
 import org.grails.datastore.gorm.validation.constraints.registry.DefaultConstraintRegistry
-import org.grails.datastore.mapping.config.Settings
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.validation.ConstraintEvalUtils
 
@@ -51,10 +50,9 @@ class DefaultConstraintEvaluatorFactoryBean implements FactoryBean<ConstraintsEv
     ConstraintsEvaluator getObject() throws Exception {
         ConstraintRegistry registry = new DefaultConstraintRegistry(messageSource)
 
-        boolean cacheAutoTimestampAnnotations = grailsApplication.config.getProperty(Settings.SETTING_AUTO_TIMESTAMP_CACHE_ANNOTATIONS, Boolean, true)
-        boolean defaultNullable = grailsApplication.config.getProperty(Settings.SETTING_DEFAULT_NULLABLE, Boolean, true)
         new DefaultConstraintEvaluator(registry, grailsDomainClassMappingContext,
-                ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config), cacheAutoTimestampAnnotations, defaultNullable)
+                ConstraintEvalUtils.getDefaultConstraints(grailsApplication.config), true,
+                ConstraintEvalUtils.getDefaultNullable(grailsApplication.config))
     }
 
     @Override

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Author.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Author.groovy
@@ -33,7 +33,7 @@ class Author {
 	static hasMany = [books: Book]
 	
 	static constraints = {
-		name blank: false
+		name blank: false, nullable: false
 		placeOfBirth nullable: true
 	}
 }

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/mock/Person.groovy
@@ -58,7 +58,7 @@ class Person {
 
 	static constraints = {
         salutation nullable: true
-		name blank: false
+		name blank: false, nullable: false
 		dateOfBirth nullable: true
 		address nullable: true
 		excludedProperty nullable: true
@@ -68,6 +68,9 @@ class Person {
 		anotherPicture nullable: true
 		password password: true
 		biography nullable: true, widget: 'textarea'
+		// declared last so it keeps sorting after the explicitly-ordered properties (preserving
+		// field-enumeration order); explicit now that properties are nullable by default
+		gender nullable: false
 	}
 
 	static scaffold = [exclude: ['excludedProperty']]

--- a/grails-fields/src/test/groovy/org/grails/scaffolding/model/property/EntityValidatorDomainPropertySpec.groovy
+++ b/grails-fields/src/test/groovy/org/grails/scaffolding/model/property/EntityValidatorDomainPropertySpec.groovy
@@ -109,6 +109,8 @@ class EntityValidatorDomainPropertySpec extends Specification implements MocksDo
             testRequired1(nullable: false, blank: false)
             testRequired2(nullable: false, blank: true)
             testRequired3(nullable: true, blank: false)
+            testRequired4(nullable: false)  // explicit now that the default is nullable; this spec
+                                            // builds its own MappingContext so it can't use the config opt-out
         }
     }
 

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/ValidationTagLibSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/ValidationTagLibSpec.groovy
@@ -658,6 +658,13 @@ class ValidationTagLibBook {
     URL publisherURL
     Date releaseDate
     BigDecimal usPrice
+
+    static constraints = {
+        title nullable: false
+        publisherURL nullable: false
+        releaseDate nullable: false
+        usPrice nullable: false
+    }
 }
 
 @Entity

--- a/grails-test-examples/app1/grails-app/conf/application.yml
+++ b/grails-test-examples/app1/grails-app/conf/application.yml
@@ -120,7 +120,6 @@ environments:
                defaultTransactionIsolation: 2
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/app1/grails-app/conf/application.yml
+++ b/grails-test-examples/app1/grails-app/conf/application.yml
@@ -118,3 +118,10 @@ environments:
                testOnReturn: false
                jdbcInterceptors: ConnectionState
                defaultTransactionIsolation: 2
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/app1/grails-app/domain/functionaltests/Book.groovy
+++ b/grails-test-examples/app1/grails-app/domain/functionaltests/Book.groovy
@@ -26,5 +26,6 @@ class Book {
     Date dateCreated
 
     static constraints = {
+        title nullable: false
     }
 }

--- a/grails-test-examples/demo33/grails-app/domain/demo/Car.groovy
+++ b/grails-test-examples/demo33/grails-app/domain/demo/Car.groovy
@@ -24,6 +24,7 @@ class Car {
     String color
 
     static constraints = {
+        color nullable: false
     }
 
     static mapping = {

--- a/grails-test-examples/gorm/grails-app/conf/application.yml
+++ b/grails-test-examples/gorm/grails-app/conf/application.yml
@@ -18,6 +18,9 @@ grails:
     profile: web
     codegen:
         defaultPackage: gorm
+    gorm:
+        default:
+            nullable: false
 info:
     app:
         name: '@info.app.name@'

--- a/grails-test-examples/hibernate5/grails-hibernate/grails-app/domain/functional/tests/Book.groovy
+++ b/grails-test-examples/hibernate5/grails-hibernate/grails-app/domain/functional/tests/Book.groovy
@@ -24,6 +24,6 @@ class Book {
     String title
 
     static constraints = {
-        title blank:false
+        title blank:false, nullable: false
     }
 }

--- a/grails-test-examples/hibernate5/grails-hibernate/grails-app/domain/functional/tests/Business.groovy
+++ b/grails-test-examples/hibernate5/grails-hibernate/grails-app/domain/functional/tests/Business.groovy
@@ -27,4 +27,7 @@ class Business {
             people: Person
     ]
 
+    static constraints = {
+        name nullable: false
+    }
 }

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
@@ -67,3 +67,10 @@ dataSources:
     driverClassName: org.h2.Driver
     dbCreate: create-drop
     url: jdbc:h2:mem:devDb2;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/grails-app/conf/application.yml
@@ -69,7 +69,6 @@ dataSources:
     url: jdbc:h2:mem:devDb2;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/hibernate7/grails-hibernate/grails-app/domain/functional/tests/Book.groovy
+++ b/grails-test-examples/hibernate7/grails-hibernate/grails-app/domain/functional/tests/Book.groovy
@@ -24,6 +24,6 @@ class Book {
     String title
 
     static constraints = {
-        title blank:false
+        title blank:false, nullable: false
     }
 }

--- a/grails-test-examples/hibernate7/grails-hibernate/grails-app/domain/functional/tests/Business.groovy
+++ b/grails-test-examples/hibernate7/grails-hibernate/grails-app/domain/functional/tests/Business.groovy
@@ -27,4 +27,7 @@ class Business {
             people: Person
     ]
 
+    static constraints = {
+        name nullable: false
+    }
 }

--- a/grails-test-examples/hibernate7/grails-multiple-datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate7/grails-multiple-datasources/grails-app/conf/application.yml
@@ -67,3 +67,10 @@ dataSources:
     driverClassName: org.h2.Driver
     dbCreate: create-drop
     url: jdbc:h2:mem:devDb2;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/hibernate7/grails-multiple-datasources/grails-app/conf/application.yml
+++ b/grails-test-examples/hibernate7/grails-multiple-datasources/grails-app/conf/application.yml
@@ -69,7 +69,6 @@ dataSources:
     url: jdbc:h2:mem:devDb2;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
@@ -99,7 +99,6 @@ environments:
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
+++ b/grails-test-examples/issue-698-domain-save-npe/grails-app/conf/application.yml
@@ -97,3 +97,10 @@ environments:
                 testOnReturn: false
                 jdbcInterceptors: ConnectionState
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/mongodb/base/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/base/grails-app/conf/application.yml
@@ -63,7 +63,6 @@ grails:
                 scriptlet: html
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/mongodb/base/grails-app/conf/application.yml
+++ b/grails-test-examples/mongodb/base/grails-app/conf/application.yml
@@ -61,3 +61,10 @@ grails:
             htmlcodec: xml
             codecs:
                 scriptlet: html
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
@@ -80,7 +80,6 @@ environments:
             url: jdbc:h2:./scaffoldingFieldsProdDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding-fields/grails-app/conf/application.yml
@@ -78,3 +78,10 @@ environments:
         dataSource:
             dbCreate: update
             url: jdbc:h2:./scaffoldingFieldsProdDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/scaffolding/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding/grails-app/conf/application.yml
@@ -98,3 +98,10 @@ environments:
                 testOnReturn: false
                 jdbcInterceptors: ConnectionState
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-examples/scaffolding/grails-app/conf/application.yml
+++ b/grails-test-examples/scaffolding/grails-app/conf/application.yml
@@ -100,7 +100,6 @@ environments:
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
+++ b/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
@@ -104,7 +104,6 @@ environments:
 book.listExcludes.vendor: ConfigVendor
 
 ---
-# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
 grails:
     gorm:
         default:

--- a/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
+++ b/grails-test-examples/views-functional-tests/grails-app/conf/application.yml
@@ -102,3 +102,10 @@ environments:
                 defaultTransactionIsolation: 2 # TRANSACTION_READ_COMMITTED
 
 book.listExcludes.vendor: ConfigVendor
+
+---
+# Grails 8 is nullable-by-default; this example asserts required-by-default validation, so opt out.
+grails:
+    gorm:
+        default:
+            nullable: false

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/CascadeValidationForEmbeddedSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/CascadeValidationForEmbeddedSpec.groovy
@@ -62,6 +62,6 @@ class CompanyAddress {
     String country
 
     static constraints = {
-        country(blank:false)
+        country(blank:false, nullable: false)
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/DomainClassDeepValidationSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/DomainClassDeepValidationSpec.groovy
@@ -66,7 +66,7 @@ class DomainClassDeepValidationSpec extends Specification implements DataTest {
 class ExampleManyChild {
 
     static constraints = {
-        childName(minSize: 1)
+        childName(minSize: 1, nullable: false)
     }
 
     String childName
@@ -96,7 +96,7 @@ class ExampleParent {
 class ExampleSingleChild {
 
     static constraints = {
-        singleName(minSize: 1)
+        singleName(minSize: 1, nullable: false)
     }
 
     String singleName

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSubclassSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSubclassSpec.groovy
@@ -171,6 +171,10 @@ class Bottom extends Middle<Album> {
 class Album {
     String title
     String artist
+
+    static constraints = {
+        title nullable: false
+    }
 }
 
 @Artefact('Controller')

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/cascade/CascadeCircularSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/cascade/CascadeCircularSpec.groovy
@@ -72,6 +72,7 @@ class Person {
     static mappedBy = [students: 'none', peers: 'none']
 
     static constraints = {
+        master nullable: false
         peers cascade: false
     }
 

--- a/grails-test-suite-uber/src/test/groovy/grails/validation/DomainConstraintGettersSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/validation/DomainConstraintGettersSpec.groovy
@@ -41,6 +41,17 @@ class DomainConstraintGettersSpec extends Specification implements DataTest {
         ]
     }
 
+    // This spec verifies which properties become constraint properties, using the default
+    // nullable constraint (and its 'nullable' validation error) as the detection mechanism.
+    // Grails 8 makes properties nullable by default, so restore required-by-default for this
+    // spec's own context to keep exercising that detection.
+    @Override
+    Closure doWithConfig() {
+        { config ->
+            config.grails.gorm.default.constraints = { '*'(nullable: false) }
+        }
+    }
+
     // STANDARD DOMAIN
 
     void 'ensure all public properties are by default constraint properties'() {

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/metaclass/ChainMethodTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/metaclass/ChainMethodTests.groovy
@@ -79,5 +79,9 @@ class TestChainController {
 @Entity
 class TestChainBook {
     String title
+
+    static constraints = {
+        title nullable: false
+    }
 }
 

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/FlashScopeWithErrorsTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/servlet/FlashScopeWithErrorsTests.groovy
@@ -67,4 +67,8 @@ class FlashScopeWithErrorsTests extends Specification implements DomainUnitTest<
 class Book {
     String title
     URL site
+
+    static constraints = {
+        title nullable: false
+    }
 }

--- a/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/grails/rest/web/RespondMethodSpec.groovy
@@ -295,7 +295,7 @@ class Book {
     String title
 
     static constraints = {
-        title blank:false
+        title blank:false, nullable: false
     }
 }
 

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/converters/JSONConverterTests.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/converters/JSONConverterTests.groovy
@@ -228,6 +228,11 @@ class Book {
    Long version
    String title
    String author
+
+   static constraints = {
+       title nullable: false
+       author nullable: false
+   }
 }
 
 class CustomCharSequence implements CharSequence {

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/JsonViewHelperSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/JsonViewHelperSpec.groovy
@@ -674,6 +674,10 @@ class Player {
     String name
     @SuppressWarnings('unused')
     static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
 }
 
 @Entity


### PR DESCRIPTION
## Summary

Change GORM's default constraint so an **unconstrained persistent (domain) property is nullable** (optional) rather than required. Today Grails applies an implicit `nullable: false` to every persistent property; this PR flips that default to `nullable: true`.

The default lives in `DefaultConstraintEvaluator` and is controlled by a new **YAML‑friendly boolean** that defaults to nullable‑by‑default:

```yaml
# application.yml — set false to restore the legacy required-by-default behaviour
grails:
  gorm:
    default:
      nullable: false
```

**Scope is the validation layer only.** Command‑object validation (`Validateable.defaultNullable()`) is intentionally left **required‑by‑default and unchanged** in this PR.

## Why this should be the Grails 8 default

**Grails is the only mainstream JVM data framework that is required‑by‑default.** Every comparable layer treats an unconstrained property as nullable and makes you opt *into* "required":

| Framework | Default for an unconstrained reference property |
|---|---|
| JPA / Hibernate | nullable (`@Column(nullable=false)` / `@NotNull` to require) |
| Spring Data JPA | nullable |
| Spring Data MongoDB | nullable (schemaless) |
| Micronaut Data | nullable (`@NonNull` / Kotlin non‑null type to require) |
| Jakarta Bean Validation (JSR‑380) | nullable — *no constraint = valid*; `@NotNull` is the opt‑in |
| **Grails / GORM (today)** | **required** (`nullable: true` to allow null) |

The case for flipping it:

1. **Principle of least surprise / ecosystem consistency.** Developers arriving from Spring Boot, Micronaut, JPA, or plain Bean Validation expect "nullable unless I say otherwise." Grails inverts that — one of the most common first‑week surprises ("why does saving fail when I didn't mark anything required?").
2. **It contradicts the storage layer.** SQL columns are nullable by default; MongoDB is schemaless. Grails' validation default is *stricter than the database it maps to*, for no structural reason.
3. **It inverts the JSR‑380 contract.** Bean Validation defines "absence of a constraint ⇒ the value is valid (including null)"; `@NotNull` is the explicit opt‑in. Grails' implicit `nullable:false` is a silent, framework‑specific reversal of the spec it otherwise embraces.
4. **It breaks composition.** Fields contributed by traits, base classes, or shared modules — or simply a new field added to an existing domain — silently become **required**, surfacing only as a runtime `ValidationException` on the first save (often in an unrelated path, e.g. a BootStrap seed). Mixing in reusable field sets is exactly the modular design Grails 8 should encourage; required‑by‑default punishes it.
5. **A major version is the right time.** Defaults that no longer match the ecosystem should be corrected at a major boundary. Grails 8 is that boundary.

## Backward compatibility

Deliberate behavior change, with a **one‑line opt‑out** to restore the legacy behavior per application. Either set the boolean flag (YAML or groovy):

```yaml
# grails-app/conf/application.yml
grails:
  gorm:
    default:
      nullable: false
```
```groovy
// grails-app/conf/application.groovy
grails.gorm.default.nullable = false
```

…or use the existing wildcard‑constraint form, which also still works:

```groovy
grails.gorm.default.constraints = {
    '*'(nullable: false)
}
```

The `grails.gorm.default.constraints` machinery applies `'*'` constraints *before* the framework default and skips the default when one is set (`canApplyNullableConstraint`), so either opt‑out composes cleanly with per‑property overrides.

Command objects are unaffected (still required‑by‑default). If you additionally want command objects to be nullable‑by‑default, that remains an explicit per‑class opt‑in via `static boolean defaultNullable() { true }`.

## Test suite

The affected test suite has been swept and the **full `./gradlew test` is green**. Rather than disabling the new default wholesale, each spec that asserts required‑by‑default semantics now declares the specific field(s) it depends on explicitly (`nullable: false`), reproducing the prior baseline for just those fields. A module‑wide `grails.gorm.default.constraints` opt‑out was deliberately **not** used as the general mechanism because that closure is also evaluated against the GORM mapping builder and can perturb per‑property mapping (e.g. `formula:`/derived‑property detection used by `f:fields`/`f:all`), and because several specs define their own `grails.gorm.default.constraints` that a module‑wide file would clobber.

A new `NullableByDefaultSpec` demonstrates the change **without any opt‑out** (an unconstrained property validates while null, while a property with an explicit `nullable: false` is still required), and verifies that `grails.gorm.default.nullable = false` restores required‑by‑default through `DefaultValidatorRegistry`.

## Notes / scope

- **Validation layer only.** Column/DDL nullability is governed separately by the mapping layer (`Property.nullable` / `GrailsDomainBinder`) and is **not** changed here; aligning the DDL default is a documented follow‑up for maintainers.
- Opening against `8.0.x`.
