### PR TITLE
Fix bootWar NPE from stray CLI WebApplicationInitializer (#15377)

### DIFF
--- a/grails-shell-cli/build.gradle
+++ b/grails-shell-cli/build.gradle
@@ -110,6 +110,11 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-simple'
     testImplementation 'org.spockframework:spock-core'
 
+    // Required to load SpringApplicationWebApplicationInitializer (extends SpringBootServletInitializer)
+    // in tests; these are compileOnly for the main source set.
+    testImplementation 'org.springframework.boot:spring-boot'
+    testImplementation 'org.springframework:spring-web'
+
     testRuntimeOnly 'net.bytebuddy:byte-buddy' // Required by Spock's mocking support
 
     // any project that should be included in the end distribution should be included here

--- a/grails-shell-cli/src/main/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializer.java
+++ b/grails-shell-cli/src/main/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializer.java
@@ -51,15 +51,28 @@ public class SpringApplicationWebApplicationInitializer extends SpringBootServle
         catch (IOException ex) {
             throw new IllegalStateException(ex);
         }
+        // This initializer only applies to CLI-packaged WARs produced by the Grails shell 'war'
+        // command, which records the application source classes in the WAR manifest via the
+        // 'Spring-Application-Source-Classes' entry. When that entry is absent (for example a
+        // standard 'bootWar' archive deployed to an external servlet container such as Tomcat),
+        // this initializer is not applicable and must stay inert so it does not interfere with
+        // the application's own SpringBootServletInitializer.
+        // See https://github.com/apache/grails-core/issues/15377
+        if (this.sources == null || this.sources.length == 0) {
+            return;
+        }
         super.onStartup(servletContext);
     }
 
     private String[] getSources(ServletContext servletContext) throws IOException {
         Manifest manifest = getManifest(servletContext);
         if (manifest == null) {
-            throw new IllegalStateException("Unable to read manifest");
+            return null;
         }
         String sources = manifest.getMainAttributes().getValue(SOURCE_ENTRY);
+        if (sources == null || sources.isBlank()) {
+            return null;
+        }
         return sources.split(",");
     }
 

--- a/grails-shell-cli/src/test/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializerSpec.groovy
+++ b/grails-shell-cli/src/test/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializerSpec.groovy
@@ -43,12 +43,16 @@ class SpringApplicationWebApplicationInitializerSpec extends Specification {
         then: 'the application boot is not disturbed and no NPE is raised'
         noExceptionThrown()
 
-        where: 'the manifest is missing or lacks the source-classes entry'
+        where: 'the manifest is missing, lacks the entry, or has a blank/whitespace-only entry'
         manifestStream << [
                 null,
                 new ByteArrayInputStream('Manifest-Version: 1.0\r\n\r\n'.getBytes('UTF-8')),
                 new ByteArrayInputStream(
-                        'Manifest-Version: 1.0\r\nImplementation-Title: my-app\r\n\r\n'.getBytes('UTF-8'))
+                        'Manifest-Version: 1.0\r\nImplementation-Title: my-app\r\n\r\n'.getBytes('UTF-8')),
+                new ByteArrayInputStream(
+                        'Manifest-Version: 1.0\r\nSpring-Application-Source-Classes: \r\n\r\n'.getBytes('UTF-8')),
+                new ByteArrayInputStream(
+                        'Manifest-Version: 1.0\r\nSpring-Application-Source-Classes:    \r\n\r\n'.getBytes('UTF-8'))
         ]
     }
 }

--- a/grails-shell-cli/src/test/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializerSpec.groovy
+++ b/grails-shell-cli/src/test/groovy/org/grails/cli/boot/SpringApplicationWebApplicationInitializerSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.cli.boot
+
+import jakarta.servlet.ServletContext
+import spock.lang.Specification
+
+/**
+ * Verifies that {@link SpringApplicationWebApplicationInitializer} stays inert when it is
+ * discovered on the classpath of a standard {@code bootWar} deployed to an external servlet
+ * container, i.e. when the {@code Spring-Application-Source-Classes} manifest entry is absent.
+ *
+ * Regression test for <a href="https://github.com/apache/grails-core/issues/15377">#15377</a>.
+ */
+class SpringApplicationWebApplicationInitializerSpec extends Specification {
+
+    void "onStartup is inert when the source-classes manifest entry is absent"() {
+        given: 'an initializer discovered in a non CLI-packaged WAR'
+        def initializer = new SpringApplicationWebApplicationInitializer()
+        ServletContext servletContext = Mock(ServletContext) {
+            getResourceAsStream('/META-INF/MANIFEST.MF') >> manifestStream
+        }
+
+        when: 'the servlet container invokes onStartup'
+        initializer.onStartup(servletContext)
+
+        then: 'the application boot is not disturbed and no NPE is raised'
+        noExceptionThrown()
+
+        where: 'the manifest is missing or lacks the source-classes entry'
+        manifestStream << [
+                null,
+                new ByteArrayInputStream('Manifest-Version: 1.0\r\n\r\n'.getBytes('UTF-8')),
+                new ByteArrayInputStream(
+                        'Manifest-Version: 1.0\r\nImplementation-Title: my-app\r\n\r\n'.getBytes('UTF-8'))
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the `Cannot invoke "String.split(String)" because "sources" is null` NPE that crashes a classic servlet-container (Tomcat) WAR deployment of a Grails 8 application using the Database Migration plugin.

## Root cause

Both Database Migration plugins - `grails-data-hibernate5-dbmigration` and `grails-data-hibernate7-dbmigration` - depend on `grails-shell-cli` at `implementation` scope. That places `org.grails.cli.boot.SpringApplicationWebApplicationInitializer` on the classpath of a normal application WAR.

That class is a `SpringBootServletInitializer` (a `WebApplicationInitializer`) intended **only** for CLI-packaged WARs produced by the shell `war` command (`WarCommand`), which records the application source classes in the WAR manifest via the `Spring-Application-Source-Classes` entry.

When a standard `bootWar` is deployed to an external servlet container such as Tomcat, Spring's `SpringServletContainerInitializer` discovers the stray initializer and invokes `onStartup`. A normal WAR manifest has no `Spring-Application-Source-Classes` entry, so `sources` was `null` and `sources.split(",")` threw an NPE, crashing context startup. The application's own `SpringBootServletInitializer` never got a chance to bootstrap.

## Fix

Make the initializer **inert** when the manifest source-classes entry is absent: `onStartup` now returns before `super.onStartup(...)` instead of throwing, so a standard WAR is unaffected and the application's own initializer bootstraps it normally. The CLI-packaged WAR path is unchanged because that manifest entry is always present there.

This single fix in the shared `grails-shell-cli` module resolves the issue for **both** dbmigration plugins, and - importantly - requires **no changes in consuming applications** (avoiding the `developmentOnly` / feature-variant / separate-artifact options that would each require app-side build changes).

## Changes

- `SpringApplicationWebApplicationInitializer.java`: early-return when there are no source classes; `getManifest` returning `null` and a blank/absent entry now yield `null` (inert) instead of throwing.
- `SpringApplicationWebApplicationInitializerSpec.groovy` (new): regression test covering a missing manifest, a manifest without the entry, and a manifest with an unrelated entry - all must not throw.
- `grails-shell-cli/build.gradle`: `testImplementation` for `spring-boot` + `spring-web` (needed to load the class under test; they are `compileOnly` in the main source set).

## Verification

- `./gradlew :grails-shell-cli:test --tests "org.grails.cli.boot.SpringApplicationWebApplicationInitializerSpec"` - BUILD SUCCESSFUL, all cases pass.
- `./gradlew clean aggregateViolations` - Checkstyle, CodeNarc, PMD, and SpotBugs all report no violations.

Fixes #15377
