### PR TITLE
Make localeResolver overridable via @ConditionalOnMissingBean

### DIFF
--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
@@ -21,6 +21,7 @@ package org.grails.plugins.i18n;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
@@ -56,6 +57,7 @@ public class I18nAutoConfiguration {
     private int fileCacheSeconds;
 
     @Bean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
+    @ConditionalOnMissingBean(name = DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
     public LocaleResolver localeResolver() {
         return new SessionLocaleResolver();
     }


### PR DESCRIPTION
## What

`I18nAutoConfiguration.localeResolver()` registers the `localeResolver` bean **unconditionally**. As a result, an application-supplied `LocaleResolver` overrides the framework default — a bean-definition override warning on startup by default, and a hard startup failure when `spring.main.allow-bean-definition-overriding=false`.

This adds `@ConditionalOnMissingBean(name = "localeResolver")` so the Grails default backs off cleanly when the application already defines one. This mirrors Spring Boot's own `WebMvcAutoConfiguration.localeResolver()`, which is `@ConditionalOnMissingBean` for exactly this reason — registering it unconditionally is the divergence.

```java
@Bean(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
@ConditionalOnMissingBean(name = DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
public LocaleResolver localeResolver() {
    return new SessionLocaleResolver();
}
```

## Scope — what this covers

`@ConditionalOnMissingBean` is evaluated **during auto-configuration**, so it lets the Grails default back off in favor of a `localeResolver` bean that is already present at that point:

- an application `@Bean localeResolver` (user `@Configuration` is processed before auto-configuration),
- an `@Import`ed configuration, or
- another auto-configuration ordered `@AutoConfigureBefore` grails-i18n.

It does **not** affect beans contributed *after* auto-configuration — e.g. a Grails plugin's `doWithSpring`, which is registered later and still overrides via the normal override mechanism. Silencing that case additionally requires the contributor to register its resolver during auto-config (e.g. an `@AutoConfigureBefore(I18nAutoConfiguration)` class) so this condition can see it and back off. This PR is the upstream half that makes such a clean backoff possible.

Behavior for a plain app (no competing `localeResolver`) is unchanged: the condition passes and the Grails default registers as before.

## Why keyed on the name, not the type

`DispatcherServlet` resolves the locale resolver by the fixed bean name `DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME` (`"localeResolver"`). A `LocaleResolver` bean registered under a different name is never the one actually used, so keying the condition on the bean name matches the real lookup semantics — a by-type condition could back off for an unrelated resolver bean that `DispatcherServlet` ignores.

## Note

The sibling beans in the same class (`localeChangeInterceptor`, `messageSource`) are also registered unconditionally; this PR is intentionally scoped to `localeResolver` only. Happy to extend if maintainers prefer.
