### PR TITLE
ci: raise publish retry timeout to give slow Nexus uploads headroom

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -496,7 +496,7 @@ jobs:
           MAVEN_PUBLISH_USERNAME: ${{ secrets.NEXUS_USER }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PW  }}
         with: 
-          timeout_seconds: 1200 # normal range 14min if build is not cached (no tests running)
+          timeout_seconds: 1800 # normal range ~14min uncached (no tests); headroom for slow Nexus uploads so a single attempt is not killed mid-publish
           max_attempts: 3 # Attempts to address: Could not write to resource 'https://repository.apache.org/content/repositories/snapshots/...' Read timed out
           retry_wait_seconds: 180
           command: ./gradlew publish aggregateChecksums aggregatePublishedArtifacts --no-build-cache --rerun-tasks
@@ -566,7 +566,7 @@ jobs:
           MAVEN_PUBLISH_USERNAME: ${{ secrets.NEXUS_USER }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PW  }}
         with:
-          timeout_seconds: 1200
+          timeout_seconds: 1800 # headroom for slow Nexus uploads so a single attempt is not killed mid-publish (see `publish` job)
           max_attempts: 3
           retry_wait_seconds: 180
           command: ./gradlew :grails-micronaut:publish :grails-micronaut-bom:publish --no-build-cache --rerun-tasks


### PR DESCRIPTION
## What

Raise the per-attempt `timeout_seconds` from `1200` (20 min) to `1800` (30 min) on both publish retry steps in `.github/workflows/gradle.yml` — the `publish` job and the `publishMicronaut` job.

## Why

CI run [28709355300](https://github.com/apache/grails-core/actions/runs/28709355300) failed with only the `publish` job red. Tracing the full log of that job (85155475687):

- The publish step wraps `./gradlew publish aggregateChecksums aggregatePublishedArtifacts --no-build-cache --rerun-tasks` in `nick-fields/retry` with `timeout_seconds: 1200` / `max_attempts: 3`.
- **All 3 attempts hit the 20-minute wall** (`Timeout of 1200000ms hit`). There was **no** `BUILD FAILED`, **no** exception, and **no** Nexus `Read timed out` — a pure per-attempt timeout.
- Because of `--no-build-cache --rerun-tasks`, every attempt spins a fresh Gradle daemon and does a full from-scratch recompile + groovydoc/javadoc for 60+ modules + upload to Apache Nexus, which legitimately runs ~14-20 min (the existing comment says *"normal range 14min"*). The last successful publish ([28537677757](https://github.com/apache/grails-core/actions/runs/28537677757)) ran the whole job in **19m48s** — essentially zero headroom.
- Recurring ~3-min stalls during Nexus uploads (varying per attempt, so upload latency, not a deadlock) pushed each attempt just past 20 min. Since every retry repeats the identical full uncached build, the retries can't rescue it — they all hit the same wall.

Raising the per-attempt timeout to 30 min gives headroom for slow Nexus uploads so a single attempt is not killed mid-publish, while keeping `max_attempts: 3` / `retry_wait_seconds: 180` for genuine transient read-timeouts. Worst case (3 × 30 min + 2 × 180 s waits) is ~96 min, well under the GitHub Actions job limit.

## Notes

- CI-config only; no source/behavior change.
- The same failed run was also re-run to confirm the diagnosis (transient slow-Nexus timing vs. a persistent defect).
