### PR TITLE
Update Spring Boot to 3.5.15

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ ext {
             'jna.version'                   : '5.17.0',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '3.5.14',
+            'spring-boot.version'           : '3.5.15',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly
@@ -74,7 +74,7 @@ ext {
             'commons-lang3.version'         : '3.20.0',
             'geb-spock.version'             : '8.0.1',
             'groovy.version'                : '4.0.32',
-            'jackson.version'               : '2.21.2',
+            'jackson.version'               : '2.21.4',
             'jquery.version'                : '3.7.1',
             'hibernate-groovy-proxy.version': '1.1',
             'jakarta-servlet-api.version'   : '6.1.0',


### PR DESCRIPTION
## Summary

Updates Spring Boot from 3.5.14 to [3.5.15](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.15).

## Details

Spring Boot 3.5.15's `spring-boot-dependencies` BOM bumps its managed `jackson-bom.version` from 2.21.2 to 2.21.4. With only the Spring Boot bump, the `validateDependencyVersions` CI check fails because `grails-bom` pins Jackson to 2.21.2 while the new Spring Boot BOM forces 2.21.4 transitively (observed on `grails-test-examples-jetty`):

```text
com.fasterxml.jackson:jackson-bom - resolved 2.21.4, expected 2.21.2
```

This PR therefore also aligns `jackson.version` in `dependencies.gradle` to 2.21.4 to keep the grails BOM consistent with the Spring Boot BOM.

## Verification

Ran the same dependency checker CI uses, both invocations green:

- `./gradlew validateDependencyVersions` (grails-core) - BUILD SUCCESSFUL
- `./gradlew validateDependencyVersions` (grails-gradle) - BUILD SUCCESSFUL
