### PR TITLE
Add `httpPostForm()` method to `HttpClientSupport`

### DIFF
--- a/grails-doc/src/en/guide/introduction/whatsNew.adoc
+++ b/grails-doc/src/en/guide/introduction/whatsNew.adoc
@@ -36,3 +36,10 @@ The Grails Gradle extension now defaults `preserveParameterNames` to `true`, so 
 
 Tag library unit tests also clean up and rebuild TagLib metadata automatically between features.
 Tests that use `TagLibUnitTest` no longer need to manage `purgeTagLibMetaClass`, and specs that mock additional tag libraries continue to work across feature methods.
+
+==== Test HTTP Client Form Requests
+
+Integration tests that implement `HttpClientSupport` can now use `httpPostForm(...)` to send `application/x-www-form-urlencoded`
+request bodies. The helper URL-encodes form fields using UTF-8, and repeated values in a `Collection` or array are encoded as
+repeated keys in insertion order.
+

--- a/grails-doc/src/en/guide/testing/integrationTesting.adoc
+++ b/grails-doc/src/en/guide/testing/integrationTesting.adoc
@@ -403,6 +403,14 @@ class DemoSpec extends Specification implements HttpClientSupport {
         response.assertJsonContains([title: 'Grails in Action'])
     }
 
+    void 'Posting form data'() {
+        when: 'you post a map it is turned into an application/x-www-form-urlencoded payload'
+        def response = httpPostForm('/api/search', [query: 'grails core', tag: ['web', 'testing']])
+
+        then:
+        response.assertStatus(200)
+    }
+
     void 'Posting and verifying XML'() {
         when: 'you can post XML using a builder'
         def response = httpPostXml('/api/books') {
@@ -456,6 +464,15 @@ class DemoSpec extends Specification implements HttpClientSupport {
 `HttpClientSupport` uses the JDK `HttpClient` under the hood and applies default request and connect timeouts of
 60 seconds and a redirect policy of always following redirects. You can use helpers `newHttpRequestWith(Closure configurer)`
 and `newHttpClientWith(Closure configurer)` to customize your own client and requests starting from the defaults.
+
+`httpPostForm(...)` sends `application/x-www-form-urlencoded` request bodies. Pass a `Map` of form fields, and the
+helper will URL-encode each entry using UTF-8. Scalar values are encoded once, while `Collection` and array values are
+encoded as repeated keys in insertion order:
+
+[source,groovy]
+----
+httpPostForm('/search', [query: 'grails core', tag: ['web', 'testing']])
+----
 
 Additional request helper methods available include `httpDelete()`, `httpHead()`, `httpOptions()`, `httpPatch()`,
 `httpPut()`, `httpTrace()`, and many assertion methods on responses.

--- a/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
+++ b/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
@@ -35,12 +35,17 @@ import org.apache.grails.testing.http.client.HttpClientSupport
 @Tag('http-client')
 class DirtyCheckBindingSpec extends Specification implements HttpClientSupport {
 
-    private static final String FORM = 'application/x-www-form-urlencoded'
-
     @Issue('https://github.com/apache/grails-core/issues/15681')
     void 'bindData over HTTP does not bind id or version on a domain extending a @DirtyCheck base'() {
         when: 'a form submission posts id, version and a regular property'
-        def response = httpPost('/dirtyCheckBinding/bind', 'id=99&version=5&description=Opening+balance', FORM)
+        def response = httpPostForm(
+                '/dirtyCheckBinding/bind',
+                [
+                        id: 99,
+                        version: 5,
+                        description: 'Opening balance'
+                ]
+        )
 
         then: 'the request succeeds'
         response.assertStatus(200)
@@ -56,12 +61,19 @@ class DirtyCheckBindingSpec extends Specification implements HttpClientSupport {
     @Issue('https://github.com/apache/grails-core/issues/15681')
     void 'binding only a regular property over HTTP leaves id and version null'() {
         when:
-        def response = httpPost('/dirtyCheckBinding/bind', 'description=Closing+balance', FORM)
+        def response = httpPostForm(
+                '/dirtyCheckBinding/bind',
+                [
+                        description: 'Closing balance'
+                ]
+        )
 
         then:
-        response.assertStatus(200)
-        response.assertContains('description=Closing balance')
-        response.assertContains('id=null')
-        response.assertContains('version=null')
+        with(response) {
+            assertStatus(200)
+            assertContains('description=Closing balance')
+            assertContains('id=null')
+            assertContains('version=null')
+        }
     }
 }

--- a/grails-testing-support-http-client/README.md
+++ b/grails-testing-support-http-client/README.md
@@ -123,6 +123,16 @@ httpPutJson('/products/1', jsonGenerator, [
 The same `JsonGenerator` overload pattern is available on `httpPostJson(...)`, `httpPutJson(...)`, and
 `httpPatchJson(...)`, including the variants that accept request headers and an explicit `HttpClient`.
 
+### Form data
+
+`httpPostForm(...)` sends `application/x-www-form-urlencoded` request bodies. Pass a `Map` of form fields and the
+helper will URL-encode each entry using UTF-8. Scalar values are encoded once, while `Collection` and array values are
+encoded as repeated keys in insertion order:
+
+```groovy
+httpPostForm('/search', [query: 'grails core', tag: ['web', 'testing']])
+```
+
 ### XML formatting
 
 XML request bodies can be generated with Groovy MarkupBuilder DSL. For the `http[Post|Patch|Put]Xml` methods,

--- a/grails-testing-support-http-client/src/main/groovy/org/apache/grails/testing/http/client/HttpClientSupport.groovy
+++ b/grails-testing-support-http-client/src/main/groovy/org/apache/grails/testing/http/client/HttpClientSupport.groovy
@@ -21,6 +21,7 @@ package org.apache.grails.testing.http.client
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import java.lang.reflect.Array
 import java.time.Duration
 
 import groovy.json.JsonGenerator
@@ -407,6 +408,25 @@ trait HttpClientSupport {
             HttpClient client
     ) {
         httpPost(headers, pathOrUrl, XmlUtils.toXml(format, body), APPLICATION_XML, client)
+    }
+
+    /**
+     * POST form data as {@code application/x-www-form-urlencoded} (UTF-8).
+     *
+     * @param headers optional request headers
+     * @param pathOrUrl relative path or absolute URL
+     * @param formData form fields to encode into the request body; collection and array values are encoded as
+     * repeated keys
+     * @param client optional {@link HttpClient} instance to use
+     * @return response with String body
+     */
+    TestHttpResponse httpPostForm(
+            Map<String, String> headers = EMPTY,
+            CharSequence pathOrUrl,
+            Map<String, ?> formData,
+            HttpClient client = null
+    ) {
+        httpPost(headers, pathOrUrl, encodeFormData(formData), 'application/x-www-form-urlencoded', client)
     }
 
     // endregion
@@ -1155,6 +1175,31 @@ trait HttpClientSupport {
 
     private void setDefaultRequestConfig(HttpRequest.Builder builder) {
         builder.timeout(Duration.ofSeconds(60))
+    }
+
+    private String encodeFormData(Map<String, ?> formData) {
+        formData.collectMany {
+            encodeFormValues(it.key, it.value)
+        }.join('&')
+    }
+
+    private List<String> encodeFormValues(String key, Object value) {
+        if (value == null) {
+            value = ''
+        }
+        if (value instanceof Iterable) {
+            return value.collect { encodeFormEntry(key, it) }
+        }
+        if (value.class.array) {
+            return (0..<Array.getLength(value)).collect {
+                encodeFormEntry(key, Array.get(value, it))
+            }
+        }
+        [encodeFormEntry(key, value)]
+    }
+
+    private String encodeFormEntry(String key, Object value) {
+        "${URLEncoder.encode(key, 'UTF-8')}=${URLEncoder.encode(value?.toString() ?: '', 'UTF-8')}"
     }
 
     private void warn(String[] lines) {

--- a/grails-testing-support-http-client/src/test/groovy/org/apache/grails/testing/http/client/HttpClientSupportSpec.groovy
+++ b/grails-testing-support-http-client/src/test/groovy/org/apache/grails/testing/http/client/HttpClientSupportSpec.groovy
@@ -408,6 +408,51 @@ class HttpClientSupportSpec extends Specification {
         'custom' | HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build()
     }
 
+    void 'form request helper encodes multi-value data and forwards headers'() {
+        given:
+        server.expectations {
+            POST('/form/post-default') {
+                called(1)
+                decoder('application/x-www-form-urlencoded', Decoders.utf8String)
+                body('name=Post+Default&tag=red&tag=blue&description=R%26D%2FQA', 'application/x-www-form-urlencoded')
+                responder {
+                    body('hello')
+                }
+            }
+            POST('/form/post-header-client') {
+                called(1)
+                header('X-Req', 'F1')
+                decoder('application/x-www-form-urlencoded', Decoders.utf8String)
+                body('name=Post+Header+Client&description=R%26D%2FQA', 'application/x-www-form-urlencoded')
+                responder {
+                    body('hello')
+                }
+            }
+        }
+
+        and:
+        def testClient = new TestClient(server.httpUrl)
+        def customClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build()
+        def multiValueFormData = [name: 'Post Default', tag: ['red', 'blue'], description: 'R&D/QA']
+
+        when:
+        def postResponse = testClient.httpPostForm(
+                '/form/post-default',
+                multiValueFormData
+        )
+        def postHeaderResponse = testClient.httpPostForm(
+                'X-Req': 'F1',
+                '/form/post-header-client',
+                [name: 'Post Header Client', description: 'R&D/QA'],
+                customClient
+        )
+
+        then:
+        postResponse.assertEquals(200, 'hello')
+        postHeaderResponse.assertEquals(200, 'hello')
+        server.verify()
+    }
+
     @Unroll
     void 'post with MultipartBody sends multipart content type and payload bytes with #label client'(HttpClient client) {
         given:


### PR DESCRIPTION
This pull request introduces a new helper method, `httpPostForm`, to the `HttpClientSupport` trait, making it easier to send `application/x-www-form-urlencoded` requests in integration tests.