### PR TITLE
Improve virtual thread cleanup for ThreadLocals

### DIFF
--- a/grails-converters/src/main/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolder.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolder.java
@@ -70,11 +70,7 @@ public class ConvertersConfigurationHolder {
     private ThreadLocal<Map<Class<? extends Converter>, ConverterConfiguration>> threadLocalConfiguration = createThreadLocalConfiguration();
 
     protected static ThreadLocal<Map<Class<? extends Converter>, ConverterConfiguration>> createThreadLocalConfiguration() {
-        return new ThreadLocal<>() {
-            protected Map<java.lang.Class<? extends Converter>, ConverterConfiguration> initialValue() {
-                return new HashMap<>();
-            }
-        };
+        return new ThreadLocal<>();
     }
 
     private ConvertersConfigurationHolder() {
@@ -162,11 +158,33 @@ public class ConvertersConfigurationHolder {
     }
 
     public static <C extends Converter> ConverterConfiguration<C> getThreadLocalConverterConfiguration(Class<C> converterClass) throws ConverterException {
-        return getInstance().threadLocalConfiguration.get().get(converterClass);
+        Map<Class<? extends Converter>, ConverterConfiguration> configurations = getThreadLocalConverterConfigurations(false);
+        return configurations != null ? configurations.get(converterClass) : null;
     }
 
     public static <C extends Converter> void setThreadLocalConverterConfiguration(Class<C> converterClass, ConverterConfiguration<C> cfg) throws ConverterException {
-        getInstance().threadLocalConfiguration.get().put(converterClass, cfg);
+        Map<Class<? extends Converter>, ConverterConfiguration> configurations = getThreadLocalConverterConfigurations(cfg != null);
+        if (cfg == null) {
+            if (configurations != null) {
+                configurations.remove(converterClass);
+                if (configurations.isEmpty()) {
+                    getInstance().threadLocalConfiguration.remove();
+                }
+            }
+        }
+        else {
+            configurations.put(converterClass, cfg);
+        }
+    }
+
+    private static Map<Class<? extends Converter>, ConverterConfiguration> getThreadLocalConverterConfigurations(boolean create) {
+        ThreadLocal<Map<Class<? extends Converter>, ConverterConfiguration>> threadLocalConfiguration = getInstance().threadLocalConfiguration;
+        Map<Class<? extends Converter>, ConverterConfiguration> configurations = threadLocalConfiguration.get();
+        if (configurations == null && create) {
+            configurations = new HashMap<>();
+            threadLocalConfiguration.set(configurations);
+        }
+        return configurations;
     }
 
     public static <C extends Converter> void setNamedConverterConfiguration(Class<C> converterClass, String name, ConverterConfiguration<C> cfg) throws ConverterException {

--- a/grails-converters/src/test/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolderSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolderSpec.groovy
@@ -1,0 +1,150 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.configuration
+
+import java.util.concurrent.atomic.AtomicReference
+
+import grails.converters.JSON
+import grails.converters.XML
+
+import spock.lang.Specification
+
+class ConvertersConfigurationHolderSpec extends Specification {
+
+    void cleanup() {
+        ConvertersConfigurationHolder.clear()
+    }
+
+    void "thread-local converter configuration is scoped to a virtual thread"() {
+        given:
+        def defaultConfiguration = new DefaultConverterConfiguration<JSON>()
+        def scopedConfiguration = new DefaultConverterConfiguration<JSON>()
+        def scopedResult = new AtomicReference<ConverterConfiguration<JSON>>()
+        def clearedResult = new AtomicReference<ConverterConfiguration<JSON>>()
+        ConvertersConfigurationHolder.setDefaultConfiguration(JSON, defaultConfiguration)
+
+        when:
+        runOnVirtualThread {
+            ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, scopedConfiguration)
+            scopedResult.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
+            ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, null)
+            clearedResult.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
+        }
+
+        then:
+        scopedResult.get().is(scopedConfiguration)
+        clearedResult.get().is(defaultConfiguration)
+        ConvertersConfigurationHolder.getConverterConfiguration(JSON).is(defaultConfiguration)
+    }
+
+    void "default converter lookups do not allocate a thread-local configuration map"() {
+        given:
+        def defaultConfiguration = new DefaultConverterConfiguration<JSON>()
+        ConvertersConfigurationHolder.setDefaultConfiguration(JSON, defaultConfiguration)
+
+        expect:
+        ConvertersConfigurationHolder.getConverterConfiguration(JSON).is(defaultConfiguration)
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON) == null
+    }
+
+    void "clearing the last thread-local converter configuration removes the map"() {
+        given:
+        def scopedConfiguration = new DefaultConverterConfiguration<JSON>()
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, scopedConfiguration)
+
+        expect:
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON).is(scopedConfiguration)
+
+        when:
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, null)
+
+        then:
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON) == null
+    }
+
+    void "clearing one converter keeps other thread-local converter configurations"() {
+        given:
+        def jsonConfiguration = new DefaultConverterConfiguration<JSON>()
+        def xmlConfiguration = new DefaultConverterConfiguration<XML>()
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, jsonConfiguration)
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(XML, xmlConfiguration)
+
+        when:
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, null)
+
+        then:
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON) == null
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(XML).is(xmlConfiguration)
+
+        when:
+        ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(XML, null)
+
+        then:
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(XML) == null
+    }
+
+    void "converter use restores a missing thread-local configuration after a named scope"() {
+        given:
+        def defaultConfiguration = new DefaultConverterConfiguration<JSON>()
+        def namedConfiguration = new DefaultConverterConfiguration<JSON>(defaultConfiguration)
+        ConvertersConfigurationHolder.setDefaultConfiguration(JSON, defaultConfiguration)
+        ConvertersConfigurationHolder.setNamedConverterConfiguration(JSON, 'named', namedConfiguration)
+        def scopedConfiguration = new AtomicReference<ConverterConfiguration<JSON>>()
+        def restoredConfiguration = new AtomicReference<ConverterConfiguration<JSON>>()
+
+        when:
+        JSON.use('named') {
+            scopedConfiguration.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
+        }
+        restoredConfiguration.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
+
+        then:
+        scopedConfiguration.get().is(namedConfiguration)
+        restoredConfiguration.get().is(defaultConfiguration)
+        ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON) == null
+    }
+
+    private static <T> T runOnVirtualThread(Closure<T> callable) {
+        def result = new AtomicReference<T>()
+        def error = new AtomicReference<Throwable>()
+        Runnable runnable = {
+            try {
+                result.set(callable.call())
+            }
+            catch (Throwable t) {
+                error.set(t)
+            }
+        } as Runnable
+
+        try {
+            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
+            thread.join()
+        }
+        catch (NoSuchMethodException ignored) {
+            Thread thread = new Thread(runnable)
+            thread.start()
+            thread.join()
+        }
+
+        if (error.get() != null) {
+            throw error.get()
+        }
+        result.get()
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolderSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/configuration/ConvertersConfigurationHolderSpec.groovy
@@ -18,6 +18,8 @@
  */
 package org.grails.web.converters.configuration
 
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
 import grails.converters.JSON
@@ -35,21 +37,21 @@ class ConvertersConfigurationHolderSpec extends Specification {
         given:
         def defaultConfiguration = new DefaultConverterConfiguration<JSON>()
         def scopedConfiguration = new DefaultConverterConfiguration<JSON>()
-        def scopedResult = new AtomicReference<ConverterConfiguration<JSON>>()
-        def clearedResult = new AtomicReference<ConverterConfiguration<JSON>>()
         ConvertersConfigurationHolder.setDefaultConfiguration(JSON, defaultConfiguration)
 
         when:
-        runOnVirtualThread {
-            ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, scopedConfiguration)
-            scopedResult.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
-            ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, null)
-            clearedResult.set(ConvertersConfigurationHolder.getConverterConfiguration(JSON))
+        def scopedConfigurations = Executors.newVirtualThreadPerTaskExecutor().withCloseable { executor ->
+            executor.submit({
+                ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, scopedConfiguration)
+                def threadLocalConfiguration = ConvertersConfigurationHolder.getConverterConfiguration(JSON)
+                ConvertersConfigurationHolder.setThreadLocalConverterConfiguration(JSON, null)
+                [threadLocalConfiguration, ConvertersConfigurationHolder.getConverterConfiguration(JSON)]
+            } as Callable<List<ConverterConfiguration<JSON>>>).get()
         }
 
         then:
-        scopedResult.get().is(scopedConfiguration)
-        clearedResult.get().is(defaultConfiguration)
+        scopedConfigurations[0].is(scopedConfiguration)
+        scopedConfigurations[1].is(defaultConfiguration)
         ConvertersConfigurationHolder.getConverterConfiguration(JSON).is(defaultConfiguration)
     }
 
@@ -120,31 +122,4 @@ class ConvertersConfigurationHolderSpec extends Specification {
         ConvertersConfigurationHolder.getThreadLocalConverterConfiguration(JSON) == null
     }
 
-    private static <T> T runOnVirtualThread(Closure<T> callable) {
-        def result = new AtomicReference<T>()
-        def error = new AtomicReference<Throwable>()
-        Runnable runnable = {
-            try {
-                result.set(callable.call())
-            }
-            catch (Throwable t) {
-                error.set(t)
-            }
-        } as Runnable
-
-        try {
-            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
-            thread.join()
-        }
-        catch (NoSuchMethodException ignored) {
-            Thread thread = new Thread(runnable)
-            thread.start()
-            thread.join()
-        }
-
-        if (error.get() != null) {
-            throw error.get()
-        }
-        result.get()
-    }
 }

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/DatastoreUtils.java
@@ -258,7 +258,7 @@ public abstract class DatastoreUtils {
             closeSession(session);
         }
         if (holderMap.isEmpty()) {
-            deferredCloseHolder.set(null);
+            deferredCloseHolder.remove();
         }
     }
 

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SoftThreadLocalMap.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/SoftThreadLocalMap.java
@@ -38,4 +38,9 @@ public class SoftThreadLocalMap extends InheritableThreadLocal<ConcurrentReferen
     protected ConcurrentReferenceHashMap initialValue() {
         return new ConcurrentReferenceHashMap();
     }
+
+    @Override
+    protected ConcurrentReferenceHashMap childValue(ConcurrentReferenceHashMap parentValue) {
+        return initialValue();
+    }
 }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/DatastoreUtilsSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/DatastoreUtilsSpec.groovy
@@ -18,9 +18,12 @@
  */
 package org.grails.datastore.mapping.core
 
+import java.util.concurrent.atomic.AtomicReference
+
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertyResolver
 import org.springframework.core.env.StandardEnvironment
+
 import spock.lang.Specification
 
 /**
@@ -38,5 +41,76 @@ class DatastoreUtilsSpec extends Specification {
         expect:
         env != null
         resolver.getProperty('grails.foo') == 'baz'
+    }
+
+    void "deferred close lifecycle is isolated on a virtual thread"() {
+        given:
+        Datastore datastore = Mock()
+        Session session = Mock()
+        def repeatedCloseMessage = new AtomicReference<String>()
+
+        when:
+        runOnVirtualThread {
+            DatastoreUtils.initDeferredClose(datastore)
+            DatastoreUtils.closeSessionOrRegisterDeferredClose(session, datastore)
+            DatastoreUtils.processDeferredClose(datastore)
+            try {
+                DatastoreUtils.processDeferredClose(datastore)
+            }
+            catch (IllegalStateException e) {
+                repeatedCloseMessage.set(e.message)
+            }
+        }
+
+        then:
+        1 * session.disconnect()
+        repeatedCloseMessage.get().contains('Deferred close not active')
+    }
+
+    void "soft thread local map does not expose parent entries to child threads"() {
+        given:
+        def threadLocal = new SoftThreadLocalMap()
+        threadLocal.get().put('tenant', 'parent')
+        def childTenant = new AtomicReference<String>()
+
+        when:
+        runOnVirtualThread {
+            childTenant.set(threadLocal.get().get('tenant') as String)
+        }
+
+        then:
+        childTenant.get() == null
+        threadLocal.get().get('tenant') == 'parent'
+
+        cleanup:
+        threadLocal.remove()
+    }
+
+    private static <T> T runOnVirtualThread(Closure<T> callable) {
+        def result = new AtomicReference<T>()
+        def error = new AtomicReference<Throwable>()
+        Runnable runnable = {
+            try {
+                result.set(callable.call())
+            }
+            catch (Throwable t) {
+                error.set(t)
+            }
+        } as Runnable
+
+        try {
+            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
+            thread.join()
+        }
+        catch (NoSuchMethodException ignored) {
+            Thread thread = new Thread(runnable)
+            thread.start()
+            thread.join()
+        }
+
+        if (error.get() != null) {
+            throw error.get()
+        }
+        result.get()
     }
 }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/DatastoreUtilsSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/core/DatastoreUtilsSpec.groovy
@@ -18,7 +18,8 @@
  */
 package org.grails.datastore.mapping.core
 
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
 
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.PropertyResolver
@@ -47,70 +48,45 @@ class DatastoreUtilsSpec extends Specification {
         given:
         Datastore datastore = Mock()
         Session session = Mock()
-        def repeatedCloseMessage = new AtomicReference<String>()
 
         when:
-        runOnVirtualThread {
-            DatastoreUtils.initDeferredClose(datastore)
-            DatastoreUtils.closeSessionOrRegisterDeferredClose(session, datastore)
-            DatastoreUtils.processDeferredClose(datastore)
-            try {
+        def repeatedCloseMessage = Executors.newVirtualThreadPerTaskExecutor().withCloseable { executor ->
+            executor.submit({
+                DatastoreUtils.initDeferredClose(datastore)
+                DatastoreUtils.closeSessionOrRegisterDeferredClose(session, datastore)
                 DatastoreUtils.processDeferredClose(datastore)
-            }
-            catch (IllegalStateException e) {
-                repeatedCloseMessage.set(e.message)
-            }
+                try {
+                    DatastoreUtils.processDeferredClose(datastore)
+                    null
+                }
+                catch (IllegalStateException e) {
+                    e.message
+                }
+            } as Callable<String>).get()
         }
 
         then:
         1 * session.disconnect()
-        repeatedCloseMessage.get().contains('Deferred close not active')
+        repeatedCloseMessage.contains('Deferred close not active')
     }
 
     void "soft thread local map does not expose parent entries to child threads"() {
         given:
         def threadLocal = new SoftThreadLocalMap()
         threadLocal.get().put('tenant', 'parent')
-        def childTenant = new AtomicReference<String>()
 
         when:
-        runOnVirtualThread {
-            childTenant.set(threadLocal.get().get('tenant') as String)
+        def childTenant = Executors.newVirtualThreadPerTaskExecutor().withCloseable { executor ->
+            executor.submit({
+                threadLocal.get().get('tenant') as String
+            } as Callable<String>).get()
         }
 
         then:
-        childTenant.get() == null
+        childTenant == null
         threadLocal.get().get('tenant') == 'parent'
 
         cleanup:
         threadLocal.remove()
-    }
-
-    private static <T> T runOnVirtualThread(Closure<T> callable) {
-        def result = new AtomicReference<T>()
-        def error = new AtomicReference<Throwable>()
-        Runnable runnable = {
-            try {
-                result.set(callable.call())
-            }
-            catch (Throwable t) {
-                error.set(t)
-            }
-        } as Runnable
-
-        try {
-            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
-            thread.join()
-        }
-        catch (NoSuchMethodException ignored) {
-            Thread thread = new Thread(runnable)
-            thread.start()
-            thread.join()
-        }
-
-        if (error.get() != null) {
-            throw error.get()
-        }
-        result.get()
     }
 }

--- a/grails-encoder/src/test/groovy/org/grails/encoder/ChainedEncodersSpec.groovy
+++ b/grails-encoder/src/test/groovy/org/grails/encoder/ChainedEncodersSpec.groovy
@@ -18,7 +18,8 @@
  */
 package org.grails.encoder;
 
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
 
 import groovy.json.StringEscapeUtils
 
@@ -70,11 +71,13 @@ class ChainedEncodersSpec extends Specification {
             source.writer.write('<1> Hello World;')
 
         when:
-            def resultStr = runOnVirtualThread {
-                def resultBuffer = new StreamCharBuffer()
-                resultBuffer.setAllowSubBuffers(false)
-                ChainedEncoders.chainEncode(source, resultBuffer.writer.encodedAppender, encoders)
-                resultBuffer.toString()
+            def resultStr = Executors.newVirtualThreadPerTaskExecutor().withCloseable { executor ->
+                executor.submit({
+                    def resultBuffer = new StreamCharBuffer()
+                    resultBuffer.setAllowSubBuffers(false)
+                    ChainedEncoders.chainEncode(source, resultBuffer.writer.encodedAppender, encoders)
+                    resultBuffer.toString()
+                } as Callable<String>).get()
             }
             def unescapedStr = StringEscapeUtils.unescapeJavaScript(resultStr)
 
@@ -118,33 +121,5 @@ class ChainedEncodersSpec extends Specification {
         public void markEncoded(CharSequence string) {
             
         }
-    }
-
-    private static <T> T runOnVirtualThread(Closure<T> callable) {
-        def result = new AtomicReference<T>()
-        def error = new AtomicReference<Throwable>()
-        Runnable runnable = {
-            try {
-                result.set(callable.call())
-            }
-            catch (Throwable t) {
-                error.set(t)
-            }
-        } as Runnable
-
-        try {
-            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
-            thread.join()
-        }
-        catch (NoSuchMethodException ignored) {
-            Thread thread = new Thread(runnable)
-            thread.start()
-            thread.join()
-        }
-
-        if (error.get() != null) {
-            throw error.get()
-        }
-        result.get()
     }
 }

--- a/grails-encoder/src/test/groovy/org/grails/encoder/ChainedEncodersSpec.groovy
+++ b/grails-encoder/src/test/groovy/org/grails/encoder/ChainedEncodersSpec.groovy
@@ -18,6 +18,8 @@
  */
 package org.grails.encoder;
 
+import java.util.concurrent.atomic.AtomicReference
+
 import groovy.json.StringEscapeUtils
 
 import org.grails.encoder.impl.HTMLEncoder
@@ -60,6 +62,26 @@ class ChainedEncodersSpec extends Specification {
             resultStr != unescapedStr
             unescapedStr == '&lt;1&gt; Hello World;'
     }
+
+    def "chaining StreamingEncoders should be possible on a virtual thread"() {
+        given:
+            def encoders = [new HTMLEncoder(), new JavaScriptEncoder()]
+            def source = new StreamCharBuffer()
+            source.writer.write('<1> Hello World;')
+
+        when:
+            def resultStr = runOnVirtualThread {
+                def resultBuffer = new StreamCharBuffer()
+                resultBuffer.setAllowSubBuffers(false)
+                ChainedEncoders.chainEncode(source, resultBuffer.writer.encodedAppender, encoders)
+                resultBuffer.toString()
+            }
+            def unescapedStr = StringEscapeUtils.unescapeJavaScript(resultStr)
+
+        then:
+            resultStr != unescapedStr
+            unescapedStr == '&lt;1&gt; Hello World;'
+    }
     
     def "chaining Encoders (mixed) should be possible"() {
         given:
@@ -96,5 +118,33 @@ class ChainedEncodersSpec extends Specification {
         public void markEncoded(CharSequence string) {
             
         }
+    }
+
+    private static <T> T runOnVirtualThread(Closure<T> callable) {
+        def result = new AtomicReference<T>()
+        def error = new AtomicReference<Throwable>()
+        Runnable runnable = {
+            try {
+                result.set(callable.call())
+            }
+            catch (Throwable t) {
+                error.set(t)
+            }
+        } as Runnable
+
+        try {
+            Thread thread = Thread.class.getMethod('startVirtualThread', Runnable).invoke(null, runnable) as Thread
+            thread.join()
+        }
+        catch (NoSuchMethodException ignored) {
+            Thread thread = new Thread(runnable)
+            thread.start()
+            thread.join()
+        }
+
+        if (error.get() != null) {
+            throw error.get()
+        }
+        result.get()
     }
 }


### PR DESCRIPTION
## Summary

This PR improves Grails 8.0.x readiness for virtual-thread workloads by tightening cleanup and isolation of thread-bound framework state.

It changes three related areas:

- `ConvertersConfigurationHolder` now creates scoped converter configuration maps lazily and removes the `ThreadLocal` entry when the last scoped converter config is cleared.
- `DatastoreUtils` now removes the deferred-close `ThreadLocal` holder after the final datastore session holder is processed.
- `SoftThreadLocalMap` now gives child threads a fresh empty map instead of exposing parent thread map state.

Regression coverage was added for converter configuration scoping, datastore deferred-close cleanup, `SoftThreadLocalMap` child-thread isolation, and encoder chaining on a virtual-thread execution path.

## Why this matters

Spring Boot 4.1 makes virtual-thread-backed execution easy to enable for Java 21+ applications. Once applications opt in, Grails framework code can run on many more short-lived execution contexts than it would with a small platform-thread pool.

That changes the cost and risk profile of `ThreadLocal` usage:

- Empty holder objects still count as per-thread retained state.
- Leaving cleared state attached to a thread makes cleanup less explicit and harder to reason about.
- Inheritable thread-local state can accidentally leak parent execution context into child work.
- These patterns are more visible when async work, scheduled work, and request-adjacent framework code run through virtual-thread-backed executors.

This PR does not try to rewrite Grails context propagation. It narrows a few known cleanup and inheritance points so the existing semantics are safer when virtual threads are enabled.

## How this works

### Converter configuration cleanup

Before this PR, `ConvertersConfigurationHolder` initialized every thread with an empty converter configuration map as soon as the thread-local value was read. Clearing a scoped converter configuration also left the map attached to the thread.

This PR changes that behavior so Grails:

1. Reads the thread-local converter map without allocating one for default lookups.
2. Allocates the map only when a scoped converter configuration is actually set.
3. Removes the converter entry when a scoped config is cleared.
4. Calls `ThreadLocal.remove()` when the map becomes empty.

The public converter behavior remains the same: configured scoped values are honored while present, and callers fall back to the default converter configuration after scoped state is cleared.

### Datastore deferred-close cleanup

`DatastoreUtils.processDeferredClose` already removed datastore entries from the deferred-close holder map. When the map became empty, it previously wrote `null` back into the `ThreadLocal`.

This PR changes that final cleanup to `ThreadLocal.remove()`. The public lifecycle stays the same: sessions are still disconnected during deferred close processing, and repeated processing still reports that deferred close is no longer active. The difference is that the thread no longer keeps a cleared holder slot around afterward.

### SoftThreadLocalMap child isolation

`SoftThreadLocalMap` extends `InheritableThreadLocal`. The default child behavior could expose parent map state to a child thread. This is a poor fit for virtual-thread-heavy execution, where child work should not accidentally inherit mutable framework state from the creating thread.

This PR overrides `childValue` so every child thread starts with a fresh empty map. Parent thread entries remain available to the parent, but they are no longer visible to the child.

## Spring Boot 4.1 integration

Spring Boot 4.1 enables virtual-thread support on Java 21+ with:

```properties
spring.threads.virtual.enabled=true
```

When that property is enabled, Boot's auto-configured task execution and scheduling infrastructure can use virtual-thread-backed components, including `SimpleAsyncTaskExecutor` for application task execution and `SimpleAsyncTaskScheduler` for scheduling. Pool-size properties are not the tuning mechanism for those virtual-thread-backed components in the same way they are for platform-thread pools.

For Grails applications, that means framework code can be reached through virtual-thread-backed Boot execution paths without the application changing Grails APIs. This PR aligns the affected Grails internals with that model by making cleared thread-local state disappear and by avoiding inherited parent map state in child threads.

## Backwards compatibility

This PR is intended to be backwards compatible for supported Grails usage.

- No public API signatures change.
- Converter configuration lookup and `JSON.use` scoped behavior continue to restore the previous/default configuration after the scope exits.
- Datastore deferred-close lifecycle behavior remains the same for callers.
- Encoder production behavior is unchanged; the PR adds virtual-thread coverage without removing the existing cache.
- Existing platform-thread applications continue to use the same public behavior, with cleaner cleanup after scoped state is cleared.

The only intentional semantic tightening is `SoftThreadLocalMap` child-thread isolation. Code that depended on child threads observing parent map entries was depending on inheritable mutable thread-local state. That behavior is unsafe for the virtual-thread model and is not something Grails should preserve as framework context propagation.

## Benefit when running virtual threads

For applications that set `spring.threads.virtual.enabled=true`, this PR helps Grails behave more predictably in virtual-thread-backed execution by:

- Avoiding per-thread converter maps for default converter lookups.
- Removing converter and datastore thread-local holders when scoped state is fully cleared.
- Preventing parent thread map entries from appearing in child threads.
- Reducing retained empty framework state across large numbers of short-lived threads.
- Keeping existing public behavior intact while making cleanup explicit.

This is a targeted readiness step, not a broad virtual-thread migration. It keeps the change set small and measurable while addressing concrete thread-local cleanup points.

## Validation

Focused verification:

- `./gradlew :grails-converters:test --tests org.grails.web.converters.configuration.ConvertersConfigurationHolderSpec :grails-datastore-core:test --tests org.grails.datastore.mapping.core.DatastoreUtilsSpec :grails-encoder:test --tests org.grails.encoder.ChainedEncodersSpec`

Full repository gate:

- `./gradlew clean aggregateViolations :grails-test-report:check --continue`

Results:

- Combined report: 13,623 tests, 0 failures, 0 errors, 267 skipped.
- Unit report: 10,729 tests, 0 failures, 0 errors, 258 skipped.
- Integration and functional report: 2,894 tests, 0 failures, 0 errors, 9 skipped.
- Checkstyle: no violations found.
- CodeNarc: no violations found.
- PMD: no violations found.
- SpotBugs: no violations found.
- Review gate: Oracle GREEN; Codex GREEN for source changes, with only untracked local artifact noise outside the shipping diff.