### PR TITLE
8.x Add statically-resolvable message(Map) for controllers

### DIFF
--- a/grails-doc/src/en/guide/theWebLayer/gsp/tags/tagsAsMethodCalls.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/tags/tagsAsMethodCalls.adoc
@@ -69,3 +69,12 @@ For tags that use a <<namespaces,custom namespace>>, use that prefix for the met
 ----
 def editor = ckeditor.editor(name: "text", width: "100%", height: "400")
 ----
+
+In controllers, most tag invocations dispatch dynamically, so they require dynamically compiled code. The `message` tag — the most common tag called from controllers — is the exception: it is declared as a real method on the controller, so the canonical idiom compiles under static compilation (`@CompileStatic` / `@GrailsCompileStatic`) as-is:
+
+[source,groovy]
+----
+flash.message = message(code: 'default.created.message', args: [classMessageArguments(book), book.id])
+----
+
+Note that this applies to controllers only — classes that implement the `TagLibraryInvoker` trait directly still dispatch `message` dynamically.

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/gsp/ControllerTagLibraryInvoker.groovy
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/gsp/ControllerTagLibraryInvoker.groovy
@@ -1,0 +1,70 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.artefact.gsp
+
+import groovy.transform.CompileStatic
+
+import org.grails.taglib.TagLibraryLookup
+import org.grails.taglib.TagOutput
+import org.grails.taglib.encoder.OutputContextLookupHelper
+
+/**
+ * The {@link TagLibraryInvoker} flavor injected into controllers. On top of the dynamic
+ * tag dispatch inherited from {@link TagLibraryInvoker}, it declares a statically-resolvable
+ * {@code message(Map)} — by far the most common tag invoked as a method from controllers, e.g.
+ * {@code flash.message = message(code: 'default.created.message', args: [...])} — so the call
+ * resolves under {@code @CompileStatic} / {@code @GrailsCompileStatic} instead of requiring
+ * dynamic dispatch through {@code methodMissing}.
+ *
+ * <p>This method deliberately lives here rather than on {@link TagLibraryInvoker} itself:
+ * tag libraries also implement that trait (via {@code grails.artefact.TagLibrary}), and a real
+ * {@code message} method inherited by every tag library would be picked up by the tag-method
+ * dispatch as if the library declared a {@code message} tag, recursing infinitely for libraries
+ * that don't.</p>
+ *
+ * @since 8.0
+ */
+@CompileStatic
+trait ControllerTagLibraryInvoker extends TagLibraryInvoker {
+
+    /**
+     * Statically-resolvable counterpart of the dynamic {@code message(...)} tag dispatch.
+     * Dispatches through the same tag-library lookup (declared namespace first, then the
+     * default namespace) and the same {@link TagOutput#captureTagOutput} machinery as the
+     * dynamic path, so behavior is identical.
+     *
+     * @param attrs the tag attributes ({@code code}, {@code args}, {@code default}, {@code error},
+     *              {@code message}, {@code locale}, {@code encodeAs})
+     * @return the resolved message
+     */
+    Object message(Map attrs) {
+        TagLibraryLookup lookup = getTagLibraryLookup()
+        if (lookup) {
+            String namespace = getTaglibNamespace()
+            if (lookup.lookupTagLibrary(namespace, 'message') == null) {
+                namespace = TagOutput.DEFAULT_NAMESPACE
+            }
+            if (lookup.lookupTagLibrary(namespace, 'message') != null) {
+                return TagOutput.captureTagOutput(lookup, namespace, 'message', attrs, null,
+                        OutputContextLookupHelper.lookupOutputContext())
+            }
+        }
+        throw new MissingMethodException('message', this.getClass(), [attrs] as Object[])
+    }
+}

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/gsp/ControllerTagLibraryInvoker.groovy
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/gsp/ControllerTagLibraryInvoker.groovy
@@ -57,10 +57,12 @@ trait ControllerTagLibraryInvoker extends TagLibraryInvoker {
         TagLibraryLookup lookup = getTagLibraryLookup()
         if (lookup) {
             String namespace = getTaglibNamespace()
-            if (lookup.lookupTagLibrary(namespace, 'message') == null) {
+            GroovyObject tagLibrary = lookup.lookupTagLibrary(namespace, 'message')
+            if (tagLibrary == null && namespace != TagOutput.DEFAULT_NAMESPACE) {
                 namespace = TagOutput.DEFAULT_NAMESPACE
+                tagLibrary = lookup.lookupTagLibrary(namespace, 'message')
             }
-            if (lookup.lookupTagLibrary(namespace, 'message') != null) {
+            if (tagLibrary != null) {
                 return TagOutput.captureTagOutput(lookup, namespace, 'message', attrs, null,
                         OutputContextLookupHelper.lookupOutputContext())
             }

--- a/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
+++ b/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
@@ -42,6 +42,9 @@ class ControllerTagLibraryInvokerMessageSpec extends Specification {
         tagLib.invokedAttrs.code == 'default.created.message'
         tagLib.invokedAttrs.args == ['Book', '1']
 
+        and: 'the dispatch decision costs a single registry lookup'
+        ((StubTagLibraryLookup) invoker.tagLibraryLookup).lookupCount <= 2
+
         and: 'the tag sees function-call semantics, exactly as dynamic controller dispatch produced'
         tagLib.invokedAttrs instanceof GroovyPageAttributes
         !((GroovyPageAttributes) tagLib.invokedAttrs).gspTagSyntaxCall
@@ -133,9 +136,11 @@ class StaticController implements ControllerTagLibraryInvoker {
 
 class StubTagLibraryLookup extends TagLibraryLookup {
     Map<String, GroovyObject> tagLibsByNamespace = [:]
+    int lookupCount = 0
 
     @Override
     GroovyObject lookupTagLibrary(String namespace, String tagName) {
+        lookupCount++
         tagName == 'message' ? tagLibsByNamespace[namespace] : null
     }
 

--- a/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
+++ b/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
@@ -20,6 +20,7 @@ package grails.artefact.gsp
 
 import groovy.transform.CompileStatic
 
+import org.grails.taglib.GroovyPageAttributes
 import org.grails.taglib.TagLibraryLookup
 
 import spock.lang.Specification
@@ -40,6 +41,24 @@ class ControllerTagLibraryInvokerMessageSpec extends Specification {
         tagLib.invokedName == 'message'
         tagLib.invokedAttrs.code == 'default.created.message'
         tagLib.invokedAttrs.args == ['Book', '1']
+
+        and: 'the tag sees function-call semantics, exactly as dynamic controller dispatch produced'
+        tagLib.invokedAttrs instanceof GroovyPageAttributes
+        !((GroovyPageAttributes) tagLib.invokedAttrs).gspTagSyntaxCall
+    }
+
+    void 'a no-arg message() call routes through the same dispatch with empty attributes'() {
+        given:
+        RecordingTagLib tagLib = new RecordingTagLib()
+        DefaultNamespaceInvoker invoker = new DefaultNamespaceInvoker()
+        invoker.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [g: tagLib])
+
+        when: 'the single-Map-parameter method is invoked without arguments'
+        def result = invoker.message()
+
+        then: 'dispatch succeeds with empty attributes, matching the previous methodMissing behavior'
+        result == 'resolved'
+        tagLib.invokedAttrs.isEmpty()
     }
 
     void 'message(Map) prefers the declared taglib namespace and falls back to the default'() {

--- a/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
+++ b/grails-gsp/grails-web-taglib/src/test/groovy/grails/artefact/gsp/ControllerTagLibraryInvokerMessageSpec.groovy
@@ -1,0 +1,144 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.artefact.gsp
+
+import groovy.transform.CompileStatic
+
+import org.grails.taglib.TagLibraryLookup
+
+import spock.lang.Specification
+
+class ControllerTagLibraryInvokerMessageSpec extends Specification {
+
+    void 'message(Map) dispatches to the message tag of the default namespace'() {
+        given:
+        RecordingTagLib tagLib = new RecordingTagLib()
+        DefaultNamespaceInvoker invoker = new DefaultNamespaceInvoker()
+        invoker.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [g: tagLib])
+
+        when:
+        def result = invoker.message(code: 'default.created.message', args: ['Book', '1'])
+
+        then:
+        result == 'resolved'
+        tagLib.invokedName == 'message'
+        tagLib.invokedAttrs.code == 'default.created.message'
+        tagLib.invokedAttrs.args == ['Book', '1']
+    }
+
+    void 'message(Map) prefers the declared taglib namespace and falls back to the default'() {
+        given: 'a tag library registered only under the default namespace'
+        RecordingTagLib tagLib = new RecordingTagLib()
+        CustomNamespaceInvoker invoker = new CustomNamespaceInvoker()
+        invoker.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [g: tagLib])
+
+        when:
+        def result = invoker.message(code: 'x')
+
+        then: 'the default-namespace tag library handles the call'
+        result == 'resolved'
+        tagLib.invokedName == 'message'
+
+        when: 'the custom namespace also provides the tag'
+        RecordingTagLib customTagLib = new RecordingTagLib()
+        invoker.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [custom: customTagLib, g: tagLib])
+        invoker.message(code: 'y')
+
+        then: 'the declared namespace wins, mirroring methodMissing dispatch order'
+        customTagLib.invokedName == 'message'
+        customTagLib.invokedAttrs.code == 'y'
+    }
+
+    void 'message(Map) throws MissingMethodException when no tag library provides the tag'() {
+        given:
+        DefaultNamespaceInvoker invoker = new DefaultNamespaceInvoker()
+        invoker.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [:])
+
+        when:
+        invoker.message(code: 'x')
+
+        then: 'the failure mode matches dynamic dispatch via methodMissing'
+        thrown(MissingMethodException)
+    }
+
+    void 'message(Map) resolves under static compilation'() {
+        given:
+        RecordingTagLib tagLib = new RecordingTagLib()
+        StaticController controller = new StaticController()
+        controller.tagLibraryLookup = new StubTagLibraryLookup(tagLibsByNamespace: [g: tagLib])
+
+        when: 'a statically compiled controller-style class invokes the canonical idiom'
+        def result = controller.created()
+
+        then:
+        result == 'resolved'
+        tagLib.invokedAttrs.code == 'default.created.message'
+    }
+}
+
+class DefaultNamespaceInvoker implements ControllerTagLibraryInvoker {
+}
+
+class CustomNamespaceInvoker implements ControllerTagLibraryInvoker {
+    @Override
+    String getTaglibNamespace() { 'custom' }
+}
+
+/**
+ * Mirrors how a {@code @GrailsCompileStatic} controller calls {@code message(...)} — this class
+ * only compiles when the trait declares a real {@code message(Map)} method, guarding the
+ * static-resolution contract.
+ */
+@CompileStatic
+class StaticController implements ControllerTagLibraryInvoker {
+    Object created() {
+        message(code: 'default.created.message', args: ['Book', '1'])
+    }
+}
+
+class StubTagLibraryLookup extends TagLibraryLookup {
+    Map<String, GroovyObject> tagLibsByNamespace = [:]
+
+    @Override
+    GroovyObject lookupTagLibrary(String namespace, String tagName) {
+        tagName == 'message' ? tagLibsByNamespace[namespace] : null
+    }
+
+    @Override
+    boolean doesTagReturnObject(String namespace, String tagName) {
+        // mirrors ValidationTagLib declaring message in returnObjectForTags
+        tagName == 'message'
+    }
+
+    @Override
+    Map<String, Object> getEncodeAsForTag(String namespace, String tagName) {
+        null
+    }
+}
+
+class RecordingTagLib {
+    String invokedName
+    Map invokedAttrs
+
+    Closure message = { Map attrs ->
+        invokedName = 'message'
+        invokedAttrs = attrs
+        'resolved'
+    }
+}

--- a/grails-gsp/plugin/src/ast/groovy/grails/compiler/traits/ControllerTagLibraryTraitInjector.groovy
+++ b/grails-gsp/plugin/src/ast/groovy/grails/compiler/traits/ControllerTagLibraryTraitInjector.groovy
@@ -20,7 +20,7 @@ package grails.compiler.traits
 
 import groovy.transform.CompileStatic
 
-import grails.artefact.gsp.TagLibraryInvoker
+import grails.artefact.gsp.ControllerTagLibraryInvoker
 
 /**
  * A {@link TraitInjector} that adds the ability to invoke tag libraries from a controller
@@ -33,6 +33,6 @@ class ControllerTagLibraryTraitInjector extends ControllerTraitInjector {
 
     @Override
     Class getTrait() {
-        TagLibraryInvoker
+        ControllerTagLibraryInvoker
     }
 }


### PR DESCRIPTION
## Summary

`message(code: ..., args: [...])` is by far the most common tag invoked as a method from controllers — it is what scaffolding generates for every flash message:

```groovy
flash.message = message(code: 'default.created.message', args: [...])
redirect book
```

Today that call only resolves via `TagLibraryInvoker.methodMissing`, so under `@CompileStatic` / `@GrailsCompileStatic` it fails to compile and forces `@CompileDynamic` onto exactly the controller actions that are otherwise fully statically compilable (the same pain #15715 addressed for attribute access). This PR makes the canonical idiom compile statically, verbatim.

## Design

A new trait `grails.artefact.gsp.ControllerTagLibraryInvoker extends TagLibraryInvoker` declares a real `Object message(Map attrs)`, and `ControllerTagLibraryTraitInjector` now injects it (controllers keep the full inherited `TagLibraryInvoker` API).

- **Dispatch parity.** The method resolves the tag through the same lookup order as `methodMissing` (declared `taglibNamespace` first, then the default namespace) and invokes it through the same `TagOutput.captureTagOutput(..., OutputContextLookupHelper.lookupOutputContext())` machinery that GSP-compiled code and the `TagLibraryMetaUtils`-registered meta-methods use — so attribute handling (`code`, `args`, `default`, `error`, `message`, `locale`, `encodeAs`), encoding, and return semantics are identical to the dynamic path. When no tag library provides the tag, it throws `MissingMethodException`, matching `methodMissing`'s failure mode.
- **Why a subtrait instead of `TagLibraryInvoker` itself:** tag libraries also implement `TagLibraryInvoker` (via `grails.artefact.TagLibrary`), and a real `message` method inherited by every tag library is picked up by `TagMethodInvoker` as if the library declared a `message` tag — recursing infinitely for libraries that don't (caught by `grails-test-suite-uber` during development). Scoping the method to the controller-injected trait avoids leaking it into the tag-dispatch path. The javadoc documents this constraint.

## Tests

New `ControllerTagLibraryInvokerMessageSpec`:
- dispatches to the `message` tag of the default namespace with attrs passed through
- prefers the declared `taglibNamespace`, falling back to the default — mirroring `methodMissing` order
- throws `MissingMethodException` when no tag library provides the tag
- a `@CompileStatic` controller-style class invoking the canonical idiom compiles and resolves (this guard fails test compilation without the trait method)

`:grails-web-taglib:test`, `:grails-gsp:test`, `:grails-test-suite-web:test`, and `:grails-test-suite-uber:test` all pass.