### PR TITLE
Update OpenTelemetry to 1.62.0 (CVE-2026-45292)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -82,7 +82,7 @@ ext {
             'junit.version'                 : '5.13.3',
             'junit-platform.version'        : '1.13.3',
             'mongodb.version'               : '5.5.2',
-            'opentelemetry.version'         : '1.55.0',
+            'opentelemetry.version'         : '1.62.0',
             'rxjava.version'                : '1.3.8',
             'rxjava2.version'               : '2.2.21',
             'rxjava3.version'               : '3.1.12',


### PR DESCRIPTION
## Description

Bumps the managed `opentelemetry.version` from `1.55.0` to `1.62.0` in `dependencies.gradle` to remediate **CVE-2026-45292**.

OpenTelemetry Java versions `<= 1.61.0` contain an unbounded memory allocation / CPU exhaustion vulnerability (CWE-770) in baggage propagation: `W3CBaggagePropagator`, `JaegerPropagator`, and `OtTracePropagator` did not enforce any size/entry limits, so an oversized `baggage` header is parsed character-by-character, leading to a denial of service. Because baggage is automatically re-injected into outgoing requests, the impact can fan out to downstream services. Fixed upstream in `1.62.0`.

- Advisory: https://github.com/open-telemetry/opentelemetry-java/security/advisories/GHSA-rcgg-9c38-7xpx
- CVE: https://www.cve.org/CVERecord?id=CVE-2026-45292

There is no pre-existing tracked issue; this PR addresses the publicly disclosed CVE directly. The vulnerability is already public and this change only consumes the upstream-patched release.

### Verification

The OpenTelemetry artifacts are pinned in the platform/BOM to override the versions pulled transitively via Selenium. Resolving `:grails-geb` confirms every `io.opentelemetry:*` artifact (including the affected `opentelemetry-api`) now resolves to `1.62.0`, forcing the transitive `1.49.0`/`1.55.0` requests up to the patched version. `:grails-bom:build` succeeds.

This is a single-line dependency version change: no API or behavior change, so no new tests or user-guide documentation are required, and `codeStyle` does not cover `dependencies.gradle`.

> Generative AI tooling was used to assist in preparing this change (CVE research, build verification, and PR drafting). The change has been reviewed and verified by the submitter.