### PR TITLE
fix(codecs): stop overriding the codecLookup bean definition

### DIFF
--- a/grails-codecs/src/main/groovy/org/grails/plugins/codecs/CodecsGrailsPlugin.groovy
+++ b/grails-codecs/src/main/groovy/org/grails/plugins/codecs/CodecsGrailsPlugin.groovy
@@ -44,10 +44,4 @@ class CodecsGrailsPlugin extends Plugin {
             URLCodec,
             RawCodec
     ]
-
-    Closure doWithSpring() {
-        { ->
-            codecLookup(DefaultCodecLookup)
-        }
-    }
 }

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/AbstractGrailsTagTests.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/AbstractGrailsTagTests.groovy
@@ -71,6 +71,7 @@ import org.grails.gsp.GroovyPagesTemplateEngine
 import org.grails.gsp.compiler.GrailsLayoutPreprocessor
 import org.grails.plugins.DefaultGrailsPlugin
 import org.grails.plugins.MockGrailsPluginManager
+import org.grails.plugins.codecs.DefaultCodecLookup
 import org.grails.taglib.GroovyPageAttributes
 import org.grails.taglib.TagOutput
 import org.grails.taglib.encoder.OutputContextLookupHelper
@@ -317,6 +318,9 @@ abstract class AbstractGrailsTagTests {
         }
         mockManager.registerProvidedArtefacts(grailsApplication)
         def springConfig = new WebRuntimeSpringConfiguration(ctx)
+        // Legacy harness: boots from the plugin pipeline, not Spring Boot auto-config,
+        // so CodecsConfiguration (the normal codecLookup source) is never processed here.
+        springConfig.addSingletonBean('codecLookup', DefaultCodecLookup)
 
         webRequest = GrailsWebMockUtil.bindMockWebRequest(ctx)
         onInit()

--- a/grails-test-examples/gsp-layout/src/test/groovy/org/apache/grails/views/gsp/layout/AbstractGrailsTagTests.groovy
+++ b/grails-test-examples/gsp-layout/src/test/groovy/org/apache/grails/views/gsp/layout/AbstractGrailsTagTests.groovy
@@ -75,6 +75,7 @@ import org.grails.gsp.GroovyPagesTemplateEngine
 import org.grails.gsp.compiler.GrailsLayoutPreprocessor
 import org.grails.plugins.DefaultGrailsPlugin
 import org.grails.plugins.MockGrailsPluginManager
+import org.grails.plugins.codecs.DefaultCodecLookup
 import org.grails.taglib.GroovyPageAttributes
 import org.grails.taglib.TagOutput
 import org.grails.taglib.encoder.OutputContextLookupHelper
@@ -322,6 +323,9 @@ abstract class AbstractGrailsTagTests {
         }
         mockManager.registerProvidedArtefacts(grailsApplication)
         def springConfig = new WebRuntimeSpringConfiguration(ctx)
+        // Legacy harness: boots from the plugin pipeline, not Spring Boot auto-config,
+        // so CodecsConfiguration (the normal codecLookup source) is never processed here.
+        springConfig.addSingletonBean('codecLookup', DefaultCodecLookup)
 
         webRequest = GrailsWebMockUtil.bindMockWebRequest(ctx)
         onInit()

--- a/grails-testing-support-core/src/main/groovy/org/grails/testing/GrailsUnitTest.groovy
+++ b/grails-testing-support-core/src/main/groovy/org/grails/testing/GrailsUnitTest.groovy
@@ -121,7 +121,7 @@ trait GrailsUnitTest {
         try {
             Method doWithSpringField = clazz.getMethod('getDoWithSpring')
             defineBeans((Closure) doWithSpringField.invoke(plugin))
-        } catch (NoSuchFieldException e) {}
+        } catch (NoSuchMethodException e) {}
     }
 
     Closure doWithSpring() {


### PR DESCRIPTION
## Summary

On startup a full Grails application logs a bean-definition override for `codecLookup`:

```
Overriding bean definition for bean 'codecLookup' with a different definition:
replacing [... factoryBeanName=org.grails.plugins.codecs.CodecsConfiguration; factoryMethodName=codecLookup ...]
with [Generic bean: class=org.grails.plugins.codecs.DefaultCodecLookup ...]
```

`codecLookup` was registered **twice**, both producing a `DefaultCodecLookup`:

- `CodecsConfiguration` — the `@Bean("codecLookup") @Primary` auto-configuration bean (loaded in every production context, including grails-testing-support and plain Spring Boot).
- `CodecsGrailsPlugin.doWithSpring` — a second registration that overrode the auto-config one (the log). Because `doWithSpring` runs after auto-configuration conditions are evaluated, the plugin bean always replaced `CodecsConfiguration`'s — silently dropping its `@Primary` marker in the process.

## Change

Remove the redundant `doWithSpring` registration so `CodecsConfiguration` is the single definition. The resulting bean is unchanged — still a `DefaultCodecLookup` under the name `codecLookup` — just registered once, with no override.

Two contexts bootstrap from plugins rather than auto-configuration and needed supporting changes:

- **`GrailsUnitTest.defineBeans(Object plugin)`** caught `NoSuchFieldException`, but `clazz.getMethod('getDoWithSpring')` throws `NoSuchMethodException`. A plugin whose `doWithSpring()` returns `null` (now including `CodecsGrailsPlugin`) therefore crashed instead of being skipped. Catch the correct exception.
- The legacy **`AbstractGrailsTagTests`** harnesses (grails-gsp and grails-test-examples/gsp-layout) load plugins but never trigger auto-configuration, so they register `codecLookup` directly.

## Verification

- Full suite green: 7754 unit + 1812 integration tests, 0 failures/errors.
- `aggregateViolations` / `codenarcMain` for the changed modules — clean.
- Booted the `gsp-sitemesh3` example app with `DefaultListableBeanFactory` at INFO: the `Overriding bean definition for bean 'codecLookup'` line is gone, and decoration/codec behavior is unchanged.