### PR TITLE
fix: parse ASCII minus in locale-aware number binding

### DIFF
--- a/grails-databinding/src/main/groovy/org/grails/databinding/converters/web/LocaleAwareNumberConverter.groovy
+++ b/grails-databinding/src/main/groovy/org/grails/databinding/converters/web/LocaleAwareNumberConverter.groovy
@@ -18,6 +18,7 @@
  */
 package org.grails.databinding.converters.web
 
+import java.text.DecimalFormat
 import java.text.NumberFormat
 import java.text.ParsePosition
 
@@ -56,12 +57,24 @@ class LocaleAwareNumberConverter implements ValueConverter {
     @Override
     Object convert(Object value) {
         def trimmedValue = value.toString().trim()
+        def formatter = numberFormatter
+        def valueToParse = replaceAsciiMinusWithLocaleMinus(formatter, trimmedValue)
         def parsePosition = new ParsePosition(0)
-        def result = numberFormatter.parse((String) value, parsePosition).asType(getTargetType())
-        if (parsePosition.index != trimmedValue.size()) {
+        def result = formatter.parse(valueToParse, parsePosition).asType(getTargetType())
+        if (parsePosition.index != valueToParse.size()) {
             throw new NumberFormatException("Unable to parse number [${value}]")
         }
         result
+    }
+
+    protected String replaceAsciiMinusWithLocaleMinus(NumberFormat formatter, String value) {
+        if (formatter instanceof DecimalFormat && value.startsWith('-')) {
+            char minusSign = formatter.decimalFormatSymbols.minusSign
+            if (minusSign != '-' as char) {
+                return String.valueOf(minusSign) + value.substring(1)
+            }
+        }
+        value
     }
 
     protected NumberFormat getNumberFormatter() {

--- a/grails-databinding/src/test/groovy/org/grails/databinding/converters/web/LocaleAwareNumberConverterSpec.groovy
+++ b/grails-databinding/src/test/groovy/org/grails/databinding/converters/web/LocaleAwareNumberConverterSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.databinding.converters.web
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class LocaleAwareNumberConverterSpec extends Specification {
+
+    private Locale defaultLocale
+
+    void setup() {
+        defaultLocale = Locale.default
+    }
+
+    void cleanup() {
+        Locale.default = defaultLocale
+    }
+
+    @Unroll
+    void 'converts #targetType.simpleName value with ASCII minus for #locale'() {
+        given:
+        Locale.default = locale
+        converter.targetType = targetType
+
+        expect:
+        converter.convert(value) == expectedValue
+
+        where:
+        locale                 | converter                                  | targetType | value     | expectedValue
+        new Locale('nb', 'NO') | new LocaleAwareNumberConverter()           | Long       | '-1'      | -1L
+        new Locale('nb', 'NO') | new LocaleAwareBigDecimalConverter()       | BigDecimal | '-1,25'   | new BigDecimal('-1.25')
+        new Locale('nb', 'NO') | new LocaleAwareBigDecimalConverter()       | BigInteger | '-1'      | new BigInteger('-1')
+        Locale.US              | new LocaleAwareNumberConverter()           | Long       | '-1'      | -1L
+        Locale.US              | new LocaleAwareBigDecimalConverter()       | BigDecimal | '-1.25'   | new BigDecimal('-1.25')
+        Locale.US              | new LocaleAwareBigDecimalConverter()       | BigInteger | '-1'      | new BigInteger('-1')
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #15714 by accepting browser-submitted ASCII hyphen-minus values in locale-aware number binding for locales whose DecimalFormat minus sign is U+2212, such as nb_NO.

The earlier PR #15475 correctly scoped the rendering fix to form field input output, but #15714 shows the remaining failure is on the request binding side. The sample application's proposed direction was right: convert a leading ASCII minus to the active locale minus before calling NumberFormat.parse, instead of changing display tags.

## Changes

- Normalize only a leading ASCII minus in LocaleAwareNumberConverter before parsing.
- Leave g:formatNumber, g:fieldValue, and form field rendering behavior unchanged.
- Add Spock coverage for Long, BigDecimal, and BigInteger converters in nb_NO and en_US.

## Verification

- ./gradlew :grails-databinding:test --tests "org.grails.databinding.converters.web.LocaleAwareNumberConverterSpec"
- ./gradlew :grails-databinding:test
- Oracle review-gate verdict: GREEN