### PR TITLE
Fix inheritance of an explicit bindable:true constraint on id/version declared in an abstract @DirtyCheck base

### DIFF
--- a/grails-test-examples/gorm/grails-app/controllers/gorm/DirtyCheckBindingController.groovy
+++ b/grails-test-examples/gorm/grails-app/controllers/gorm/DirtyCheckBindingController.groovy
@@ -20,7 +20,7 @@
 package gorm
 
 /**
- * Controller used by the functional tests for issue 15681 and PR 15699. It binds the incoming request
+ * Controller used by the functional tests for issues 15681 and 15795. It binds the incoming request
  * parameters to a new domain instance and renders the resulting {@code id}, {@code version} and
  * {@code description} so the tests can assert over HTTP which properties were bound.
  */

--- a/grails-test-examples/gorm/grails-app/domain/gorm/BindableIdRecord.groovy
+++ b/grails-test-examples/gorm/grails-app/domain/gorm/BindableIdRecord.groovy
@@ -20,21 +20,14 @@
 package gorm
 
 /**
- * Controller used by the functional tests for issue 15681 and PR 15699. It binds the incoming request
- * parameters to a new domain instance and renders the resulting {@code id}, {@code version} and
- * {@code description} so the tests can assert over HTTP which properties were bound.
+ * Concrete GORM domain class (located in {@code grails-app/domain}) that extends an abstract
+ * {@code @DirtyCheck} base which declares an explicit {@code id bindable: true} constraint. The subclass
+ * declares no constraint of its own, so the bindable constraint must be inherited and {@code id} must be
+ * bound by data binding. See PR 15699.
  */
-class DirtyCheckBindingController {
+class BindableIdRecord extends AbstractBindableIdRecord {
 
-    def bind() {
-        def record = new DirtyCheckedRecord()
-        bindData(record, params)
-        render "id=${record.id}|version=${record.version}|description=${record.description}"
-    }
-
-    def bindInheritedBindableId() {
-        def record = new BindableIdRecord()
-        bindData(record, params)
-        render "id=${record.id}|version=${record.version}|description=${record.description}"
+    static constraints = {
+        description nullable: true
     }
 }

--- a/grails-test-examples/gorm/grails-app/domain/gorm/BindableIdRecord.groovy
+++ b/grails-test-examples/gorm/grails-app/domain/gorm/BindableIdRecord.groovy
@@ -23,7 +23,7 @@ package gorm
  * Concrete GORM domain class (located in {@code grails-app/domain}) that extends an abstract
  * {@code @DirtyCheck} base which declares an explicit {@code id bindable: true} constraint. The subclass
  * declares no constraint of its own, so the bindable constraint must be inherited and {@code id} must be
- * bound by data binding. See PR 15699.
+ * bound by data binding. See issue 15795.
  */
 class BindableIdRecord extends AbstractBindableIdRecord {
 

--- a/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
+++ b/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
@@ -65,7 +65,7 @@ class DirtyCheckBindingSpec extends Specification implements HttpClientSupport {
         response.assertContains('version=null')
     }
 
-    @Issue('https://github.com/apache/grails-core/pull/15795')
+    @Issue('https://github.com/apache/grails-core/issues/15795')
     void 'an explicit bindable:true id constraint declared on a @DirtyCheck base is inherited and binds over HTTP'() {
         when: 'a form submission posts id, version and a regular property to a domain whose base opts id into binding'
         def response = httpPost('/dirtyCheckBinding/bindInheritedBindableId', 'id=99&version=5&description=Opening+balance', FORM)

--- a/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
+++ b/grails-test-examples/gorm/src/integration-test/groovy/gorm/DirtyCheckBindingSpec.groovy
@@ -64,4 +64,22 @@ class DirtyCheckBindingSpec extends Specification implements HttpClientSupport {
         response.assertContains('id=null')
         response.assertContains('version=null')
     }
+
+    @Issue('https://github.com/apache/grails-core/pull/15795')
+    void 'an explicit bindable:true id constraint declared on a @DirtyCheck base is inherited and binds over HTTP'() {
+        when: 'a form submission posts id, version and a regular property to a domain whose base opts id into binding'
+        def response = httpPost('/dirtyCheckBinding/bindInheritedBindableId', 'id=99&version=5&description=Opening+balance', FORM)
+
+        then: 'the request succeeds'
+        response.assertStatus(200)
+
+        and: 'the regular property is bound'
+        response.assertContains('description=Opening balance')
+
+        and: 'id is bound because the inherited constraint explicitly opts it in'
+        response.assertContains('id=99')
+
+        and: 'version remains unbound as no constraint opts it in'
+        response.assertContains('version=null')
+    }
 }

--- a/grails-test-examples/gorm/src/main/groovy/gorm/AbstractBindableIdRecord.groovy
+++ b/grails-test-examples/gorm/src/main/groovy/gorm/AbstractBindableIdRecord.groovy
@@ -26,8 +26,8 @@ import grails.gorm.dirty.checking.DirtyCheck
  * {@link DirtyCheck} that explicitly opts {@code id} into data binding via a {@code bindable: true} constraint.
  * A concrete domain subclass which declares no constraint of its own must inherit this constraint, so that
  * {@code id} is bound. This guards against the regression described in
- * <a href="https://github.com/apache/grails-core/pull/15699">PR 15699</a>, where the inherited-whitelist filter
- * stripped explicitly bindable special properties declared up the hierarchy.
+ * <a href="https://github.com/apache/grails-core/issues/15795">issue 15795</a>, where the inherited-whitelist
+ * filter stripped explicitly bindable special properties declared up the hierarchy.
  */
 @DirtyCheck
 abstract class AbstractBindableIdRecord {

--- a/grails-test-examples/gorm/src/main/groovy/gorm/AbstractBindableIdRecord.groovy
+++ b/grails-test-examples/gorm/src/main/groovy/gorm/AbstractBindableIdRecord.groovy
@@ -19,22 +19,21 @@
 
 package gorm
 
+import grails.gorm.dirty.checking.DirtyCheck
+
 /**
- * Controller used by the functional tests for issue 15681 and PR 15699. It binds the incoming request
- * parameters to a new domain instance and renders the resulting {@code id}, {@code version} and
- * {@code description} so the tests can assert over HTTP which properties were bound.
+ * Abstract base class living in {@code src/main/groovy} (i.e. not itself a domain class) annotated with
+ * {@link DirtyCheck} that explicitly opts {@code id} into data binding via a {@code bindable: true} constraint.
+ * A concrete domain subclass which declares no constraint of its own must inherit this constraint, so that
+ * {@code id} is bound. This guards against the regression described in
+ * <a href="https://github.com/apache/grails-core/pull/15699">PR 15699</a>, where the inherited-whitelist filter
+ * stripped explicitly bindable special properties declared up the hierarchy.
  */
-class DirtyCheckBindingController {
+@DirtyCheck
+abstract class AbstractBindableIdRecord {
+    String description
 
-    def bind() {
-        def record = new DirtyCheckedRecord()
-        bindData(record, params)
-        render "id=${record.id}|version=${record.version}|description=${record.description}"
-    }
-
-    def bindInheritedBindableId() {
-        def record = new BindableIdRecord()
-        bindData(record, params)
-        render "id=${record.id}|version=${record.version}|description=${record.description}"
+    static constraints = {
+        id bindable: true
     }
 }

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/binding/DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/binding/DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec.groovy
@@ -117,6 +117,36 @@ class DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec extends
         obj.version == null
     }
 
+    @Issue('https://github.com/apache/grails-core/pull/15795')
+    void 'Test explicit bindable:true on a special property declared in a @DirtyCheck abstract base is inherited by the domain subclass'() {
+        when: 'a domain subclass inherits a bindable:true id constraint from its abstract base and declares no constraint of its own'
+        def obj = new DomainInheritingBindableId(id: 11L, version: 4L, name: 'Ada', title: 'Countess')
+
+        then: 'the explicitly bindable id is bound through inheritance'
+        obj.id == 11L
+
+        and: 'regular properties are bound'
+        obj.name == 'Ada'
+        obj.title == 'Countess'
+
+        and: 'version, which was not made explicitly bindable, remains excluded'
+        obj.version == null
+    }
+
+    @Issue('https://github.com/apache/grails-core/pull/15795')
+    void 'Test a bindable:false override in the domain subclass wins over an inherited bindable:true special property constraint'() {
+        when: 'a domain subclass overrides the inherited bindable:true id constraint with bindable:false'
+        def obj = new DomainOverridingBindableIdToFalse(id: 22L, version: 6L, name: 'Linus', title: 'Engineer')
+
+        then: 'regular properties are bound'
+        obj.name == 'Linus'
+        obj.title == 'Engineer'
+
+        and: 'the subclass override prevents id from being bound and version stays excluded'
+        obj.id == null
+        obj.version == null
+    }
+
     @Issue('https://github.com/apache/grails-core/issues/15681')
     void 'Test id and version are not bound across multiple levels of abstract inheritance'() {
         when: 'a domain class extends a plain abstract class which extends a @DirtyCheck abstract base'
@@ -183,6 +213,29 @@ class DomainWithInheritedBindableTimestamps extends AbstractDirtyCheckedBaseWith
     static constraints = {
         dateCreated bindable: true
         lastUpdated bindable: true
+    }
+}
+
+@DirtyCheck
+abstract class AbstractDirtyCheckedBaseWithBindableId {
+    String name
+
+    static constraints = {
+        id bindable: true
+    }
+}
+
+@Entity
+class DomainInheritingBindableId extends AbstractDirtyCheckedBaseWithBindableId {
+    String title
+}
+
+@Entity
+class DomainOverridingBindableIdToFalse extends AbstractDirtyCheckedBaseWithBindableId {
+    String title
+
+    static constraints = {
+        id bindable: false
     }
 }
 

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/binding/DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/binding/DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec.groovy
@@ -117,7 +117,7 @@ class DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec extends
         obj.version == null
     }
 
-    @Issue('https://github.com/apache/grails-core/pull/15795')
+    @Issue('https://github.com/apache/grails-core/issues/15795')
     void 'Test explicit bindable:true on a special property declared in a @DirtyCheck abstract base is inherited by the domain subclass'() {
         when: 'a domain subclass inherits a bindable:true id constraint from its abstract base and declares no constraint of its own'
         def obj = new DomainInheritingBindableId(id: 11L, version: 4L, name: 'Ada', title: 'Countess')
@@ -133,7 +133,7 @@ class DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec extends
         obj.version == null
     }
 
-    @Issue('https://github.com/apache/grails-core/pull/15795')
+    @Issue('https://github.com/apache/grails-core/issues/15795')
     void 'Test a bindable:false override in the domain subclass wins over an inherited bindable:true special property constraint'() {
         when: 'a domain subclass overrides the inherited bindable:true id constraint with bindable:false'
         def obj = new DomainOverridingBindableIdToFalse(id: 22L, version: 6L, name: 'Linus', title: 'Engineer')
@@ -144,6 +144,23 @@ class DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec extends
 
         and: 'the subclass override prevents id from being bound and version stays excluded'
         obj.id == null
+        obj.version == null
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/15795')
+    void 'Test an explicit bindable:true special property constraint propagates through an intermediate plain abstract level'() {
+        when: 'a domain class extends a plain abstract class which extends a @DirtyCheck base declaring id bindable:true'
+        def obj = new DomainInheritingBindableIdThroughIntermediate(id: 33L, version: 8L, grandparentName: 'g', parentName: 'p', childName: 'c')
+
+        then: 'the explicitly bindable id is bound even though the constraint is declared two levels up'
+        obj.id == 33L
+
+        and: 'all regular properties throughout the hierarchy are bound'
+        obj.grandparentName == 'g'
+        obj.parentName == 'p'
+        obj.childName == 'c'
+
+        and: 'version, which was not made explicitly bindable, remains excluded'
         obj.version == null
     }
 
@@ -237,6 +254,25 @@ class DomainOverridingBindableIdToFalse extends AbstractDirtyCheckedBaseWithBind
     static constraints = {
         id bindable: false
     }
+}
+
+@DirtyCheck
+abstract class AbstractDirtyCheckedGrandparentWithBindableId {
+    String grandparentName
+
+    static constraints = {
+        id bindable: true
+    }
+}
+
+@CompileStatic
+abstract class AbstractPlainParentOfBindableId extends AbstractDirtyCheckedGrandparentWithBindableId {
+    String parentName
+}
+
+@Entity
+class DomainInheritingBindableIdThroughIntermediate extends AbstractPlainParentOfBindableId {
+    String childName
 }
 
 @DirtyCheck

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/DefaultASTDatabindingHelper.java
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/DefaultASTDatabindingHelper.java
@@ -54,6 +54,8 @@ public class DefaultASTDatabindingHelper implements ASTDatabindingHelper {
 
     private static Map<ClassNode, Set<String>> CLASS_NODE_TO_WHITE_LIST_PROPERTY_NAMES = new HashMap<>();
 
+    private static Map<ClassNode, Set<String>> CLASS_NODE_TO_EXPLICITLY_BINDABLE_SPECIAL_PROPERTY_NAMES = new HashMap<>();
+
     @SuppressWarnings("serial")
     private static final List<ClassNode> SIMPLE_TYPES = new ArrayList<>() {
         {
@@ -141,17 +143,35 @@ public class DefaultASTDatabindingHelper implements ASTDatabindingHelper {
         return propertyNames;
     }
 
+    private Set<String> getExplicitlyBindableSpecialPropertyNamesForParentClass(final SourceUnit sourceUnit, final ClassNode parentClassNode) {
+        if (!CLASS_NODE_TO_EXPLICITLY_BINDABLE_SPECIAL_PROPERTY_NAMES.containsKey(parentClassNode)) {
+            getPropertyNamesToIncludeInWhiteList(sourceUnit, parentClassNode);
+        }
+        final Set<String> explicitlyBindable = CLASS_NODE_TO_EXPLICITLY_BINDABLE_SPECIAL_PROPERTY_NAMES.get(parentClassNode);
+        return explicitlyBindable != null ? explicitlyBindable : new HashSet<>();
+    }
+
     private Set<String> getPropertyNamesToIncludeInWhiteList(final SourceUnit sourceUnit, final ClassNode classNode) {
         final Set<String> propertyNamesToIncludeInWhiteList = new HashSet<>();
         final Set<String> unbindablePropertyNames = new HashSet<>();
         final Set<String> bindablePropertyNames = new HashSet<>();
+
+        // Special properties (id/version/dateCreated/lastUpdated) made bindable via an explicit constraint
+        // somewhere in the class hierarchy. These are tracked separately so the inherited-whitelist filter
+        // below can tell an explicit bindable: true from a special property that merely landed in a non-domain
+        // parent's whitelist by default (for example id/version injected onto a @DirtyCheck base class).
+        final Set<String> explicitlyBindableSpecialPropertyNames = new HashSet<>();
         final boolean isDomainClass = GrailsASTUtils.isDomainClass(classNode, sourceUnit);
         if (!classNode.getSuperClass().equals(new ClassNode(Object.class))) {
             final Set<String> parentClassPropertyNames = getPropertyNamesToIncludeInWhiteListForParentClass(sourceUnit, classNode.getSuperClass());
+            final Set<String> parentExplicitlyBindableSpecialPropertyNames = getExplicitlyBindableSpecialPropertyNamesForParentClass(sourceUnit, classNode.getSuperClass());
+            explicitlyBindableSpecialPropertyNames.addAll(parentExplicitlyBindableSpecialPropertyNames);
             for (final String parentPropertyName : parentClassPropertyNames) {
                 // A domain class never binds its special properties (id/version/dateCreated/lastUpdated) by
                 // default, so don't inherit them from a non-domain parent such as a @DirtyCheck base class.
-                if (isDomainClass && DOMAIN_CLASS_PROPERTIES_TO_EXCLUDE_BY_DEFAULT.contains(parentPropertyName)) {
+                // An explicit bindable: true constraint declared up the hierarchy is honoured, however.
+                if (isDomainClass && DOMAIN_CLASS_PROPERTIES_TO_EXCLUDE_BY_DEFAULT.contains(parentPropertyName) &&
+                        !parentExplicitlyBindableSpecialPropertyNames.contains(parentPropertyName)) {
                     continue;
                 }
                 bindablePropertyNames.add(parentPropertyName);
@@ -183,9 +203,13 @@ public class DefaultASTDatabindingHelper implements ASTDatabindingHelper {
                                 if (Boolean.TRUE.equals(bindableValue)) {
                                     unbindablePropertyNames.remove(propertyName);
                                     bindablePropertyNames.add(propertyName);
+                                    if (DOMAIN_CLASS_PROPERTIES_TO_EXCLUDE_BY_DEFAULT.contains(propertyName)) {
+                                        explicitlyBindableSpecialPropertyNames.add(propertyName);
+                                    }
                                 } else {
                                     bindablePropertyNames.remove(propertyName);
                                     unbindablePropertyNames.add(propertyName);
+                                    explicitlyBindableSpecialPropertyNames.remove(propertyName);
                                 }
                             } else {
                                 GrailsASTUtils.warning(sourceUnit, valueExpression, "The bindable constraint for property [" +
@@ -233,6 +257,7 @@ public class DefaultASTDatabindingHelper implements ASTDatabindingHelper {
             }
         }
         CLASS_NODE_TO_WHITE_LIST_PROPERTY_NAMES.put(classNode, propertyNamesToIncludeInWhiteList);
+        CLASS_NODE_TO_EXPLICITLY_BINDABLE_SPECIAL_PROPERTY_NAMES.put(classNode, explicitlyBindableSpecialPropertyNames);
         Map<String, ClassNode> allAssociationMap = GrailsASTUtils.getAllAssociationMap(classNode);
         for (String associationName : allAssociationMap.keySet()) {
             if (!propertyNamesToIncludeInWhiteList.contains(associationName) && !unbindablePropertyNames.contains(associationName)) {


### PR DESCRIPTION
 ## Description

  When an abstract base class — for example a `@DirtyCheck` class in `src/main/groovy` — declares an
  explicit `bindable: true` constraint on one of the default-excluded special properties
  (`id`, `version`, `dateCreated`, `lastUpdated`), a concrete domain subclass that does not redeclare
  the constraint failed to inherit it. The property was silently excluded from data binding even though
  the parent explicitly opted it in.

  This is a regression introduced by the fix for #15681 (PR #15699).

  ### Root cause

  PR #15699 added a filter in `DefaultASTDatabindingHelper.getPropertyNamesToIncludeInWhiteList` that
  strips the default-excluded special properties from the *inherited* parent whitelist for any domain
  class. That correctly stops GORM-injected `id`/`version` from leaking out of a non-domain `@DirtyCheck`
  base, but the filter was unconditional: it could not distinguish a special property that landed in the
  parent whitelist *by default* from one the parent made bindable via an *explicit* `bindable: true`
  constraint. As a result the explicit constraint was discarded.

  ### Fix

  The helper now tracks which excluded-by-default special properties were made bindable via an explicit
  constraint, propagates that set down the inheritance hierarchy, and only skips an inherited special
  property when it was **not** explicitly opted in:

  - The #15681 behavior is preserved — special properties that only landed in a non-domain parent's
    whitelist by default are still not inherited.
  - A subclass `bindable: false` override still wins over an inherited `bindable: true`.

  ### Tests

  - **Unit** (`DefaultASTDatabindingHelperDomainClassSpecialPropertiesSpec`): an explicit `bindable: true`
    on `id` declared in a `@DirtyCheck` abstract base is inherited by the domain subclass (this case fails
    without the fix), and a subclass `bindable: false` override beats the inherited `bindable: true`.
  - **Functional** (`grails-test-examples-gorm` / `DirtyCheckBindingSpec`): a new `@DirtyCheck` base
    (`AbstractBindableIdRecord`) opting `id` into binding, an inheriting domain class (`BindableIdRecord`),
    a controller action, and an end-to-end HTTP assertion that the inherited `id` is bound while `version`
  remains unbound.

Fixes #15795

## Contributor Checklist

### Issue and Scope

- [x] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. <!-- replace #15795 above with the ticket you created -->
- [x] This PR addresses the **complete scope** of the linked issue.
- [x] This PR contains a **single, focused change**.
- [x] This PR targets the **correct branch** for the type of change:
    - **Patch release branches** (e.g., `7.0.x`): Bug fixes only. No new features or API changes.

### Code Quality

- [x] I have **added or updated tests** that cover the changes introduced in this PR.
- [x] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`. <!-- run before pushing -->
- [x] My code follows the project's **code style** guidelines. I have run `./gradlew codeStyle` and resolved any violations.
- [x] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring.
- [x] If generative AI tooling was used in preparing this contribution, a quality model was used to ensure contributions are **consistent with the project's quality standards**.

### Licensing and Attribution

- [x] All contributed code is provided under the Apache License 2.0, and new source files include the appropriate **Apache license header**.
- [x] I have the necessary rights to submit this contribution and confirm it is my own original work.
- [x] If generative AI tooling was used in preparing this contribution, I have followed the ASF's policy on generative tooling and have properly attributed its use.

### Documentation

- [x] If this PR introduces user-facing changes, I have included or updated the relevant documentation. <!-- N/A: restores previously documented bindable-constraint inheritance behavior; no doc change required -->
- [x] If this PR adds a new feature, I have updated the **What's New** section of the Grails Guide. <!-- N/A: bug fix, not a feature -->
- [x] If this PR introduces breaking changes or changes that require user action during an upgrade, I have updated the **Upgrade Notes**. <!-- N/A: no breaking change -->
- [x] The PR description clearly explains **what** was changed and **why**.