### PR TITLE
Avoid creating sessions during invalidate

### DIFF
--- a/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsHttpSession.java
+++ b/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsHttpSession.java
@@ -189,9 +189,13 @@ public class GrailsHttpSession implements HttpSession {
      */
     @Deprecated
     public void invalidate() {
-        createSessionIfNecessary();
         synchronized (this) {
-            adaptee.invalidate();
+            HttpSession session = adaptee;
+            if (session == null) session = request.getSession(false);
+            if (session != null) {
+                adaptee = session;
+                session.invalidate();
+            }
         }
     }
 

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsHttpSessionSpec.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsHttpSessionSpec.groovy
@@ -1,0 +1,67 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.web.servlet.mvc
+
+import org.springframework.mock.web.MockHttpServletRequest
+
+import spock.lang.Specification
+
+class GrailsHttpSessionSpec extends Specification {
+
+    void 'invalidate does not create a servlet session when none exists'() {
+        given:
+        def request = new MockHttpServletRequest()
+        def session = new GrailsHttpSession(request)
+
+        expect:
+        request.getSession(false) == null
+
+        when:
+        session.invalidate()
+
+        then:
+        request.getSession(false) == null
+    }
+
+    void 'invalidate invalidates an existing servlet session without prior wrapper access'() {
+        given:
+        def request = new MockHttpServletRequest()
+        def existingSession = request.getSession(true)
+        existingSession.setAttribute('name', 'value')
+        def session = new GrailsHttpSession(request)
+
+        when:
+        session.invalidate()
+
+        then:
+        request.getSession(false) == null
+
+        when:
+        existingSession.getAttribute('name')
+
+        then:
+        thrown(IllegalStateException)
+
+        when:
+        session.getAttribute('name')
+
+        then:
+        thrown(IllegalStateException)
+    }
+}


### PR DESCRIPTION
## Summary

- Avoid creating a servlet session when GrailsHttpSession.invalidate() is called without an existing session
- Preserve invalidated-wrapper semantics when an existing request session is invalidated before wrapper access
- Add GrailsHttpSessionSpec regression coverage

## Verification

- `.\\gradlew.bat --no-daemon --no-parallel --max-workers=1 :grails-web-common:test --tests "grails.web.servlet.mvc.GrailsHttpSessionSpec"`
- Review gate: Oracle GREEN and Codex GREEN for diff hash `81bc27b564a1b4dc3e0d900a1d56aaae6519941b`

## Notes

- Full aggregate gate was attempted sequentially but aborted after unrelated Gradle worker connection resets and a stale/corrupt XML report from an unrelated Hibernate module. The focused affected-module spec passed after clearing that stale artifact.
