### PR TITLE
fix: align H7 HibernateGormStaticApi internal SQL method names with H5

### DIFF
--- a/grails-data-hibernate7/core/src/main/groovy/grails/gorm/hibernate/HibernateEntity.groovy
+++ b/grails-data-hibernate7/core/src/main/groovy/grails/gorm/hibernate/HibernateEntity.groovy
@@ -49,7 +49,7 @@ trait HibernateEntity<D> extends GormEntity<D> {
      */
     @Generated
     static List<D> findAllWithSql(CharSequence sql) {
-        currentHibernateStaticApi().findAllWithNativeSql(sql, Collections.emptyMap())
+        currentHibernateStaticApi().findAllWithSql(sql, Collections.emptyMap())
     }
 
     /**
@@ -61,7 +61,7 @@ trait HibernateEntity<D> extends GormEntity<D> {
      */
     @Generated
     static D findWithSql(CharSequence sql) {
-        currentHibernateStaticApi().findWithNativeSql(sql, Collections.emptyMap())
+        currentHibernateStaticApi().findWithSql(sql, Collections.emptyMap())
     }
 
     /**
@@ -74,7 +74,7 @@ trait HibernateEntity<D> extends GormEntity<D> {
      */
     @Generated
     static List<D> findAllWithSql(CharSequence sql, Map args) {
-        currentHibernateStaticApi().findAllWithNativeSql(sql, args)
+        currentHibernateStaticApi().findAllWithSql(sql, args)
     }
 
     /**
@@ -87,7 +87,7 @@ trait HibernateEntity<D> extends GormEntity<D> {
      */
     @Generated
     static D findWithSql(CharSequence sql, Map args) {
-        currentHibernateStaticApi().findWithNativeSql(sql, args)
+        currentHibernateStaticApi().findWithSql(sql, args)
     }
 
     @Generated

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
@@ -279,8 +279,8 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
         doSingleInternal(sql, [:], [], args, true) as D
     }
 
-    List<D> findAllWithSql(CharSequence query, Map args = Collections.emptyMap()) {
-        doListInternal(query, [:], [], args, true)
+    List<D> findAllWithSql(CharSequence sql, Map args = Collections.emptyMap()) {
+        doListInternal(sql, [:], [], args, true)
     }
 
     // The single-argument CharSequence overloads accept a plain String (executed as written, as

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/HibernateGormStaticApi.groovy
@@ -275,11 +275,11 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
         doListInternal(query, namedParams, [], args, false)
     }
 
-    D findWithNativeSql(CharSequence sql, Map args = Collections.emptyMap()) {
+    D findWithSql(CharSequence sql, Map args = Collections.emptyMap()) {
         doSingleInternal(sql, [:], [], args, true) as D
     }
 
-    List<D> findAllWithNativeSql(CharSequence query, Map args = Collections.emptyMap()) {
+    List<D> findAllWithSql(CharSequence query, Map args = Collections.emptyMap()) {
         doListInternal(query, [:], [], args, true)
     }
 

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/releaseHistory.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/releaseHistory.adoc
@@ -29,7 +29,7 @@ Key features and changes relative to GORM for Hibernate 5:
 * **Hibernate ORM 7** — Full support for Hibernate 7, including Jakarta Persistence 3.2 and the Apache License 2.0.
 * **Spring Boot 4 / Spring Framework 7** — Grails {grailsMajorVersion} vendors the removed `org.springframework.orm.hibernate5` classes into `grails-data-hibernate7-spring-orm` under the `org.grails.orm.hibernate.support.hibernate7` package.
 * **HQL injection safety** — Single-argument `find`, `findAll`, `executeQuery`, and `executeUpdate` accept a plain `String` as on Hibernate 5; when a Groovy GString is passed, its `${value}` interpolations are bound as named parameters instead of being interpolated into the query text, so the idiomatic interpolated form is injection-safe by binding.
-* **Native SQL queries** — New `findWithNativeSql` / `findAllWithNativeSql` methods added.
+* **SQL query helpers** - `findWithSql` / `findAllWithSql` are available with the same names as Hibernate 5.
 * **Native query temporal types** — Native SQL queries return `java.time` types by default instead of legacy `java.sql` types.
 * **Removed deprecated Session API** — Hibernate's `save()`, `update()`, `delete()`, `load()`, and `get()` are replaced by JPA equivalents (`persist`, `merge`, `remove`, `getReference`, `find`). GORM's own dynamic methods are unaffected.
 * **`CascadeType.SAVE_UPDATE` removed** — GORM's ORM DSL `cascade: 'save-update'` string continues to work; direct use of the Hibernate `CascadeType` enum requires migration.

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
@@ -54,17 +54,14 @@ Book.executeQuery("from Book where title like ?1", [params.title + '%'])
 
 As in any ORM, manually concatenating untrusted input into a plain `String` (for example `"... where title = '" + userInput + "'"`) remains an injection risk and should be avoided in favour of the GString or parameterized forms above.
 
-===== `findWithSql` / `findAllWithSql` renamed
+===== SQL query helpers
 
-`findWithSql` and `findAllWithSql` are deprecated. Use `findWithNativeSql` and `findAllWithNativeSql` instead. The old names remain as delegating aliases for backwards compatibility.
+Hibernate 7 keeps the Hibernate 5 method names for raw SQL query helpers:
 
 [source,groovy]
 ----
-// Before (deprecated)
+Book.findWithSql("select * from book where id = ${params.id}")
 Book.findAllWithSql("select * from book where ...")
-
-// After
-Book.findAllWithNativeSql("select * from book where ...")
 ----
 
 ==== Schema-per-Tenant — Schema Names Are Now Quoted

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
@@ -56,8 +56,6 @@ As in any ORM, manually concatenating untrusted input into a plain `String` (for
 
 ===== SQL query helpers
 
-Hibernate 7 keeps the Hibernate 5 method names for raw SQL query helpers:
-
 [source,groovy]
 ----
 Book.findWithSql("select * from book where id = ${params.id}")

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/querying/nativeSql.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/querying/nativeSql.adoc
@@ -20,9 +20,9 @@ under the License.
 [[querying-native-sql]]
 == SQL Queries
 
-GORM provides `findWithSql` and `findAllWithSql` for executing raw SQL when HQL or the Criteria API cannot express the query you need (e.g. database-specific functions, complex joins, or legacy SQL).
+GORM provides `findWithSql` and `findAllWithSql` for executing raw SQL when HQL or the DetachedCriteria API cannot express the query you need (e.g. database-specific functions, complex joins, or legacy SQL).
 
-WARNING: Raw SQL bypasses Hibernate's type system and object mapping. Prefer HQL, the Criteria API, or dynamic finders wherever possible. Use SQL only when there is no higher-level alternative.
+WARNING: Raw SQL bypasses Hibernate's type system and object mapping. Prefer HQL, the DetachedCriteria API, or dynamic finders wherever possible. Use SQL only when there is no higher-level alternative.
 
 === Methods
 

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/querying/nativeSql.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/querying/nativeSql.adoc
@@ -18,11 +18,11 @@ under the License.
 ////
 
 [[querying-native-sql]]
-== Native SQL Queries
+== SQL Queries
 
-GORM provides `findWithNativeSql` and `findAllWithNativeSql` for executing raw SQL when HQL or the Criteria API cannot express the query you need (e.g. database-specific functions, complex joins, or legacy SQL).
+GORM provides `findWithSql` and `findAllWithSql` for executing raw SQL when HQL or the Criteria API cannot express the query you need (e.g. database-specific functions, complex joins, or legacy SQL).
 
-WARNING: Native SQL bypasses Hibernate's type system and object mapping. Prefer HQL, the Criteria API, or dynamic finders wherever possible. Use native SQL only when there is no higher-level alternative.
+WARNING: Raw SQL bypasses Hibernate's type system and object mapping. Prefer HQL, the Criteria API, or dynamic finders wherever possible. Use SQL only when there is no higher-level alternative.
 
 === Methods
 
@@ -30,20 +30,20 @@ WARNING: Native SQL bypasses Hibernate's type system and object mapping. Prefer 
 |===
 | Method | Description
 
-| `findWithNativeSql(CharSequence sql)`
+| `findWithSql(CharSequence sql)`
 | Returns the first result mapped to the domain class
 
-| `findWithNativeSql(CharSequence sql, Map args)`
+| `findWithSql(CharSequence sql, Map args)`
 | Returns the first result; `args` controls pagination (`max`, `offset`, `cache`)
 
-| `findAllWithNativeSql(CharSequence sql)`
+| `findAllWithSql(CharSequence sql)`
 | Returns all results mapped to the domain class
 
-| `findAllWithNativeSql(CharSequence sql, Map args)`
+| `findAllWithSql(CharSequence sql, Map args)`
 | Returns all results; `args` controls pagination
 |===
 
-=== Safe Usage — GString Value Parameters
+=== Safe Usage - GString Value Parameters
 
 When a query contains user-supplied **values** (not identifiers), use Groovy GString interpolation. GORM extracts each `${expression}` and binds it as a named JDBC parameter, preventing injection.
 
@@ -51,8 +51,8 @@ When a query contains user-supplied **values** (not identifiers), use Groovy GSt
 ----
 String nameFilter = params.name  // user input
 
-// ✅ SAFE — ${nameFilter} is bound as :p0, never inlined into the SQL string
-List results = Club.findAllWithNativeSql(
+// SAFE - ${nameFilter} is bound as :p0, never inlined into the SQL string
+List results = Club.findAllWithSql(
     "select * from club c where c.name like ${nameFilter} order by c.name")
 ----
 
@@ -62,36 +62,23 @@ A plain `String` constant with no user data is safe and accepted directly.
 
 [source,groovy]
 ----
-// ✅ SAFE — no user input, static SQL
-List results = Club.findAllWithNativeSql(
+// SAFE - no user input, static SQL
+List results = Club.findAllWithSql(
     "select * from club c order by c.name")
 ----
 
 === What Cannot Be Parameterized
 
-SQL identifiers — table names, column names, schema names — **cannot** be bound as JDBC parameters. Do not interpolate them from user input under any circumstances.
+SQL identifiers - table names, column names, schema names - **cannot** be bound as JDBC parameters. Do not interpolate them from user input under any circumstances.
 
 [source,groovy]
 ----
-// ❌ UNSAFE — table name from user input, cannot be made safe via GString
+// UNSAFE - table name from user input, cannot be made safe via GString
 String table = params.table
-Club.findAllWithNativeSql("select * from ${table}")  // DO NOT DO THIS
+Club.findAllWithSql("select * from ${table}")  // DO NOT DO THIS
 
-// ❌ UNSAFE — string concatenation, no protection at all
-Club.findAllWithNativeSql("select * from club where name = '" + userInput + "'")
+// UNSAFE - string concatenation, no protection at all
+Club.findAllWithSql("select * from club where name = '" + userInput + "'")
 ----
 
-If you need dynamic identifiers (e.g. schema-per-tenant), use the JDBC identifier quoting API (`connection.metaData.identifierQuoteString`) to quote and sanitize the name before use — the same mechanism used internally by `DefaultSchemaHandler`.
-
-=== Deprecated Names
-
-`findWithSql` and `findAllWithSql` are deprecated aliases for `findWithNativeSql` and `findAllWithNativeSql`. They remain functional for backwards compatibility but will be removed in a future release.
-
-[source,groovy]
-----
-// Deprecated — replace with findAllWithNativeSql
-Club.findAllWithSql("select * from club")
-
-// Preferred
-Club.findAllWithNativeSql("select * from club")
-----
+If you need dynamic identifiers (e.g. schema-per-tenant), use the JDBC identifier quoting API (`connection.metaData.identifierQuoteString`) to quote and sanitize the name before use - the same mechanism used internally by `DefaultSchemaHandler`.


### PR DESCRIPTION
Rename findWithNativeSql/findAllWithNativeSql to findWithSql/findAllWithSql in HibernateGormStaticApi so the Native suffix is not visible outside the implementation. HibernateEntity already exposes the correct public names; only the internal delegation calls are updated.

## Description
<!-- Describe your change and the problem it solves. Link to the related issue(s) if they exist. -->

## Contributor Checklist

Please review the following checklist before submitting your pull request. Pull requests that do not meet these requirements may be closed without review.

### Issue and Scope

- [ ] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. If no approved issue exists, please give background on why this change is necessary.  Tickets are preferred for release change log history.
- [ ] This PR addresses the **complete scope** of the linked issue. Partial implementations or unfinished work should not be submitted for review.
- [X ] This PR contains a **single, focused change**. Unrelated changes should be submitted as separate pull requests.
- [ ] This PR targets the **correct branch** for the type of change:
    - **Patch release branches** (e.g., `7.0.x`): Bug fixes only. No new features or API changes.
    - **Minor release branches** (e.g., `7.1.x`): New features are welcome, but breaking existing APIs must be avoided.
    - **Major release branches** (e.g., `8.0.x`): Reserved for major changes. Breaking API changes are permitted.

### Code Quality

- [ X] I have **added or updated tests** that cover the changes introduced in this PR. All code contributions are expected to include appropriate test coverage.
- [X ] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`.
- [ X] My code follows the project's **code style** guidelines. I have run `./gradlew codeStyle` and resolved any violations. See [Code Style](../CONTRIBUTING.md#code-style) for details.
- [X ] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring unless it was **explicitly approved** in the linked issue. Unsolicited reformatting will not be accepted.
- [ X] If generative AI tooling was used in preparing this contribution, a quality model was used to ensure contributions are **consistent with the project's quality standards**.

### Licensing and Attribution

- [X ] All contributed code is provided under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), and new source files include the appropriate **Apache license header**.
- [X ] I have the necessary rights to submit this contribution and confirm it is my own original work (see [Legal Notice](../CONTRIBUTING.md#i-want-to-contribute)).
- [ X] If generative AI tooling was used in preparing this contribution, I have followed the [Apache Software Foundation's policy on generative tooling](https://www.apache.org/legal/generative-tooling.html) and have properly attributed its use.

### Documentation

- [ ] If this PR introduces user-facing changes, I have included or updated the relevant documentation.
- [ ] If this PR adds a new feature, I have updated the **What's New** section of the Grails Guide.
- [ ] If this PR introduces breaking changes or changes that require user action during an upgrade, I have updated the **Upgrade Notes** for the corresponding version in the Grails Guide.
- [ X] The PR description clearly explains **what** was changed and **why**.

---

> **First-time contributors:** Please read our [Contributing Guide](../CONTRIBUTING.md) before submitting.
> Pull requests that appear to be auto-generated, incomplete, or unrelated to an approved issue may be
> closed to help maintainers focus on reviewed and planned work. We appreciate your understanding.
