### PR TITLE
Use config-driven Grails version docs

### DIFF
--- a/.agents/skills/grails-developer/SKILL.md
+++ b/.agents/skills/grails-developer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grails-developer
-description: Comprehensive guide for Grails 7 development, covering web applications, REST APIs, GORM, controllers, services, views, plugins, and testing with Spock and Geb
+description: Comprehensive guide for current Grails development, covering web applications, REST APIs, GORM, controllers, services, views, plugins, and testing with Spock and Geb
 license: Apache-2.0
 ---
 <!--
@@ -11,7 +11,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more contributor l
 
 ## What I Do
 
-- Provide detailed guidance for building Grails 7 web applications and REST APIs.
+- Provide detailed guidance for building current Grails web applications and REST APIs.
 - Assist with GORM for data modeling, controllers for request handling, services for business logic, and views (GSP, JSON, Markup).
 - Support testing with Spock 2.3 (unit/integration tests) and Geb for browser automation.
 - Guide plugin usage and development, security implementation, and deployment strategies.
@@ -19,7 +19,7 @@ Licensed to the Apache Software Foundation (ASF) under one or more contributor l
 
 ## When to Use Me
 
-Activate this skill when developing with Grails 7, including:
+Activate this skill when developing with current Grails, including:
 
 - Building CRUD applications, RESTful APIs, or full-stack web applications.
 - Working with GORM domain classes, constraints, and relationships.
@@ -30,7 +30,7 @@ Activate this skill when developing with Grails 7, including:
 
 ## Technology Stack
 
-Grails 7 is built on:
+Current Grails is built on:
 - **Spring Boot**: 4.0.x
 - **Spring Framework**: 7.0.x
 - **Groovy**: 4.0.x
@@ -862,7 +862,7 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
 
 ## Resources
 
-- **Grails 7 User Guide**: https://grails.apache.org/docs/latest/guide/single.html
+- **Grails User Guide**: https://grails.apache.org/docs/latest/guide/single.html
 - **GORM Documentation**: https://grails.apache.org/docs/latest/grails-data/
 - **Grails Plugins**: https://grails.apache.org/plugins.html
 - **Groovy 4 Documentation**: https://docs.groovy-lang.org/docs/groovy-4.0.30/html/documentation/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ export GRADLE_OPTS="-Xms2G -Xmx5G"
 
 | Skill | Path | Use For |
 |-------|------|---------|
-| **grails-developer** | `.agents/skills/grails-developer/SKILL.md` | Grails 7 apps, GORM, controllers, views |
+| **grails-developer** | `.agents/skills/grails-developer/SKILL.md` | Current Grails apps, GORM, controllers, views |
 | **groovy-developer** | `.agents/skills/groovy-developer/SKILL.md` | Groovy 4 syntax, closures, DSLs, Spock |
 | **java-developer** | `.agents/skills/java-developer/SKILL.md` | Java 17 features, Groovy interop |
 | **hibernate-developer** | `.agents/skills/hibernate-developer/SKILL.md` | Hibernate 7 mapping, binders, generators |
@@ -277,7 +277,7 @@ and known non-findings — before reporting issues.
 
 ## Resources
 
-- **Grails 7 Guide**: https://grails.apache.org/docs/latest/guide/single.html
+- **Grails Guide**: https://grails.apache.org/docs/latest/guide/single.html
 - **Groovy 4 Docs**: https://docs.groovy-lang.org/docs/groovy-4.0.30/html/documentation/
 - **Spock 2.3 Docs**: https://spockframework.org/spock/docs/2.3/all_in_one.html
 - **GORM Docs**: https://grails.apache.org/docs/latest/grails-data/

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ release page. You can use the command `./grails-forge-cli --help` to see what's 
 ### SDKMAN
 
 If managing multiple, local copies of the Grails CLI, it is recommended to use [SDKMAN!](https://sdkman.io/). Assuming
-SDKMAN is installed, this command would install the `7.0.0-M4` version:
+SDKMAN is installed, this command installs the latest available version:
 
-     sdk install grails 7.0.0-M4
+     sdk install grails
 
 Apache Grails versions installed via SDKMAN! include the following commands `grails`, `grails-shell-cli`, &
 `grails-forge-cli`. The grails command simply delegates to forge or the legacy shell. For further information on SDKMAN,

--- a/build-logic/docs-core/src/main/groovy/grails/doc/DocPublisher.groovy
+++ b/build-logic/docs-core/src/main/groovy/grails/doc/DocPublisher.groovy
@@ -241,7 +241,7 @@ class DocPublisher {
         def ext = asciidoc ? '.adoc' : '.gdoc'
 
         if (yamlTocFile.exists()) {
-            def tocStrategy = new YamlTocStrategy(new FileResourceChecker(guideSrcDir), ext)
+            def tocStrategy = new YamlTocStrategy(new FileResourceChecker(guideSrcDir), ext, engineProperties)
             guide = tocStrategy.generateToc(yamlTocFile)
 
             // A set of all gdoc files.

--- a/build-logic/docs-core/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
+++ b/build-logic/docs-core/src/main/groovy/grails/doc/internal/YamlTocStrategy.groovy
@@ -29,12 +29,14 @@ import org.yaml.snakeyaml.constructor.SafeConstructor
 class YamlTocStrategy {
 
     private final parser = new Yaml(new SafeConstructor(new LoaderOptions()))
+    private final Map substitutionProperties
     private resourceChecker
     private String ext = '.gdoc'
 
-    YamlTocStrategy(resourceChecker, String ext = '.gdoc') {
+    YamlTocStrategy(resourceChecker, String ext = '.gdoc', Map properties = [:]) {
         this.resourceChecker = resourceChecker
         this.ext = ext
+        this.substitutionProperties = properties ?: [:]
     }
 
     UserGuideNode generateToc(yaml) {
@@ -67,7 +69,7 @@ class YamlTocStrategy {
 
     private processSection(Map sections, UserGuideNode node) {
         if (sections.title) {
-            node.title = sections.title
+            node.title = replaceProperties(sections.title)
             sections = sections.clone()
             sections.remove('title')
         }
@@ -80,7 +82,14 @@ class YamlTocStrategy {
     }
 
     private processSection(String title, UserGuideNode node) {
-        node.title = title
+        node.title = replaceProperties(title)
+    }
+
+    private String replaceProperties(String title) {
+        title.replaceAll(/\{[^}]+\}/) { String propertyExpression ->
+            String propertyName = propertyExpression[1..-2]
+            substitutionProperties.containsKey(propertyName) ? substitutionProperties[propertyName].toString() : propertyExpression
+        }
     }
 
     private determineFilePath(basename, parent) {

--- a/build-logic/docs-core/src/test/groovy/grails/doc/internal/YamlTocStrategySpec.groovy
+++ b/build-logic/docs-core/src/test/groovy/grails/doc/internal/YamlTocStrategySpec.groovy
@@ -79,6 +79,26 @@ class YamlTocStrategySpec extends Specification {
         toc.children[1].children[1].parent == toc.children[1]
         !(toc.children[0].children[1].parent == toc)
     }
+
+    def "substitutes configured properties in titles"() {
+      given: "A YAML loader with documentation properties"
+        def loader = new YamlTocStrategy(new MockResourceChecker([
+                "intro.gdoc",
+                "intro/whatsNew.gdoc",
+                "history.gdoc"]), '.gdoc', [grailsMajorVersion: '8'])
+
+      when: "A test YAML document with property placeholders is loaded"
+        def toc = loader.load("""\
+                intro:
+                  title: Introduction
+                  whatsNew: What's new in Grails {grailsMajorVersion}?
+                history: History for Grails {unknownVersion}
+                """.stripIndent())
+
+      then: "Known properties are substituted and unknown properties are preserved"
+        toc.children[0].children[0].title == "What's new in Grails 8?"
+        toc.children[1].title == "History for Grails {unknownVersion}"
+    }
 }
 
 class MockResourceChecker {

--- a/grails-data-docs/data-mapping-website/src/main/resources/index.html
+++ b/grails-data-docs/data-mapping-website/src/main/resources/index.html
@@ -102,7 +102,7 @@
                         <h2>Graphql GORM</h2>
                     </div>
                     <ul>
-                        <li class='legend'>The GORM GraphQL library has not been ported to Grails 7.x.  Pull requests are welcome.
+                        <li class='legend'>The GORM GraphQL library has not been ported to the current Grails release.  Pull requests are welcome.
                         </li>
                     </ul>
                 </div>
@@ -115,7 +115,7 @@
                     </div>
                     <ul>
                         <li class='legend'>
-                          Neo4j has not been ported to Grails 7.x.  Pull requests are welcome.
+                          Neo4j has not been ported to the current Grails release.  Pull requests are welcome.
                         </li>
                     </ul>
                 </div>
@@ -126,7 +126,7 @@
                     </div>
                     <ul>
                         <li class='legend'>
-                          RxGORM has not been ported to Grails 7.x.  Pull requests are welcome.
+                          RxGORM has not been ported to the current Grails release.  Pull requests are welcome.
                         </li>
                     </ul>
                 </div>

--- a/grails-data-hibernate7/dbmigration/README.md
+++ b/grails-data-hibernate7/dbmigration/README.md
@@ -38,7 +38,9 @@ This module includes code from the [Liquibase Hibernate extension](https://githu
 
 ## Branches
 
-**9.0.x** Version of the plugin compatible with the current Grails release and Liquibase 4.27
+**8.0.x** Version of the plugin compatible with Grails 8 and Liquibase 4.27
+
+The temporary 9.0.x snapshots were never released. Since Grails Data was merged into grails-core, Grails Data and GORM modules use the same version as Grails itself.
 
 **5.0.x** Version of the plugin compatible with Grails 6 and Liquibase 4.19
 
@@ -68,7 +70,8 @@ One popular approach is to have a root changelog named changelog.groovy (or chan
 * 3.x: Grails 3 with Hibernate 5
 * 4.0.x Grails 5
 * 5.0.x Grails 6
-* 9.0.x Current Grails release
+* 7.0.x Grails 7 with Hibernate 5
+* 8.0.x Grails 8 with Hibernate 7
 
 ## Documentation
 

--- a/grails-data-hibernate7/dbmigration/README.md
+++ b/grails-data-hibernate7/dbmigration/README.md
@@ -38,7 +38,7 @@ This module includes code from the [Liquibase Hibernate extension](https://githu
 
 ## Branches
 
-**9.0.x** Version of the plugin compatible with Grails 7 and Liquibase 4.27
+**9.0.x** Version of the plugin compatible with the current Grails release and Liquibase 4.27
 
 **5.0.x** Version of the plugin compatible with Grails 6 and Liquibase 4.19
 
@@ -62,12 +62,13 @@ Database migrations are represented in text form, either using a Groovy DSL or n
 One popular approach is to have a root changelog named changelog.groovy (or changelog.xml) and to include a changelog per feature/branch that includes multiple smaller changelogs. Once the feature is finished and merged into the main development tree/trunk the changelog files can either stay as they are or be merged into one large file. Use whatever approach makes sense for your applications, but keep in mind that there are many options available for changelog management.
 
 ## Versions
+
 * 1.x: Grails 2
 * 2.x: Grails 3 with Hibernate 4
 * 3.x: Grails 3 with Hibernate 5
 * 4.0.x Grails 5
 * 5.0.x Grails 6
-* 9.0.x Grails 7
+* 9.0.x Current Grails release
 
 ## Documentation
 

--- a/grails-data-hibernate7/docs/build.gradle
+++ b/grails-data-hibernate7/docs/build.gradle
@@ -29,6 +29,7 @@ version = projectVersion
 
 ext {
     isReleaseVersion = !projectVersion.endsWith('-SNAPSHOT')
+    grailsMajorVersion = projectVersion.tokenize('.')[0]
     coreProjects = ['grails-datastore-core', 'grails-datamapping-core']
 }
 
@@ -78,6 +79,7 @@ tasks.named('asciidoctor', AsciidoctorTask) { AsciidoctorTask it ->
             'toc'                       : 'left',
             'icons'                     : 'font',
             'reproducible'              : '',
+            'grailsMajorVersion'        : grailsMajorVersion,
             'version'                   : projectVersion,
             'pluginVersion'             : projectVersion,
             'groupId'                   : project.group,

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/gettingStarted.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/gettingStarted.adoc
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-To use GORM {pluginVersion} for Hibernate in Grails 7 you can specify the following configuration in `build.gradle`:
+To use GORM {pluginVersion} for Hibernate in Grails {grailsMajorVersion} you can specify the following configuration in `build.gradle`:
 
 [source,groovy,subs="attributes"]
 ----

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/gettingStarted/hibernateVersions.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/gettingStarted/hibernateVersions.adoc
@@ -22,9 +22,9 @@ under the License.
 
 GORM for Hibernate 7 (`grails-data-hibernate7`) requires Hibernate ORM 7.x and Jakarta EE 10 (`jakarta.*` packages).
 
-=== Grails 8 with Hibernate 7
+=== Grails {grailsMajorVersion} with Hibernate 7
 
-Grails 8 ships with Hibernate 5 as the default, but provides first-class support for Hibernate 7 via a dedicated BOM and plugin artifact.
+Grails {grailsMajorVersion} ships with Hibernate 5 as the default, but provides first-class support for Hibernate 7 via a dedicated BOM and plugin artifact.
 
 [source,groovy]
 .build.gradle

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/releaseHistory.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/releaseHistory.adoc
@@ -20,14 +20,14 @@ under the License.
 [[introduction-releaseHistory]]
 == Release History
 
-==== GORM for Hibernate 7 (Grails 8.x)
+==== GORM for Hibernate 7 (Grails {grailsMajorVersion}.x)
 
-GORM for Hibernate 7 is a new integration module shipping with Grails 8.x that targets Hibernate ORM 7.x and Jakarta EE 10.
+GORM for Hibernate 7 is a new integration module shipping with Grails {grailsMajorVersion}.x that targets Hibernate ORM 7.x and Jakarta EE 10.
 
 Key features and changes relative to GORM for Hibernate 5:
 
 * **Hibernate ORM 7** — Full support for Hibernate 7, including Jakarta Persistence 3.2 and the Apache License 2.0.
-* **Spring Boot 4 / Spring Framework 7** — Grails 8 vendors the removed `org.springframework.orm.hibernate5` classes into `grails-data-hibernate7-spring-orm` under the `org.grails.orm.hibernate.support.hibernate7` package.
+* **Spring Boot 4 / Spring Framework 7** — Grails {grailsMajorVersion} vendors the removed `org.springframework.orm.hibernate5` classes into `grails-data-hibernate7-spring-orm` under the `org.grails.orm.hibernate.support.hibernate7` package.
 * **HQL injection safety** — Single-argument `find`, `findAll`, `executeQuery`, and `executeUpdate` accept a plain `String` as on Hibernate 5; when a Groovy GString is passed, its `${value}` interpolations are bound as named parameters instead of being interpolated into the query text, so the idiomatic interpolated form is injection-safe by binding.
 * **Native SQL queries** — New `findWithNativeSql` / `findAllWithNativeSql` methods added.
 * **Native query temporal types** — Native SQL queries return `java.time` types by default instead of legacy `java.sql` types.
@@ -39,4 +39,4 @@ Key features and changes relative to GORM for Hibernate 5:
 ==== Previous History
 
 For the history of GORM for Hibernate 5 (Grails 7.x and earlier), see the
-https://grails.apache.org/docs/latest/guide/single.html[Grails 7 User Guide] or the GORM for Hibernate 5 documentation.
+https://grails.apache.org/docs/7.0.x/guide/single.html[Grails 7 User Guide] or the GORM for Hibernate 5 documentation.

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/introduction/upgradeNotes.adoc
@@ -20,11 +20,11 @@ under the License.
 [[upgrade-notes]]
 == Upgrade Notes
 
-=== Grails 8 / Hibernate 7
+=== Grails {grailsMajorVersion} / Hibernate 7
 
 ==== Query API — Injection Safety
 
-The Grails 8 / Hibernate 7 query API keeps the Hibernate 5 calling conventions while making the idiomatic Groovy query form injection-safe by default. There is no breaking change here: the methods that accepted a plain `String` on Hibernate 5 still do.
+The Grails {grailsMajorVersion} / Hibernate 7 query API keeps the Hibernate 5 calling conventions while making the idiomatic Groovy query form injection-safe by default. There is no breaking change here: the methods that accepted a plain `String` on Hibernate 5 still do.
 
 ===== Single-argument HQL overloads
 

--- a/grails-data-neo4j/README.md
+++ b/grails-data-neo4j/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # GORM for Neo4j
 
-This project has not been updated for Grails 7 yet and is not included in the build.
+This project has not been updated for the current Grails release yet and is not included in the build.
 
 This project implements [GORM](https://grails.apache.org/docs/latest/grails-data/) for the Neo4j 3.x Graph Database using the Bolt Java Driver.
 

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -616,6 +616,7 @@ publishGuideTask.configure { PublishGuideTask publish ->
 
     publish.properties = project.provider {
         def projectVersionForURL = projectVersion.endsWith('-SNAPSHOT') ? 'SNAPSHOT' : projectVersion
+        def grailsMajorVersion = projectVersion.tokenize('.')[0]
         def springVersion = getVersion('spring-core')
         def springBootVersion = getVersion('spring-boot')
         def spockVersion = getVersion("spock-core")
@@ -657,6 +658,7 @@ publishGuideTask.configure { PublishGuideTask publish ->
                 'springVersion'            : springVersion,
                 'gradleVersion'            : gradle.gradleVersion,
                 'GrailsVersion'            : projectVersion,
+                'grailsMajorVersion'       : grailsMajorVersion,
                 'grailsVersionForURL'      : projectVersionForURL,
                 'version'                  : projectVersion,
                 'gormVersion'              : projectVersion,

--- a/grails-doc/src/en/guide/bestPractices/codeAnalysisGroovy.adoc
+++ b/grails-doc/src/en/guide/bestPractices/codeAnalysisGroovy.adoc
@@ -43,7 +43,7 @@ extensions.configure(CodeNarcExtension) {
 }
 ----
 
-NOTE: Use the `-groovy-4.0` variant of CodeNarc for Grails 7 projects (which use Groovy 4.x). The plain artifact without a `-groovy-4.0` suffix is built for Groovy 3.x and will not work correctly.
+NOTE: Use the `-groovy-4.0` variant of CodeNarc for Grails {grailsMajorVersion} projects (which use Groovy 4.x). The plain artifact without a `-groovy-4.0` suffix is built for Groovy 3.x and will not work correctly.
 
 You can then run CodeNarc with:
 

--- a/grails-doc/src/en/guide/conf/config/logging.adoc
+++ b/grails-doc/src/en/guide/conf/config/logging.adoc
@@ -21,7 +21,7 @@ Logging is handled by the https://logback.qos.ch[Logback logging framework] and 
 
 The Grails Environments `development`, `test` and `production` can be used with <springProfile name="development"> to configure environment specific logging.  This was one of the features lost when logback removed groovy configuration.  
 
-// To be re-included when a Grails 7 release of the plugin gets released
+// To be re-included when a Grails {grailsMajorVersion} release of the plugin gets released
 // See: virtualdogbert/logback-groovy-config#15
 //
 // NOTE: Since Grails 5.1.2 support for groovy configuration (`grails-app/conf/logback.groovy`) has been removed (by logback 1.2.9). It is possible to add back groovy configuration by adding the https://github.com/virtualdogbert/logback-groovy-config[logback-groovy-config] library to your project.

--- a/grails-doc/src/en/guide/gettingStarted/downloadingAndInstalling.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/downloadingAndInstalling.adoc
@@ -75,10 +75,10 @@ With the `grails forge` CLI, the goal was to transition all other historical cap
 Although some advancements have been made in this transition, substantial work is still outstanding.
 The `grails forge` can be extended by forking the repository and hosting your own Grails Application Forge internally, which is generally more complex than extending `grails shell` with a custom profile.
 
-==== Both CLIs exist in Grails 7
-For the reasons listed above, Grails 7 now includes both CLIs and a combined delegating CLI that can invoke either CLI.  `grails-shell`, `grails-profiles`, `grails-wrapper` and `grails-forge` projects are now all part of the grails-core project and are released together.
+==== Both CLIs exist in Grails {grailsMajorVersion}
+For the reasons listed above, Grails {grailsMajorVersion} includes both CLIs and a combined delegating CLI that can invoke either CLI.  `grails-shell`, `grails-profiles`, `grails-wrapper` and `grails-forge` projects are now all part of the grails-core project and are released together.
 
-Grails 7 adds the following commands to any Grails install:
+Grails {grailsMajorVersion} provides the following commands in any Grails install:
 
 1. `grails-forge-cli` - the forge cli that was shipped as `grails` initially in Grails 6. This CLI has both interactive completion & bash autocompletion.
 Long term, we intend to fold the legacy shell functions into it - including the ability to create custom commands & supporting a custom layout.

--- a/grails-doc/src/en/guide/gettingStarted/usingInteractiveMode.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/usingInteractiveMode.adoc
@@ -23,7 +23,7 @@ Since 3.0, Grails has an interactive mode which makes command execution faster s
 
 image::interactive-output.png[]
 
-NOTE: As of **Grails 7**, both the Grails Shell CLI and the Forge CLI are available. Interactive mode is part of the Grails Shell CLI and is accessed by typing `grails` without additional arguments. Grails Forge CLI is accessed as `grails -t forge`.
+NOTE: In **Grails {grailsMajorVersion}**, both the Grails Shell CLI and the Forge CLI are available. Interactive mode is part of the Grails Shell CLI and is accessed by typing `grails` without additional arguments. Grails Forge CLI is accessed as `grails -t forge`.
 
 For more information on the capabilities of interactive mode refer to the section on link:commandLine.html#interactiveMode[Interactive Mode] in the user guide.
 

--- a/grails-doc/src/en/guide/index.adoc
+++ b/grails-doc/src/en/guide/index.adoc
@@ -28,7 +28,7 @@ Puneet Behl, Graeme Rocher, Peter Ledbrook, Marc Palmer, Jeff Brown, Luke Daley,
 include::introduction.adoc[]
 
 [[whatsNew]]
-=== What's new in Grails 7?
+=== What's new in Grails {grailsMajorVersion}?
 
 include::introduction/whatsNew.adoc[]
 

--- a/grails-doc/src/en/guide/introduction/whatsNew.adoc
+++ b/grails-doc/src/en/guide/introduction/whatsNew.adoc
@@ -17,19 +17,19 @@ specific language governing permissions and limitations
 under the License.
 ////
 
-This section covers all the new features introduced in Grails 8
+This section covers all the new features introduced in Grails {grailsMajorVersion}
 
 === Overview
 
-Grails 8 is a major release that includes new features, improvements, and dependency upgrades.
+Grails {grailsMajorVersion} is a major release that includes new features, improvements, and dependency upgrades.
 This release focuses on enhancing the developer experience, improving performance, and ensuring compatibility with the latest technologies.
 
-For detailed information on how to upgrade to Grails 8, including major dependency changes, please see the xref:upgrading#upgrading80x[Upgrading from Grails 7 to Grails 8] section.
+For detailed information on how to upgrade to Grails {grailsMajorVersion}, including major dependency changes, please see the xref:upgrading#upgrading80x[Upgrading from Grails 7 to Grails {grailsMajorVersion}] section.
 Notable new features are included below.
 
 ==== GSP Tag Library Improvements
 
-Grails 8 continues the move toward method-based TagLib handlers while preserving compatibility with existing closure-based tags.
+Grails {grailsMajorVersion} continues the move toward method-based TagLib handlers while preserving compatibility with existing closure-based tags.
 Method-defined tags now bind named attributes more predictably, exclude inherited framework and `Object` methods from tag dispatch, and preserve real namespace property getters.
 
 The Grails Gradle extension now defaults `preserveParameterNames` to `true`, so application Groovy compilation preserves method parameter names for features such as typed method TagLib arguments.

--- a/grails-doc/src/en/guide/toc.yml
+++ b/grails-doc/src/en/guide/toc.yml
@@ -16,7 +16,7 @@
 introduction:
   title: Introduction
   whatsNew:
-    title: What's new in Grails 7?
+    title: What's new in Grails {grailsMajorVersion}?
     dependencyUpgrades: Updated Dependencies
 gettingStarted:
   title: Getting Started

--- a/grails-doc/src/en/guide/validation/constraints.adoc
+++ b/grails-doc/src/en/guide/validation/constraints.adoc
@@ -51,7 +51,7 @@ class User {
 
 In this example we've declared that the `login` property must be between 5 and 15 characters long, it cannot be blank and must be unique. We've also applied other constraints to the `password`, `email` and `age` properties.
 
-NOTE: As of Grails 8, domain class properties are *nullable by default*: an unconstrained property is optional unless you declare `nullable: false` (prior to Grails 8 the default was the opposite — an implicit `nullable: false` was applied to every property). To restore the legacy required-by-default behaviour application-wide, set `grails.gorm.default.nullable = false`.
+NOTE: As of Grails {grailsMajorVersion}, domain class properties are *nullable by default*: an unconstrained property is optional unless you declare `nullable: false` (prior to Grails {grailsMajorVersion} the default was the opposite — an implicit `nullable: false` was applied to every property). To restore the legacy required-by-default behaviour application-wide, set `grails.gorm.default.nullable = false`.
 
 A complete reference for the available constraints can be found in the Quick Reference section under the Constraints heading.
 

--- a/grails-doc/src/en/ref/Command Line/create-app.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-app.adoc
@@ -25,7 +25,7 @@ The `create-app` command serves as the initial step in Grails application develo
 
 [NOTE]
 ====
-In Grails 7, `create-app` is available in both the **Grails Shell CLI** and the **Forge CLI**.
+In Grails {grailsMajorVersion}, `create-app` is available in both the **Grails Shell CLI** and the **Forge CLI**.
 
 - Most users should use the **Grails Shell CLI** by default (`grails create-app bookstore`). This version supports core development commands and project lifecycle management, and includes basic `create-*` flags like `--inplace`, `--features`, and `--profile`.
 

--- a/grails-doc/src/en/ref/Constraints/nullable.adoc
+++ b/grails-doc/src/en/ref/Constraints/nullable.adoc
@@ -27,7 +27,7 @@ under the License.
 
 Allows a property to be set to `null`.
 
-NOTE: As of Grails 8, an unconstrained persistent property is *nullable by default*, aligning Grails with the rest of the JVM persistence/validation ecosystem (JPA/Hibernate, Spring Data, Micronaut Data and Jakarta Bean Validation). Declare `nullable: false` to make a property required. To restore the legacy required-by-default behaviour for an application, set `grails.gorm.default.nullable` to `false`:
+NOTE: As of Grails {grailsMajorVersion}, an unconstrained persistent property is *nullable by default*, aligning Grails with the rest of the JVM persistence/validation ecosystem (JPA/Hibernate, Spring Data, Micronaut Data and Jakarta Bean Validation). Declare `nullable: false` to make a property required. To restore the legacy required-by-default behaviour for an application, set `grails.gorm.default.nullable` to `false`:
 
 [source,yaml]
 .grails-app/conf/application.yml

--- a/settings.gradle
+++ b/settings.gradle
@@ -205,7 +205,7 @@ include(
         'grails-datamapping-core-test',
 
         // RX projects
-        // until this can be finished ported to the current Grails release, we are disabling
+        // until this can be finished being ported to the current Grails release, we are disabling
         //'grails-datamapping-rx',
 
         // Testing Support
@@ -267,7 +267,7 @@ project(':grails-gsp-spring-boot').projectDir = file('grails-gsp/spring-boot')
 // Data Mapping - Documentation
 include 'grails-data-docs-guide-developer'
 project(':grails-data-docs-guide-developer').projectDir = file('grails-data-docs/guide-developer')
-// until this can be finished ported to the current Grails release, we are disabling
+// until this can be finished being ported to the current Grails release, we are disabling
 // include 'grails-data-docs-guide-rx'
 // project(':grails-data-docs-guide-rx').projectDir = file('docs/guide-rx')
 include 'grails-data-docs-guide-whats-new'

--- a/settings.gradle
+++ b/settings.gradle
@@ -205,7 +205,7 @@ include(
         'grails-datamapping-core-test',
 
         // RX projects
-        // until this can be finished ported to grails 7, we are disabling
+        // until this can be finished ported to the current Grails release, we are disabling
         //'grails-datamapping-rx',
 
         // Testing Support
@@ -267,7 +267,7 @@ project(':grails-gsp-spring-boot').projectDir = file('grails-gsp/spring-boot')
 // Data Mapping - Documentation
 include 'grails-data-docs-guide-developer'
 project(':grails-data-docs-guide-developer').projectDir = file('grails-data-docs/guide-developer')
-// until this can be finished ported to grails 7, we are disabling
+// until this can be finished ported to the current Grails release, we are disabling
 // include 'grails-data-docs-guide-rx'
 // project(':grails-data-docs-guide-rx').projectDir = file('docs/guide-rx')
 include 'grails-data-docs-guide-whats-new'


### PR DESCRIPTION
## Summary

- derive a `grailsMajorVersion` docs attribute from `projectVersion`
- let YAML guide TOC titles substitute configured doc properties
- replace stale current-version Grails 7/8 wording with config-driven or version-neutral text

## Verification

- `./gradlew :grails-doc:publishGuide -x aggregateGroovydoc`
- `./gradlew :grails-data-hibernate7-docs:asciidoctor`
- `./gradlew aggregateViolations :grails-test-report:check --continue` attempted twice, but both runs exceeded the 10-minute shell cap while still running tests
- `./gradlew aggregateViolations :grails-test-report:check --continue` generated aggregate violation reports before timing out: Checkstyle, CodeNarc, PMD, and SpotBugs all reported no violations
- `./gradlew :grails-doc:publishGuide -x aggregateGroovydoc` rerun after the timed-out full validation
- `./gradlew :grails-data-hibernate7-docs:asciidoctor` rerun after the timed-out full validation
- `./gradlew.bat check` from `build-logic`
- `git diff --check`

Assisted-by: Hephaestus:gpt-5.5
