### PR TITLE
Publish Grails skills through SkillsJars

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements; and to You under the Apache License, Version 2.0.
+-->
+
+# Grails Agent Skills
+
+The canonical Grails agent skills live in this directory.
+
+The repository root `skills` path is intentionally a symbolic link to this directory so [SkillsJars](https://www.skillsjars.com/) can discover the skills without maintaining duplicate files. SkillsJars deploys from public GitHub repositories by scanning `skills/**/SKILL.md` and then publishes one Maven Central artifact per skill under `com.skillsjars`.
+
+Run this check before publishing or updating a skill:
+
+```bash
+./gradlew verifySkillsJarsSources
+```
+
+After changes are merged to the public branch, publish them from SkillsJars by submitting:
+
+| Field | Value |
+|-------|-------|
+| GitHub Org | `apache` |
+| GitHub Repo | `grails-core` |
+
+Expected coordinates use the `apache__grails-core__<skill-name>` artifact pattern, for example `com.skillsjars:apache__grails-core__grails-developer:<date>-<commit>`.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -6,9 +6,16 @@ Licensed to the Apache Software Foundation (ASF) under one or more contributor l
 
 # Grails Agent Skills
 
-The canonical Grails agent skills live in this directory.
+The canonical Grails agent skills live in this directory. Skills that are only useful while working in the Grails framework repository stay here and are not published through SkillsJars.
 
-The repository root `skills` path is intentionally a symbolic link to this directory so [SkillsJars](https://www.skillsjars.com/) can discover the skills without maintaining duplicate files. SkillsJars deploys from public GitHub repositories by scanning `skills/**/SKILL.md` and then publishes one Maven Central artifact per skill under `com.skillsjars`.
+The repository root `skills/` directory contains normal skill directories for app-facing skills that are useful when building or upgrading end-user Grails applications. Each published directory contains only a `SKILL.md` symbolic link back to the canonical source in `.agents/skills`, so [SkillsJars](https://www.skillsjars.com/) can discover and package the skills without duplicating content. SkillsJars deploys from public GitHub repositories by scanning `skills/**/SKILL.md` and then publishes one Maven Central artifact per discovered skill under `com.skillsjars`.
+
+| Published skill | Source skill | Use |
+|-----------------|--------------|-----|
+| `grails-developer` | `.agents/skills/grails-developer` | Building current Grails web applications, REST APIs, GORM models, controllers, services, views, plugins, and tests |
+| `grails-8-upgrade` | `.agents/skills/grails-8-upgrade` | Upgrading Grails applications from Grails 7.x to Grails 8 |
+
+The repository-specific `hibernate-developer`, `test-fixer`, and `violation-fixer` skills are intentionally not linked from `skills/` because they are for Grails framework development. Contributors already receive them from this repository when working on Grails core.
 
 Run this check before publishing or updating a skill:
 

--- a/build.gradle
+++ b/build.gradle
@@ -119,6 +119,48 @@ tasks.register('publishAllToMavenLocal') {
     }
 }
 
+tasks.register('verifySkillsJarsSources') {
+    description = 'Verifies the SkillsJars publication path points at the agent-local skill sources.'
+    group = 'verification'
+
+    def agentSkillsDir = layout.projectDirectory.dir('.agents/skills')
+    def skillsJarsLink = layout.projectDirectory.file('skills')
+
+    inputs.dir(agentSkillsDir)
+    inputs.files(skillsJarsLink)
+
+    doLast {
+        def expectedTarget = '.agents/skills'
+        def skillsPath = skillsJarsLink.asFile.toPath()
+        def actualTarget = null
+
+        if (java.nio.file.Files.isSymbolicLink(skillsPath)) {
+            actualTarget = java.nio.file.Files.readSymbolicLink(skillsPath).toString().replace('\\', '/')
+        }
+        else if (skillsJarsLink.asFile.isFile()) {
+            actualTarget = skillsJarsLink.asFile.getText('UTF-8').trim().replace('\\', '/')
+        }
+
+        if (actualTarget != expectedTarget) {
+            throw new GradleException("The SkillsJars publication path must be a symlink to ${expectedTarget}, but found ${actualTarget ?: 'no link target'}.")
+        }
+
+        def gitMode = providers.exec {
+            commandLine 'git', 'ls-files', '-s', 'skills'
+        }.standardOutput.asText.get().trim().split(' ')[0]
+        if (gitMode != '120000') {
+            throw new GradleException("The SkillsJars publication path must be committed as a symlink with git mode 120000, but found mode ${gitMode ?: 'none'}.")
+        }
+
+        def skillMarkers = fileTree(agentSkillsDir).matching {
+            include '**/SKILL.md'
+        }.files
+        if (skillMarkers.empty) {
+            throw new GradleException("No SkillsJars skill marker files found under ${expectedTarget}.")
+        }
+    }
+}
+
 apply {
     from layout.projectDirectory.file('gradle/publish-root-config.gradle')
     from layout.projectDirectory.file('gradle/rat-root-config.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -120,43 +120,63 @@ tasks.register('publishAllToMavenLocal') {
 }
 
 tasks.register('verifySkillsJarsSources') {
-    description = 'Verifies the SkillsJars publication path points at the agent-local skill sources.'
+    description = 'Verifies the SkillsJars publication paths point at the app-facing Grails skill sources.'
     group = 'verification'
 
-    def agentSkillsDir = layout.projectDirectory.dir('.agents/skills')
-    def skillsJarsLink = layout.projectDirectory.file('skills')
+    def skillsJarsDir = layout.projectDirectory.dir('skills')
+    def publishedSkills = [
+            'grails-8-upgrade': '../../.agents/skills/grails-8-upgrade/SKILL.md',
+            'grails-developer': '../../.agents/skills/grails-developer/SKILL.md',
+    ]
 
-    inputs.dir(agentSkillsDir)
-    inputs.files(skillsJarsLink)
+    inputs.dir(layout.projectDirectory.dir('.agents/skills'))
+    inputs.dir(skillsJarsDir)
 
     doLast {
-        def expectedTarget = '.agents/skills'
-        def skillsPath = skillsJarsLink.asFile.toPath()
-        def actualTarget = null
-
-        if (java.nio.file.Files.isSymbolicLink(skillsPath)) {
-            actualTarget = java.nio.file.Files.readSymbolicLink(skillsPath).toString().replace('\\', '/')
-        }
-        else if (skillsJarsLink.asFile.isFile()) {
-            actualTarget = skillsJarsLink.asFile.getText('UTF-8').trim().replace('\\', '/')
+        if (!skillsJarsDir.asFile.directory) {
+            throw new GradleException('The SkillsJars publication path must be a skills directory containing app-facing skill symlinks.')
         }
 
-        if (actualTarget != expectedTarget) {
-            throw new GradleException("The SkillsJars publication path must be a symlink to ${expectedTarget}, but found ${actualTarget ?: 'no link target'}.")
+        def actualSkillNames = skillsJarsDir.asFile.listFiles().findAll { File file -> file.directory }.collect { File file -> file.name } as Set
+        def expectedSkillNames = publishedSkills.keySet() as Set
+        def missingSkillNames = expectedSkillNames - actualSkillNames
+        def extraSkillNames = actualSkillNames - expectedSkillNames
+        if (missingSkillNames || extraSkillNames) {
+            throw new GradleException("SkillsJars must publish exactly ${expectedSkillNames}, but missing ${missingSkillNames} and found extra ${extraSkillNames}.")
         }
 
-        def gitMode = providers.exec {
-            commandLine 'git', 'ls-files', '-s', 'skills'
-        }.standardOutput.asText.get().trim().split(' ')[0]
-        if (gitMode != '120000') {
-            throw new GradleException("The SkillsJars publication path must be committed as a symlink with git mode 120000, but found mode ${gitMode ?: 'none'}.")
-        }
+        publishedSkills.each { String skillName, String expectedSkillTarget ->
+            def skillDir = skillsJarsDir.dir(skillName).asFile
+            if (!skillDir.directory) {
+                throw new GradleException("The SkillsJars skill ${skillName} must be a directory containing SKILL.md.")
+            }
 
-        def skillMarkers = fileTree(agentSkillsDir).matching {
-            include '**/SKILL.md'
-        }.files
-        if (skillMarkers.empty) {
-            throw new GradleException("No SkillsJars skill marker files found under ${expectedTarget}.")
+            def skillLink = skillsJarsDir.file("${skillName}/SKILL.md").asFile
+            def skillPath = skillLink.toPath()
+            def actualTarget = null
+
+            if (java.nio.file.Files.isSymbolicLink(skillPath)) {
+                actualTarget = java.nio.file.Files.readSymbolicLink(skillPath).toString().replace('\\', '/')
+            }
+            else if (skillLink.isFile()) {
+                actualTarget = skillLink.getText('UTF-8').trim().replace('\\', '/')
+            }
+
+            if (actualTarget != expectedSkillTarget) {
+                throw new GradleException("The SkillsJars skill ${skillName} marker must be a symlink to ${expectedSkillTarget}, but found ${actualTarget ?: 'no link target'}.")
+            }
+
+            def gitMode = providers.exec {
+                commandLine 'git', 'ls-files', '-s', "skills/${skillName}/SKILL.md"
+            }.standardOutput.asText.get().trim().split(' ')[0]
+            if (gitMode != '120000') {
+                throw new GradleException("The SkillsJars skill ${skillName} marker must be committed as a symlink with git mode 120000, but found mode ${gitMode ?: 'none'}.")
+            }
+
+            def sourceSkillFile = layout.projectDirectory.file(expectedSkillTarget.substring(6))
+            if (!sourceSkillFile.asFile.file) {
+                throw new GradleException("The SkillsJars skill ${skillName} target ${expectedSkillTarget} does not exist.")
+            }
         }
     }
 }

--- a/gradle/rat-root-config.gradle
+++ b/gradle/rat-root-config.gradle
@@ -26,6 +26,7 @@ tasks.named('rat') {
             'CHECKSUMS', // build artifact for storing checksums for easy verification
             'PUBLISHED_ARTIFACTS', // build artifact for storing published artifacts coordinates & paths
             'licenses/**', // licenses directory excluded
+            'skills', // SkillsJars discovery symlink; licensed skill sources live under .agents/skills
             '.git-blame-ignore-revs', // git configuration isn't code
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java',
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONArray.java',

--- a/gradle/rat-root-config.gradle
+++ b/gradle/rat-root-config.gradle
@@ -26,7 +26,8 @@ tasks.named('rat') {
             'CHECKSUMS', // build artifact for storing checksums for easy verification
             'PUBLISHED_ARTIFACTS', // build artifact for storing published artifacts coordinates & paths
             'licenses/**', // licenses directory excluded
-            'skills', // SkillsJars discovery symlink; licensed skill sources live under .agents/skills
+            'skills/**', // SkillsJars discovery symlinks; licensed skill sources live under .agents/skills
+            '.claude/skills/**', // Claude skill aliases; licensed skill sources live under .agents/skills
             '.git-blame-ignore-revs', // git configuration isn't code
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONObject.java',
             'grails-web-common/src/main/groovy/org/grails/web/json/JSONArray.java',

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+.agents/skills

--- a/skills
+++ b/skills
@@ -1,1 +1,0 @@
-.agents/skills

--- a/skills/grails-8-upgrade/SKILL.md
+++ b/skills/grails-8-upgrade/SKILL.md
@@ -1,0 +1,1 @@
+../../.agents/skills/grails-8-upgrade/SKILL.md

--- a/skills/grails-developer/SKILL.md
+++ b/skills/grails-developer/SKILL.md
@@ -1,0 +1,1 @@
+../../.agents/skills/grails-developer/SKILL.md


### PR DESCRIPTION
## The Problem

[SkillsJars](https://skillsjars.com) discovers and publishes agent skills from a root-level `skills/**/SKILL.md` layout. Grails keeps its canonical skill sources under `.agents/skills`, which SkillsJars does not scan by default - and that directory also contains **framework-contributor-only** skills that should not be published to application developers.

## The Fix

Expose only the app-facing Grails skills through the SkillsJars discovery path, without duplicating any content, while keeping contributor skills internal.

**Published** via root-level `skills/` (real directories whose `SKILL.md` is a symlink to the canonical source):

- `skills/grails-developer/SKILL.md` -> `.agents/skills/grails-developer/SKILL.md`
- `skills/grails-8-upgrade/SKILL.md` -> `.agents/skills/grails-8-upgrade/SKILL.md`

**Kept internal** under `.agents/skills` only: `hibernate-developer`, `test-fixer`, `violation-fixer`, and other core-contributor workflow skills.

The change also:

- uses real skill directories with `SKILL.md` symlinks so SkillsJars discovers normal skill folders;
- adds a **`verifySkillsJarsSources`** Gradle task asserting the exact published skill set, symlink targets, git mode `120000`, and canonical source markers;
- excludes only the symlink alias paths from RAT (the licensed sources remain under `.agents/skills`);
- documents the canonical location, the public discovery aliases, and the publish workflow.

## How to publish after merge

Submit the SkillsJars form with GitHub Org `apache` and Repo `grails-core`. SkillsJars shallow-clones the public repo, scans `skills/**/SKILL.md`, and publishes Maven Central artifacts under `com.skillsjars`:

- `com.skillsjars:apache__grails-core__grails-developer:<date>-<commit>`
- `com.skillsjars:apache__grails-core__grails-8-upgrade:<date>-<commit>`

## Testing

- `./gradlew verifySkillsJarsSources` passes; `git diff --cached --check` clean.
- `./gradlew rat` no longer reports the `skills/**` or tracked `.claude/skills/**` symlink aliases.

Refs #15454
