### PR TITLE
7.2.x (grails-scaffolding) - Parameterize the @Scaffold controller superclass so scaffolded controller members aren't type-erased

### DIFF
--- a/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -22,6 +22,7 @@ package org.grails.compiler.scaffolding
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.ast.ClassHelper
 import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.GenericsType
 import org.codehaus.groovy.ast.expr.ClassExpression
 import org.codehaus.groovy.ast.expr.ConstantExpression
 import org.codehaus.groovy.classgen.GeneratorContext
@@ -118,7 +119,17 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
                         GrailsASTUtils.error(source, classNode, "Scaffolded controller (${classNode.name}) with @Scaffold does not have domain class set.", true)
                     }
                 }
-                classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                // Parameterize the superclass (e.g. RestfulController<Domain>) so inherited actions and
+                // super.* calls resolve to the domain type under static compilation, not the GormEntity
+                // upper bound. Mirrors ScaffoldingServiceInjector.
+                ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
+                parameterizedSuper.setGenericsTypes(
+                    [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
+                // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
+                // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
+                // written raw. Required - do not remove.
+                classNode.setUsingGenerics(true)
+                classNode.setSuperClass(parameterizedSuper)
                 def readOnlyExpression = (ConstantExpression) annotationNode?.getMember('readOnly')
                 new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean() ?: false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {

--- a/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
+++ b/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjector.groovy
@@ -120,16 +120,24 @@ class ScaffoldingControllerInjector implements GrailsArtefactClassInjector {
                     }
                 }
                 // Parameterize the superclass (e.g. RestfulController<Domain>) so inherited actions and
-                // super.* calls resolve to the domain type under static compilation, not the GormEntity
-                // upper bound. Mirrors ScaffoldingServiceInjector.
-                ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
-                parameterizedSuper.setGenericsTypes(
-                    [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
-                // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
-                // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
-                // written raw. Required - do not remove.
-                classNode.setUsingGenerics(true)
-                classNode.setSuperClass(parameterizedSuper)
+                // super.* calls
+                // resolve to the domain type under static compilation, not the GormEntity
+                // upper bound. Mirrors ScaffoldingServiceInjector. Only single-type-parameter bases are parameterized — a
+                // base declaring zero or multiple type parameters would get a malformed generic
+                // signature from a single domain argument, so those keep the previous raw form.
+                GenericsType[] declaredTypeParams = superClassNode.redirect().genericsTypes
+                if (declaredTypeParams != null && declaredTypeParams.length == 1) {
+                    ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
+                    parameterizedSuper.setGenericsTypes(
+                        [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
+                    // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
+                    // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
+                    // written raw. Required - do not remove.
+                    classNode.setUsingGenerics(true)
+                    classNode.setSuperClass(parameterizedSuper)
+                } else {
+                    classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                }
                 def readOnlyExpression = (ConstantExpression) annotationNode?.getMember('readOnly')
                 new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean() ?: false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {

--- a/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
+++ b/grails-scaffolding/src/main/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjector.groovy
@@ -93,15 +93,23 @@ class ScaffoldingServiceInjector implements GrailsArtefactClassInjector {
                     GrailsASTUtils.error(source, classNode, "Scaffolded service (${classNode.name}) with @Scaffold does not have domain class set.", true)
                 }
                 // Parameterize the superclass (e.g. GormService<Domain>) so inherited get()/list()/save()
-                // resolve to the domain type under static compilation, not the GormEntity upper bound.
-                ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
-                parameterizedSuper.setGenericsTypes(
-                    [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
-                // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
-                // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
-                // written raw. Required - do not remove.
-                classNode.setUsingGenerics(true)
-                classNode.setSuperClass(parameterizedSuper)
+                // resolve to the domain type under static compilation, not the GormEntity
+                // upper bound. Only single-type-parameter bases are parameterized — a
+                // base declaring zero or multiple type parameters would get a malformed generic
+                // signature from a single domain argument, so those keep the previous raw form.
+                GenericsType[] declaredTypeParams = superClassNode.redirect().genericsTypes
+                if (declaredTypeParams != null && declaredTypeParams.length == 1) {
+                    ClassNode parameterizedSuper = superClassNode.getPlainNodeReference()
+                    parameterizedSuper.setGenericsTypes(
+                        [new GenericsType(GrailsASTUtils.nonGeneric(domainClass))] as GenericsType[])
+                    // Injection runs at CANONICALIZATION (after generics resolution), so the generic superclass
+                    // signature is only emitted when the class node itself reports usesGenerics; otherwise it is
+                    // written raw. Required - do not remove.
+                    classNode.setUsingGenerics(true)
+                    classNode.setSuperClass(parameterizedSuper)
+                } else {
+                    classNode.setSuperClass(GrailsASTUtils.nonGeneric(superClassNode, domainClass))
+                }
                 def readOnlyExpression = (ConstantExpression) annotationNode.getMember('readOnly')
                 new ResourceTransform().addConstructor(classNode, domainClass, readOnlyExpression?.getValue()?.asBoolean() ?: false)
             } else if (!currentSuperClass.isDerivedFrom(superClassNode)) {

--- a/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjectorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjectorSpec.groovy
@@ -125,6 +125,33 @@ class WidgetController {
         parameterized.actualTypeArguments[0].name == 'com.example.Widget'
     }
 
+    void 'a custom base with multiple type parameters keeps the raw superclass instead of a malformed signature'() {
+        given: 'a base whose generic arity does not match the single domain argument'
+        gcl.parseClass('''
+package com.example
+import grails.rest.RestfulController
+import org.grails.datastore.gorm.GormEntity
+class MultiParamController<T extends GormEntity<T>, S> extends RestfulController<T> {
+    MultiParamController(Class<T> resource, boolean readOnly) {
+        super(resource, readOnly)
+    }
+}
+''')
+
+        when:
+        def controllerClass = parseScaffoldController('WidgetController', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(MultiParamController<Widget, String>)
+class WidgetController {
+}
+''')
+
+        then: 'the declared base is kept, written raw - and superclass reflection does not throw'
+        controllerClass.superclass.name == 'com.example.MultiParamController'
+        controllerClass.genericSuperclass == controllerClass.superclass
+    }
+
     void 'the parameterized superclass narrows inherited resource hooks to the domain type under static compilation'() {
         when: 'a statically-compiled scaffolded controller overrides the hooks and narrows the super results'
         def controllerClass = parseScaffoldController('WidgetController', '''

--- a/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjectorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingControllerInjectorSpec.groovy
@@ -1,0 +1,162 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.compiler.scaffolding
+
+import java.lang.reflect.ParameterizedType
+
+import grails.compiler.ast.ClassInjector
+import grails.rest.RestfulController
+import org.grails.compiler.injection.GrailsAwareClassLoader
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class ScaffoldingControllerInjectorSpec extends Specification {
+
+    private static final String DOMAIN_SRC = '''
+package com.example
+import org.grails.datastore.gorm.GormEntity
+class Widget implements GormEntity<Widget> {
+    String name
+}
+'''
+
+    @TempDir
+    File tmpDir
+
+    GrailsAwareClassLoader gcl
+
+    def setup() {
+        gcl = new GrailsAwareClassLoader()
+        gcl.classInjectors = [new ScaffoldingControllerInjector()] as ClassInjector[]
+        gcl.parseClass(DOMAIN_SRC)
+    }
+
+    /**
+     * The ScaffoldingControllerInjector only runs for sources whose URL matches the
+     * grails-app/controllers/**Controller.groovy pattern, and the compiler only resolves that
+     * URL when the file actually exists on disk - so the controller must be written to a real file.
+     */
+    private Class<?> parseScaffoldController(String simpleName, String source) {
+        def controllerDir = new File(tmpDir, 'grails-app/controllers/com/example')
+        controllerDir.mkdirs()
+        def controllerFile = new File(controllerDir, "${simpleName}.groovy")
+        controllerFile.text = source
+        gcl.parseClass(controllerFile)
+    }
+
+    void 'the @Scaffold(Domain) superclass is parameterized as RestfulController<Domain> rather than raw'() {
+        when:
+        def controllerClass = parseScaffoldController('WidgetController', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(Widget)
+class WidgetController {
+}
+''')
+
+        then: 'the generic superclass carries the domain type argument, not an erased raw type'
+        controllerClass.genericSuperclass instanceof ParameterizedType
+
+        and:
+        ParameterizedType parameterized = controllerClass.genericSuperclass as ParameterizedType
+        parameterized.rawType == RestfulController
+        parameterized.actualTypeArguments.length == 1
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'the @Scaffold(RestfulController<Domain>) generic form is parameterized as RestfulController<Domain>'() {
+        when:
+        def controllerClass = parseScaffoldController('WidgetController', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+import grails.rest.RestfulController
+@Scaffold(RestfulController<Widget>)
+class WidgetController {
+}
+''')
+
+        then:
+        ParameterizedType parameterized = controllerClass.genericSuperclass as ParameterizedType
+        parameterized.rawType == RestfulController
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'a custom scaffold base is preserved and parameterized as CustomBase<Domain>'() {
+        given: 'a custom RestfulController subclass used as the scaffold base'
+        gcl.parseClass('''
+package com.example
+import grails.rest.RestfulController
+import org.grails.datastore.gorm.GormEntity
+class ApiController<T extends GormEntity<T>> extends RestfulController<T> {
+    ApiController(Class<T> resource, boolean readOnly) {
+        super(resource, readOnly)
+    }
+}
+''')
+
+        when:
+        def controllerClass = parseScaffoldController('WidgetController', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(ApiController<Widget>)
+class WidgetController {
+}
+''')
+
+        then: 'the declared custom base is kept (not collapsed to RestfulController) and carries the domain type argument'
+        ParameterizedType parameterized = controllerClass.genericSuperclass as ParameterizedType
+        parameterized.rawType.name == 'com.example.ApiController'
+        parameterized.actualTypeArguments[0].name == 'com.example.Widget'
+    }
+
+    void 'the parameterized superclass narrows inherited resource hooks to the domain type under static compilation'() {
+        when: 'a statically-compiled scaffolded controller overrides the hooks and narrows the super results'
+        def controllerClass = parseScaffoldController('WidgetController', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+import groovy.transform.CompileStatic
+@Scaffold(Widget)
+@CompileStatic
+class WidgetController {
+    @Override
+    protected Widget queryForResource(Serializable id) {
+        Widget found = super.queryForResource(id)
+        found
+    }
+    @Override
+    protected Widget createResource() {
+        Widget created = super.createResource()
+        created.name = 'fresh'
+        created
+    }
+    @Override
+    protected List<Widget> listAllResources(Map params) {
+        List<Widget> all = super.listAllResources(params)
+        all
+    }
+}
+''')
+
+        then: '''static compilation succeeds without casts: the type checker resolves queryForResource():T,
+                  createResource():T and listAllResources():List<T> through the RestfulController<Widget>
+                  superclass. With the prior raw superclass these erased to GormEntity and the Widget
+                  assignments and the created.name property write would have failed to compile.'''
+        controllerClass != null
+    }
+}

--- a/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjectorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/org/grails/compiler/scaffolding/ScaffoldingServiceInjectorSpec.groovy
@@ -125,6 +125,33 @@ class WidgetService {
         parameterized.actualTypeArguments[0].name == 'com.example.Widget'
     }
 
+    void 'a custom base with multiple type parameters keeps the raw superclass instead of a malformed signature'() {
+        given: 'a base whose generic arity does not match the single domain argument'
+        gcl.parseClass('''
+package com.example
+import grails.plugin.scaffolding.GormService
+import org.grails.datastore.gorm.GormEntity
+class MultiParamRepository<T extends GormEntity<T>, S> extends GormService<T> {
+    MultiParamRepository(Class<T> resource, boolean readOnly) {
+        super(resource, readOnly)
+    }
+}
+''')
+
+        when:
+        def serviceClass = parseScaffoldService('WidgetService', '''
+package com.example
+import grails.plugin.scaffolding.annotation.Scaffold
+@Scaffold(MultiParamRepository<Widget, String>)
+class WidgetService {
+}
+''')
+
+        then: 'the declared base is kept, written raw - and superclass reflection does not throw'
+        serviceClass.superclass.name == 'com.example.MultiParamRepository'
+        serviceClass.genericSuperclass == serviceClass.superclass
+    }
+
     void 'the parameterized superclass narrows inherited get()/list()/save() to the domain type under static compilation'() {
         given:
         parseScaffoldService('WidgetService', '''


### PR DESCRIPTION
## Summary

Controller-side counterpart of #15717. `ScaffoldingControllerInjector` set the injected superclass via `GrailsASTUtils.nonGeneric(superClassNode, domainClass)`, so a scaffolded controller's superclass was written **raw** and every inherited generic member erased to its `GormEntity` upper bound under static compilation:

```groovy
@Scaffold(RestfulController<Widget>)
@GrailsCompileStatic
class WidgetController {
    @Override
    protected Widget queryForResource(Serializable id) {
        def widget = super.queryForResource(id)   // before: typed GormEntity, not Widget
        (widget?.owner == currentOwner) ? widget : null
    }
}
```

fails with:

```
[Static type checking] - No such property: owner for class: org.grails.datastore.gorm.GormEntity
[Static type checking] - Cannot return value of type org.grails.datastore.gorm.GormEntity for method returning com.example.Widget
```

The common workaround in real apps is sprinkling `@CompileDynamic` over every `queryForResource`/`createResource`/`listAllResources` override, giving up static compilation exactly where project-scoping security checks live.

## Design

Same pattern #15717 applied to `ScaffoldingServiceInjector`: take a `getPlainNodeReference()` copy of the resolved superclass, set its generics to the domain type, mark the class node with `setUsingGenerics(true)` — injection runs at CANONICALIZATION (after generics resolution), so the generic superclass signature is only emitted when the class node itself reports `usesGenerics`; otherwise it is written raw — then `setSuperClass(parameterizedSuper)`. Applies to all three forms: `@Scaffold(Widget)`, `@Scaffold(RestfulController<Widget>)`, and custom bases `@Scaffold(ApiController<Widget>)` (the declared base is preserved, not collapsed to `RestfulController`).

## Tests

New `ScaffoldingControllerInjectorSpec` mirroring `ScaffoldingServiceInjectorSpec`:

- simple form `@Scaffold(Widget)` → `genericSuperclass` is `RestfulController<Widget>`, not raw
- generic form `@Scaffold(RestfulController<Widget>)` → parameterized
- custom scaffold base preserved and parameterized as `CustomBase<Widget>`
- a `@CompileStatic` scaffolded controller overriding `queryForResource` / `createResource` / `listAllResources` and narrowing the `super.*` results to the domain type compiles without casts

All four tests fail against the previous injector and pass with the fix; `:grails-scaffolding:test` passes in full.