### PR TITLE
8.0.x  FIX:  Overriding bean definition for bean 'dispatcherServlet' with a different definition

### DIFF
--- a/grails-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
+++ b/grails-controllers/src/main/groovy/org/grails/plugins/web/controllers/ControllersAutoConfiguration.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.servlet.autoconfigure.HttpEncodingAutoConfiguration;
 import org.springframework.boot.servlet.filter.OrderedCharacterEncodingFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration;
 import org.springframework.boot.webmvc.autoconfigure.DispatcherServletRegistrationBean;
 import org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration;
 import org.springframework.context.ApplicationContext;
@@ -51,7 +52,7 @@ import org.grails.web.servlet.mvc.GrailsDispatcherServlet;
 import org.grails.web.servlet.mvc.GrailsWebRequestFilter;
 
 @AutoConfiguration(
-        before = {HttpEncodingAutoConfiguration.class, WebMvcAutoConfiguration.class},
+        before = {DispatcherServletAutoConfiguration.class, HttpEncodingAutoConfiguration.class, WebMvcAutoConfiguration.class},
         after = {GrailsDomainClassAutoConfiguration.class}
 )
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)


### PR DESCRIPTION
## What

`ControllersAutoConfiguration` defines its own `dispatcherServlet` (a `GrailsDispatcherServlet`) and `dispatcherServletRegistration` beans, but it is **not** ordered before Spring Boot's `DispatcherServletAutoConfiguration`. As a result Spring Boot registers its own beans first and Grails *overrides* them on startup:

```
INFO  o.s.b.f.s.DefaultListableBeanFactory : Overriding bean definition for bean 'dispatcherServlet' with a different definition:
  replacing [... DispatcherServletAutoConfiguration$DispatcherServletConfiguration ...]
  with      [... ControllersAutoConfiguration ...]
INFO  o.s.b.f.s.DefaultListableBeanFactory : Overriding bean definition for bean 'dispatcherServletRegistration' with a different definition:
  replacing [... DispatcherServletAutoConfiguration$DispatcherServletRegistrationConfiguration ...]
  with      [... ControllersAutoConfiguration ...]
```

This emits two INFO `Overriding bean definition` messages and depends on `spring.main.allow-bean-definition-overriding` to win.

## Change

Add `DispatcherServletAutoConfiguration` to the existing `@AutoConfiguration(before = …)` list:

```java
@AutoConfiguration(
        before = {DispatcherServletAutoConfiguration.class, HttpEncodingAutoConfiguration.class, WebMvcAutoConfiguration.class},
        after = {GrailsDomainClassAutoConfiguration.class}
)
```

Grails now registers `dispatcherServlet` / `dispatcherServletRegistration` first, so Spring Boot's `DefaultDispatcherServletCondition` and `DispatcherServletRegistrationCondition` find the existing beans and **back off** through their own conditions rather than being overridden.

## Why it's safe

- Runtime behavior is unchanged — `GrailsDispatcherServlet` still handles requests in both cases; only the registration mechanism changes (back-off instead of override).
- Converts an override into idiomatic auto-configuration ordering and removes two INFO log lines, reducing reliance on bean-definition overriding.

## Verification

- `./gradlew :grails-controllers:compileGroovy` — BUILD SUCCESSFUL.
- Mechanism follows Spring Boot's `DefaultDispatcherServletCondition` (backs off when a `dispatcherServlet`-named `DispatcherServlet` bean already exists).
