### PR TITLE
Do not close an externally-supplied MongoClient in GORM for MongoDB

### DIFF
--- a/grails-data-mongodb/boot-plugin/src/main/groovy/org/grails/datastore/gorm/mongodb/boot/autoconfigure/MongoDbGormAutoConfiguration.groovy
+++ b/grails-data-mongodb/boot-plugin/src/main/groovy/org/grails/datastore/gorm/mongodb/boot/autoconfigure/MongoDbGormAutoConfiguration.groovy
@@ -24,6 +24,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoClients
 
 import org.springframework.beans.BeansException
+import org.springframework.beans.factory.DisposableBean
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfigurationPackages
@@ -54,7 +55,7 @@ import org.grails.datastore.mapping.services.Service
 @Configuration
 @ConditionalOnMissingBean(MongoDatastore)
 @AutoConfigureAfter(MongoAutoConfiguration)
-class MongoDbGormAutoConfiguration implements ApplicationContextAware {
+class MongoDbGormAutoConfiguration implements ApplicationContextAware, DisposableBean {
 
     @Autowired(required = false)
     private MongoProperties mongoProperties
@@ -66,6 +67,14 @@ class MongoDbGormAutoConfiguration implements ApplicationContextAware {
     MongoClientSettings mongoOptions
 
     ConfigurableApplicationContext applicationContext
+
+    /**
+     * Whether the {@link #mongo} client was created by this auto-configuration rather than supplied
+     * as an existing bean. Only an internally created client is closed on shutdown; a client provided
+     * as a bean is owned by the application context (or the user), and GORM no longer closes a client
+     * it did not create.
+     */
+    private boolean mongoClientCreatedInternally = false
 
     @Bean
     MongoDatastore mongoDatastore() {
@@ -91,6 +100,7 @@ class MongoDbGormAutoConfiguration implements ApplicationContextAware {
         }
         else if (mongoProperties != null) {
             this.mongo = MongoClients.create(mongoOptions)
+            this.mongoClientCreatedInternally = true
             datastore = new MongoDatastore(mongo, environment, eventPublisher, packages as Package[])
         }
         else {
@@ -125,6 +135,19 @@ class MongoDbGormAutoConfiguration implements ApplicationContextAware {
             throw new IllegalArgumentException('MongoDbGormAutoConfiguration requires an instance of ConfigurableApplicationContext')
         }
         this.applicationContext = (ConfigurableApplicationContext) applicationContext
+    }
+
+    /**
+     * Closes the {@link MongoClient} only when it was created by this auto-configuration. A client
+     * supplied as an existing bean is owned by the application context (or the user) and must not be
+     * closed here. The {@code mongoDatastore} bean is created after this configuration, so it is
+     * destroyed first, leaving its sessions closed before the client itself is closed.
+     */
+    @Override
+    void destroy() throws Exception {
+        if (mongoClientCreatedInternally && mongo != null) {
+            mongo.close()
+        }
     }
 
 }

--- a/grails-data-mongodb/boot-plugin/src/test/groovy/org/grails/datastore/gorm/mongodb/boot/autoconfigure/MongoDbGormAutoConfigurationCloseSpec.groovy
+++ b/grails-data-mongodb/boot-plugin/src/test/groovy/org/grails/datastore/gorm/mongodb/boot/autoconfigure/MongoDbGormAutoConfigurationCloseSpec.groovy
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.mongodb.boot.autoconfigure
+
+import com.mongodb.client.MongoClient
+import spock.lang.Specification
+
+class MongoDbGormAutoConfigurationCloseSpec extends Specification {
+
+    void 'a MongoClient created by the auto-configuration is closed on shutdown'() {
+        given: 'an auto-configuration that created its own client'
+        def mongoClient = Mock(MongoClient)
+        def configuration = new MongoDbGormAutoConfiguration()
+        configuration.mongo = mongoClient
+        configuration.@mongoClientCreatedInternally = true
+
+        when: 'the context is shut down'
+        configuration.destroy()
+
+        then: 'the client it created is closed'
+        1 * mongoClient.close()
+    }
+
+    void 'an externally supplied MongoClient bean is not closed on shutdown'() {
+        given: 'an auto-configuration handed an existing client bean'
+        def mongoClient = Mock(MongoClient)
+        def configuration = new MongoDbGormAutoConfiguration()
+        configuration.mongo = mongoClient
+
+        when: 'the context is shut down'
+        configuration.destroy()
+
+        then: 'the externally owned client is left open'
+        0 * mongoClient.close()
+    }
+}

--- a/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
+++ b/grails-data-mongodb/core/src/main/groovy/org/grails/datastore/mapping/mongo/MongoDatastore.java
@@ -282,7 +282,8 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
      * @param mappingContext The mapping context
      */
     public MongoDatastore(MongoClient mongoClient, PropertyResolver configuration, MongoMappingContext mappingContext, ConfigurableApplicationEventPublisher eventPublisher) {
-        this(createDefaultConnectionSources(mongoClient, configuration, mappingContext), mappingContext, eventPublisher);
+        // The client is supplied by the caller, so GORM must not close it (closeable = false).
+        this(createDefaultConnectionSources(mongoClient, configuration, mappingContext, false), mappingContext, eventPublisher);
     }
 
     /**
@@ -346,7 +347,8 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
      * @param mappingContext The mapping context
      */
     public MongoDatastore(MongoClientSettings.Builder clientOptions, PropertyResolver configuration, MongoMappingContext mappingContext, ConfigurableApplicationEventPublisher eventPublisher) {
-        this(createMongoClient(configuration, clientOptions, mappingContext), configuration, mappingContext, eventPublisher);
+        // GORM builds the client from the supplied options, so it owns it and must close it (closeable = true).
+        this(createDefaultConnectionSources(createMongoClient(configuration, clientOptions, mappingContext), configuration, mappingContext, true), mappingContext, eventPublisher);
     }
 
     /**
@@ -357,7 +359,8 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
      * @param mappingContext The mapping context
      */
     public MongoDatastore(MongoClientSettings.Builder clientOptions, PropertyResolver configuration, MongoMappingContext mappingContext) {
-        this(createMongoClient(configuration, clientOptions, mappingContext), configuration, mappingContext, new DefaultApplicationEventPublisher());
+        // GORM builds the client from the supplied options, so it owns it and must close it (closeable = true).
+        this(createDefaultConnectionSources(createMongoClient(configuration, clientOptions, mappingContext), configuration, mappingContext, true), mappingContext, new DefaultApplicationEventPublisher());
     }
 
     /**
@@ -956,17 +959,21 @@ public class MongoDatastore extends AbstractDatastore implements MappingContext.
     }
 
     /**
-     * Creates the connection sources for an existing {@link MongoClient}
+     * Creates the connection sources for a {@link MongoClient}.
      *
      * @param mongoClient The {@link MongoClient}
      * @param configuration The configuration
      * @param mappingContext The {@link MongoMappingContext}
+     * @param closeable whether GORM owns the client and should close it on shutdown. Pass
+     *                  {@code false} for an externally-supplied client (its lifecycle is owned by the
+     *                  caller, e.g. a Spring-managed bean) and {@code true} for a client GORM created
+     *                  itself, so it is not leaked.
      * @return The {@link ConnectionSources}
      */
-    protected static ConnectionSources<MongoClient, MongoConnectionSourceSettings> createDefaultConnectionSources(MongoClient mongoClient, PropertyResolver configuration, MongoMappingContext mappingContext) {
+    protected static ConnectionSources<MongoClient, MongoConnectionSourceSettings> createDefaultConnectionSources(MongoClient mongoClient, PropertyResolver configuration, MongoMappingContext mappingContext, boolean closeable) {
         MongoConnectionSourceSettings settings = new MongoConnectionSourceSettings();
         settings.setDatabaseName(mappingContext.getDefaultDatabaseName());
-        ConnectionSource<MongoClient, MongoConnectionSourceSettings> defaultConnectionSource = new DefaultConnectionSource<>(ConnectionSource.DEFAULT, mongoClient, settings);
+        ConnectionSource<MongoClient, MongoConnectionSourceSettings> defaultConnectionSource = new DefaultConnectionSource<>(ConnectionSource.DEFAULT, mongoClient, settings, closeable);
         return new InMemoryConnectionSources<>(defaultConnectionSource, new MongoConnectionSourceFactory(), configuration);
     }
 

--- a/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/mapping/mongo/MongoDatastoreExternalClientSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/org/grails/datastore/mapping/mongo/MongoDatastoreExternalClientSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.mapping.mongo
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.client.MongoClient
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.core.connections.DefaultConnectionSource
+import org.grails.datastore.mapping.mongo.config.MongoMappingContext
+import spock.lang.Specification
+
+class MongoDatastoreExternalClientSpec extends Specification {
+
+    void 'an externally supplied MongoClient is not closed when the datastore is closed'() {
+        given: 'a datastore built around an externally managed MongoClient'
+        def mongoClient = Mock(MongoClient)
+        def datastore = new MongoDatastore(mongoClient)
+
+        when: 'the default connection source is inspected'
+        def defaultConnectionSource = datastore.connectionSources.defaultConnectionSource
+
+        then: 'it wraps the supplied client but does not own its lifecycle'
+        defaultConnectionSource instanceof DefaultConnectionSource
+        defaultConnectionSource.source.is(mongoClient)
+        !((DefaultConnectionSource) defaultConnectionSource).closeable
+
+        when: 'the datastore is closed'
+        datastore.close()
+
+        then: 'the externally managed client is left open for its provider to manage'
+        0 * mongoClient.close()
+    }
+
+    void 'a MongoClient that GORM builds from a settings builder is owned and closed by GORM'() {
+        given: 'a datastore constructed from a MongoClientSettings builder (GORM creates the client)'
+        def datastore = new MongoDatastore(
+                MongoClientSettings.builder(),
+                DatastoreUtils.createPropertyResolver([:]),
+                new MongoMappingContext('test'))
+
+        when: 'the default connection source is inspected'
+        def defaultConnectionSource = datastore.connectionSources.defaultConnectionSource
+
+        then: 'GORM owns the client it created and will close it on shutdown'
+        ((DefaultConnectionSource) defaultConnectionSource).closeable
+
+        cleanup:
+        datastore?.close()
+    }
+}

--- a/grails-data-mongodb/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
+++ b/grails-data-mongodb/docs/src/docs/asciidoc/gettingStarted/outsideGrails.adoc
@@ -44,6 +44,18 @@ def datastore = new MongoDatastore(Person)
 println Person.count()
 ----
 
+You can also supply your own `com.mongodb.client.MongoClient` if you need to configure the driver directly:
+
+[source,groovy]
+----
+MongoClient mongoClient = MongoClients.create("mongodb://localhost/mydb")
+def datastore = new MongoDatastore(mongoClient, Person)
+
+println Person.count()
+----
+
+NOTE: When you supply your own `MongoClient`, GORM does not close it when the datastore shuts down — the client is owned by whoever created it, so you are responsible for closing it. When GORM creates the client itself (for example `new MongoDatastore(Person)`), it closes it for you.
+
 For configuration you can either pass a map or an instance of the `org.springframework.core.env.PropertyResolver` interface:
 
 [source,groovy]

--- a/grails-data-mongodb/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
+++ b/grails-data-mongodb/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
@@ -49,3 +49,22 @@ abstract class BookService {
 
 Please note that with autowire by-type as the default, when multiple beans for same type are found the application with throw Exception. Use the Spring `@Qualifier annotation for https://docs.spring.io/spring-framework/docs/5.3.10/reference/html/core.html#beans-autowired-annotation-qualifiers[Fine-tuning Annotation Based Autowiring with Qualifiers].
 
+==== MongoClient Lifecycle for an Externally-Supplied Client
+
+When you construct a `MongoDatastore` with a `MongoClient` that you created yourself, GORM no longer closes that client when the datastore shuts down. The client is owned by whoever created it, so closing it is now your responsibility.
+
+This only affects you if you previously relied on `MongoDatastore.close()` to also close a client you passed in:
+
+[source,groovy]
+----
+MongoClient mongoClient = MongoClients.create("mongodb://localhost/mydb")
+MongoDatastore datastore = new MongoDatastore(mongoClient, Person)
+
+// ...
+
+datastore.close()    // no longer closes mongoClient
+mongoClient.close()  // close the client you created
+----
+
+No change is required when GORM creates the client itself — for example `new MongoDatastore(Person)`, or configuration-driven setups where GORM builds the client from `grails.mongodb.*` settings — because GORM continues to own and close those clients. A `MongoClient` registered as a Spring bean likewise continues to be closed by the `ApplicationContext`.
+

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/connections/DefaultConnectionSource.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/connections/DefaultConnectionSource.java
@@ -33,12 +33,40 @@ public class DefaultConnectionSource<T, S extends ConnectionSourceSettings> impl
     protected final String name;
     protected final T source;
     protected final S settings;
+    protected final boolean closeable;
     protected boolean closed = false;
 
     public DefaultConnectionSource(String name, T source, S settings) {
+        this(name, source, settings, true);
+    }
+
+    /**
+     * Creates a connection source, optionally taking ownership of the underlying source.
+     *
+     * @param name the name of the connection source
+     * @param source the underlying native source (for example a {@code MongoClient} or {@code DataSource})
+     * @param settings the settings
+     * @param closeable whether {@link #close()} should close the underlying {@code source}. Pass
+     *                  {@code false} when the source is externally managed and its lifecycle is owned
+     *                  by the provider (for example a Spring-managed {@code MongoClient} bean), so that
+     *                  GORM does not close a source it did not create.
+     * @since 8.0
+     */
+    public DefaultConnectionSource(String name, T source, S settings, boolean closeable) {
         this.name = name;
         this.source = source;
         this.settings = settings;
+        this.closeable = closeable;
+    }
+
+    /**
+     * @return whether {@link #close()} will close the underlying {@link #getSource() source}. When
+     * {@code false} the source is externally managed and its lifecycle is owned by the provider, so
+     * GORM will not close it.
+     * @since 8.0
+     */
+    public boolean isCloseable() {
+        return this.closeable;
     }
 
     @Override
@@ -58,6 +86,10 @@ public class DefaultConnectionSource<T, S extends ConnectionSourceSettings> impl
 
     @Override
     public void close() throws IOException {
+        if (!closeable) {
+            this.closed = true;
+            return;
+        }
         if (source instanceof Closeable) {
             try {
                 ((Closeable) source).close();

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/connections/DefaultConnectionSourceSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/connections/DefaultConnectionSourceSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.mapping.core.connections
+
+import spock.lang.Specification
+
+class DefaultConnectionSourceSpec extends Specification {
+
+    void 'close() closes a closeable source by default'() {
+        given: 'a connection source over a closeable native source'
+        def source = Mock(Closeable)
+        def connectionSource = new DefaultConnectionSource('test', source, null)
+
+        expect: 'the source is owned by the connection source'
+        connectionSource.closeable
+
+        when: 'the connection source is closed'
+        connectionSource.close()
+
+        then: 'the underlying source is closed'
+        1 * source.close()
+    }
+
+    void 'close() does not close the source when not closeable'() {
+        given: 'a connection source over an externally managed source'
+        def source = Mock(Closeable)
+        def connectionSource = new DefaultConnectionSource('test', source, null, false)
+
+        expect: 'the source is not owned by the connection source'
+        !connectionSource.closeable
+
+        when: 'the connection source is closed'
+        connectionSource.close()
+
+        then: 'the underlying source is left open for its provider to manage'
+        0 * source.close()
+    }
+
+    void 'close() closes an autocloseable source when closeable'() {
+        given: 'a connection source over an autocloseable native source'
+        def source = Mock(AutoCloseable)
+        def connectionSource = new DefaultConnectionSource('test', source, null, true)
+
+        when: 'the connection source is closed'
+        connectionSource.close()
+
+        then: 'the underlying source is closed'
+        1 * source.close()
+    }
+}


### PR DESCRIPTION
## What

GORM's connection-source shutdown closes any `Closeable` source, and `com.mongodb.client.MongoClient` is `Closeable`, so a client handed to GORM — a Spring-managed bean, or one passed to `new MongoDatastore(mongoClient, ...)` — was closed when the datastore shut down. That double-closes a client whose lifecycle is owned elsewhere.

This makes GORM **not close a `MongoClient` it did not create**:

- `DefaultConnectionSource` gains a non-closeable mode (new 4-arg constructor + `isCloseable()`); the existing constructor is unchanged, so there is no behavior change for current callers.
- `MongoDatastore.createDefaultConnectionSources` wraps an externally-supplied client as non-closeable.
- `MongoDbGormAutoConfiguration` implements `DisposableBean` and closes only the client it created itself; a client supplied as a bean is left for the application context to close.

GORM still closes clients it creates from `grails.mongodb.*` configuration.

## Why

- Removes a redundant double-close in the common Spring Boot setup (Spring already owns and closes the `MongoClient` bean).
- Establishes "whoever creates the client owns closing it" — the safe basis for sharing one `MongoClient` across GORM and other consumers.

## Behavior change

The only externally-visible change: callers that relied on `MongoDatastore.close()` to also close a client they passed in must now close it themselves. Documented in the upgrade notes.

## Tests

- `DefaultConnectionSourceSpec` — closes by default; no-op when non-closeable; closes an `AutoCloseable` when closeable.
- `MongoDatastoreExternalClientSpec` — a supplied client is not closed on datastore shutdown.
- `MongoDbGormAutoConfigurationCloseSpec` — the auto-config closes only an internally-created client.

Targets `8.0.x`.
