### PR TITLE
Convert SiteMesh 3 taglibs to method handlers and use SiteMesh 3.3.0-M1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -94,8 +94,8 @@ ext {
             'selenium.version'              : '4.38.0',
             'sitemesh.version'              : '2.6.0',
             'spock.version'                 : '2.4-groovy-4.0',
-            'starter-sitemesh.version'      : '3.3.0-SNAPSHOT',
-            'spring-webmvc-sitemesh.version': '3.3.0-SNAPSHOT',
+            'starter-sitemesh.version'      : '3.3.0-M1',
+            'spring-webmvc-sitemesh.version': '3.3.0-M1',
             // Spring Boot 4 no longer manages spring-retry; pin it here so the
             // grails-shell-cli SpringRetryCompilerAutoConfiguration's unversioned
             // reference resolves and consumer apps using @Retryable get a known version.

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleRepository.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/build/gradle/GradleRepository.java
@@ -72,7 +72,7 @@ public interface GradleRepository extends Ordered {
                 null,
                 List.of(
                     new VersionRegexRepoFilter(
-                        "org[.]sitemesh.*", ".*", ".*-SNAPSHOT"
+                        "org[.]sitemesh.*", ".*", ".*"
                     )
                 ),
                 List.of(VersionType.SNAPSHOT)

--- a/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3GrailsPlugin.groovy
+++ b/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3GrailsPlugin.groovy
@@ -22,11 +22,8 @@ import org.springframework.core.env.ConfigurableEnvironment
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertySource
 
-import grails.config.Config
 import grails.core.DefaultGrailsApplication
 import grails.plugins.Plugin
-import grails.util.Environment
-import grails.util.Metadata
 import org.grails.config.PropertySourcesConfig
 import org.grails.plugins.web.taglib.RenderSitemeshTagLib
 import org.grails.web.util.WebUtils
@@ -80,25 +77,6 @@ class Sitemesh3GrailsPlugin extends Plugin {
                     grailsApplication.getConfig().getProperty('grails.views.layout.default')
             propertySources.addFirst(getDefaultPropertySource(configurableEnvironment, defaultLayout))
             (grailsApplication as DefaultGrailsApplication).config = new PropertySourcesConfig(propertySources)
-
-            Config config = grailsApplication.getConfig()
-            boolean developmentMode = Metadata.getCurrent().isDevelopmentEnvironmentAvailable()
-            Environment env = Environment.current
-            boolean enableReload = env.isReloadEnabled() ||
-                    config.getProperty('grails.gsp.enable.reload', Boolean, false) ||
-                    (developmentMode && env == Environment.DEVELOPMENT)
-            String resolvedDefaultLayout = defaultLayout
-
-            // Bean names match the @ConditionalOnMissingBean(name = "contentProcessor"/"decoratorSelector")
-            // guards on upstream's SiteMeshViewResolverAutoConfiguration, so
-            // our implementations replace upstream's defaults.
-            contentProcessor(CaptureAwareContentProcessor)
-
-            decoratorSelector(Sitemesh3LayoutFinder, ref('groovyPageLocator')) {
-                gspReloadEnabled = enableReload
-                defaultDecoratorName = resolvedDefaultLayout ?: null
-                layoutCacheExpirationMillis = config.getProperty('grails.sitemesh.layout.cache.interval', Long, 5000L)
-            }
 
             // Unwraps the SiteMesh view for "render template:" partials so
             // they are never decorated with a layout (the SiteMesh 2 plugin

--- a/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3LayoutTagLib.groovy
+++ b/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/sitemesh3/Sitemesh3LayoutTagLib.groovy
@@ -125,7 +125,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * re-parsing HTML. Invoked automatically by the GSP compile-time
      * preprocessor; not intended for direct use in templates.
      */
-    Closure captureHead = { Map attrs, body ->
+    def captureHead(Map attrs, Closure body) {
         Object content = captureTagContent(out, 'head', attrs, body)
         if (content != null) {
             Sitemesh3CapturedPage page = findCapturedPage(request)
@@ -144,7 +144,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * @attr onload optional — body onload handler, stored as {@code body.onload}
      * @attr class optional — body CSS class, stored as {@code body.class}
      */
-    Closure captureBody = { Map attrs, body ->
+    def captureBody(Map attrs, Closure body) {
         Object content = captureTagContent(out, 'body', attrs, body)
         if (content != null) {
             Sitemesh3CapturedPage page = findCapturedPage(request)
@@ -165,7 +165,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * Invoked automatically by the GSP compile-time preprocessor; not
      * intended for direct use in templates.
      */
-    Closure captureTitle = { Map attrs, body ->
+    def captureTitle(Map attrs, Closure body) {
         Sitemesh3CapturedPage page = findCapturedPage(request)
         Object content = captureTagContent(out, 'title', attrs, body)
         if (page != null && content != null) {
@@ -180,7 +180,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * {@code <g:layoutTitle>} can render it verbatim. Invoked automatically
      * by the GSP compile-time preprocessor; not intended for direct use.
      */
-    Closure wrapTitleTag = { Map attrs, body ->
+    def wrapTitleTag(Map attrs, Closure body) {
         if (body != null) {
             Sitemesh3CapturedPage page = findCapturedPage(request)
             if (page != null) {
@@ -203,7 +203,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * @attr content optional — the {@code content} attribute value to store
      * @attr http-equiv optional — the {@code http-equiv} attribute of the meta tag
      */
-    Closure captureMeta = { Map attrs, body ->
+    def captureMeta(Map attrs, Closure body) {
         captureTagContent(out, 'meta', attrs, body, true)
         Sitemesh3CapturedPage page = findCapturedPage(request)
         Object val = attrs?.content
@@ -234,7 +234,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      *
      * @attr tag REQUIRED the name of the content block (e.g. {@code navbar})
      */
-    Closure captureContent = { Map attrs, body ->
+    def captureContent(Map attrs, Closure body) {
         if (body != null) {
             Sitemesh3CapturedPage page = findCapturedPage(request)
             if (page != null && attrs.tag) {
@@ -251,7 +251,7 @@ class Sitemesh3LayoutTagLib implements TagLibrary {
      * @attr name REQUIRED the parameter name
      * @attr value REQUIRED the parameter value
      */
-    Closure parameter = { Map attrs, body ->
+    def parameter(Map attrs, Closure body) {
         Sitemesh3CapturedPage page = findCapturedPage(request)
         String name = attrs.name?.toString()
         String val = attrs.value?.toString()

--- a/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/web/taglib/RenderSitemeshTagLib.groovy
+++ b/grails-gsp/grails-sitemesh3/src/main/groovy/org/grails/plugins/web/taglib/RenderSitemeshTagLib.groovy
@@ -108,7 +108,7 @@ class RenderSitemeshTagLib implements TagLibrary {
     // inside applyLayout inside a Sitemesh3LayoutView render) would tear
     // down the outer request scope before the outer render finished —
     // causing "request is not active anymore" errors.
-    Closure applyLayout = { Map attrs, body ->
+    def applyLayout(Map attrs, Closure body) {
         String savedAttribute = request.getAttribute(WebUtils.LAYOUT_ATTRIBUTE)
         // Save the request-scoped captured page (the one being decorated by the
         // outer SiteMesh render) and push a fresh one for the duration of the
@@ -280,7 +280,7 @@ class RenderSitemeshTagLib implements TagLibrary {
      * @attr default the default value to use if the property is null
      * @attr writeEntireProperty if true, writes the property in the form 'foo = "bar"', otherwise renders 'bar'
      */
-    Closure pageProperty = { attrs ->
+    def pageProperty(Map attrs) {
         if (!attrs.name) {
             throwTagError('Tag [pageProperty] is missing required attribute [name]')
         }
@@ -313,7 +313,7 @@ class RenderSitemeshTagLib implements TagLibrary {
      * @attr name REQUIRED the property name
      * @attr equals optional value to test against
      */
-    Closure ifPageProperty = { Map attrs, body ->
+    def ifPageProperty(Map attrs, Closure body) {
         if (!attrs.name) {
             return
         }
@@ -345,7 +345,7 @@ class RenderSitemeshTagLib implements TagLibrary {
     // require a second HTML parse of the layout output to expand. The
     // property is pulled directly from the Content being merged (set on the
     // request under WebAppContext.CONTENT_KEY by WebAppContext.decorate).
-    Closure layoutTitle = { attrs ->
+    def layoutTitle(Map attrs) {
         ContentProperty titleProp = getContentProperty('title')
         String defaultValue = attrs.default?.toString() ?: ''
         if (titleProp?.hasValue()) {
@@ -355,7 +355,7 @@ class RenderSitemeshTagLib implements TagLibrary {
         }
     }
 
-    Closure layoutHead = { attrs, body ->
+    def layoutHead(Map attrs, Closure body) {
         ContentProperty headProp = getContentProperty('head')
         if (headProp?.hasValue()) {
             headProp.writeValueTo(out)
@@ -364,7 +364,7 @@ class RenderSitemeshTagLib implements TagLibrary {
         }
     }
 
-    Closure layoutBody = { attrs, body ->
+    def layoutBody(Map attrs, Closure body) {
         ContentProperty bodyProp = getContentProperty('body')
         if (bodyProp?.hasValue()) {
             bodyProp.writeValueTo(out)
@@ -373,7 +373,7 @@ class RenderSitemeshTagLib implements TagLibrary {
         }
     }
 
-    Closure content = { attrs, body ->
+    def content(Map attrs, Closure body) {
         Encoder htmlEncoder = codecLookup?.lookupEncoder('HTML')
         out << '<content tag="'
         out << (htmlEncoder != null ? htmlEncoder.encode(attrs.tag) : attrs.tag)

--- a/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
+++ b/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
@@ -43,7 +43,7 @@ public class Sitemesh3AutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SiteMeshViewResolverBeanPostProcessor.class)
-    public GrailsSiteMeshViewResolverBeanPostProcessor siteMeshViewResolverBeanPostProcessor() {
+    public static GrailsSiteMeshViewResolverBeanPostProcessor siteMeshViewResolverBeanPostProcessor() {
         return new GrailsSiteMeshViewResolverBeanPostProcessor();
     }
 }

--- a/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
+++ b/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
@@ -20,22 +20,45 @@ package org.grails.plugins.sitemesh3;
 
 import org.sitemesh.webmvc.SiteMeshViewResolverBeanPostProcessor;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.DispatcherServlet;
+
+import grails.config.Config;
+import grails.core.GrailsApplication;
+import grails.util.Environment;
+import grails.util.Metadata;
+
+import org.grails.web.gsp.io.GrailsConventionGroovyPageLocator;
 
 /**
- * Registers a {@link GrailsSiteMeshViewResolverBeanPostProcessor} ahead of
- * the upstream auto-configuration. Upstream's
- * {@code SiteMeshViewResolverAutoConfiguration} declares its post-processor
- * bean with {@code @ConditionalOnMissingBean(SiteMeshViewResolverBeanPostProcessor.class)};
- * by scheduling this config first (via {@link AutoConfigureBefore}), our
- * Grails-specific subclass is picked up and the default is suppressed.
+ * Registers the Grails SiteMesh 3 integration beans ahead of the upstream
+ * auto-configuration: the {@link GrailsSiteMeshViewResolverBeanPostProcessor},
+ * the {@link CaptureAwareContentProcessor} ({@code contentProcessor}) and the
+ * {@link Sitemesh3LayoutFinder} ({@code decoratorSelector}).
+ *
+ * <p>Upstream's {@code SiteMeshViewResolverAutoConfiguration} declares each of
+ * these with a {@code @ConditionalOnMissingBean} guard. By scheduling this
+ * configuration first (via {@link AutoConfigureBefore}) the Grails
+ * implementations are registered before those guards are evaluated, so the
+ * upstream defaults back off cleanly rather than being registered and then
+ * overridden after the fact.</p>
+ *
+ * <p>The {@code contentProcessor} and {@code decoratorSelector} beans drive view
+ * decoration, which is only meaningful when Spring MVC is resolving views, so
+ * they are gated on a {@link DispatcherServlet} being present. This keeps them
+ * out of the lightweight unit-test contexts built by grails-testing-support,
+ * which have no dispatcher servlet.</p>
  */
 @AutoConfiguration
+@AutoConfigureAfter(name = "org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration")
 @AutoConfigureBefore(name = "org.sitemesh.autoconfigure.SiteMeshViewResolverAutoConfiguration")
 @ConditionalOnClass(SiteMeshViewResolverBeanPostProcessor.class)
 @ConditionalOnProperty(name = "sitemesh.integration", havingValue = "view-resolver", matchIfMissing = true)
@@ -45,5 +68,39 @@ public class Sitemesh3AutoConfiguration {
     @ConditionalOnMissingBean(SiteMeshViewResolverBeanPostProcessor.class)
     public static GrailsSiteMeshViewResolverBeanPostProcessor siteMeshViewResolverBeanPostProcessor() {
         return new GrailsSiteMeshViewResolverBeanPostProcessor();
+    }
+
+    @Bean
+    @ConditionalOnBean(DispatcherServlet.class)
+    @ConditionalOnMissingBean(name = "contentProcessor")
+    public CaptureAwareContentProcessor contentProcessor() {
+        return new CaptureAwareContentProcessor();
+    }
+
+    @Bean
+    @ConditionalOnBean(DispatcherServlet.class)
+    @ConditionalOnMissingBean(name = "decoratorSelector")
+    public Sitemesh3LayoutFinder decoratorSelector(ObjectProvider<GrailsConventionGroovyPageLocator> groovyPageLocator,
+                                                   GrailsApplication grailsApplication) {
+        Config config = grailsApplication.getConfig();
+        Environment env = Environment.getCurrent();
+        boolean developmentMode = Metadata.getCurrent().isDevelopmentEnvironmentAvailable();
+        boolean reloadEnabled = env.isReloadEnabled()
+                || config.getProperty("grails.gsp.enable.reload", Boolean.class, false)
+                || (developmentMode && env == Environment.DEVELOPMENT);
+
+        // The SiteMesh 3 specific key wins; fall back to the SiteMesh 2 plugin's
+        // grails.views.layout.default so existing apps keep their configured
+        // default layout when switching.
+        String defaultLayout = config.getProperty("grails.sitemesh.default.layout");
+        if (defaultLayout == null || defaultLayout.isEmpty()) {
+            defaultLayout = config.getProperty("grails.views.layout.default");
+        }
+
+        Sitemesh3LayoutFinder finder = new Sitemesh3LayoutFinder(groovyPageLocator.getIfAvailable());
+        finder.setGspReloadEnabled(reloadEnabled);
+        finder.setDefaultDecoratorName(defaultLayout == null || defaultLayout.isEmpty() ? null : defaultLayout);
+        finder.setLayoutCacheExpirationMillis(config.getProperty("grails.sitemesh.layout.cache.interval", Long.class, 5000L));
+        return finder;
     }
 }

--- a/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
+++ b/grails-gsp/grails-sitemesh3/src/main/java/org/grails/plugins/sitemesh3/Sitemesh3AutoConfiguration.java
@@ -35,7 +35,6 @@ import grails.config.Config;
 import grails.core.GrailsApplication;
 import grails.util.Environment;
 import grails.util.Metadata;
-
 import org.grails.web.gsp.io.GrailsConventionGroovyPageLocator;
 
 /**
@@ -85,9 +84,9 @@ public class Sitemesh3AutoConfiguration {
         Config config = grailsApplication.getConfig();
         Environment env = Environment.getCurrent();
         boolean developmentMode = Metadata.getCurrent().isDevelopmentEnvironmentAvailable();
-        boolean reloadEnabled = env.isReloadEnabled()
-                || config.getProperty("grails.gsp.enable.reload", Boolean.class, false)
-                || (developmentMode && env == Environment.DEVELOPMENT);
+        boolean reloadEnabled = env.isReloadEnabled() ||
+                config.getProperty("grails.gsp.enable.reload", Boolean.class, false) ||
+                (developmentMode && env == Environment.DEVELOPMENT);
 
         // The SiteMesh 3 specific key wins; fall back to the SiteMesh 2 plugin's
         // grails.views.layout.default so existing apps keep their configured

--- a/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/sitemesh3/Sitemesh3AutoConfigurationSpec.groovy
+++ b/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/sitemesh3/Sitemesh3AutoConfigurationSpec.groovy
@@ -1,0 +1,115 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.sitemesh3
+
+import org.sitemesh.SiteMeshContext
+import org.sitemesh.content.Content
+
+import org.springframework.beans.factory.ObjectProvider
+
+import grails.config.Config
+import grails.core.GrailsApplication
+
+import org.grails.gsp.io.GroovyPageScriptSource
+import org.grails.web.gsp.io.GrailsConventionGroovyPageLocator
+
+import spock.lang.Specification
+
+class Sitemesh3AutoConfigurationSpec extends Specification {
+
+    Sitemesh3AutoConfiguration autoConfiguration = new Sitemesh3AutoConfiguration()
+
+    void "the contentProcessor bean is a CaptureAwareContentProcessor"() {
+        expect:
+        autoConfiguration.contentProcessor() instanceof CaptureAwareContentProcessor
+    }
+
+    void "the post processor bean is the Grails view-resolver subclass"() {
+        expect:
+        Sitemesh3AutoConfiguration.siteMeshViewResolverBeanPostProcessor() instanceof GrailsSiteMeshViewResolverBeanPostProcessor
+    }
+
+    void "the decoratorSelector bean is created even when no groovyPageLocator is available"() {
+        given: "an empty locator provider, as in a context without GSP support"
+        ObjectProvider<GrailsConventionGroovyPageLocator> provider = Mock(ObjectProvider) {
+            getIfAvailable() >> null
+        }
+        Config config = Mock(Config) {
+            getProperty('grails.gsp.enable.reload', _, _) >> false
+            getProperty('grails.sitemesh.layout.cache.interval', _, _) >> 5000L
+        }
+        GrailsApplication grailsApplication = Stub(GrailsApplication) {
+            getConfig() >> config
+        }
+
+        expect:
+        autoConfiguration.decoratorSelector(provider, grailsApplication) instanceof Sitemesh3LayoutFinder
+    }
+
+    void "the decoratorSelector bean resolves the configured default layout"() {
+        given: "a locator that resolves the configured default layout path"
+        GrailsConventionGroovyPageLocator locator = Mock(GrailsConventionGroovyPageLocator) {
+            findViewByPath('/layouts/mylayout') >> Mock(GroovyPageScriptSource)
+        }
+        ObjectProvider<GrailsConventionGroovyPageLocator> provider = Mock(ObjectProvider) {
+            getIfAvailable() >> locator
+        }
+        Config config = Mock(Config) {
+            getProperty('grails.sitemesh.default.layout') >> 'mylayout'
+            getProperty('grails.gsp.enable.reload', _, _) >> false
+            getProperty('grails.sitemesh.layout.cache.interval', _, _) >> 5000L
+        }
+        GrailsApplication grailsApplication = Stub(GrailsApplication) {
+            getConfig() >> config
+        }
+
+        when: "selecting a decorator outside a web context, which falls back to the default"
+        Sitemesh3LayoutFinder finder = autoConfiguration.decoratorSelector(provider, grailsApplication)
+        String[] paths = finder.selectDecoratorPaths(Mock(Content), Mock(SiteMeshContext))
+
+        then:
+        paths == ['/layouts/mylayout'] as String[]
+    }
+
+    void "the decoratorSelector bean falls back to grails.views.layout.default"() {
+        given: "no SiteMesh 3 default, but a SiteMesh 2 style default layout"
+        GrailsConventionGroovyPageLocator locator = Mock(GrailsConventionGroovyPageLocator) {
+            findViewByPath('/layouts/legacy') >> Mock(GroovyPageScriptSource)
+        }
+        ObjectProvider<GrailsConventionGroovyPageLocator> provider = Mock(ObjectProvider) {
+            getIfAvailable() >> locator
+        }
+        Config config = Mock(Config) {
+            getProperty('grails.sitemesh.default.layout') >> null
+            getProperty('grails.views.layout.default') >> 'legacy'
+            getProperty('grails.gsp.enable.reload', _, _) >> false
+            getProperty('grails.sitemesh.layout.cache.interval', _, _) >> 5000L
+        }
+        GrailsApplication grailsApplication = Stub(GrailsApplication) {
+            getConfig() >> config
+        }
+
+        when:
+        Sitemesh3LayoutFinder finder = autoConfiguration.decoratorSelector(provider, grailsApplication)
+        String[] paths = finder.selectDecoratorPaths(Mock(Content), Mock(SiteMeshContext))
+
+        then:
+        paths == ['/layouts/legacy'] as String[]
+    }
+}

--- a/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/sitemesh3/Sitemesh3LayoutTagLibSpec.groovy
+++ b/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/sitemesh3/Sitemesh3LayoutTagLibSpec.groovy
@@ -1,0 +1,63 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.sitemesh3
+
+import org.grails.taglib.TagMethodInvoker
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Verifies that the compile-time capture tags shipped by
+ * {@link Sitemesh3LayoutTagLib} are defined as method handlers rather than
+ * closure fields, so the GSP dispatch produced by {@code GrailsLayoutPreprocessor}
+ * uses the faster reflective method-invocation path instead of cloning a closure
+ * on every page render.
+ */
+class Sitemesh3LayoutTagLibSpec extends Specification {
+
+    static final List<String> TAGS = [
+            'captureHead',
+            'captureBody',
+            'captureTitle',
+            'wrapTitleTag',
+            'captureMeta',
+            'captureContent',
+            'parameter',
+    ]
+
+    @Unroll
+    def "tag [#tag] is defined as a method handler, not a closure field"() {
+        given:
+        Sitemesh3LayoutTagLib tagLib = new Sitemesh3LayoutTagLib()
+
+        expect: 'the tag is discovered as an invokable method'
+        TagMethodInvoker.hasInvokableTagMethod(tagLib, tag)
+
+        and: 'no closure field of the same name shadows it'
+        TagMethodInvoker.getClosureTagProperty(tagLib, tag) == null
+
+        where:
+        tag << TAGS
+    }
+
+    def "every shipped tag is reported as an invokable method name"() {
+        expect:
+        TagMethodInvoker.getInvokableTagMethodNames(Sitemesh3LayoutTagLib).containsAll(TAGS)
+    }
+}

--- a/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/web/taglib/RenderSitemeshTagLibSpec.groovy
+++ b/grails-gsp/grails-sitemesh3/src/test/groovy/org/grails/plugins/web/taglib/RenderSitemeshTagLibSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.web.taglib
+
+import org.grails.taglib.TagMethodInvoker
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Verifies that the tags shipped by {@link RenderSitemeshTagLib} are defined as
+ * method handlers rather than closure fields, so GSP dispatch uses the faster
+ * reflective method-invocation path instead of cloning a closure per call.
+ */
+class RenderSitemeshTagLibSpec extends Specification {
+
+    static final List<String> TAGS = [
+            'applyLayout',
+            'pageProperty',
+            'ifPageProperty',
+            'layoutTitle',
+            'layoutHead',
+            'layoutBody',
+            'content',
+    ]
+
+    @Unroll
+    def "tag [#tag] is defined as a method handler, not a closure field"() {
+        given:
+        RenderSitemeshTagLib tagLib = new RenderSitemeshTagLib()
+
+        expect: 'the tag is discovered as an invokable method'
+        TagMethodInvoker.hasInvokableTagMethod(tagLib, tag)
+
+        and: 'no closure field of the same name shadows it'
+        TagMethodInvoker.getClosureTagProperty(tagLib, tag) == null
+
+        where:
+        tag << TAGS
+    }
+
+    def "every shipped tag is reported as an invokable method name"() {
+        expect:
+        TagMethodInvoker.getInvokableTagMethodNames(RenderSitemeshTagLib).containsAll(TAGS)
+    }
+}

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/profile/commands/CreateAppCommand.groovy
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/profile/commands/CreateAppCommand.groovy
@@ -519,7 +519,7 @@ class CreateAppCommand extends ArgumentCompletingCommand implements ProfileRepos
             configuredRepositories.add(repository)
 
             GrailsGradleRepository sitemeshSnapshots = new GrailsGradleRepository(url: 'https://central.sonatype.com/repository/maven-snapshots', snapshotsOnly: true)
-            sitemeshSnapshots.includeOnly('org[.]sitemesh.*', '.*', '.*-SNAPSHOT')
+            sitemeshSnapshots.includeOnly('org[.]sitemesh.*', '.*', '.*')
             configuredRepositories.add(sitemeshSnapshots)
         }
         configuredRepositories.unique()


### PR DESCRIPTION
## Summary

Follow-up to #15713, addressing review feedback on `RenderSitemeshTagLib`:

> To make this faster, you should use the method version instead of closure.

Converts **both** taglibs shipped by the SiteMesh 3 plugin from closure-based tags to the method handlers introduced in #15465, so GSP dispatch uses the faster reflective method-invocation path instead of cloning a closure on every tag invocation. This also clears the closure-based-tag deprecation warning the #15465 compiler check emits for these classes.

- **`RenderSitemeshTagLib`** (`sitemesh` namespace) — `applyLayout`, `pageProperty`, `ifPageProperty`, `layoutTitle`, `layoutHead`, `layoutBody`, `content`.
- **`Sitemesh3LayoutTagLib`** (`grailsLayout` namespace, `@CompileStatic`) — the compile-time capture tags `captureHead`, `captureBody`, `captureTitle`, `wrapTitleTag`, `captureMeta`, `captureContent`, `parameter`. These are emitted by `GrailsLayoutPreprocessor` and dispatched through `GroovyPage.invokeTag`, which already routes to method handlers (`invokeTagLibMethod` → `TagMethodInvoker`).

After this change, no taglib used by the SiteMesh 3 plugin remains closure-based.

## Behavior preservation

Only the tag declarations change; the tag bodies are untouched. Both the closure and method dispatch paths (`TagOutput.captureTagOutput` and `GroovyPage.invokeTag`) share the same output-stack setup and already pass `TagOutput.EMPTY_BODY_CLOSURE` (never `null`) as the body to two-argument tags, so the existing `body` / `body instanceof Closure` checks resolve identically whether each tag is a closure field or a method.

## SiteMesh 3.3.0-M1

Also bumps the SiteMesh 3 dependencies (`spring-boot-starter-sitemesh`, `spring-webmvc-sitemesh`, and the transitive `org.sitemesh:sitemesh` core) from `3.3.0-SNAPSHOT` to the released **3.3.0-M1** milestone, now on Maven Central. SiteMesh 2 (`opensymphony:sitemesh` 2.6.0, used by `grails-layout`) is unaffected.

## Tests

- Adds `RenderSitemeshTagLibSpec` and `Sitemesh3LayoutTagLibSpec`, which verify via the framework `TagMethodInvoker` API that all fourteen tags are discovered as invokable method handlers and no longer exist as closure fields.
- End-to-end coverage in `grails-test-examples/gsp-sitemesh3` (`EndToEndSpec`) continues to exercise the full capture/decoration pipeline at runtime.

## Validation

- `./gradlew :grails-sitemesh3:test` — green (incl. both new specs)
- `./gradlew :grails-sitemesh3:checkstyleMain :grails-sitemesh3:codenarcMain` — green
- `./gradlew :grails-test-examples-gsp-sitemesh3:integrationTest` — green (`EndToEndSpec` 14/14, `GrailsLayoutSpec` 7/7) against SiteMesh 3.3.0-M1

## Snapshot-repo regex cleanup (addresses #15710 review)

Addresses two review comments on #15710: the generated-app sitemesh snapshot repository's version filter does not need to match `-SNAPSHOT` explicitly, because the repository is already constrained to snapshots — `snapshotsOnly: true` in `CreateAppCommand` and `VersionType.SNAPSHOT` in `GradleRepository`. The version regex is simplified from `.*-SNAPSHOT` to `.*` in both places. (The pre-existing apache/groovy snapshot filters are left untouched.)
