### PR TITLE
Fix HQL injection: reject plain-String single-arg query overloads

### DIFF
--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
@@ -295,28 +295,32 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
         findAllWithNativeSql(query, args)
     }
 
-    // The single-argument CharSequence overloads accept a plain String (executed as written, as
-    // on Hibernate 5) or a Groovy GString. A GString is never interpolated into the query text:
-    // HqlQueryContext expands every ${value} into a bound named parameter (see
-    // buildNamedParameterQueryFromGString), so the idiomatic Groovy form
-    // executeQuery("from Foo where bar = ${userInput}") is injection-safe by binding, not escaping.
+    // The single-argument CharSequence overloads require a Groovy GString so that every
+    // interpolated value is automatically extracted into a bound named parameter by
+    // HqlQueryContext.buildNamedParameterQueryFromGString, making the idiomatic form
+    // executeQuery("from Foo where bar = ${userInput}") injection-safe by binding.
+    // Passing a plain String is rejected to prevent silent injection vulnerabilities.
     @Override
     List<D> findAll(CharSequence query) {
+        HqlQueryContext.guardAgainstUnsafeString(query, 'findAll')
         doListInternal(query, [:], [], [:], false)
     }
 
     @Override
     List executeQuery(CharSequence query) {
+        HqlQueryContext.guardAgainstUnsafeString(query, 'executeQuery')
         doListInternal(query, [:], [], [:], false)
     }
 
     @Override
     Integer executeUpdate(CharSequence query) {
+        HqlQueryContext.guardAgainstUnsafeString(query, 'executeUpdate')
         doInternalExecuteUpdate(query, [:], [], [:])
     }
 
     @Override
     D find(CharSequence query) {
+        HqlQueryContext.guardAgainstUnsafeString(query, 'find')
         doSingleInternal(query, [:], [], [:], false)
     }
 

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/HqlQueryContext.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/HqlQueryContext.java
@@ -72,6 +72,28 @@ public record HqlQueryContext(
     // ─── Factory ─────────────────────────────────────────────────────────────
 
     /**
+     * Guards the no-params single-argument query overloads (find, findAll, executeQuery,
+     * executeUpdate) against plain-String calls that have no bound parameters and are therefore
+     * vulnerable to HQL/SQL injection.
+     *
+     * <p>Pass the method name so the error message can point the caller to the correct fix.
+     *
+     * @throws UnsupportedOperationException when {@code query} is a plain {@link String} rather
+     *                                        than a Groovy {@link GString}
+     */
+    public static void guardAgainstUnsafeString(CharSequence query, String method) {
+        if (!(query instanceof GString)) {
+            throw new UnsupportedOperationException(
+                method + "(CharSequence) only accepts a Groovy GString with interpolated parameters " +
+                "(e.g. " + method + "(\"from Foo where bar = ${value}\")). " +
+                "Use the parameterized overload " + method + "(CharSequence, Map) or " +
+                method + "(CharSequence, Collection, Map) " +
+                "to pass a plain String query safely."
+            );
+        }
+    }
+
+    /**
      * Resolves the final HQL string, the result target class, and expands any {@link GString} into
      * named parameters. No {@code Session} is required.
      */

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/query/HqlQueryContextSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/query/HqlQueryContextSpec.groovy
@@ -195,6 +195,37 @@ class HqlQueryContextSpec extends Specification {
         "select b from Book b"          | false
         "select count(b.id) from Book b"| true
     }
+
+    @Unroll
+    void "guardAgainstUnsafeString rejects plain String for #method"() {
+        given:
+        String userInput = "'; DROP TABLE books; --"
+        String unsafeQuery = "from HqlQueryContextSpecBook where title = '" + userInput + "'"
+
+        when:
+        HqlQueryContext.guardAgainstUnsafeString(unsafeQuery, method)
+
+        then:
+        def ex = thrown(UnsupportedOperationException)
+        ex.message.startsWith("${method}(CharSequence)")
+        ex.message.contains("Groovy GString")
+        ex.message.contains("${method}(CharSequence, Map)")
+
+        where:
+        method << ["find", "findAll", "executeQuery", "executeUpdate"]
+    }
+
+    void "guardAgainstUnsafeString accepts GString safely"() {
+        given:
+        String title = "The Hobbit"
+        GString safeQuery = "from HqlQueryContextSpecBook where title = ${title}"
+
+        when:
+        HqlQueryContext.guardAgainstUnsafeString(safeQuery, "find")
+
+        then:
+        noExceptionThrown()
+    }
 }
 
 @Entity


### PR DESCRIPTION
## Summary

- `HqlQueryContext.guardAgainstUnsafeString(CharSequence, String)` added: throws `UnsupportedOperationException` when a plain `String` (not a Groovy `GString`) is passed to a no-params query overload, preventing silent HQL/SQL injection via string concatenation.
- The four single-argument `CharSequence` overloads in `HibernateGormStaticApi` — `find`, `findAll`, `executeQuery`, `executeUpdate` — now call the guard before delegating.
- Five new Spock features in `HqlQueryContextSpec` cover all four method names (plain-String rejection) and the GString-accepted path.

## Why

The single-arg overloads previously accepted any `CharSequence`, including a hand-concatenated `String` like:

```groovy
Book.find("from Book where title = '" + userInput + "'")
```

This would execute verbatim with no parameter binding, exposing callers to HQL injection. A `GString` is safe because `HqlQueryContext` extracts its interpolated values into bound named parameters. A plain `String` has no such mechanism; callers must use the parameterized overloads instead.

## Safe alternatives

```groovy
// GString — safe, values are bound automatically
Book.find("from Book where title = ${userInput}")

// Parameterized overload — safe, explicit binding
Book.find("from Book where title = :t", [t: userInput])
```

## Test plan

- [x] `HqlQueryContextSpec` — 5 new features, all passing (42 total, 0 failures)
- [x] `guardAgainstUnsafeString` rejects plain String for `find`, `findAll`, `executeQuery`, `executeUpdate`
- [x] `guardAgainstUnsafeString` accepts GString without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)