### PR TITLE
Ensure that the GlobalGrailsClassInjectorTransformation fails in the grails-core build if the wrong directory is passed

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
@@ -110,7 +110,9 @@ class CompilePlugin implements Plugin<Project> {
                 // encoding needs to be the same since it's different across platforms
                 it.options.encoding = StandardCharsets.UTF_8.name()
                 it.options.fork = true
-                it.options.forkOptions.jvmArgs = ['-Xms128M', '-Xmx2G']
+                // always set an isolated build to ensure grails.factories aren't accidentally merged since every project
+                // in this mono repo should be an isolated projected
+                it.options.forkOptions.jvmArgs = ['-Xms128M', '-Xmx2G', '-Dgrails.isolated.build=true']
                 if (System.getenv('SUPPRESS_DEPRECATION_WARNINGS') == 'true') {
                     it.options.compilerArgs += ['-Xlint:-removal']
                 }

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -187,7 +187,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
      * @return {@code true} when the {@code grails.isolated.build} system property is {@code true}.
      */
     static boolean isIsolatedBuild() {
-        return Boolean.parseBoolean(System.getProperty(ISOLATED_BUILD_PROPERTY))
+        System.getProperty(ISOLATED_BUILD_PROPERTY, 'false').toBoolean()
     }
 
     static File resolveCompilationTargetDirectory(SourceUnit source) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -191,7 +191,7 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
     }
 
     static File resolveCompilationTargetDirectory(SourceUnit source) {
-        resolveCompilationTargetDirectory(source, isIsolatedBuild())
+        resolveCompilationTargetDirectory(source, isolatedBuild)
     }
 
     static File resolveCompilationTargetDirectory(SourceUnit source, boolean isolatedBuild) {

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -208,9 +208,9 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             // grails-plugin.xml can leak into another. In an isolated build, fail loudly instead.
             if (isolatedBuild) {
                 throw new IllegalStateException(
-                        "Unable to resolve the compilation target directory for '${source?.name}' while " +
-                        'GRAILS_ISOLATED_BUILD=true. Refusing to fall back to the shared relative ' +
-                        "'build/classes/main' path, which would leak generated metadata between modules. " +
+                        "Unable to resolve the compilation target directory for '${source?.name}' while the " +
+                        "'${ISOLATED_BUILD_PROPERTY}' system property is set. Refusing to fall back to the shared " +
+                        "relative 'build/classes/main' path, which would leak generated metadata between modules. " +
                         'Ensure the Groovy compiler supplies CompilerConfiguration.targetDirectory.')
             }
             targetDirectory = new File('build/classes/main')

--- a/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
+++ b/grails-core/src/main/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformation.groovy
@@ -176,7 +176,25 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
         generatePluginXml(pluginClassNode, pluginVersion, transformedClasses, pluginXmlFile)
     }
 
+    /**
+     * The system property signalling that each project compiles into its own isolated output
+     * directory. When set, the transform must never fall back to a shared/guessed location, which can
+     * leak one module's generated metadata into another.
+     */
+    public static final String ISOLATED_BUILD_PROPERTY = 'grails.isolated.build'
+
+    /**
+     * @return {@code true} when the {@code grails.isolated.build} system property is {@code true}.
+     */
+    static boolean isIsolatedBuild() {
+        return Boolean.parseBoolean(System.getProperty(ISOLATED_BUILD_PROPERTY))
+    }
+
     static File resolveCompilationTargetDirectory(SourceUnit source) {
+        resolveCompilationTargetDirectory(source, isIsolatedBuild())
+    }
+
+    static File resolveCompilationTargetDirectory(SourceUnit source, boolean isolatedBuild) {
         File targetDirectory = null
         if (source.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit') {
             targetDirectory = GroovyEclipseCompilationHelper.resolveEclipseCompilationTargetDirectory(source)
@@ -184,6 +202,17 @@ class GlobalGrailsClassInjectorTransformation implements ASTTransformation, Comp
             targetDirectory = source.configuration.targetDirectory
         }
         if (targetDirectory == null) {
+            // The relative fallback is resolved against the compiler's working directory, which is shared
+            // across every module of a multi-project build (e.g. the reused Gradle compiler worker). That
+            // makes it a single path for all modules, so one module's generated grails.factories /
+            // grails-plugin.xml can leak into another. In an isolated build, fail loudly instead.
+            if (isolatedBuild) {
+                throw new IllegalStateException(
+                        "Unable to resolve the compilation target directory for '${source?.name}' while " +
+                        'GRAILS_ISOLATED_BUILD=true. Refusing to fall back to the shared relative ' +
+                        "'build/classes/main' path, which would leak generated metadata between modules. " +
+                        'Ensure the Groovy compiler supplies CompilerConfiguration.targetDirectory.')
+            }
             targetDirectory = new File('build/classes/main')
         }
         return targetDirectory

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
@@ -24,6 +24,7 @@ import org.codehaus.groovy.ast.ClassNode
 import org.codehaus.groovy.classgen.GeneratorContext
 import org.codehaus.groovy.control.CompilationFailedException
 import org.codehaus.groovy.control.CompilationUnit
+import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
 import org.codehaus.groovy.control.SourceUnit
 import spock.lang.Specification
@@ -121,5 +122,105 @@ class FooGrailsPlugin {
             xml.type.text() == "BarGrailsPlugin"
             xml.resources.resource.size() == 2
             xml.resources.resource.text() == "FooBar"
+    }
+
+    void "isIsolatedBuild reflects the grails.isolated.build system property"() {
+        given:
+            String original = System.getProperty('grails.isolated.build')
+
+        when:
+            System.setProperty('grails.isolated.build', value)
+
+        then:
+            GlobalGrailsClassInjectorTransformation.isIsolatedBuild() == expected
+
+        cleanup:
+            if (original != null) {
+                System.setProperty('grails.isolated.build', original)
+            } else {
+                System.clearProperty('grails.isolated.build')
+            }
+
+        where:
+            value   || expected
+            'true'  || true
+            'false' || false
+            'TRUE'  || true
+            'yes'   || false
+    }
+
+    private SourceUnit sourceUnitWithTarget(File targetDirectory) {
+        def configuration = new CompilerConfiguration()
+        configuration.setTargetDirectory((File) targetDirectory)
+        Stub(SourceUnit) {
+            getConfiguration() >> configuration
+            getName() >> 'TestSource'
+        }
+    }
+
+    void "resolveCompilationTargetDirectory returns the configured target directory"() {
+        given:
+            File target = new File(System.getProperty('java.io.tmpdir'), 'isolated-target/build/classes/groovy/main')
+            def source = sourceUnitWithTarget(target)
+
+        expect: "the configured directory is used regardless of build isolation"
+            GlobalGrailsClassInjectorTransformation.resolveCompilationTargetDirectory(source, false) == target
+            GlobalGrailsClassInjectorTransformation.resolveCompilationTargetDirectory(source, true) == target
+    }
+
+    void "resolveCompilationTargetDirectory falls back to the shared relative path for a non-isolated build"() {
+        given: "a source unit without a configured target directory"
+            def source = sourceUnitWithTarget(null)
+
+        when:
+            File resolved = GlobalGrailsClassInjectorTransformation.resolveCompilationTargetDirectory(source, false)
+
+        then: "the legacy relative fallback is used"
+            resolved == new File('build/classes/main')
+    }
+
+    void "resolveCompilationTargetDirectory fails fast instead of falling back for an isolated build"() {
+        given: "a source unit without a configured target directory"
+            def source = sourceUnitWithTarget(null)
+
+        when: "the target directory cannot be resolved in an isolated build"
+            GlobalGrailsClassInjectorTransformation.resolveCompilationTargetDirectory(source, true)
+
+        then: "the build fails loudly rather than writing to a shared location"
+            IllegalStateException e = thrown()
+            e.message.contains('GRAILS_ISOLATED_BUILD=true')
+    }
+
+    void "findSourceDirectory prefers the per-project base.dir system property when set"() {
+        given: "base.dir points at an existing directory"
+            File baseDir = File.createTempDir()
+            System.setProperty('base.dir', baseDir.absolutePath)
+            File target = new File(baseDir, 'build/classes/groovy/main')
+
+        when:
+            File resolved = GlobalGrailsClassInjectorTransformation.findSourceDirectory(target)
+
+        then: "the build-tool supplied base.dir wins"
+            resolved == baseDir
+
+        cleanup:
+            System.clearProperty('base.dir')
+            baseDir.deleteDir()
+    }
+
+    void "findSourceDirectory walks up to the project directory when base.dir is not set"() {
+        given: "no base.dir and a standard per-project compile target"
+            System.clearProperty('base.dir')
+            File projectDir = File.createTempDir()
+            File target = new File(projectDir, 'build/classes/groovy/main')
+
+        when:
+            File resolved = GlobalGrailsClassInjectorTransformation.findSourceDirectory(target)
+
+        then: "it resolves to the parent of the build directory"
+            resolved == projectDir
+
+        cleanup:
+            projectDir.deleteDir()
     }
 }

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
@@ -124,29 +124,25 @@ class FooGrailsPlugin {
             xml.resources.resource.text() == "FooBar"
     }
 
+    @RestoreSystemProperties
     void "isIsolatedBuild reflects the grails.isolated.build system property"() {
-        given:
-            String original = System.getProperty('grails.isolated.build')
-
         when:
             System.setProperty('grails.isolated.build', value)
 
         then:
             GlobalGrailsClassInjectorTransformation.isIsolatedBuild() == expected
 
-        cleanup:
-            if (original != null) {
-                System.setProperty('grails.isolated.build', original)
-            } else {
-                System.clearProperty('grails.isolated.build')
-            }
-
         where:
             value   || expected
             'true'  || true
             'false' || false
             'TRUE'  || true
-            'yes'   || false
+            'y'     || true
+            'null'  || false
+            '1'     || true
+            '0'     || false
+            '-1'    || false
+            ''      || false
     }
 
     private SourceUnit sourceUnitWithTarget(File targetDirectory) {

--- a/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/compiler/injection/GlobalGrailsClassInjectorTransformationSpec.groovy
@@ -28,6 +28,7 @@ import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.control.Phases
 import org.codehaus.groovy.control.SourceUnit
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
 
 /**
  * Created by graemerocher on 19/09/14.
@@ -184,9 +185,10 @@ class FooGrailsPlugin {
 
         then: "the build fails loudly rather than writing to a shared location"
             IllegalStateException e = thrown()
-            e.message.contains('GRAILS_ISOLATED_BUILD=true')
+            e.message.contains(GlobalGrailsClassInjectorTransformation.ISOLATED_BUILD_PROPERTY)
     }
 
+    @RestoreSystemProperties
     void "findSourceDirectory prefers the per-project base.dir system property when set"() {
         given: "base.dir points at an existing directory"
             File baseDir = File.createTempDir()
@@ -200,10 +202,10 @@ class FooGrailsPlugin {
             resolved == baseDir
 
         cleanup:
-            System.clearProperty('base.dir')
             baseDir.deleteDir()
     }
 
+    @RestoreSystemProperties
     void "findSourceDirectory walks up to the project directory when base.dir is not set"() {
         given: "no base.dir and a standard per-project compile target"
             System.clearProperty('base.dir')


### PR DESCRIPTION
After trying to build the 8.0.x build, it was not reproducible because the grails.factories file in grails-core was merged with grails-core & grails-gsp projects somehow.  The only way I can see this happening is if there is an incorrect base directory or a missing directory.  This change is meant to be a "catch all" to find these cases.  The goal is to merge this and then retry the 8.0.0-M2 build and see if this helps.