### PR TITLE
fix(ci): remove filter-by-range from release-drafter to stop v0.1.0 draft flood

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -16,8 +16,19 @@
 # Maintains one draft GitHub Release per active release branch (7.0.x, 7.1.x,
 # 7.2.x, 8.0.x, ...). Each branch produces an independent draft because the
 # release-drafter config in .github/release-drafter.yml combines
-# `filter-by-commitish: true`, `filter-by-range: ~MAJOR.MINOR.0`, and
-# `tag-prefix: v` so that drafts created on one branch never leak into another.
+# `filter-by-commitish: true` (a release's target_commitish must equal the
+# branch) with `tag-prefix: v`, so drafts created on one branch never leak
+# into another.
+#
+# NOTE: do NOT reintroduce a `filter-by-range: ~MAJOR.MINOR.0` filter here.
+# When a release branch has no published release inside its own MAJOR.MINOR
+# range (e.g. 7.2.x before its first tag, or any newly-cut branch),
+# release-drafter falls back to its default version 0.1.0. That 0.1.0 draft
+# does NOT satisfy `~MAJOR.MINOR.0`, so on the next run the range filter hides
+# the draft the action itself just created - it reports "No draft release
+# found" and creates ANOTHER 0.1.0 draft, repeating on every push and flooding
+# the releases page with untagged-* drafts. `filter-by-commitish` alone gives
+# full per-branch isolation without this failure mode.
 #
 # Companion config: .github/release-drafter.yml
 name: "Release - Drafter"
@@ -70,25 +81,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # release-drafter's `filter-by-range` keeps the action looking only at
-      # releases whose tag falls inside this branch's MAJOR.MINOR series. This
-      # is what prevents 7.0.x's draft from being computed against 7.1.x's
-      # tags (or vice versa). It is derived dynamically from the branch name
-      # so this workflow file works identically on every release branch.
-      - name: "🔢 Derive semver range from branch"
-        id: version
-        run: |
-          set -euo pipefail
-          BRANCH="${{ github.event.pull_request.base.ref || github.ref_name }}"
-          if [[ "$BRANCH" =~ ^([0-9]+)\.([0-9]+)\.x$ ]]; then
-            RANGE="~${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.0"
-            echo "Branch $BRANCH -> filter-by-range $RANGE"
-            echo "range=$RANGE" >> "$GITHUB_OUTPUT"
-          else
-            echo "Branch $BRANCH is not a release branch; skipping range filter (will only match the configured prerelease/commitish filters)"
-            echo "range=" >> "$GITHUB_OUTPUT"
-          fi
-
       # Pinned to v7.3.1 by commit SHA per the ASF security policy (matches
       # the pinning convention already used by other ASF-approved actions in
       # this repo). v7.2.1 or later is required because it ships PR #1593 - the
@@ -122,7 +114,6 @@ jobs:
           # producing the "Validation Failed: target_commitish invalid" error
           # historically seen on PRs (see INFRA-27602).
           commitish: ${{ github.event.pull_request.base.ref || github.ref_name }}
-          filter-by-range: ${{ steps.version.outputs.range }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -156,7 +147,7 @@ jobs:
               echo ""
               echo "release-drafter ran but did not produce a draft release id."
               echo "Common causes: GitHub API rate limit exhausted, no prior"
-              echo "release matched the commitish/range/tag-prefix filters, or"
+              echo "release matched the commitish/tag-prefix filters, or"
               echo "the action errored. Check the previous step's logs."
             } >> "$GITHUB_STEP_SUMMARY"
             echo "::warning title=Release draft missing::release-drafter produced no draft for branch ${BRANCH}. Step outcome was '${DRAFT_OUTCOME}'. See workflow summary."


### PR DESCRIPTION
## Summary

Follow-up fix to #15623. That PR's release-drafter overhaul added a workflow step computing `filter-by-range: ~MAJOR.MINOR.0` and passing it to release-drafter as "defense-in-depth" cross-branch isolation. That filter is **redundant and actively harmful**, and is the cause of the flood of fake `v0.1.0` draft releases (`untagged-*`) on the [releases page](https://github.com/apache/grails-core/releases).

## Root cause

On any release branch with **no published release inside its own `MAJOR.MINOR` range** (today `7.2.x`, which has no tag yet; and every newly-cut branch in the future), release-drafter finds no "last release" and falls back to its default version `0.1.0`.

`0.1.0` does **not** satisfy the semver range `~7.2.0` (`>=7.2.0 <7.3.0`). So on the *next* run the `filter-by-range` filter **hides the very `v0.1.0` draft the action just created**, logs `No draft release found`, and creates **another** `v0.1.0` draft. This repeats on every push, flooding the releases page.

Verified live in the `7.2.x` drafter run [27720548965](https://github.com/apache/grails-core/actions/runs/27720548965):

```
Branch 7.2.x -> filter-by-range ~7.2.0
Found 343 releases
No draft release found
##[warning]No published release found
   - last release: none
RESOLVED_VERSION: 0.1.0
Creating new release...        <- new v0.1.0 draft every single run
```

## Fix

Remove the `filter-by-range` mechanism entirely - the "Derive semver range from branch" step and the `filter-by-range` input.

Per-branch isolation is **already fully provided** by `filter-by-commitish: true` in `.github/release-drafter.yml` (a release's `target_commitish` must equal the branch; release-drafter strips `refs/heads/` before comparing, so the legacy `refs/heads/7.0.x` releases still match correctly). With `filter-by-range` gone:

- `7.2.x` finds and **updates its single existing draft** instead of duplicating it.
- `7.0.x` / `7.1.x` / `8.0.x` keep resolving the next version correctly from their in-branch releases (`v7.0.11` -> `v7.0.12`, `v7.1.1` -> `v7.1.2`, `v8.0.0-M1` -> `v8.0.0`).

A do-not-reintroduce comment is added so the trap is not re-added later.

## Cleanup (already done out-of-band)

The 68 accumulated fake `v0.1.0` draft releases have been deleted via the API. The three legitimate drafts (`v8.0.0`, `v7.1.2`, `v7.0.12`) were preserved.

## Cascade

Lands on `7.0.x` and should be merged forward into `7.1.x` / `7.2.x` / `8.0.x` in the usual cascade, same as #15623.

Assisted-by: claude-code:claude-4.8-opus
