### PR TITLE
Update Spring Boot 4.1 dependency versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -26,7 +26,7 @@ ext {
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
             'asset-pipeline-gradle.version' : '5.1.0-M4',
-            'byte-buddy.version'            : '1.18.8',
+            'byte-buddy.version'            : '1.18.10',
             'commons-text.version'          : '1.15.0',
             'directory-watcher.version'     : '0.19.1',
             'gradle-groovy.version'         : '4.0.32',
@@ -39,7 +39,7 @@ ext {
             'jna.version'                   : '5.18.1',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '4.1.0-RC1',
+            'spring-boot.version'           : '4.1.0',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly
@@ -86,7 +86,7 @@ ext {
             'jakarta-validation.version': '3.1.1',
             'jquery.version'                : '3.7.1',
             'junit.version'                 : '6.0.3',
-            'mongodb.version'               : '5.7.0-beta1',
+            'mongodb.version'               : '5.8.0',
             'rxjava.version'                : '1.3.8',
             'rxjava2.version'               : '2.2.21',
             'rxjava3.version'               : '3.1.12',

--- a/grails-shell-cli/build.gradle
+++ b/grails-shell-cli/build.gradle
@@ -57,7 +57,9 @@ dependencies {
     api 'org.apache.ant:ant'
     api 'org.fusesource.jansi:jansi'
     api 'org.jline:jline'
-    api "org.gradle:gradle-tooling-api:$gradleToolingApiVersion"
+    api("org.gradle:gradle-tooling-api:$gradleToolingApiVersion") {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
     
     compileOnly 'org.springframework.boot:spring-boot'
     compileOnly 'org.springframework.boot:spring-boot-loader-tools'


### PR DESCRIPTION
## Summary
- Update Spring Boot from 4.1.0-RC1 to 4.1.0
- Align Byte Buddy and MongoDB driver versions with the Spring Boot 4.1.0 managed dependency set
- Exclude the Gradle Tooling API SLF4J edge so grails-shell-cli resolves the Boot-managed SLF4J API

## Verification
- `./gradlew.bat validateDependencyVersions --continue --stacktrace`
- `grails-gradle: ./gradlew.bat validateDependencyVersions --continue --stacktrace`
- `./gradlew.bat :grails-bom:build :grails-gradle:grails-gradle-bom:build :grails-shell-cli:build :grails-data-hibernate5-dbmigration:build :grails-data-hibernate7-dbmigration:build -PskipTests`
- `./gradlew.bat :grails-shell-cli:dependencyInsight --dependency org.slf4j:slf4j-api --configuration runtimeClasspath`