### PR TITLE
build(deps): update Gradle to 9.6.0

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -8,5 +8,4 @@
 java=21.0.7-librca
 # Keep gradle version synced with gradle.properties (gradleToolingApiVersion).
 # Update the gradle-bootstrap project to propagate the version to all gradle-wrapper.properties files.
-gradle=9.5.1
-
+gradle=9.6.0

--- a/build-logic/gradle/wrapper/gradle-wrapper.properties
+++ b/build-logic/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ expectitCoreVersion=0.9.0
 gparsVersion=1.2.1
 # Keep gradle version synced with .sdkmanrc, all gradle-wrapper.properties files,
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
-gradleToolingApiVersion=9.5.1
+gradleToolingApiVersion=9.6.0
 javassistVersion=3.30.2-GA
 jnrPosixVersion=3.1.20
 joddWotVersion=3.3.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/grails-forge/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-forge/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
@@ -34,7 +34,7 @@ Features features)
 @* Keep gradle version synced with .sdkmanrc, gradle.properties (gradleToolingApiVersion), all gradle-wrapper.properties files *@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties
@@ -2,7 +2,7 @@
 # and grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/gradleWrapperProperties.rocker.raw
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/grails-shell-cli/src/test/resources/gradle-sample/gradle/wrapper/gradle-wrapper.properties
+++ b/grails-shell-cli/src/test/resources/gradle-sample/gradle/wrapper/gradle-wrapper.properties
@@ -19,7 +19,7 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updates the Gradle wrapper and Tooling API from 9.5.1 to [9.6.0](https://gradle.org/releases/#9.6.0) on the 8.0.x branch.

Keeps the Gradle version synchronized across every documented location:

- `gradle/wrapper/gradle-wrapper.properties`
- `build-logic/gradle/wrapper/gradle-wrapper.properties`
- `grails-forge/gradle/wrapper/gradle-wrapper.properties`
- `grails-gradle/gradle/wrapper/gradle-wrapper.properties`
- `grails-profiles/base/skeleton/gradle/wrapper/gradle-wrapper.properties`
- `grails-profiles/profile/skeleton/gradle/wrapper/gradle-wrapper.properties`
- `grails-shell-cli` gradle-sample wrapper
- `grails-forge` `gradleWrapperProperties.rocker.raw` template (generated app wrapper)
- `gradle.properties` (`gradleToolingApiVersion`)
- `.sdkmanrc`

Verification:

- `./gradlew --version` reports Gradle 9.6.0
- `./gradlew help` completes successfully on Gradle 9.6.0

Release notes: https://github.com/gradle/gradle/releases/tag/v9.6.0
