### PR TITLE
Clarify exception resolver request logging metadata

### DIFF
--- a/grails-web-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/grails-web-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -109,8 +109,7 @@
         {
             "name": "grails.exceptionresolver.logRequestParameters",
             "type": "java.lang.Boolean",
-            "description": "Whether to log request parameters in exception stack traces.",
-            "defaultValue": true
+            "description": "Whether to log request parameters in exception stack traces. Defaults to true in development and false otherwise."
         },
         {
             "name": "grails.exceptionresolver.params.exclude",


### PR DESCRIPTION
## The Problem

The runtime default for `grails.exceptionresolver.logRequestParameters` is **environment-dependent**: request-parameter logging is enabled in development and disabled everywhere else.

The Spring configuration metadata, however, advertised a single unconditional `defaultValue`. IDEs and config-metadata consumers that read that value would present a default that does not match what actually happens at runtime outside development.

## The Fix

Make the published metadata tell the truth instead of a misleading constant.

- **Removed** the unconditional metadata `defaultValue`.
- **Documented** the real environment-dependent behavior (enabled in development, disabled otherwise) directly in the property description.

## Files

- `grails-web-core/.../META-INF/spring-configuration-metadata.json` - drop the hard-coded default, describe the dev/non-dev behavior.

## Testing

- `:grails-web-core:processResources` succeeds and the emitted metadata for `grails.exceptionresolver.logRequestParameters` has no `defaultValue` and carries the environment-dependent description.
- LSP diagnostics clean for the metadata JSON.
