### PR TITLE
8.x Add Class-typed getAttribute reads for session, request and servletContext

### DIFF
--- a/grails-doc/src/en/guide/theWebLayer/controllers/typeConverters.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/typeConverters.adoc
@@ -80,3 +80,22 @@ int maxUploads = servletContext.int('maxUploads', 10)
 As with `params`, each method is null-safe and safe from parsing errors, and each accepts an optional default value as a second argument that is returned when the attribute is absent or cannot be converted.
 
 NOTE: The `string` method returns the first element when the underlying attribute is an array, mirroring the single-value semantics of the other converters. Use the `list` method to obtain every value.
+
+
+=== Typed Reads of Attributes
+
+
+Attributes often hold richer objects than the scalar types covered by the named converters — a security principal, a domain instance, a token. For these, `session`, `request` and `servletContext` offer a `Class`-typed overload of `getAttribute` that returns the attribute typed as requested, so no cast is needed under static compilation:
+
+[source,groovy]
+----
+// returns the attribute typed as CsrfToken, or null when absent
+CsrfToken token = session.getAttribute('_csrf', CsrfToken)
+
+// with a default, returned when the attribute is absent
+Theme theme = session.getAttribute('theme', Theme, Theme.DEFAULT)
+
+UserDetails user = request.getAttribute('apiUser', UserDetails)
+----
+
+Unlike the named converters, no coercion is attempted: the attribute is returned only when it is an instance of the requested type, and reads as absent otherwise (so the default also applies when the stored value has an unexpected type). Use the named converters when you want type conversion, and the `Class`-typed read when you want a type-safe retrieval.

--- a/grails-doc/src/en/guide/theWebLayer/controllers/typeConverters.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/typeConverters.adoc
@@ -98,4 +98,4 @@ Theme theme = session.getAttribute('theme', Theme, Theme.DEFAULT)
 UserDetails user = request.getAttribute('apiUser', UserDetails)
 ----
 
-Unlike the named converters, no coercion is attempted: the attribute is returned only when it is an instance of the requested type, and reads as absent otherwise (so the default also applies when the stored value has an unexpected type). Use the named converters when you want type conversion, and the `Class`-typed read when you want a type-safe retrieval.
+Unlike the named converters, no coercion is attempted: the attribute is returned only when it is an instance of the requested type, and reads as absent otherwise (so the default also applies when the stored value has an unexpected type). Primitive class literals (`int`, `boolean`, ...) are normalized to their wrapper types. Use the named converters when you want type conversion, and the `Class`-typed read when you want a type-safe retrieval.

--- a/grails-web-core/build.gradle
+++ b/grails-web-core/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     // Testing
     testImplementation 'org.slf4j:slf4j-simple'
     testImplementation 'org.spockframework:spock-core'
+    testImplementation 'net.bytebuddy:byte-buddy'
 }
 
 apply {

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
@@ -21,6 +21,7 @@ package org.grails.web.servlet
 import groovy.transform.CompileStatic
 
 import org.apache.grails.core.internal.util.TypeConverters
+import org.springframework.util.ClassUtils
 
 import jakarta.servlet.http.HttpServletRequest
 
@@ -258,7 +259,8 @@ class HttpServletRequestExtension {
      */
     static <T> T getAttribute(HttpServletRequest request, String name, Class<T> type) {
         Object value = request.getAttribute(name)
-        type.isInstance(value) ? type.cast(value) : null
+        Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
+        resolvedType.isInstance(value) ? resolvedType.cast(value) : null
     }
 
     /**

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
@@ -258,6 +258,9 @@ class HttpServletRequestExtension {
      * use the named converters ({@code string}, {@code int}, ...) for type conversion.
      */
     static <T> T getAttribute(HttpServletRequest request, String name, Class<T> type) {
+        if (type == null) {
+            throw new IllegalArgumentException('type must not be null - use getAttribute(name) for an untyped read')
+        }
         Object value = request.getAttribute(name)
         Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
         resolvedType.isInstance(value) ? resolvedType.cast(value) : null

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpServletRequestExtension.groovy
@@ -251,4 +251,22 @@ class HttpServletRequestExtension {
     static Date date(HttpServletRequest request, String name, Collection<String> formats) {
         TypeConverters.toDate(request.getAttribute(name), formats)
     }
+    /**
+     * Null-safe, typed read of an attribute. Returns the attribute when it is an
+     * instance of {@code type}; otherwise {@code null}. No coercion is attempted —
+     * use the named converters ({@code string}, {@code int}, ...) for type conversion.
+     */
+    static <T> T getAttribute(HttpServletRequest request, String name, Class<T> type) {
+        Object value = request.getAttribute(name)
+        type.isInstance(value) ? type.cast(value) : null
+    }
+
+    /**
+     * Null-safe, typed read of an attribute with a default. Returns {@code defaultValue}
+     * when the attribute is absent or is not an instance of {@code type}.
+     */
+    static <T> T getAttribute(HttpServletRequest request, String name, Class<T> type, T defaultValue) {
+        T value = getAttribute(request, name, type)
+        value != null ? value : defaultValue
+    }
 }

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
@@ -147,4 +147,22 @@ class HttpSessionExtension {
     static Date date(HttpSession session, String name, Collection<String> formats) {
         TypeConverters.toDate(session.getAttribute(name), formats)
     }
+    /**
+     * Null-safe, typed read of an attribute. Returns the attribute when it is an
+     * instance of {@code type}; otherwise {@code null}. No coercion is attempted —
+     * use the named converters ({@code string}, {@code int}, ...) for type conversion.
+     */
+    static <T> T getAttribute(HttpSession session, String name, Class<T> type) {
+        Object value = session.getAttribute(name)
+        type.isInstance(value) ? type.cast(value) : null
+    }
+
+    /**
+     * Null-safe, typed read of an attribute with a default. Returns {@code defaultValue}
+     * when the attribute is absent or is not an instance of {@code type}.
+     */
+    static <T> T getAttribute(HttpSession session, String name, Class<T> type, T defaultValue) {
+        T value = getAttribute(session, name, type)
+        value != null ? value : defaultValue
+    }
 }

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
@@ -21,6 +21,7 @@ package org.grails.web.servlet
 import groovy.transform.CompileStatic
 
 import org.apache.grails.core.internal.util.TypeConverters
+import org.springframework.util.ClassUtils
 
 import jakarta.servlet.http.HttpSession
 
@@ -154,7 +155,8 @@ class HttpSessionExtension {
      */
     static <T> T getAttribute(HttpSession session, String name, Class<T> type) {
         Object value = session.getAttribute(name)
-        type.isInstance(value) ? type.cast(value) : null
+        Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
+        resolvedType.isInstance(value) ? resolvedType.cast(value) : null
     }
 
     /**

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/HttpSessionExtension.groovy
@@ -154,6 +154,9 @@ class HttpSessionExtension {
      * use the named converters ({@code string}, {@code int}, ...) for type conversion.
      */
     static <T> T getAttribute(HttpSession session, String name, Class<T> type) {
+        if (type == null) {
+            throw new IllegalArgumentException('type must not be null - use getAttribute(name) for an untyped read')
+        }
         Object value = session.getAttribute(name)
         Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
         resolvedType.isInstance(value) ? resolvedType.cast(value) : null

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
@@ -21,6 +21,7 @@ package org.grails.web.servlet
 import groovy.transform.CompileStatic
 
 import org.apache.grails.core.internal.util.TypeConverters
+import org.springframework.util.ClassUtils
 
 import jakarta.servlet.ServletContext
 
@@ -141,7 +142,8 @@ class ServletContextExtension {
      */
     static <T> T getAttribute(ServletContext context, String name, Class<T> type) {
         Object value = context.getAttribute(name)
-        type.isInstance(value) ? type.cast(value) : null
+        Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
+        resolvedType.isInstance(value) ? resolvedType.cast(value) : null
     }
 
     /**

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
@@ -141,6 +141,9 @@ class ServletContextExtension {
      * use the named converters ({@code string}, {@code int}, ...) for type conversion.
      */
     static <T> T getAttribute(ServletContext context, String name, Class<T> type) {
+        if (type == null) {
+            throw new IllegalArgumentException('type must not be null - use getAttribute(name) for an untyped read')
+        }
         Object value = context.getAttribute(name)
         Class<T> resolvedType = (Class<T>) ClassUtils.resolvePrimitiveIfNecessary(type)
         resolvedType.isInstance(value) ? resolvedType.cast(value) : null

--- a/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
+++ b/grails-web-core/src/main/groovy/org/grails/web/servlet/ServletContextExtension.groovy
@@ -134,4 +134,22 @@ class ServletContextExtension {
     static Date date(ServletContext context, String name, Collection<String> formats) {
         TypeConverters.toDate(context.getAttribute(name), formats)
     }
+    /**
+     * Null-safe, typed read of an attribute. Returns the attribute when it is an
+     * instance of {@code type}; otherwise {@code null}. No coercion is attempted —
+     * use the named converters ({@code string}, {@code int}, ...) for type conversion.
+     */
+    static <T> T getAttribute(ServletContext context, String name, Class<T> type) {
+        Object value = context.getAttribute(name)
+        type.isInstance(value) ? type.cast(value) : null
+    }
+
+    /**
+     * Null-safe, typed read of an attribute with a default. Returns {@code defaultValue}
+     * when the attribute is absent or is not an instance of {@code type}.
+     */
+    static <T> T getAttribute(ServletContext context, String name, Class<T> type, T defaultValue) {
+        T value = getAttribute(context, name, type)
+        value != null ? value : defaultValue
+    }
 }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
@@ -24,6 +24,8 @@ import jakarta.servlet.http.HttpServletRequest
 
 import org.springframework.mock.web.MockHttpServletRequest
 
+import net.bytebuddy.ByteBuddy
+
 import spock.lang.Specification
 
 class HttpServletRequestExtensionSpec extends Specification {
@@ -105,36 +107,32 @@ class HttpServletRequestExtensionSpec extends Specification {
             request.getAttribute('count', Integer, 7) == 42
     }
 
-    void "Class-typed getAttribute matches proxied values — both JVM proxy mechanisms"() {
+    void "Class-typed getAttribute matches a ByteBuddy subclass proxy (the GORM/Hibernate mechanism)"() {
         given:
             HttpServletRequest request = new MockHttpServletRequest()
 
-            // (1) Interface proxy: a JDK dynamic proxy's runtime-generated class *implements* the
-            // requested interface, so isInstance(interface) is true — the non-obvious runtime case.
-            CharSequence jdkProxy = (CharSequence) java.lang.reflect.Proxy.newProxyInstance(
-                    getClass().classLoader, [CharSequence] as Class[],
-                    { Object proxy, java.lang.reflect.Method method, Object[] args ->
-                        method.name == 'toString' ? 'proxied' : null } as java.lang.reflect.InvocationHandler)
-            request.setAttribute('jdkProxy', jdkProxy)
+            // A real ByteBuddy subclass proxy — the same machinery GORM/Hibernate use for lazy
+            // entity proxies: the generated class *extends* the target, so isInstance(target) is true.
+            Class<? extends ProxiedEntity> proxyClass = new ByteBuddy()
+                    .subclass(ProxiedEntity)
+                    .make()
+                    .load(getClass().classLoader)
+                    .loaded
+            ProxiedEntity proxy = proxyClass.getDeclaredConstructor().newInstance()
+            request.setAttribute('entity', proxy)
 
-            // (2) Subclass proxy: CGLIB / ByteBuddy / Hibernate-lazy proxies *extend* the target
-            // class. isInstance walks the class hierarchy the same way whether the subclass is
-            // generated at runtime or declared here, so a plain subclass exercises the same path.
-            ProxiedBase subclassProxy = new ProxiedSubclass()
-            request.setAttribute('subclassProxy', subclassProxy)
+        expect: 'the stored value is a generated subclass, not the entity class itself'
+            proxy.class != ProxiedEntity
+            ProxiedEntity.isInstance(proxy)
 
-        expect: 'isInstance is true for the proxied interface and the proxied superclass'
-            request.getAttribute('jdkProxy', CharSequence).is(jdkProxy)
-            request.getAttribute('subclassProxy', ProxiedBase).is(subclassProxy)
+        and: 'the Class-typed read returns the proxy, typed as the entity'
+            request.getAttribute('entity', ProxiedEntity).is(proxy)
 
-        and: 'null (not an unsafe cast) when the value is not actually an instance of the requested type'
-            request.getAttribute('jdkProxy', StringBuilder) == null
+        and: 'null (not an unsafe cast) when the requested type is unrelated'
+            request.getAttribute('entity', Date) == null
     }
 
-    static class ProxiedBase {
-    }
-
-    static class ProxiedSubclass extends ProxiedBase {
+    static class ProxiedEntity {
     }
 
     @CompileStatic

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
@@ -105,6 +105,38 @@ class HttpServletRequestExtensionSpec extends Specification {
             request.getAttribute('count', Integer, 7) == 42
     }
 
+    void "Class-typed getAttribute matches proxied values — both JVM proxy mechanisms"() {
+        given:
+            HttpServletRequest request = new MockHttpServletRequest()
+
+            // (1) Interface proxy: a JDK dynamic proxy's runtime-generated class *implements* the
+            // requested interface, so isInstance(interface) is true — the non-obvious runtime case.
+            CharSequence jdkProxy = (CharSequence) java.lang.reflect.Proxy.newProxyInstance(
+                    getClass().classLoader, [CharSequence] as Class[],
+                    { Object proxy, java.lang.reflect.Method method, Object[] args ->
+                        method.name == 'toString' ? 'proxied' : null } as java.lang.reflect.InvocationHandler)
+            request.setAttribute('jdkProxy', jdkProxy)
+
+            // (2) Subclass proxy: CGLIB / ByteBuddy / Hibernate-lazy proxies *extend* the target
+            // class. isInstance walks the class hierarchy the same way whether the subclass is
+            // generated at runtime or declared here, so a plain subclass exercises the same path.
+            ProxiedBase subclassProxy = new ProxiedSubclass()
+            request.setAttribute('subclassProxy', subclassProxy)
+
+        expect: 'isInstance is true for the proxied interface and the proxied superclass'
+            request.getAttribute('jdkProxy', CharSequence).is(jdkProxy)
+            request.getAttribute('subclassProxy', ProxiedBase).is(subclassProxy)
+
+        and: 'null (not an unsafe cast) when the value is not actually an instance of the requested type'
+            request.getAttribute('jdkProxy', StringBuilder) == null
+    }
+
+    static class ProxiedBase {
+    }
+
+    static class ProxiedSubclass extends ProxiedBase {
+    }
+
     @CompileStatic
     static class StaticCaller {
         static StringBuilder readPrincipal(HttpServletRequest request) {

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
@@ -63,8 +63,46 @@ class HttpServletRequestExtensionSpec extends Specification {
             StaticCaller.readName(request) == 'anonymous'
     }
 
+
+    void "Test the Class-typed getAttribute returns the attribute only when it is an instance of the requested type"() {
+        given:
+            HttpServletRequest request = new MockHttpServletRequest()
+            request.setAttribute('principal', new StringBuilder('alice'))
+            request.setAttribute('count', 42)
+
+        expect: 'a matching type returns the typed attribute'
+            request.getAttribute('principal', StringBuilder).toString() == 'alice'
+            request.getAttribute('count', Integer) == 42
+
+        and: 'a supertype of the stored attribute matches too'
+            request.getAttribute('principal', CharSequence).toString() == 'alice'
+
+        and: 'absent and wrong-typed attributes read as null - no coercion is attempted'
+            request.getAttribute('missing', StringBuilder) == null
+            request.getAttribute('count', String) == null
+
+        and: 'the Class-typed overload resolves to the requested type under static compilation'
+            StaticCaller.readPrincipal(request).toString() == 'alice'
+    }
+
+    void "Test the Class-typed getAttribute honors the default for absent and wrong-typed attributes"() {
+        given:
+            HttpServletRequest request = new MockHttpServletRequest()
+            request.setAttribute('count', 42)
+
+        expect:
+            request.getAttribute('missing', String, 'fallback') == 'fallback'
+            request.getAttribute('count', String, 'fallback') == 'fallback'
+            request.getAttribute('count', Integer, 7) == 42
+    }
+
     @CompileStatic
     static class StaticCaller {
+        static StringBuilder readPrincipal(HttpServletRequest request) {
+            StringBuilder principal = request.getAttribute('principal', StringBuilder)
+            principal
+        }
+
         static Integer readPage(HttpServletRequest request) {
             request.int('page', 1)
         }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
@@ -84,6 +84,12 @@ class HttpServletRequestExtensionSpec extends Specification {
         and: 'primitive class literals are normalized to their wrappers'
             request.getAttribute('count', int) == 42
 
+        when: 'a null type is passed'
+            request.getAttribute('count', (Class) null)
+
+        then: 'the contract violation is reported clearly rather than as a bare NPE'
+            thrown(IllegalArgumentException)
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(request).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpServletRequestExtensionSpec.groovy
@@ -81,6 +81,9 @@ class HttpServletRequestExtensionSpec extends Specification {
             request.getAttribute('missing', StringBuilder) == null
             request.getAttribute('count', String) == null
 
+        and: 'primitive class literals are normalized to their wrappers'
+            request.getAttribute('count', int) == 42
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(request).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
@@ -109,6 +109,9 @@ class HttpSessionExtensionSpec extends Specification {
             session.getAttribute('missing', StringBuilder) == null
             session.getAttribute('count', String) == null
 
+        and: 'primitive class literals are normalized to their wrappers'
+            session.getAttribute('count', int) == 42
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(session).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
@@ -91,8 +91,46 @@ class HttpSessionExtensionSpec extends Specification {
             StaticCaller.readTimeZone(session) == 'America/Los_Angeles'
     }
 
+
+    void "Test the Class-typed getAttribute returns the attribute only when it is an instance of the requested type"() {
+        given:
+            HttpSession session = new MockHttpSession()
+            session.setAttribute('principal', new StringBuilder('alice'))
+            session.setAttribute('count', 42)
+
+        expect: 'a matching type returns the typed attribute'
+            session.getAttribute('principal', StringBuilder).toString() == 'alice'
+            session.getAttribute('count', Integer) == 42
+
+        and: 'a supertype of the stored attribute matches too'
+            session.getAttribute('principal', CharSequence).toString() == 'alice'
+
+        and: 'absent and wrong-typed attributes read as null - no coercion is attempted'
+            session.getAttribute('missing', StringBuilder) == null
+            session.getAttribute('count', String) == null
+
+        and: 'the Class-typed overload resolves to the requested type under static compilation'
+            StaticCaller.readPrincipal(session).toString() == 'alice'
+    }
+
+    void "Test the Class-typed getAttribute honors the default for absent and wrong-typed attributes"() {
+        given:
+            HttpSession session = new MockHttpSession()
+            session.setAttribute('count', 42)
+
+        expect:
+            session.getAttribute('missing', String, 'fallback') == 'fallback'
+            session.getAttribute('count', String, 'fallback') == 'fallback'
+            session.getAttribute('count', Integer, 7) == 42
+    }
+
     @CompileStatic
     static class StaticCaller {
+        static StringBuilder readPrincipal(HttpSession session) {
+            StringBuilder principal = session.getAttribute('principal', StringBuilder)
+            principal
+        }
+
         static Integer readAge(HttpSession session) {
             session.int('age')
         }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/HttpSessionExtensionSpec.groovy
@@ -112,6 +112,12 @@ class HttpSessionExtensionSpec extends Specification {
         and: 'primitive class literals are normalized to their wrappers'
             session.getAttribute('count', int) == 42
 
+        when: 'a null type is passed'
+            session.getAttribute('count', (Class) null)
+
+        then: 'the contract violation is reported clearly rather than as a bare NPE'
+            thrown(IllegalArgumentException)
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(session).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
@@ -80,6 +80,12 @@ class ServletContextExtensionSpec extends Specification {
         and: 'primitive class literals are normalized to their wrappers'
             context.getAttribute('count', int) == 42
 
+        when: 'a null type is passed'
+            context.getAttribute('count', (Class) null)
+
+        then: 'the contract violation is reported clearly rather than as a bare NPE'
+            thrown(IllegalArgumentException)
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(context).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
@@ -77,6 +77,9 @@ class ServletContextExtensionSpec extends Specification {
             context.getAttribute('missing', StringBuilder) == null
             context.getAttribute('count', String) == null
 
+        and: 'primitive class literals are normalized to their wrappers'
+            context.getAttribute('count', int) == 42
+
         and: 'the Class-typed overload resolves to the requested type under static compilation'
             StaticCaller.readPrincipal(context).toString() == 'alice'
     }

--- a/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
+++ b/grails-web-core/src/test/groovy/org/grails/web/servlet/ServletContextExtensionSpec.groovy
@@ -59,8 +59,46 @@ class ServletContextExtensionSpec extends Specification {
             StaticCaller.readAppName(context) == 'grails'
     }
 
+
+    void "Test the Class-typed getAttribute returns the attribute only when it is an instance of the requested type"() {
+        given:
+            ServletContext context = new MockServletContext()
+            context.setAttribute('principal', new StringBuilder('alice'))
+            context.setAttribute('count', 42)
+
+        expect: 'a matching type returns the typed attribute'
+            context.getAttribute('principal', StringBuilder).toString() == 'alice'
+            context.getAttribute('count', Integer) == 42
+
+        and: 'a supertype of the stored attribute matches too'
+            context.getAttribute('principal', CharSequence).toString() == 'alice'
+
+        and: 'absent and wrong-typed attributes read as null - no coercion is attempted'
+            context.getAttribute('missing', StringBuilder) == null
+            context.getAttribute('count', String) == null
+
+        and: 'the Class-typed overload resolves to the requested type under static compilation'
+            StaticCaller.readPrincipal(context).toString() == 'alice'
+    }
+
+    void "Test the Class-typed getAttribute honors the default for absent and wrong-typed attributes"() {
+        given:
+            ServletContext context = new MockServletContext()
+            context.setAttribute('count', 42)
+
+        expect:
+            context.getAttribute('missing', String, 'fallback') == 'fallback'
+            context.getAttribute('count', String, 'fallback') == 'fallback'
+            context.getAttribute('count', Integer, 7) == 42
+    }
+
     @CompileStatic
     static class StaticCaller {
+        static StringBuilder readPrincipal(ServletContext context) {
+            StringBuilder principal = context.getAttribute('principal', StringBuilder)
+            principal
+        }
+
         static Integer readMaxUploads(ServletContext context) {
             context.int('maxUploads', 1)
         }


### PR DESCRIPTION
## Summary

Follow-up to #15715. The named converters (`string`, `int`, `boolean`, …) cover scalar attribute values, but attributes frequently hold richer objects — a security principal, a domain instance, a CSRF token — where today the only statically-compilable read is a cast at every call site:

```groovy
CsrfToken token = (CsrfToken) session.getAttribute('_csrf')
UserDetails user = request.getAttribute(USER_ATTRIBUTE) as UserDetails
```

This adds a `Class`-typed overload of `getAttribute` (plus a default-value variant) to `session`, `request` and `servletContext`:

```groovy
CsrfToken token   = session.getAttribute('_csrf', CsrfToken)
UserDetails user  = request.getAttribute('apiUser', UserDetails)
Theme theme       = session.getAttribute('theme', Theme, Theme.DEFAULT)
```

The generic signature (`static <T> T getAttribute(holder, String name, Class<T> type)`) lets the static compiler infer the return type from the class literal, so the read compiles under `@CompileStatic` / `@GrailsCompileStatic` with no cast.

## Design

- **Typed read, not coercion.** The attribute is returned only when it is an instance of the requested type; absent and wrong-typed attributes read as `null` (so the default-value overload also applies on a type mismatch). No `TypeConverters` delegation — the named converters remain the coercing API, the `Class` overload is the type-safe retrieval API. Two simple contracts instead of one mixed one.
- **Overloads `getAttribute` rather than introducing a new verb.** Mirrors `grails.config.Config.getProperty(String key, Class<T> targetType, T defaultValue)` (and Spring's `Environment.getProperty(key, type, default)`), and shows up in IDE completion right next to the raw `getAttribute(String)`.
- **Scope: the three attribute holders only.** `flash` is skipped — it is a `Map`, and Groovy's DGM `Map.get(key, default)` (which *inserts* the default) makes a two-arg sibling on flash a semantic trap. `params` is skipped — its values are Strings, where a non-coercing typed read is not useful.

## Tests & docs

- `HttpSessionExtensionSpec`, `HttpServletRequestExtensionSpec`, `ServletContextExtensionSpec` each gain two features: instance-match / supertype-match / absent / wrong-type-reads-as-null semantics, default-value behavior, and a `@CompileStatic` static-resolution guard (the guard fails test compilation without the new extension methods).
- New "Typed Reads of Attributes" subsection in the controllers guide, following the "Type Conversion of Attributes" section from #15715.

`:grails-web-core:test` passes in full.