### PR TITLE
feat(grails-data-neo4j): wire Neo4j adapter to GormRegistry's GormApiFactory mechanism (PR3)

### DIFF
--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jDatastore.java
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jDatastore.java
@@ -434,6 +434,10 @@ public class Neo4jDatastore extends AbstractDatastore implements Closeable, Stat
     protected GormEnhancer initialize(Neo4jConnectionSourceSettings settings) {
         registerEventListeners(this.eventPublisher);
 
+        // Must run before the GormEnhancer constructor (below) registers this datastore's entities,
+        // otherwise GormRegistry falls back to the generic DefaultGormApiFactory for them.
+        org.grails.datastore.gorm.GormRegistry.getInstance().registerApiFactory(Neo4jDatastore.class, new Neo4jGormApiFactory());
+
         this.mappingContext.addMappingContextListener(new MappingContext.Listener() {
             @Override
             public void persistentEntityAdded(PersistentEntity entity) {

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jGormApiFactory.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/main/groovy/org/grails/datastore/gorm/neo4j/Neo4jGormApiFactory.groovy
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.neo4j
+
+import groovy.transform.CompileStatic
+
+import org.grails.datastore.gorm.DatastoreResolver
+import org.grails.datastore.gorm.DefaultGormApiFactory
+import org.grails.datastore.gorm.GormRegistry
+import org.grails.datastore.gorm.finders.FinderMethod
+import org.grails.datastore.gorm.neo4j.api.Neo4jGormStaticApi
+import org.grails.datastore.mapping.model.MappingContext
+
+/**
+ * Neo4j-specific {@link org.grails.datastore.gorm.GormApiFactory} that creates a
+ * {@link Neo4jGormStaticApi} instead of the generic {@code GormStaticApi}. Without it the
+ * {@link GormRegistry} falls back to the {@link DefaultGormApiFactory}, whose generic
+ * {@code GormStaticApi} breaks casts like {@code (Neo4jGormStaticApi) GormEnhancer.findStaticApi(...)}
+ * used by {@code Neo4jEntity}/{@code Node} for {@code cypherStatic}, {@code findRelationship},
+ * {@code findPath}, etc. The instance and validation APIs reuse the generic GORM implementations
+ * inherited from {@link DefaultGormApiFactory}, matching {@code Neo4jDatastore}'s existing
+ * {@code GormEnhancer} overrides.
+ */
+@CompileStatic
+class Neo4jGormApiFactory extends DefaultGormApiFactory {
+
+    @Override
+    <D> Neo4jGormStaticApi<D> createStaticApi(Class<D> persistentClass, MappingContext mappingContext, DatastoreResolver resolver, String qualifier, GormRegistry registry) {
+        Neo4jDatastore neo4jDatastore = (Neo4jDatastore) resolver.resolve()
+        List<FinderMethod> finders = createDynamicFinders(resolver, mappingContext)
+        return new Neo4jGormStaticApi<D>(persistentClass, neo4jDatastore, finders, neo4jDatastore.getTransactionManager())
+    }
+}

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/CypherQueryStringSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/CypherQueryStringSpec.groovy
@@ -21,15 +21,12 @@ package grails.gorm.tests
 
 
 import org.apache.grails.data.neo4j.core.Neo4jGormDatastoreSpec
-import spock.lang.PendingFeature
 import org.neo4j.driver.Result
 
 /**
  * @author graemerocher
  */
 class CypherQueryStringSpec extends Neo4jGormDatastoreSpec {
-
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - static cypher/string-query calls resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test execute update method"() {
         given:
         setupDomain()
@@ -43,7 +40,6 @@ class CypherQueryStringSpec extends Neo4jGormDatastoreSpec {
         club.ground == "Alliance Arena"
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - static cypher/string-query calls resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test find method that accepts cypher"() {
         given:
         setupDomain()
@@ -87,7 +83,6 @@ class CypherQueryStringSpec extends Neo4jGormDatastoreSpec {
         team.club.name == 'FC Bayern Muenchen'
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - static cypher/string-query calls resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test findAll method that accepts cypher"() {
         given:
         setupDomain()
@@ -132,7 +127,6 @@ class CypherQueryStringSpec extends Neo4jGormDatastoreSpec {
         result.next().get('n').asMap().get('name') == name
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - static cypher/string-query calls resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "Test convert nodes using asType for a cypher result"() {
         given:
         setupDomain()

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/NativeIdentityGeneratorSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/NativeIdentityGeneratorSpec.groovy
@@ -22,7 +22,6 @@ package grails.gorm.tests
 
 import org.apache.grails.data.neo4j.core.Neo4jGormDatastoreSpec
 import grails.gorm.annotation.Entity
-import spock.lang.PendingFeature
 
 /**
  * @author graemerocher
@@ -45,7 +44,6 @@ class NativeIdentityGeneratorSpec extends Neo4jGormDatastoreSpec {
         Competition.get(c2.id).id == 1L
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Competition's static API always resolves to the generic GormStaticApi, whose saveAll() has its own bug (returns flush()'s null instead of the persisted ids). Neo4jGormStaticApi#saveAll already fixes this but is unreachable until PR2 wires up the factory")
     void "Test native id generator save multiple"() {
         when:"An entity with a native id is persisted"
         def c1 = new Competition(name:"FA Cup")

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/OneToManyUpdateSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/OneToManyUpdateSpec.groovy
@@ -22,7 +22,6 @@ package grails.gorm.tests
 
 import org.apache.grails.data.neo4j.core.Neo4jGormDatastoreSpec
 import spock.lang.Issue
-import spock.lang.PendingFeature
 
 /**
  * @author graemerocher
@@ -31,7 +30,6 @@ class OneToManyUpdateSpec extends Neo4jGormDatastoreSpec {
 
 
     @Issue('https://github.com/apache/grails-data-mapping/issues/575')
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Club.cypherStatic(...) resolves to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "Test updates to one to many don't create duplicate relationships"() {
         given:" a one to many relationship"
         Club club = new Club(name:"Manchester United")

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/multitenancy/MultiTenancySpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/multitenancy/MultiTenancySpec.groovy
@@ -30,7 +30,6 @@ import org.grails.datastore.mapping.multitenancy.AllTenantsResolver
 import org.grails.datastore.mapping.multitenancy.exceptions.TenantNotFoundException
 import org.grails.datastore.mapping.multitenancy.resolvers.SystemPropertyTenantResolver
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -63,7 +62,6 @@ class MultiTenancySpec extends Specification {
         System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "")
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - CompanyC.find(cypher, params) resolves to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "Test persist and retrieve entities with multi tenancy"() {
         when:"A tenant id is present"
         System.setProperty(SystemPropertyTenantResolver.PROPERTY_NAME, "test1")

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/path/PathSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/path/PathSpec.groovy
@@ -24,7 +24,6 @@ import grails.gorm.transactions.Rollback
 import grails.neo4j.Path
 import org.grails.datastore.gorm.neo4j.Neo4jDatastore
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,7 +35,6 @@ class PathSpec extends Specification {
     @Shared @AutoCleanup Neo4jDatastore datastore = new Neo4jDatastore(getClass().getPackage())
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test simple shortest path with findShortestPath"() {
 
         given:
@@ -76,7 +74,6 @@ class PathSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test simple shortest path with findShortestPath with proxies"() {
         given:
         def barney = new Person(name: "Barney")
@@ -110,7 +107,6 @@ class PathSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test simple shortest path"() {
         given:
         def barney = new Person(name: "Barney")
@@ -142,7 +138,6 @@ class PathSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test simple shortest pathTo"() {
         given:
         def barney = new Person(name: "Barney")
@@ -174,7 +169,6 @@ class PathSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test shortest path with arguments"() {
         given:
         def barney = new Person(name: "Barney")
@@ -206,7 +200,6 @@ class PathSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findShortestPath/findPath/findPathTo resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test shortest path with gstring arguments"() {
         given:
         def barney = new Person(name: "Barney")

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/path/RelationshipSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/path/RelationshipSpec.groovy
@@ -25,7 +25,6 @@ import grails.neo4j.Path
 import grails.neo4j.Relationship
 import org.grails.datastore.gorm.neo4j.Neo4jDatastore
 import spock.lang.AutoCleanup
-import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -36,7 +35,6 @@ class RelationshipSpec extends Specification {
     @Shared @AutoCleanup Neo4jDatastore datastore = new Neo4jDatastore(getClass().getPackage())
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findRelationship(s) resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test find relationship"() {
         given:
         def barney = new Person(name: "Barney")
@@ -64,7 +62,6 @@ class RelationshipSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findRelationship(s) resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test find relationships"() {
         given:
         def barney = new Person(name: "Barney")
@@ -93,7 +90,6 @@ class RelationshipSpec extends Specification {
     }
 
     @Rollback
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - Person.findRelationship(s) resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     void "test find relationships for types"() {
         given:
         def barney = new Person(name: "Barney")

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/org/grails/datastore/gorm/neo4j/ApiExtensionsSpec.groovy
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/src/test/groovy/org/grails/datastore/gorm/neo4j/ApiExtensionsSpec.groovy
@@ -23,7 +23,6 @@ import grails.gorm.tests.Club
 import grails.gorm.tests.League
 import grails.gorm.tests.Team
 import org.apache.grails.data.neo4j.core.Neo4jGormDatastoreSpec
-import spock.lang.PendingFeature
 
 /**
  * check the traverser extension
@@ -34,7 +33,6 @@ class ApiExtensionsSpec extends Neo4jGormDatastoreSpec {
         manager.registerDomainClasses(Club, Team, League)
     }
 
-    @PendingFeature(reason = "Neo4jGormApiFactory isn't registered with GormRegistry yet (PR2 scope) - static cypher calls resolve to the generic GormStaticApi instead of Neo4jGormStaticApi")
     def "test cypher queries"() {
         setup:
         new Club(name:'person1').save()


### PR DESCRIPTION
> **📖 Neo4j GormRegistry migration — reading order: 3 of 5**:
>
> 1. #15816 — PR1: Groovy4/Jakarta/GORM8 baseline migration (no GormRegistry coupling)
> 2. #15951 — PR2: fold standalone build into root `settings.gradle`
> 3. **#15817** — PR3: wire `Neo4jGormApiFactory` into GormRegistry — *this PR*
> 4. #15832 — PR4: re-add example apps and docs into monorepo
> 5. #15833 — PR5: Checkstyle/CodeNarc cleanup
>
> _You are reading **3 of 5**._
>
> This Neo4j chain branches off the core GormRegistry O(M+N) scaling stack's head (#15779 → #15780 → #15790) — it depends on that stack but is its own separate sequence, not additional steps within it.
>
> Previously combined PR2 (wiring) and PR3 (settings.gradle fold) in this one PR; split per [review feedback](https://github.com/apache/grails-core/pull/15816#issuecomment-4931129546) so the fold lands earlier (#15951, now PR2) and this PR is wiring-only.

## Summary

Completes the Neo4j GormRegistry migration plan's PR3, on top of #15816 (PR1, baseline) and #15951 (PR2, `settings.gradle` fold): registers a `Neo4jGormApiFactory` so entities backed by `Neo4jDatastore` resolve a `Neo4jGormStaticApi` through `GormRegistry` instead of silently falling back to the generic `GormStaticApi`. Without this, static/cypher-string API calls (`cypherStatic`, `findRelationship(s)`, `findPath*`, `findShortestPath`, `find`/`findAll` with a cypher string) threw `ClassCastException` or `UnsupportedOperationException`, since those methods only exist on `Neo4jGormStaticApi`.

**This turned out to require far less than the "rewrite Neo4jEntity/Node/Relationship traits" originally scoped in the migration plan** - a nice, concrete dividend of the GormRegistry refactor: adding a new datastore's wiring is now a small, mechanical exercise rather than an integration project. Neo4j's instance and validation APIs were already generic (`GormInstanceApi`/`GormValidationApi`, no Neo4j-specific subclass), matching `DefaultGormApiFactory`'s base implementations already - only the static API needed a factory override, mirroring `MongoGormApiFactory`'s exact shape (which only overrides `createStaticApi()` for the same reason). The whole change is a ~25-line factory class plus a single line registering it.

- `Neo4jGormApiFactory#createStaticApi()` resolves the datastore via `DatastoreResolver#resolve()` rather than Neo4j's old bespoke `getDatastoreForQualifier()`/`datastoresByConnectionSource` logic - qualifier/multi-datasource routing is now handled generically by `GormRegistry`/`GormApiResolver` (the O(M+N) scaling work this plan depends on). Verified this doesn't regress Neo4j's own multi-tenancy/multi-datasource tests.
- `registerApiFactory()` is called from `Neo4jDatastore#initialize()`, before constructing the `GormEnhancer` whose constructor eagerly registers this datastore's entities - registering after would leave those entities bound to the generic factory forever, since `GormEnhancer` only registers each entity once.
- 17 of the 34 tests marked `@PendingFeature` in the baseline PR now pass and had their annotations removed (`ApiExtensionsSpec`, `CypherQueryStringSpec`, `OneToManyUpdateSpec`, `MultiTenancySpec`, `PathSpec`, `RelationshipSpec`, `NativeIdentityGeneratorSpec`'s `saveAll` test - whose fix was already in place from the baseline PR but unreachable until this factory was registered).

## Test plan

- [x] `./gradlew :grails-datastore-gorm-neo4j:test` - `BUILD SUCCESSFUL`, 198/215 passing, 0 failures, 17 skipped (4 genuinely pending and unrelated to this change, plus pre-existing `@Ignore`'d tests)
- [x] Verified no regressions in previously-passing tests, including multi-tenancy/multi-datasource specs, after switching to the generic `DatastoreResolver`-based routing

Generated with Claude
