### PR TITLE
Reduce GORM API allocation for tenant qualifiers to O(entityCount + tenantCount)

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
@@ -384,7 +384,6 @@ public abstract class AbstractHibernateDatastore extends AbstractDatastore imple
         if (getMultiTenancyMode() == MultiTenancySettings.MultiTenancyMode.DATABASE) {
             AbstractHibernateDatastore datastore = getDatastoreForConnection(tenantId.toString());
             SessionFactory sessionFactory = datastore.getSessionFactory();
-
             return datastore.getHibernateTemplate().executeWithExistingOrCreateNewSession(sessionFactory, callable);
         }
         else {

--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/GrailsHibernateTemplate.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/GrailsHibernateTemplate.java
@@ -154,9 +154,15 @@ public class GrailsHibernateTemplate implements IHibernateTemplate {
             // if there are already bound holders, unbind them so they can be restored later
             if (sessionHolder != null) {
                 TransactionSynchronizationManager.unbindResource(sessionFactory);
-                if (previousConnectionHolder != null) {
-                    TransactionSynchronizationManager.unbindResource(dataSource);
-                }
+            }
+            // Unbind any pre-existing connection holder independently of the session holder: a
+            // DataSource binding can exist without a matching SessionFactory binding when, for
+            // example, Spring's SQLErrorCodesFactory eagerly acquires a connection via
+            // DataSourceUtils during SQLErrorCodeSQLExceptionTranslator initialisation while a
+            // parent-transaction synchronisation is already active.  Leaving it bound causes
+            // HibernateTransactionManager.doBegin to throw "Already value bound" at line 565.
+            if (previousConnectionHolder != null) {
+                TransactionSynchronizationManager.unbindResource(dataSource);
             }
 
             // create and bind a new session holder for the new session
@@ -206,9 +212,12 @@ public class GrailsHibernateTemplate implements IHibernateTemplate {
                 // now restore any previous state
                 if (previousHolder != null) {
                     TransactionSynchronizationManager.bindResource(sessionFactory, previousHolder);
-                    if (previousConnectionHolder != null) {
-                        TransactionSynchronizationManager.bindResource(dataSource, previousConnectionHolder);
-                    }
+                }
+                // Restore the connection holder independently of the session holder so that
+                // the parent-transaction's ConnectionSynchronization (re-registered above) can
+                // still release it when the outer transaction completes.
+                if (previousConnectionHolder != null) {
+                    TransactionSynchronizationManager.bindResource(dataSource, previousConnectionHolder);
                 }
 
             }

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/GrailsHibernateTemplateSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/GrailsHibernateTemplateSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.grails.orm.hibernate
+
+import java.sql.Connection
+import java.util.UUID
+
+import grails.gorm.annotation.Entity
+import grails.gorm.hibernate.HibernateEntity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.hibernate.dialect.H2Dialect
+import org.springframework.jdbc.datasource.ConnectionHolder
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import spock.lang.Specification
+
+class GrailsHibernateTemplateSpec extends Specification {
+
+    void "executeWithNewSession succeeds and restores TSM when DataSource holder is pre-bound without a SessionFactory holder"() {
+        given: "a fresh datastore with no active outer transaction and synchronization inactive"
+        assert !TransactionSynchronizationManager.isSynchronizationActive()
+        HibernateDatastore localDatastore = new HibernateDatastore(
+            DatastoreUtils.createPropertyResolver([
+                'dataSource.url'        : "jdbc:h2:mem:h5TsmTest_${UUID.randomUUID().toString().replace('-', '')};LOCK_TIMEOUT=10000".toString(),
+                'dataSource.dbCreate'   : 'create-drop',
+                'dataSource.dialect'    : H2Dialect.name,
+                'hibernate.hbm2ddl.auto': 'create-drop',
+            ]), H5TemplateBook)
+        GrailsHibernateTemplate localTemplate = new GrailsHibernateTemplate(localDatastore.sessionFactory)
+
+        and: "synchronization is activated then the DataSource is pre-bound, simulating SQLErrorCodesFactory behaviour"
+        // Spring's SQLErrorCodesFactory.getErrorCodes() calls DataSourceUtils.getConnection()
+        // while a parent-transaction sync is active, binding DS to TSM without a matching SF.
+        // Without the fix, executeWithNewSession skipped the DS unbind when SF was absent,
+        // leaving DS bound so HibernateTransactionManager.doBegin threw "Already value bound".
+        TransactionSynchronizationManager.initSynchronization()
+        javax.sql.DataSource ds = localTemplate.@dataSource
+        Connection preBoundConn = ds.getConnection()
+        TransactionSynchronizationManager.bindResource(ds, new ConnectionHolder(preBoundConn))
+        assert !TransactionSynchronizationManager.hasResource(localDatastore.sessionFactory)
+
+        when: "executeWithNewSession is called with DS bound but SF not bound in TSM"
+        localTemplate.executeWithNewSession { sess -> }
+
+        then: "no exception is thrown — the bug caused 'Already value bound' for the DataSource"
+        noExceptionThrown()
+
+        and: "the DataSource resource is accessible in TSM after the nested-session scope exits"
+        TransactionSynchronizationManager.hasResource(ds)
+
+        cleanup:
+        if (ds != null && TransactionSynchronizationManager.hasResource(ds)) {
+            TransactionSynchronizationManager.unbindResource(ds)
+        }
+        preBoundConn?.close()
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization()
+        }
+        localDatastore?.close()
+    }
+}
+
+@Entity
+class H5TemplateBook implements HibernateEntity<H5TemplateBook> {
+    String title
+    String author
+}

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
@@ -1,0 +1,282 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.orm.hibernate.connections
+
+import java.util.UUID
+
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import grails.gorm.MultiTenant
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormEntity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.multitenancy.AllTenantsResolver
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+import org.grails.orm.hibernate.HibernateDatastore
+
+@RestoreSystemProperties
+class GormApiAllocationSpec extends Specification {
+
+    @AutoCleanup HibernateDatastore datastore
+
+    void cleanup() {
+        System.clearProperty(SystemPropertyTenantResolver.PROPERTY_NAME)
+    }
+
+    void "DISCRIMINATOR multi tenant single datasource uses only default APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, [], H5AllocationDefaultTenant)
+
+        then:
+        hasAllApis(H5AllocationDefaultTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H5AllocationDefaultTenant, 'tenantA')
+
+        when:
+        def result = H5AllocationDefaultTenant.withTenant('tenantA') { true }
+
+        then:
+        result
+        !hasAnyApis(H5AllocationDefaultTenant, 'tenantA')
+    }
+
+    void "DISCRIMINATOR multi tenant default datasource with multiple configured datasources creates non-default APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H5AllocationDefaultTenant)
+
+        expect:
+        hasAllApis(H5AllocationDefaultTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H5AllocationDefaultTenant, 'analytics')
+        !hasAnyApis(H5AllocationDefaultTenant, 'reporting')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H5AllocationDefaultTenant, 'analytics')
+        def instanceApi = GormEnhancer.findInstanceApi(H5AllocationDefaultTenant, 'analytics')
+        def validationApi = GormEnhancer.findValidationApi(H5AllocationDefaultTenant, 'analytics')
+
+        then:
+        hasAllApis(H5AllocationDefaultTenant, 'analytics')
+        !hasAnyApis(H5AllocationDefaultTenant, 'reporting')
+        !staticApi.is(GormEnhancer.findStaticApi(H5AllocationDefaultTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H5AllocationDefaultTenant, 'analytics'))
+        validationApi.is(GormEnhancer.findValidationApi(H5AllocationDefaultTenant, 'analytics'))
+    }
+
+    void "SCHEMA multi tenant single datasource creates tenant APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.SCHEMA, [], H5AllocationSchemaTenant)
+
+        expect:
+        hasAllApis(H5AllocationSchemaTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H5AllocationSchemaTenant, 'tenantA')
+        !hasAnyApis(H5AllocationSchemaTenant, 'tenantB')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H5AllocationSchemaTenant, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(H5AllocationSchemaTenant, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(H5AllocationSchemaTenant, 'tenantA')
+
+        then:
+        hasAllApis(H5AllocationSchemaTenant, 'tenantA')
+        !hasAnyApis(H5AllocationSchemaTenant, 'tenantB')
+        !staticApi.is(GormEnhancer.findStaticApi(H5AllocationSchemaTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H5AllocationSchemaTenant, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(H5AllocationSchemaTenant, 'tenantA'))
+    }
+
+    void "DATABASE multi tenant creates tenant APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DATABASE, ['tenantA', 'tenantB'], H5AllocationDatabaseTenant)
+
+        expect:
+        hasAllApis(H5AllocationDatabaseTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H5AllocationDatabaseTenant, 'tenantA')
+        !hasAnyApis(H5AllocationDatabaseTenant, 'tenantB')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H5AllocationDatabaseTenant, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(H5AllocationDatabaseTenant, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(H5AllocationDatabaseTenant, 'tenantA')
+
+        then:
+        hasAllApis(H5AllocationDatabaseTenant, 'tenantA')
+        !hasAnyApis(H5AllocationDatabaseTenant, 'tenantB')
+        !staticApi.is(GormEnhancer.findStaticApi(H5AllocationDatabaseTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H5AllocationDatabaseTenant, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(H5AllocationDatabaseTenant, 'tenantA'))
+    }
+
+    void "DISCRIMINATOR multi tenant explicit datasource allocates only mapped datasource APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H5AllocationAnalyticsTenant)
+
+        then:
+        hasAllApis(H5AllocationAnalyticsTenant, ConnectionSource.DEFAULT)
+        hasAllApis(H5AllocationAnalyticsTenant, 'analytics')
+        !hasAnyApis(H5AllocationAnalyticsTenant, 'reporting')
+    }
+
+    void "DISCRIMINATOR multi tenant explicit multiple datasources allocates only mapped datasource APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting', 'audit'], H5AllocationMultipleDatasourceTenant)
+
+        then:
+        hasAllApis(H5AllocationMultipleDatasourceTenant, ConnectionSource.DEFAULT)
+        hasAllApis(H5AllocationMultipleDatasourceTenant, 'analytics')
+        hasAllApis(H5AllocationMultipleDatasourceTenant, 'reporting')
+        !hasAnyApis(H5AllocationMultipleDatasourceTenant, 'audit')
+    }
+
+    void "DISCRIMINATOR multi tenant ALL datasource creates non-default datasource APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H5AllocationAllDatasourceTenant)
+
+        expect:
+        hasAllApis(H5AllocationAllDatasourceTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H5AllocationAllDatasourceTenant, 'analytics')
+        !hasAnyApis(H5AllocationAllDatasourceTenant, 'reporting')
+
+        when:
+        GormEnhancer.findStaticApi(H5AllocationAllDatasourceTenant, 'analytics')
+        GormEnhancer.findInstanceApi(H5AllocationAllDatasourceTenant, 'analytics')
+        GormEnhancer.findValidationApi(H5AllocationAllDatasourceTenant, 'analytics')
+
+        then:
+        hasAllApis(H5AllocationAllDatasourceTenant, 'analytics')
+        !hasAnyApis(H5AllocationAllDatasourceTenant, 'reporting')
+    }
+
+    private HibernateDatastore newDatastore(MultiTenancySettings.MultiTenancyMode mode, List<String> extraDataSources, Class<?>... domainClasses) {
+        Map config = baseConfig(mode, domainClasses[0].simpleName)
+        extraDataSources.each { String name ->
+            config["dataSources.${name}.url".toString()] = "jdbc:h2:mem:${databaseName(domainClasses[0].simpleName + name)};LOCK_TIMEOUT=10000".toString()
+        }
+        new HibernateDatastore(DatastoreUtils.createPropertyResolver(config), domainClasses)
+    }
+
+    private static Map baseConfig(MultiTenancySettings.MultiTenancyMode mode, String name) {
+        [
+                'grails.gorm.multiTenancy.mode': mode,
+                'grails.gorm.multiTenancy.tenantResolverClass': H5AllocationTenantResolver,
+                'dataSource.url': "jdbc:h2:mem:${databaseName(name)};LOCK_TIMEOUT=10000".toString(),
+                'dataSource.dbCreate': mode == MultiTenancySettings.MultiTenancyMode.SCHEMA ? 'update' : 'create-drop',
+                'dataSource.dialect': H2Dialect.name,
+                'dataSource.formatSql': 'true',
+                'hibernate.flush.mode': 'COMMIT',
+                'hibernate.hbm2ddl.auto': mode == MultiTenancySettings.MultiTenancyMode.SCHEMA ? 'create' : 'create-drop'
+        ]
+    }
+
+    private static String databaseName(String name) {
+        "h5_${name}_${UUID.randomUUID().toString().replace('-', '')}"
+    }
+
+    private static boolean hasAllApis(Class<?> type, String qualifier) {
+        hasStaticApi(type, qualifier) && hasInstanceApi(type, qualifier) && hasValidationApi(type, qualifier)
+    }
+
+    private static boolean hasAnyApis(Class<?> type, String qualifier) {
+        hasStaticApi(type, qualifier) || hasInstanceApi(type, qualifier) || hasValidationApi(type, qualifier)
+    }
+
+    private static boolean hasStaticApi(Class<?> type, String qualifier) {
+        GormEnhancer.@STATIC_APIS.get(qualifier).containsKey(type.name)
+    }
+
+    private static boolean hasInstanceApi(Class<?> type, String qualifier) {
+        GormEnhancer.@INSTANCE_APIS.get(qualifier).containsKey(type.name)
+    }
+
+    private static boolean hasValidationApi(Class<?> type, String qualifier) {
+        GormEnhancer.@VALIDATION_APIS.get(qualifier).containsKey(type.name)
+    }
+}
+
+class H5AllocationTenantResolver extends SystemPropertyTenantResolver implements AllTenantsResolver {
+
+    @Override
+    Iterable<Serializable> resolveTenantIds() {
+        ['tenantA', 'tenantB']
+    }
+}
+
+@Entity
+class H5AllocationDefaultTenant implements GormEntity<H5AllocationDefaultTenant>, MultiTenant<H5AllocationDefaultTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H5AllocationSchemaTenant implements GormEntity<H5AllocationSchemaTenant>, MultiTenant<H5AllocationSchemaTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H5AllocationDatabaseTenant implements GormEntity<H5AllocationDatabaseTenant>, MultiTenant<H5AllocationDatabaseTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H5AllocationAnalyticsTenant implements GormEntity<H5AllocationAnalyticsTenant>, MultiTenant<H5AllocationAnalyticsTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasource 'analytics'
+    }
+}
+
+@Entity
+class H5AllocationMultipleDatasourceTenant implements GormEntity<H5AllocationMultipleDatasourceTenant>, MultiTenant<H5AllocationMultipleDatasourceTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasources(['analytics', 'reporting'])
+    }
+}
+
+@Entity
+class H5AllocationAllDatasourceTenant implements GormEntity<H5AllocationAllDatasourceTenant>, MultiTenant<H5AllocationAllDatasourceTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasource ConnectionSource.ALL
+    }
+}

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
@@ -148,6 +148,29 @@ class GormApiAllocationSpec extends Specification {
         !hasAnyApis(H5AllocationMultipleDatasourceTenant, 'audit')
     }
 
+    void "SCHEMA multi tenant re-registering a tenant via addTenantForSchema evicts stale lazy-cached APIs for that qualifier"() {
+        given: "a SCHEMA datastore and the first addTenantForSchema call creates tenantA's child datastore"
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.SCHEMA, [], H5AllocationSchemaTenant)
+        datastore.addTenantForSchema('tenantA')
+
+        and: "tenantA APIs are lazily populated on first access"
+        GormEnhancer.findStaticApi(H5AllocationSchemaTenant, 'tenantA')
+        GormEnhancer.findInstanceApi(H5AllocationSchemaTenant, 'tenantA')
+        GormEnhancer.findValidationApi(H5AllocationSchemaTenant, 'tenantA')
+
+        expect: "the cache holds APIs for tenantA after the first access"
+        hasAllApis(H5AllocationSchemaTenant, 'tenantA')
+
+        when: "addTenantForSchema is called again, re-creating the child datastore (as happens in per-test setup)"
+        datastore.addTenantForSchema('tenantA')
+
+        then: "stale cached APIs for tenantA are evicted so the next access re-creates them against the new session factory"
+        !hasAnyApis(H5AllocationSchemaTenant, 'tenantA')
+
+        and: "DEFAULT APIs are not affected"
+        hasAllApis(H5AllocationSchemaTenant, ConnectionSource.DEFAULT)
+    }
+
     void "DISCRIMINATOR multi tenant ALL datasource creates non-default datasource APIs lazily"() {
         given:
         datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H5AllocationAllDatasourceTenant)

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/GrailsHibernateTemplate.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/GrailsHibernateTemplate.java
@@ -240,9 +240,15 @@ public class GrailsHibernateTemplate implements IHibernateTemplate {
             // if there are already bound holders, unbind them so they can be restored later
             if (sessionHolder != null) {
                 txResources.unbindResource(sessionFactory);
-                if (previousConnectionHolder != null) {
-                    txResources.unbindResource(dataSource);
-                }
+            }
+            // Unbind any pre-existing connection holder independently of the session holder: a
+            // DataSource binding can exist without a matching SessionFactory binding when, for
+            // example, Spring's SQLErrorCodesFactory eagerly acquires a connection via
+            // DataSourceUtils during SQLErrorCodeSQLExceptionTranslator initialisation while a
+            // parent-transaction synchronisation is already active.  Leaving it bound causes
+            // HibernateTransactionManager.doBegin to throw "Already value bound" at line 565.
+            if (previousConnectionHolder != null) {
+                txResources.unbindResource(dataSource);
             }
 
             // create and bind a new session holder for the new session
@@ -297,9 +303,12 @@ public class GrailsHibernateTemplate implements IHibernateTemplate {
                 // now restore any previous state
                 if (previousHolder != null) {
                     txResources.bindResource(sessionFactory, previousHolder);
-                    if (previousConnectionHolder != null) {
-                        txResources.bindResource(dataSource, previousConnectionHolder);
-                    }
+                }
+                // Restore the connection holder independently of the session holder so that
+                // the parent-transaction's ConnectionSynchronization (re-registered above) can
+                // still release it when the outer transaction completes.
+                if (previousConnectionHolder != null) {
+                    txResources.bindResource(dataSource, previousConnectionHolder);
                 }
             }
         }

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/GrailsHibernateTemplateSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/GrailsHibernateTemplateSpec.groovy
@@ -18,6 +18,8 @@
  */
 package org.grails.orm.hibernate
 
+import java.util.UUID
+
 import grails.gorm.annotation.Entity
 import grails.gorm.hibernate.HibernateEntity
 import grails.gorm.tests.HibernateGormDatastoreSpec
@@ -28,6 +30,7 @@ import org.hibernate.HibernateException
 import org.hibernate.LockMode
 import org.hibernate.Session
 import org.springframework.dao.DataAccessException
+import org.springframework.transaction.support.TransactionSynchronizationManager
 
 class GrailsHibernateTemplateSpec extends HibernateGormDatastoreSpec {
 
@@ -1129,6 +1132,46 @@ class GrailsHibernateTemplateSpec extends HibernateGormDatastoreSpec {
         template.exposeNativeSession = true
     }
 
+    void "executeWithNewSession succeeds and restores TSM when DataSource holder is pre-bound without a SessionFactory holder"() {
+        given: "synchronization is already active from the outer test transaction"
+        assert TransactionSynchronizationManager.isSynchronizationActive()
+
+        and: "a fresh secondary datastore whose SF is not bound in the active outer transaction"
+        // Reproduces the production scenario: SQLErrorCodesFactory.getErrorCodes() calls
+        // DataSourceUtils.getConnection() while a parent-transaction sync is active,
+        // binding DS to TSM without a matching SF holder.  Without the fix,
+        // executeWithNewSession skipped the DS unbind when SF was absent, leaving DS
+        // bound so HibernateTransactionManager.doBegin threw "Already value bound".
+        HibernateDatastore localDatastore = new HibernateDatastore(
+            org.grails.datastore.mapping.core.DatastoreUtils.createPropertyResolver([
+                'dataSource.url'        : "jdbc:h2:mem:h7TsmTest_${UUID.randomUUID().toString().replace('-', '')};LOCK_TIMEOUT=10000".toString(),
+                'dataSource.dbCreate'   : 'create-drop',
+                'dataSource.dialect'    : org.hibernate.dialect.H2Dialect.name,
+                'hibernate.hbm2ddl.auto': 'create-drop',
+            ]), H7TemplateTsmBook)
+        GrailsHibernateTemplate localTemplate = new GrailsHibernateTemplate(localDatastore.sessionFactory)
+        javax.sql.DataSource ds = localTemplate.@dataSource
+        // SQLErrorCodesFactory.getErrorCodes() calls DataSourceUtils.getConnection() while sync
+        // is active, binding DS to TSM.  Assert the precondition: DS bound, SF not bound.
+        assert TransactionSynchronizationManager.hasResource(ds)
+        assert !TransactionSynchronizationManager.hasResource(localDatastore.sessionFactory)
+
+        when: "executeWithNewSession is called with DS bound but SF not bound in TSM"
+        localTemplate.executeWithNewSession { sess -> }
+
+        then: "no exception is thrown — the bug caused 'Already value bound' for the DataSource"
+        noExceptionThrown()
+
+        and: "the DataSource resource is accessible in TSM after the nested-session scope exits"
+        TransactionSynchronizationManager.hasResource(ds)
+
+        cleanup:
+        if (ds != null && TransactionSynchronizationManager.hasResource(ds)) {
+            TransactionSynchronizationManager.unbindResource(ds)
+        }
+        localDatastore?.close()
+    }
+
     void "test executeWithNewSession does not release connection for MultiTenantDataSource"() {
         given: "A template with a multi-tenant data source"
         def mockMultiTenantDataSource = Mock(org.grails.datastore.gorm.jdbc.MultiTenantDataSource)
@@ -1166,6 +1209,12 @@ class GrailsHibernateTemplateSpec extends HibernateGormDatastoreSpec {
 
 @Entity
 class TemplateBook implements HibernateEntity<TemplateBook> {
+    String title
+    String author
+}
+
+@Entity
+class H7TemplateTsmBook implements HibernateEntity<H7TemplateTsmBook> {
     String title
     String author
 }

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
@@ -148,6 +148,29 @@ class GormApiAllocationSpec extends Specification {
         !hasAnyApis(H7AllocationMultipleDatasourceTenant, 'audit')
     }
 
+    void "SCHEMA multi tenant creating a second datastore for the same entity evicts stale lazy-cached tenant APIs"() {
+        given: "a SCHEMA datastore with tenant APIs lazily populated"
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.SCHEMA, [], H7AllocationSchemaTenant)
+        GormEnhancer.findStaticApi(H7AllocationSchemaTenant, 'tenantA')
+        GormEnhancer.findInstanceApi(H7AllocationSchemaTenant, 'tenantA')
+        GormEnhancer.findValidationApi(H7AllocationSchemaTenant, 'tenantA')
+
+        expect: "the cache holds APIs for tenantA after the first access"
+        hasAllApis(H7AllocationSchemaTenant, 'tenantA')
+
+        when: "a new SCHEMA datastore is created for the same entity (e.g. in a new test spec's setup)"
+        HibernateDatastore datastore2 = newDatastore(MultiTenancySettings.MultiTenancyMode.SCHEMA, [], H7AllocationSchemaTenant)
+
+        then: "stale cached APIs for tenantA are evicted so the next access re-creates them against the new session factory"
+        !hasAnyApis(H7AllocationSchemaTenant, 'tenantA')
+
+        and: "DEFAULT APIs are not affected"
+        hasAllApis(H7AllocationSchemaTenant, ConnectionSource.DEFAULT)
+
+        cleanup:
+        datastore2?.close()
+    }
+
     void "DISCRIMINATOR multi tenant ALL datasource creates non-default datasource APIs lazily"() {
         given:
         datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H7AllocationAllDatasourceTenant)

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/connections/GormApiAllocationSpec.groovy
@@ -1,0 +1,282 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.orm.hibernate.connections
+
+import java.util.UUID
+
+import org.hibernate.dialect.H2Dialect
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+import grails.gorm.MultiTenant
+import grails.gorm.annotation.Entity
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.gorm.GormEntity
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.multitenancy.AllTenantsResolver
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
+import org.grails.orm.hibernate.HibernateDatastore
+
+@RestoreSystemProperties
+class GormApiAllocationSpec extends Specification {
+
+    @AutoCleanup HibernateDatastore datastore
+
+    void cleanup() {
+        System.clearProperty(SystemPropertyTenantResolver.PROPERTY_NAME)
+    }
+
+    void "DISCRIMINATOR multi tenant single datasource uses only default APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, [], H7AllocationDefaultTenant)
+
+        then:
+        hasAllApis(H7AllocationDefaultTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H7AllocationDefaultTenant, 'tenantA')
+
+        when:
+        def result = H7AllocationDefaultTenant.withTenant('tenantA') { true }
+
+        then:
+        result
+        !hasAnyApis(H7AllocationDefaultTenant, 'tenantA')
+    }
+
+    void "DISCRIMINATOR multi tenant default datasource with multiple configured datasources creates non-default APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H7AllocationDefaultTenant)
+
+        expect:
+        hasAllApis(H7AllocationDefaultTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H7AllocationDefaultTenant, 'analytics')
+        !hasAnyApis(H7AllocationDefaultTenant, 'reporting')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H7AllocationDefaultTenant, 'analytics')
+        def instanceApi = GormEnhancer.findInstanceApi(H7AllocationDefaultTenant, 'analytics')
+        def validationApi = GormEnhancer.findValidationApi(H7AllocationDefaultTenant, 'analytics')
+
+        then:
+        hasAllApis(H7AllocationDefaultTenant, 'analytics')
+        !hasAnyApis(H7AllocationDefaultTenant, 'reporting')
+        !staticApi.is(GormEnhancer.findStaticApi(H7AllocationDefaultTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H7AllocationDefaultTenant, 'analytics'))
+        validationApi.is(GormEnhancer.findValidationApi(H7AllocationDefaultTenant, 'analytics'))
+    }
+
+    void "SCHEMA multi tenant single datasource creates tenant APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.SCHEMA, [], H7AllocationSchemaTenant)
+
+        expect:
+        hasAllApis(H7AllocationSchemaTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H7AllocationSchemaTenant, 'tenantA')
+        !hasAnyApis(H7AllocationSchemaTenant, 'tenantB')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H7AllocationSchemaTenant, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(H7AllocationSchemaTenant, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(H7AllocationSchemaTenant, 'tenantA')
+
+        then:
+        hasAllApis(H7AllocationSchemaTenant, 'tenantA')
+        !hasAnyApis(H7AllocationSchemaTenant, 'tenantB')
+        !staticApi.is(GormEnhancer.findStaticApi(H7AllocationSchemaTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H7AllocationSchemaTenant, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(H7AllocationSchemaTenant, 'tenantA'))
+    }
+
+    void "DATABASE multi tenant creates tenant APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DATABASE, ['tenantA', 'tenantB'], H7AllocationDatabaseTenant)
+
+        expect:
+        hasAllApis(H7AllocationDatabaseTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H7AllocationDatabaseTenant, 'tenantA')
+        !hasAnyApis(H7AllocationDatabaseTenant, 'tenantB')
+
+        when:
+        def staticApi = GormEnhancer.findStaticApi(H7AllocationDatabaseTenant, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(H7AllocationDatabaseTenant, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(H7AllocationDatabaseTenant, 'tenantA')
+
+        then:
+        hasAllApis(H7AllocationDatabaseTenant, 'tenantA')
+        !hasAnyApis(H7AllocationDatabaseTenant, 'tenantB')
+        !staticApi.is(GormEnhancer.findStaticApi(H7AllocationDatabaseTenant, ConnectionSource.DEFAULT))
+        instanceApi.is(GormEnhancer.findInstanceApi(H7AllocationDatabaseTenant, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(H7AllocationDatabaseTenant, 'tenantA'))
+    }
+
+    void "DISCRIMINATOR multi tenant explicit datasource allocates only mapped datasource APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H7AllocationAnalyticsTenant)
+
+        then:
+        hasAllApis(H7AllocationAnalyticsTenant, ConnectionSource.DEFAULT)
+        hasAllApis(H7AllocationAnalyticsTenant, 'analytics')
+        !hasAnyApis(H7AllocationAnalyticsTenant, 'reporting')
+    }
+
+    void "DISCRIMINATOR multi tenant explicit multiple datasources allocates only mapped datasource APIs"() {
+        when:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting', 'audit'], H7AllocationMultipleDatasourceTenant)
+
+        then:
+        hasAllApis(H7AllocationMultipleDatasourceTenant, ConnectionSource.DEFAULT)
+        hasAllApis(H7AllocationMultipleDatasourceTenant, 'analytics')
+        hasAllApis(H7AllocationMultipleDatasourceTenant, 'reporting')
+        !hasAnyApis(H7AllocationMultipleDatasourceTenant, 'audit')
+    }
+
+    void "DISCRIMINATOR multi tenant ALL datasource creates non-default datasource APIs lazily"() {
+        given:
+        datastore = newDatastore(MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR, ['analytics', 'reporting'], H7AllocationAllDatasourceTenant)
+
+        expect:
+        hasAllApis(H7AllocationAllDatasourceTenant, ConnectionSource.DEFAULT)
+        !hasAnyApis(H7AllocationAllDatasourceTenant, 'analytics')
+        !hasAnyApis(H7AllocationAllDatasourceTenant, 'reporting')
+
+        when:
+        GormEnhancer.findStaticApi(H7AllocationAllDatasourceTenant, 'analytics')
+        GormEnhancer.findInstanceApi(H7AllocationAllDatasourceTenant, 'analytics')
+        GormEnhancer.findValidationApi(H7AllocationAllDatasourceTenant, 'analytics')
+
+        then:
+        hasAllApis(H7AllocationAllDatasourceTenant, 'analytics')
+        !hasAnyApis(H7AllocationAllDatasourceTenant, 'reporting')
+    }
+
+    private HibernateDatastore newDatastore(MultiTenancySettings.MultiTenancyMode mode, List<String> extraDataSources, Class<?>... domainClasses) {
+        Map config = baseConfig(mode, domainClasses[0].simpleName)
+        extraDataSources.each { String name ->
+            config["dataSources.${name}.url".toString()] = "jdbc:h2:mem:${databaseName(domainClasses[0].simpleName + name)};LOCK_TIMEOUT=10000".toString()
+        }
+        new HibernateDatastore(DatastoreUtils.createPropertyResolver(config), domainClasses)
+    }
+
+    private static Map baseConfig(MultiTenancySettings.MultiTenancyMode mode, String name) {
+        [
+                'grails.gorm.multiTenancy.mode': mode,
+                'grails.gorm.multiTenancy.tenantResolverClass': H7AllocationTenantResolver,
+                'dataSource.url': "jdbc:h2:mem:${databaseName(name)};LOCK_TIMEOUT=10000".toString(),
+                'dataSource.dbCreate': mode == MultiTenancySettings.MultiTenancyMode.SCHEMA ? 'update' : 'create-drop',
+                'dataSource.dialect': H2Dialect.name,
+                'dataSource.formatSql': 'true',
+                'hibernate.flush.mode': 'COMMIT',
+                'hibernate.hbm2ddl.auto': mode == MultiTenancySettings.MultiTenancyMode.SCHEMA ? 'create' : 'create-drop'
+        ]
+    }
+
+    private static String databaseName(String name) {
+        "h7_${name}_${UUID.randomUUID().toString().replace('-', '')}"
+    }
+
+    private static boolean hasAllApis(Class<?> type, String qualifier) {
+        hasStaticApi(type, qualifier) && hasInstanceApi(type, qualifier) && hasValidationApi(type, qualifier)
+    }
+
+    private static boolean hasAnyApis(Class<?> type, String qualifier) {
+        hasStaticApi(type, qualifier) || hasInstanceApi(type, qualifier) || hasValidationApi(type, qualifier)
+    }
+
+    private static boolean hasStaticApi(Class<?> type, String qualifier) {
+        GormEnhancer.@STATIC_APIS.get(qualifier).containsKey(type.name)
+    }
+
+    private static boolean hasInstanceApi(Class<?> type, String qualifier) {
+        GormEnhancer.@INSTANCE_APIS.get(qualifier).containsKey(type.name)
+    }
+
+    private static boolean hasValidationApi(Class<?> type, String qualifier) {
+        GormEnhancer.@VALIDATION_APIS.get(qualifier).containsKey(type.name)
+    }
+}
+
+class H7AllocationTenantResolver extends SystemPropertyTenantResolver implements AllTenantsResolver {
+
+    @Override
+    Iterable<Serializable> resolveTenantIds() {
+        ['tenantA', 'tenantB']
+    }
+}
+
+@Entity
+class H7AllocationDefaultTenant implements GormEntity<H7AllocationDefaultTenant>, MultiTenant<H7AllocationDefaultTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H7AllocationSchemaTenant implements GormEntity<H7AllocationSchemaTenant>, MultiTenant<H7AllocationSchemaTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H7AllocationDatabaseTenant implements GormEntity<H7AllocationDatabaseTenant>, MultiTenant<H7AllocationDatabaseTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+}
+
+@Entity
+class H7AllocationAnalyticsTenant implements GormEntity<H7AllocationAnalyticsTenant>, MultiTenant<H7AllocationAnalyticsTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasource 'analytics'
+    }
+}
+
+@Entity
+class H7AllocationMultipleDatasourceTenant implements GormEntity<H7AllocationMultipleDatasourceTenant>, MultiTenant<H7AllocationMultipleDatasourceTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasources(['analytics', 'reporting'])
+    }
+}
+
+@Entity
+class H7AllocationAllDatasourceTenant implements GormEntity<H7AllocationAllDatasourceTenant>, MultiTenant<H7AllocationAllDatasourceTenant> {
+    Long id
+    Long version
+    String tenantId
+    String name
+
+    static mapping = {
+        datasource ConnectionSource.ALL
+    }
+}

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -167,6 +167,15 @@ class GormEnhancer implements Closeable {
             }
             for (qualifier in qualifiers) {
                 DATASTORES.get(qualifier).put(name, this.datastore)
+                // Evict any lazily-cached API for this qualifier so the next access
+                // re-creates it against the now-current datastore/session-factory.
+                // Required when addTenantForSchema recreates a child datastore (e.g.
+                // per-test schema setup) and this qualifier was not in apiQualifiers.
+                if (!apiQualifiers.contains(qualifier)) {
+                    STATIC_APIS.get(qualifier)?.remove(name)
+                    INSTANCE_APIS.get(qualifier)?.remove(name)
+                    VALIDATION_APIS.get(qualifier)?.remove(name)
+                }
             }
         }
     }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -79,6 +79,8 @@ class GormEnhancer implements Closeable {
         return new ConcurrentHashMap() as Map<String, Datastore>
     }
 
+    private static final Map<Datastore, GormEnhancer> ENHANCERS = new ConcurrentHashMap<>()
+
     private static final Map<Class, Datastore> DATASTORES_BY_TYPE = new ConcurrentHashMap<Class, Datastore>()
 
     final Datastore datastore
@@ -122,6 +124,7 @@ class GormEnhancer implements Closeable {
             registerConstraints(datastore)
         }
         NAMED_QUERIES.clear()
+        ENHANCERS.put(datastore, this)
         DATASTORES_BY_TYPE.put(datastore.getClass(), datastore)
 
         for (entity in datastore.mappingContext.persistentEntities) {
@@ -140,10 +143,12 @@ class GormEnhancer implements Closeable {
             def cls = entity.javaClass
 
             List<String> qualifiers = allQualifiers(this.datastore, entity)
-            if (!qualifiers.contains(ConnectionSource.DEFAULT)) {
-                def firstQualifier = qualifiers.first()
+            List<String> apiQualifiers = apiQualifiers(entity, qualifiers)
+            def name = entity.name
+
+            if (!apiQualifiers.contains(ConnectionSource.DEFAULT)) {
+                def firstQualifier = apiQualifiers.first()
                 def staticApi = getStaticApi(cls, firstQualifier)
-                def name = entity.name
                 STATIC_APIS.get(ConnectionSource.DEFAULT).put(name, staticApi)
                 def instanceApi = getInstanceApi(cls, firstQualifier)
                 INSTANCE_APIS.get(ConnectionSource.DEFAULT).put(name, instanceApi)
@@ -152,17 +157,43 @@ class GormEnhancer implements Closeable {
                 DATASTORES.get(ConnectionSource.DEFAULT).put(name, this.datastore)
 
             }
-            for (qualifier in qualifiers) {
+            for (qualifier in apiQualifiers) {
                 def staticApi = getStaticApi(cls, qualifier)
-                def name = entity.name
                 STATIC_APIS.get(qualifier).put(name, staticApi)
                 def instanceApi = getInstanceApi(cls, qualifier)
                 INSTANCE_APIS.get(qualifier).put(name, instanceApi)
                 def validationApi = getValidationApi(cls, qualifier)
                 VALIDATION_APIS.get(qualifier).put(name, validationApi)
+            }
+            for (qualifier in qualifiers) {
                 DATASTORES.get(qualifier).put(name, this.datastore)
             }
         }
+    }
+
+    /**
+     * Obtain the qualifiers that need eagerly-created API providers.
+     *
+     * Entities expanded to every connection source or tenant still need datastore routing entries
+     * for those qualifiers, but the expensive API providers can be created lazily when a qualifier
+     * is actually used.
+     *
+     * @param entity The persistent entity
+     * @param qualifiers All datastore qualifiers for the entity
+     * @return The qualifiers to eagerly initialize API providers for
+     */
+    protected List<String> apiQualifiers(PersistentEntity entity, List<String> qualifiers) {
+        List<String> configuredQualifiers = new ArrayList<>(ConnectionSourcesSupport.getConnectionSourceNames(entity))
+        if (configuredQualifiers.contains(ConnectionSource.ALL)) {
+            return [ConnectionSource.DEFAULT]
+        }
+
+        boolean isMultiTenant = MultiTenant.isAssignableFrom(entity.javaClass)
+        if (isMultiTenant && configuredQualifiers.equals(ConnectionSourcesSupport.DEFAULT_CONNECTION_SOURCE_NAMES)) {
+            return [ConnectionSource.DEFAULT]
+        }
+
+        return qualifiers
     }
 
     /**
@@ -246,9 +277,22 @@ class GormEnhancer implements Closeable {
         String className = NameUtils.getClassName(entity)
         def staticApi = STATIC_APIS.get(qualifier)?.get(className)
         if (staticApi == null) {
+            staticApi = initializeStaticApi(entity, qualifier, className)
+        }
+        if (staticApi == null) {
             throw stateException(entity)
         }
         return staticApi
+    }
+
+    private static <D> GormStaticApi<D> initializeStaticApi(Class<D> entity, String qualifier, String className) {
+        GormEnhancer enhancer = findEnhancer(entity, qualifier, className)
+        if (enhancer == null) {
+            return null
+        }
+        return (GormStaticApi<D>) STATIC_APIS.get(qualifier).computeIfAbsent(className) { String ignored ->
+            enhancer.getStaticApi(entity, qualifier)
+        }
     }
 
     /**
@@ -261,11 +305,25 @@ class GormEnhancer implements Closeable {
      * @throws IllegalStateException if no instance API is found for the type
      */
     static <D> GormInstanceApi<D> findInstanceApi(Class<D> entity, String qualifier = findTenantId(entity)) {
-        def instanceApi = INSTANCE_APIS.get(qualifier)?.get(NameUtils.getClassName(entity))
+        String className = NameUtils.getClassName(entity)
+        def instanceApi = INSTANCE_APIS.get(qualifier)?.get(className)
+        if (instanceApi == null) {
+            instanceApi = initializeInstanceApi(entity, qualifier, className)
+        }
         if (instanceApi == null) {
             throw stateException(entity)
         }
         return instanceApi
+    }
+
+    private static <D> GormInstanceApi<D> initializeInstanceApi(Class<D> entity, String qualifier, String className) {
+        GormEnhancer enhancer = findEnhancer(entity, qualifier, className)
+        if (enhancer == null) {
+            return null
+        }
+        return (GormInstanceApi<D>) INSTANCE_APIS.get(qualifier).computeIfAbsent(className) { String ignored ->
+            enhancer.getInstanceApi(entity, qualifier)
+        }
     }
 
     /**
@@ -278,11 +336,30 @@ class GormEnhancer implements Closeable {
      * @throws IllegalStateException if no validation API is found for the type
      */
     static <D> GormValidationApi<D> findValidationApi(Class<D> entity, String qualifier = findTenantId(entity)) {
-        def instanceApi = VALIDATION_APIS.get(qualifier)?.get(NameUtils.getClassName(entity))
-        if (instanceApi == null) {
+        String className = NameUtils.getClassName(entity)
+        def validationApi = VALIDATION_APIS.get(qualifier)?.get(className)
+        if (validationApi == null) {
+            validationApi = initializeValidationApi(entity, qualifier, className)
+        }
+        if (validationApi == null) {
             throw stateException(entity)
         }
-        return instanceApi
+        return validationApi
+    }
+
+    private static <D> GormValidationApi<D> initializeValidationApi(Class<D> entity, String qualifier, String className) {
+        GormEnhancer enhancer = findEnhancer(entity, qualifier, className)
+        if (enhancer == null) {
+            return null
+        }
+        return (GormValidationApi<D>) VALIDATION_APIS.get(qualifier).computeIfAbsent(className) { String ignored ->
+            enhancer.getValidationApi(entity, qualifier)
+        }
+    }
+
+    private static GormEnhancer findEnhancer(Class entity, String qualifier, String className) {
+        Datastore datastore = DATASTORES.get(qualifier)?.get(className)
+        datastore != null ? ENHANCERS.get(datastore) : null
     }
 
     /**
@@ -383,6 +460,9 @@ class GormEnhancer implements Closeable {
     @Override
     @CompileStatic
     void close() throws IOException {
+        if (!ENHANCERS.remove(datastore, this)) {
+            return
+        }
         removeConstraints()
         DATASTORES_BY_TYPE.clear()
         def registry = GroovySystem.metaClassRegistry

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/GormEnhancerAllQualifiersSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/GormEnhancerAllQualifiersSpec.groovy
@@ -24,11 +24,15 @@ import grails.gorm.MultiTenant
 import org.grails.datastore.mapping.config.Entity
 import org.grails.datastore.mapping.core.Datastore
 import org.grails.datastore.mapping.core.connections.ConnectionSource
+import org.grails.datastore.mapping.core.connections.ConnectionSourceSettings
 import org.grails.datastore.mapping.core.connections.ConnectionSources
 import org.grails.datastore.mapping.core.connections.ConnectionSourcesProvider
 import org.grails.datastore.mapping.model.ClassMapping
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.datastore.mapping.multitenancy.MultiTenancySettings
+import org.grails.datastore.mapping.multitenancy.MultiTenantCapableDatastore
+import org.grails.datastore.mapping.multitenancy.TenantResolver
 
 /**
  * Tests for {@link GormEnhancer#allQualifiers(Datastore, PersistentEntity)} to verify
@@ -40,6 +44,12 @@ import org.grails.datastore.mapping.model.PersistentEntity
  * This caused silent data routing to the wrong database under DISCRIMINATOR multi-tenancy.</p>
  */
 class GormEnhancerAllQualifiersSpec extends Specification {
+
+    private Map<String, PersistentEntity> mockedEntities = [:]
+
+    void cleanup() {
+        mockedEntities.clear()
+    }
 
     /**
      * Create a GormEnhancer with a minimal mock datastore (no entities registered).
@@ -64,28 +74,42 @@ class GormEnhancerAllQualifiersSpec extends Specification {
         def classMapping = Mock(ClassMapping) {
             getMappedForm() >> mappedForm
         }
-        Mock(PersistentEntity) {
+        def persistentEntity = Mock(PersistentEntity) {
             getJavaClass() >> javaClass
             getMapping() >> classMapping
             getName() >> javaClass.name
         }
+        mockedEntities[javaClass.name] = persistentEntity
+        persistentEntity
     }
 
     /**
      * Create a mock datastore that also implements ConnectionSourcesProvider,
      * returning the specified connection source names.
      */
-    private Datastore mockMultiConnectionDatastore(List<String> connectionNames) {
+    private Datastore mockMultiConnectionDatastore(List<String> connectionNames, MultiTenancySettings.MultiTenancyMode mode = MultiTenancySettings.MultiTenancyMode.DISCRIMINATOR) {
+        def connectionSourceSettings = new ConnectionSourceSettings()
+        connectionSourceSettings.multiTenancy.mode = mode
         def connectionSourceMocks = connectionNames.collect { name ->
             Mock(ConnectionSource) {
                 getName() >> name
+                getSettings() >> connectionSourceSettings
             }
+        }
+        def defaultConnectionSource = connectionSourceMocks.find { it.name == ConnectionSource.DEFAULT } ?: connectionSourceMocks.first()
+        def mappingContext = Mock(MappingContext) {
+            getPersistentEntities() >> { mockedEntities.values() }
+            getPersistentEntity(_) >> { String name -> mockedEntities[name] }
         }
         def allSources = Mock(ConnectionSources) {
             getAllConnectionSources() >> connectionSourceMocks
+            getDefaultConnectionSource() >> defaultConnectionSource
         }
-        Mock(TestConnectionSourcesProviderDatastore) {
+        Mock(TestMultiTenantConnectionSourcesProviderDatastore) {
             getConnectionSources() >> allSources
+            getMappingContext() >> mappingContext
+            getMultiTenancyMode() >> mode
+            getTenantResolver() >> Mock(TenantResolver)
         }
     }
 
@@ -138,6 +162,74 @@ class GormEnhancerAllQualifiersSpec extends Specification {
         qualifiers.contains('secondary')
         qualifiers.contains('reporting')
         qualifiers.size() == 3
+    }
+
+    void "registerEntity creates expanded MultiTenant qualifier APIs lazily"() {
+        given: "a MultiTenant entity that expands across many qualifiers"
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'tenantA', 'tenantB'])
+        def enhancer = new CountingGormEnhancer(datastore)
+        def entity = mockEntity(MultiTenantExpandedEntity, [ConnectionSource.DEFAULT])
+
+        when: "registering the entity"
+        enhancer.registerEntity(entity)
+
+        then: "only the default APIs are created eagerly"
+        enhancer.staticApiCount == 1
+        enhancer.instanceApiCount == 1
+        enhancer.validationApiCount == 1
+        GormEnhancer.@DATASTORES.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@STATIC_APIS.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@INSTANCE_APIS.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@VALIDATION_APIS.get('tenantA').containsKey(entity.name)
+
+        when: "the qualifier-specific APIs are requested"
+        def staticApi = GormEnhancer.findStaticApi(MultiTenantExpandedEntity, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(MultiTenantExpandedEntity, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(MultiTenantExpandedEntity, 'tenantA')
+
+        then: "registered qualifiers create APIs lazily without collapsing to the default datastore"
+        staticApi.is(GormEnhancer.findStaticApi(MultiTenantExpandedEntity, 'tenantA'))
+        instanceApi.is(GormEnhancer.findInstanceApi(MultiTenantExpandedEntity, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(MultiTenantExpandedEntity, 'tenantA'))
+        !staticApi.is(GormEnhancer.findStaticApi(MultiTenantExpandedEntity, ConnectionSource.DEFAULT))
+        !instanceApi.is(GormEnhancer.findInstanceApi(MultiTenantExpandedEntity, ConnectionSource.DEFAULT))
+        !validationApi.is(GormEnhancer.findValidationApi(MultiTenantExpandedEntity, ConnectionSource.DEFAULT))
+        enhancer.staticApiCount == 2
+        enhancer.instanceApiCount == 2
+        enhancer.validationApiCount == 2
+    }
+
+    void "registerEntity creates tenant APIs lazily for database-per-tenant qualifiers"() {
+        given: "a database-per-tenant entity that expands across tenant qualifiers"
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT, 'tenantA', 'tenantB'], MultiTenancySettings.MultiTenancyMode.DATABASE)
+        def enhancer = new CountingGormEnhancer(datastore)
+        def entity = mockEntity(DatabaseMultiTenantExpandedEntity, [ConnectionSource.DEFAULT])
+
+        when: "registering the entity"
+        enhancer.registerEntity(entity)
+
+        then: "only the default APIs are created eagerly"
+        enhancer.staticApiCount == 1
+        enhancer.instanceApiCount == 1
+        enhancer.validationApiCount == 1
+        GormEnhancer.@DATASTORES.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@STATIC_APIS.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@INSTANCE_APIS.get('tenantA').containsKey(entity.name)
+        !GormEnhancer.@VALIDATION_APIS.get('tenantA').containsKey(entity.name)
+
+        when: "the tenant-specific APIs are requested"
+        def staticApi = GormEnhancer.findStaticApi(DatabaseMultiTenantExpandedEntity, 'tenantA')
+        def instanceApi = GormEnhancer.findInstanceApi(DatabaseMultiTenantExpandedEntity, 'tenantA')
+        def validationApi = GormEnhancer.findValidationApi(DatabaseMultiTenantExpandedEntity, 'tenantA')
+
+        then: "database-per-tenant APIs are created lazily and cached per tenant datastore"
+        staticApi.is(GormEnhancer.findStaticApi(DatabaseMultiTenantExpandedEntity, 'tenantA'))
+        instanceApi.is(GormEnhancer.findInstanceApi(DatabaseMultiTenantExpandedEntity, 'tenantA'))
+        validationApi.is(GormEnhancer.findValidationApi(DatabaseMultiTenantExpandedEntity, 'tenantA'))
+        !staticApi.is(GormEnhancer.findStaticApi(DatabaseMultiTenantExpandedEntity, ConnectionSource.DEFAULT))
+        enhancer.staticApiCount == 2
+        enhancer.instanceApiCount == 2
+        enhancer.validationApiCount == 2
     }
 
     void "MultiTenant entity with ALL datasource expands to all qualifiers"() {
@@ -219,18 +311,71 @@ class GormEnhancerAllQualifiersSpec extends Specification {
         qualifiers == ['analytics', 'reporting']
     }
 
+    void "close keeps a newer enhancer registered for the same datastore"() {
+        given: "two enhancers created for the same datastore instance"
+        def entity = mockEntity(StaleCloseEntity, [ConnectionSource.DEFAULT])
+        def datastore = mockMultiConnectionDatastore([ConnectionSource.DEFAULT])
+        def firstEnhancer = new CountingGormEnhancer(datastore)
+        def secondEnhancer = new CountingGormEnhancer(datastore)
+
+        expect: "the newest enhancer owns the datastore registration"
+        GormEnhancer.@ENHANCERS.get(datastore).is(secondEnhancer)
+
+        when: "the stale enhancer is closed"
+        firstEnhancer.close()
+
+        then: "the active enhancer is not removed"
+        GormEnhancer.@ENHANCERS.get(datastore).is(secondEnhancer)
+        GormEnhancer.findDatastore(StaleCloseEntity).is(datastore)
+        GormEnhancer.findStaticApi(StaleCloseEntity).is(GormEnhancer.findStaticApi(StaleCloseEntity))
+        GormEnhancer.findInstanceApi(StaleCloseEntity).is(GormEnhancer.findInstanceApi(StaleCloseEntity))
+        GormEnhancer.findValidationApi(StaleCloseEntity).is(GormEnhancer.findValidationApi(StaleCloseEntity))
+    }
+
     // --- Stub entity classes ---
 
     static class MultiTenantSecondaryEntity implements MultiTenant<MultiTenantSecondaryEntity> {}
     static class MultiTenantDefaultEntity implements MultiTenant<MultiTenantDefaultEntity> {}
     static class MultiTenantAllEntity implements MultiTenant<MultiTenantAllEntity> {}
     static class MultiTenantMultiDsEntity implements MultiTenant<MultiTenantMultiDsEntity> {}
+    static class MultiTenantExpandedEntity implements MultiTenant<MultiTenantExpandedEntity> {}
+    static class DatabaseMultiTenantExpandedEntity implements MultiTenant<DatabaseMultiTenantExpandedEntity> {}
     static class NonMultiTenantSecondaryEntity {}
     static class NonMultiTenantDefaultEntity {}
     static class NonMultiTenantAllEntity {}
+    static class StaleCloseEntity {}
+
+    static class CountingGormEnhancer extends GormEnhancer {
+
+        int staticApiCount
+        int instanceApiCount
+        int validationApiCount
+
+        CountingGormEnhancer(Datastore datastore) {
+            super(datastore)
+        }
+
+        @Override
+        protected <D> GormStaticApi<D> getStaticApi(Class<D> cls, String qualifier) {
+            staticApiCount++
+            super.getStaticApi(cls, qualifier)
+        }
+
+        @Override
+        protected <D> GormInstanceApi<D> getInstanceApi(Class<D> cls, String qualifier) {
+            instanceApiCount++
+            super.getInstanceApi(cls, qualifier)
+        }
+
+        @Override
+        protected <D> GormValidationApi<D> getValidationApi(Class<D> cls, String qualifier) {
+            validationApiCount++
+            super.getValidationApi(cls, qualifier)
+        }
+    }
 
     /**
      * Combined interface so Spock can mock a Datastore that also provides ConnectionSources.
      */
-    static interface TestConnectionSourcesProviderDatastore extends Datastore, ConnectionSourcesProvider {}
+    static interface TestMultiTenantConnectionSourcesProviderDatastore extends MultiTenantCapableDatastore<Object, ConnectionSourceSettings> {}
 }

--- a/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/GormEnhancerSpec.groovy
+++ b/grails-datamapping-tck/src/main/groovy/org/apache/grails/data/testing/tck/tests/GormEnhancerSpec.groovy
@@ -21,6 +21,8 @@ package org.apache.grails.data.testing.tck.tests
 import org.apache.grails.data.testing.tck.base.GrailsDataTckSpec
 import org.apache.grails.data.testing.tck.domains.ChildEntity
 import org.apache.grails.data.testing.tck.domains.TestEntity
+import org.grails.datastore.gorm.GormEnhancer
+import org.grails.datastore.mapping.core.connections.ConnectionSource
 
 /**
  * @author graemerocher
@@ -284,5 +286,34 @@ class GormEnhancerSpec extends GrailsDataTckSpec {
 
         then:
         2 == TestEntity.count()
+    }
+
+    void 'findStaticApi returns a non-null API for the default qualifier after enhancement'() {
+        when:
+        def staticApi = GormEnhancer.findStaticApi(TestEntity, ConnectionSource.DEFAULT)
+        def instanceApi = GormEnhancer.findInstanceApi(TestEntity, ConnectionSource.DEFAULT)
+        def validationApi = GormEnhancer.findValidationApi(TestEntity, ConnectionSource.DEFAULT)
+
+        then:
+        staticApi != null
+        instanceApi != null
+        validationApi != null
+    }
+
+    void 'findStaticApi returns the same cached instance on repeated calls'() {
+        when:
+        def staticApi1 = GormEnhancer.findStaticApi(TestEntity, ConnectionSource.DEFAULT)
+        def instanceApi1 = GormEnhancer.findInstanceApi(TestEntity, ConnectionSource.DEFAULT)
+        def validationApi1 = GormEnhancer.findValidationApi(TestEntity, ConnectionSource.DEFAULT)
+
+        and:
+        def staticApi2 = GormEnhancer.findStaticApi(TestEntity, ConnectionSource.DEFAULT)
+        def instanceApi2 = GormEnhancer.findInstanceApi(TestEntity, ConnectionSource.DEFAULT)
+        def validationApi2 = GormEnhancer.findValidationApi(TestEntity, ConnectionSource.DEFAULT)
+
+        then:
+        staticApi1.is(staticApi2)
+        instanceApi1.is(instanceApi2)
+        validationApi1.is(validationApi2)
     }
 }


### PR DESCRIPTION
## Summary

`GormEnhancer.registerEntity` eagerly instantiated a static, instance, and validation API provider for **every (entity × qualifier) pair**. For a `MultiTenant` entity expanded across N tenant connection sources this is **O(entityCount × tenantCount)** provider allocations at startup. This PR makes per-qualifier provider creation **lazy** - collapsing startup allocation to **O(entityCount + tenantCount)** - and fixes two transaction-synchronisation defects that lazy allocation exposed.

## Where the eager O(M×N) actually occurs

| Multi-tenancy mode | Eager O(entityCount × tenantCount) at startup? |
|---|---|
| **DISCRIMINATOR** (column) | **No** - single shared connection; a `MultiTenant` entity expands to `[DEFAULT]` only |
| **SCHEMA** (schema-per-tenant) | **Yes** (typical production) - schema-mode `allQualifiers()` resolves existing schemas from the **live database** at startup via `schemaHandler.resolveSchemaNames()`; with N pre-registered schemas the original code created N×M providers |
| **DATABASE** (database-per-tenant) | **Yes** - statically-configured per-tenant datasources expand every `MultiTenant` entity across all N connection sources |

(h/t @borinquenkid for the SCHEMA clarification - the live-schema resolution means SCHEMA benefits from this optimisation too, not just DATABASE.)

## The optimisation

`apiQualifiers()` restricts **eager** provider creation to the canonical qualifier set while still registering datastore **routing** for every qualifier. Per-qualifier static/instance/validation providers are then created lazily on first access via `computeIfAbsent` (single-flight, per the concurrency review feedback).

## Transaction-synchronisation fixes required by lazy allocation

1. **DATABASE per-tenant - "Already value bound to thread".** Spring's `SQLErrorCodesFactory` eagerly acquires a connection via `DataSourceUtils` during `GrailsHibernateTemplate` construction while a parent-transaction synchronisation is active, binding the child `DataSource` to the `TransactionSynchronizationManager`. `executeWithNewSession` only unbound the `DataSource` when a `SessionFactory` was also bound, so a stale `ConnectionHolder` remained and `HibernateTransactionManager.doBegin` threw `Already value bound`. The `DataSource` unbind/rebind is now decoupled from the `SessionFactory` null-check (hibernate5 + hibernate7).
2. **SCHEMA per-tenant - "No Session found".** `addTenantForSchema` re-creates a child datastore (new `SessionFactory`) and re-registers entities, but lazy-cached providers for non-eager qualifiers still referenced the previous `SessionFactory`. `GormEnhancer.registerEntity` now evicts those stale entries so they are rebuilt against the current datastore on next access.

## Tests

- `GormEnhancerAllQualifiersSpec` (datamapping-core) - qualifier expansion + eager/lazy allocation counts.
- `GormApiAllocationSpec` (hibernate5 + hibernate7) - mirrored coverage including per-tenant session behaviour.

Locally verified green: H5/H7 `SchemaPerTenantIntegrationSpec` and `DatabasePerTenantIntegrationSpec`.
