### PR TITLE
Update Spring Boot to 3.5.16

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -37,7 +37,7 @@ ext {
             'jna.version'                   : '5.17.0',
             'jquery.version'                : '3.7.1',
             'objenesis.version'             : '3.4',
-            'spring-boot.version'           : '3.5.15',
+            'spring-boot.version'           : '3.5.16',
     ]
 
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly


### PR DESCRIPTION
## Summary

Updates Spring Boot from 3.5.15 to [3.5.16](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.16).

## Details

Spring Boot 3.5.16's `spring-boot-dependencies` BOM keeps its managed `jackson-bom.version` at 2.21.4, matching the Grails BOM's `jackson.version` pin from the previous Spring Boot update.

The 3.5.16 release notes list dependency upgrades for Spring AMQP 3.2.12, Spring Data BOM 2025.0.13, and Spring Integration 6.5.10. No additional Grails BOM alignment was needed; `validateDependencyVersions` passed for both grails-core and grails-gradle.

## Verification

Ran the same dependency checker CI uses, both invocations green:

- `./gradlew validateDependencyVersions` (grails-core) - BUILD SUCCESSFUL
- `./gradlew validateDependencyVersions` (grails-gradle) - BUILD SUCCESSFUL
