### PR TITLE
Make grailsDomainClassMappingContext deferrable; register it via auto-configuration for MongoDB

### DIFF
--- a/grails-data-mongodb/core/src/main/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializer.groovy
+++ b/grails-data-mongodb/core/src/main/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializer.groovy
@@ -110,10 +110,15 @@ class MongoDbDataStoreSpringInitializer extends AbstractDatastoreInitializer {
                 mongoDatastore(MongoDatastore, mongo, configuration, eventPublisher, collectMappedClasses(DATASTORE_TYPE))
             }
 
-            mongoMappingContext(mongoDatastore: 'getMappingContext')
+            // MongoMappingContextAutoConfiguration may already register mongoMappingContext (a lazy view of
+            // mongoDatastore.getMappingContext()) so the framework grailsDomainClassMappingContext fallback backs
+            // off; register it here only when it has not, to avoid overriding that definition.
+            if (!containsRegisteredBean(delegate, beanDefinitionRegistry, 'mongoMappingContext')) {
+                mongoMappingContext(mongoDatastore: 'getMappingContext')
 
-            if (!secondaryDatastore) {
-                registerAlias('mongoMappingContext', 'grailsDomainClassMappingContext')
+                if (!secondaryDatastore) {
+                    registerAlias('mongoMappingContext', 'grailsDomainClassMappingContext')
+                }
             }
 
             mongoTransactionManager(mongoDatastore: 'getTransactionManager')

--- a/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
+++ b/grails-data-mongodb/core/src/test/groovy/grails/mongodb/bootstrap/MongoDbDataStoreSpringInitializerSpec.groovy
@@ -33,6 +33,7 @@ import org.grails.datastore.mapping.mongo.MongoDatastore
 import org.grails.datastore.mapping.mongo.config.MongoMappingContext
 import org.grails.datastore.mapping.mongo.config.MongoSettings
 import org.grails.datastore.mapping.query.Query
+import org.springframework.beans.factory.support.RootBeanDefinition
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import spock.lang.Ignore
 import spock.lang.Issue
@@ -204,6 +205,43 @@ class MongoDbDataStoreSpringInitializerSpec extends AutoStartedMongoSpec {
         Person.findByBirthday(birthday).birthday == birthday
         !Person.findByBirthday(new Birthday(new Date() - 7))
 
+    }
+
+    void "Test a lazy pre-registered mongoMappingContext delegating to the datastore is used, and custom marshallers still work"() {
+        given: "a lazy mongoMappingContext delegating to mongoDatastore.getMappingContext() plus the alias, as MongoMappingContextAutoConfiguration registers them before the datastore is defined"
+        def initializer = makeInitializer([
+                (MongoSettings.SETTING_HOST): mongoHost,
+                (MongoSettings.SETTING_PORT): mongoPort,
+        ], Person)
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext()
+        applicationContext.beanFactory.registerSingleton('birthdayMarshaller', new BirthdayCustomTypeMarshaller())
+        RootBeanDefinition mappingContextDefinition = new RootBeanDefinition()
+        mappingContextDefinition.setFactoryBeanName('mongoDatastore')
+        mappingContextDefinition.setFactoryMethodName('getMappingContext')
+        mappingContextDefinition.setLazyInit(true)
+        applicationContext.registerBeanDefinition('mongoMappingContext', mappingContextDefinition)
+        applicationContext.registerAlias('mongoMappingContext', 'grailsDomainClassMappingContext')
+
+        when: "the initializer configures the datastore (and skips re-registering mongoMappingContext)"
+        initializer.configureForBeanDefinitionRegistry(applicationContext)
+        applicationContext.refresh()
+        MongoDatastore mongoDatastore = applicationContext.getBean(MongoDatastore)
+
+        then: "mongoMappingContext and its alias resolve to the datastore's own single context"
+        applicationContext.getBean('mongoMappingContext').is(mongoDatastore.mappingContext)
+        applicationContext.getBean('grailsDomainClassMappingContext').is(mongoDatastore.mappingContext)
+
+        when: "an entity with a custom-marshalled type is persisted"
+        Person.DB.drop()
+        def birthday = new Birthday(new Date())
+        new Person(name: 'Bob', home: Point.valueOf(10, 10), birthday: birthday).save(flush: true)
+
+        then: "the Spring-registered marshaller is honoured through the shared context"
+        Person.findByBirthday(birthday).birthday == birthday
+        !Person.findByBirthday(new Birthday(new Date() - 7))
+
+        cleanup:
+        mongoDatastore?.destroy()
     }
 
     private MongoDbDataStoreSpringInitializer makeInitializer(Map config, Class... domainClasses) {

--- a/grails-data-mongodb/grails-plugin/src/main/groovy/grails/plugins/mongodb/MongoMappingContextAutoConfiguration.groovy
+++ b/grails-data-mongodb/grails-plugin/src/main/groovy/grails/plugins/mongodb/MongoMappingContextAutoConfiguration.groovy
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugins.mongodb
+
+import groovy.transform.CompileStatic
+
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Lazy
+
+import org.grails.datastore.mapping.mongo.MongoDatastore
+import org.grails.datastore.mapping.mongo.config.MongoMappingContext
+
+/**
+ * Registers {@code mongoMappingContext} (aliased to {@code grailsDomainClassMappingContext}) <em>before</em>
+ * {@code GrailsDomainClassAutoConfiguration}, so its framework fallback — now
+ * {@code @ConditionalOnMissingBean(name = "grailsDomainClassMappingContext")} — backs off instead of leaving an
+ * orphaned definition that the datastore's alias later shadows.
+ *
+ * <p>The bean is <strong>lazy</strong> and delegates to the datastore's own context. Its definition exists early
+ * (satisfying the back-off), but it is not resolved until first use — by which point
+ * {@code MongoDbDataStoreSpringInitializer} has registered {@code mongoDatastore}. So the shared context is the
+ * datastore's own, built from the autowired connection sources; Spring-registered codecs and custom type
+ * marshallers are honoured, exactly as when the initializer registers the context itself. There is no
+ * independently-built context.
+ *
+ * <p>Ordering is declared {@code beforeName} rather than as a class reference so this module need not put
+ * {@code grails-domain-class} on its compile classpath.
+ *
+ * <p>Engages only when MongoDB is the primary datastore, i.e. no GORM-Hibernate is present
+ * ({@code @ConditionalOnMissingClass}). This mirrors {@code MongodbGrailsPlugin}'s
+ * {@code setSecondaryDatastore(hasHibernatePlugin())}: when Hibernate is present MongoDB is secondary, must not own
+ * {@code grailsDomainClassMappingContext}, and the initializer keeps its own path (registering the context without
+ * the alias).
+ */
+@CompileStatic
+@AutoConfiguration(beforeName = 'org.grails.plugins.domain.GrailsDomainClassAutoConfiguration')
+@ConditionalOnClass(MongoDatastore)
+@ConditionalOnMissingClass('org.grails.orm.hibernate.HibernateDatastore')
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+class MongoMappingContextAutoConfiguration {
+
+    @Lazy
+    @Bean(name = ['mongoMappingContext', 'grailsDomainClassMappingContext'])
+    MongoMappingContext mongoMappingContext(MongoDatastore mongoDatastore) {
+        (MongoMappingContext) mongoDatastore.mappingContext
+    }
+}

--- a/grails-data-mongodb/grails-plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/grails-data-mongodb/grails-plugin/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+grails.plugins.mongodb.MongoMappingContextAutoConfiguration

--- a/grails-domain-class/src/main/groovy/org/grails/plugins/domain/GrailsDomainClassAutoConfiguration.groovy
+++ b/grails-domain-class/src/main/groovy/org/grails/plugins/domain/GrailsDomainClassAutoConfiguration.groovy
@@ -24,6 +24,7 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.context.MessageSource
 import org.springframework.context.annotation.Bean
@@ -56,6 +57,7 @@ class GrailsDomainClassAutoConfiguration {
 
     @Lazy
     @Bean(name = 'grailsDomainClassMappingContext')
+    @ConditionalOnMissingBean(name = 'grailsDomainClassMappingContext')
     DefaultMappingContextFactoryBean grailsDomainClassMappingContext(List<ConstraintFactory> factories) {
         new DefaultMappingContextFactoryBean(grailsApplication, messageSources).tap {
             constraintFactories = factories ?: []


### PR DESCRIPTION
## What

Makes the framework `grailsDomainClassMappingContext` fallback **back off** in a Grails + MongoDB app, instead of being left as an orphaned bean definition that the datastore's alias silently shadows.

## Background

`GrailsDomainClassAutoConfiguration` registers a fallback `grailsDomainClassMappingContext` for apps with domain classes but no GORM datastore. In a MongoDB app the datastore registers `mongoMappingContext` and adds an alias `grailsDomainClassMappingContext`; that alias shadows the fallback definition (which, being `@Lazy`, never instantiates). No override is logged, but the registry is left with a name that is simultaneously a definition and an alias.

## The tricky part, and how this handles it

The correct Mongo mapping context can only be built **late** — the datastore builds it from its autowired connection sources, so Spring-registered codecs and custom type marshallers are applied. It cannot be rebuilt independently up front without losing them.

So the auto-configuration registers `mongoMappingContext` as a **lazy bean that delegates to `mongoDatastore.getMappingContext()`**:

```groovy
@Lazy
@Bean(name = ['mongoMappingContext', 'grailsDomainClassMappingContext'])
MongoMappingContext mongoMappingContext(MongoDatastore mongoDatastore) {
    (MongoMappingContext) mongoDatastore.mappingContext
}
```

The **definition** exists early (so `GrailsDomainClassAutoConfiguration`'s fallback, now `@ConditionalOnMissingBean(name = 'grailsDomainClassMappingContext')`, backs off), but it isn't **resolved** until first use — by which point `MongoDbDataStoreSpringInitializer` has registered `mongoDatastore`. The shared context is therefore the datastore's own; nothing is built independently.

## Changes

**grails-core** (behaviour-neutral on its own):
- `GrailsDomainClassAutoConfiguration.grailsDomainClassMappingContext` → `@ConditionalOnMissingBean(name = 'grailsDomainClassMappingContext')`. Evaluated before any `doWithSpring`, so with no datastore the fallback still registers exactly as before.

**grails-data-mongodb**:
- New `MongoMappingContextAutoConfiguration` — the lazy delegating bean above, ordered `beforeName GrailsDomainClassAutoConfiguration`.
- It engages only when MongoDB is the primary datastore — `@ConditionalOnMissingClass("org.grails.orm.hibernate.HibernateDatastore")` — mirroring `MongodbGrailsPlugin.setSecondaryDatastore(hasHibernatePlugin())`. When Hibernate is present MongoDB is secondary and keeps its own path.
- `MongoDbDataStoreSpringInitializer` registers `mongoMappingContext` (and the alias, when primary) **only when it is not already registered**, to avoid overriding the auto-config definition. The datastore construction is otherwise unchanged.

No core API changes — `MongoDatastore` is untouched.

## Tests

`MongoDbDataStoreSpringInitializerSpec` (MongoDB testcontainer), new case: with a lazy `mongoMappingContext` delegating to `mongoDatastore.getMappingContext()` pre-registered (as the auto-configuration does), `mongoMappingContext` and its `grailsDomainClassMappingContext` alias resolve to the datastore's own context, and an entity with a **Spring-registered custom type marshaller** round-trips — proving codecs/marshallers survive the early registration. Existing cases (custom codecs from Spring, custom type marshallers, primary/secondary alias, geo/constraints) still pass.

## Follow-ups

- An app-slice test asserting the auto-configuration ordering makes the fallback back off in a real Spring Boot context (this PR's test simulates the pre-registered bean directly).
- The same pattern for Hibernate — where the visible `Overriding bean definition` log originates — is harder because its mapping context is bound to the `SessionFactory`, and is left for a separate change.
