### PR TITLE
Add available-locale discovery and a language selector to i18n

### DIFF
--- a/grails-doc/src/en/guide/i18n/changingLocales.adoc
+++ b/grails-doc/src/en/guide/i18n/changingLocales.adoc
@@ -28,7 +28,14 @@ Grails will automatically switch the user's locale and subsequent requests will 
 
 To offer a language selector, the i18n plugin discovers the locales your application is actually translated into by scanning the classpath for `messages_&#42;.properties` bundles (plus the default locale, configurable via `grails.i18n.default.locale`). This list is exposed as the `AvailableLocaleResolver` bean and published to the servlet context under the `availableLocales` attribute. The `<g:localeSelect available="true"/>` tag renders a `<select>` limited to those locales, and you can iterate the list directly in a view to build your own switcher:
 
-By default every `&#42;.properties` bundle on the classpath is considered, so locales contributed by plugins &mdash; whose bundles are namespaced (for example `spring-security-core_fr.properties`) &mdash; are listed alongside your application's own. Candidate suffixes are validated against `Locale.getISOLanguages()`, so non-i18n properties files (such as `application.properties`) are ignored. To restrict discovery to your application's own `messages_&#42;.properties` bundles, set `grails.i18n.availableLocales.includePlugins=false`:
+[source,xml]
+----
+<g:each in="${application.getAttribute('availableLocales')}" var="locale">
+    <a href="?lang=${locale.toLanguageTag()}">${locale.getDisplayName(locale)}</a>
+</g:each>
+----
+
+By default every `&#42;.properties` bundle on the classpath is considered, so locales contributed by plugins &mdash; whose bundles are namespaced (for example `spring-security-core_fr.properties`) &mdash; are listed alongside your application's own. Candidate suffixes are validated against the ISO language codes (and the ISO country codes when a country is present), so non-i18n properties files (such as `application.properties`) are ignored. To restrict discovery to your application's own `messages_&#42;.properties` bundles, set `grails.i18n.availableLocales.includePlugins=false`:
 
 [source,yaml]
 .grails-app/conf/application.yml
@@ -37,14 +44,6 @@ grails:
     i18n:
         availableLocales:
             includePlugins: false   # list only the application's own translations
-----
-
-
-[source,xml]
-----
-<g:each in="${application.getAttribute('availableLocales')}" var="locale">
-    <a href="?lang=${locale.toLanguageTag()}">${locale.getDisplayName(locale)}</a>
-</g:each>
 ----
 
 Applications created with `grails create-app` include a ready-made language dropdown in the default layout that uses exactly this mechanism.

--- a/grails-doc/src/en/guide/i18n/changingLocales.adoc
+++ b/grails-doc/src/en/guide/i18n/changingLocales.adoc
@@ -28,6 +28,18 @@ Grails will automatically switch the user's locale and subsequent requests will 
 
 To offer a language selector, the i18n plugin discovers the locales your application is actually translated into by scanning the classpath for `messages_&#42;.properties` bundles (plus the default locale, configurable via `grails.i18n.default.locale`). This list is exposed as the `AvailableLocaleResolver` bean and published to the servlet context under the `availableLocales` attribute. The `<g:localeSelect available="true"/>` tag renders a `<select>` limited to those locales, and you can iterate the list directly in a view to build your own switcher:
 
+By default every `&#42;.properties` bundle on the classpath is considered, so locales contributed by plugins &mdash; whose bundles are namespaced (for example `spring-security-core_fr.properties`) &mdash; are listed alongside your application's own. Candidate suffixes are validated against `Locale.getISOLanguages()`, so non-i18n properties files (such as `application.properties`) are ignored. To restrict discovery to your application's own `messages_&#42;.properties` bundles, set `grails.i18n.availableLocales.includePlugins=false`:
+
+[source,yaml]
+.grails-app/conf/application.yml
+----
+grails:
+    i18n:
+        availableLocales:
+            includePlugins: false   # list only the application's own translations
+----
+
+
 [source,xml]
 ----
 <g:each in="${application.getAttribute('availableLocales')}" var="locale">

--- a/grails-doc/src/en/guide/i18n/changingLocales.adoc
+++ b/grails-doc/src/en/guide/i18n/changingLocales.adoc
@@ -26,6 +26,17 @@ By default, the user locale is detected from the incoming `Accept-Language` head
 
 Grails will automatically switch the user's locale and subsequent requests will use the switched locale.
 
+To offer a language selector, the i18n plugin discovers the locales your application is actually translated into by scanning the classpath for `messages_&#42;.properties` bundles (plus the default locale, configurable via `grails.i18n.default.locale`). This list is exposed as the `AvailableLocaleResolver` bean and published to the servlet context under the `availableLocales` attribute. The `<g:localeSelect available="true"/>` tag renders a `<select>` limited to those locales, and you can iterate the list directly in a view to build your own switcher:
+
+[source,xml]
+----
+<g:each in="${application.getAttribute('availableLocales')}" var="locale">
+    <a href="?lang=${locale.toLanguageTag()}">${locale.getDisplayName(locale)}</a>
+</g:each>
+----
+
+Applications created with `grails create-app` include a ready-made language dropdown in the default layout that uses exactly this mechanism.
+
 By default, Grails uses {springapi}org/springframework/web/servlet/i18n/SessionLocaleResolver.html[SessionLocaleResolver] as the `localeResolver` bean.
 
 You can change the default locale easily: 

--- a/grails-doc/src/en/ref/Tags - GSP/localeSelect.adoc
+++ b/grails-doc/src/en/ref/Tags - GSP/localeSelect.adoc
@@ -35,6 +35,9 @@ Generates an HTML select with ``Locale``s as values
 ----
 <!-- create a locale select -->
 <g:localeSelect name="myLocale" value="${locale}" />
+
+<!-- list only the locales the application is translated into -->
+<g:localeSelect name="myLocale" available="true" />
 ----
 
 
@@ -46,5 +49,6 @@ Attributes
 * `name` - The name to be used for the select box
 * `value` (optional) - The selected {javase}java.base/java/util/Locale.html[Locale]; defaults to the current request locale if not specified
 * `locale` (optional) - The {javase}java.base/java/util/Locale.html[Locale] to use for formatting the locale names. Defaults to the current request locale and then the system default locale if not specified
+* `available` (optional) - If `true`, lists only the locales the application is actually translated into (those with a `messages_&#42;.properties` bundle on the classpath, as discovered by the i18n plugin) rather than every locale the JVM knows about. Defaults to `false`.
 
 

--- a/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
+++ b/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
@@ -16,6 +16,24 @@
         <a class="navbar-brand d-flex align-items-center" href="${request.contextPath}/">
             <asset:image class="w-75" src="grails.svg" alt="Grails Logo"/>
         </a>
+        <g:set var="availableLocales" value="${application.getAttribute('availableLocales')}"/>
+        <g:if test="${availableLocales && availableLocales.size() > 1}">
+            <g:set var="currentLocale" value="${org.springframework.web.servlet.support.RequestContextUtils.getLocale(request)}"/>
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="localeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="bi bi-globe me-1"></i>${currentLocale.getDisplayName(currentLocale)}
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
+                        <g:each in="${availableLocales}" var="availableLocale">
+                            <li>
+                                <a class="dropdown-item${availableLocale == currentLocale ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
+                            </li>
+                        </g:each>
+                    </ul>
+                </li>
+            </ul>
+        </g:if>
     </div>
 </nav>
 

--- a/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
+++ b/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
@@ -28,7 +28,7 @@
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
                         <g:each in="${availableLocales}" var="availableLocale">
                             <li>
-                                <a class="dropdown-item${availableLocale == currentLocale ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
+                                <a class="dropdown-item${availableLocale.language == currentLocale.language ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
                             </li>
                         </g:each>
                     </ul>

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -81,6 +81,19 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         output.containsKey("grails-app/views/notFound.gsp")
     }
 
+    void "test default layout includes the language selector dropdown"() {
+        when:
+        final def output = generate(ApplicationType.WEB, new Options(DevelopmentReloading.DEVTOOLS))
+        final String layout = output["grails-app/views/layouts/main.gsp"]
+
+        then: "the navbar reads the i18n plugin's published available locales"
+        layout.contains("application.getAttribute('availableLocales')")
+
+        and: "and renders a Bootstrap dropdown that switches language via ?lang="
+        layout.contains("dropdown-toggle")
+        layout.contains('?lang=${availableLocale.toLanguageTag()}')
+    }
+
     @Unroll
     void "test grails-gsp gradle plugins and dependencies are present for #applicationType application"() {
         when:

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -972,9 +972,20 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr name REQUIRED The name of the select
      * @attr value The set locale, defaults to the current request locale if not specified
      * @attr locale The locale to use for formatting the locale names. Defaults to the current request locale and then the system default locale if not specified
+     * @attr available If <code>true</code>, list only the locales the application is translated into
+     * (those with a <code>messages_*.properties</code> bundle, as published to the servlet context by
+     * the i18n plugin) instead of every locale the JVM knows about. Defaults to <code>false</code>.
      */
     def localeSelect(Map attrs) {
-        attrs.from = Locale.getAvailableLocales()
+        def availableAttr = attrs.remove('available')
+        boolean availableOnly = availableAttr != null && Boolean.valueOf(availableAttr.toString())
+        if (availableOnly) {
+            def availableLocales = request.servletContext?.getAttribute('availableLocales')
+            attrs.from = availableLocales ?: [RCU.getLocale(request)]
+        }
+        else {
+            attrs.from = Locale.getAvailableLocales()
+        }
         attrs.value = (attrs.value ?: RCU.getLocale(request))?.toString()
         // set the key as a closure that formats the locale
         attrs.optionKey = { it.country ? "${it.language}_${it.country}" : it.language }

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectAvailableSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectAvailableSpec.groovy
@@ -54,6 +54,18 @@ class LocaleSelectAvailableSpec extends Specification implements TagLibUnitTest<
         output.contains('value="fr"')
     }
 
+    void 'an explicit available="false" keeps the full JVM locale list even when locales are published'() {
+        given:
+        request.servletContext.setAttribute('availableLocales',
+                [Locale.forLanguageTag('en'), Locale.forLanguageTag('es')])
+
+        when:
+        String output = applyTemplate('<g:localeSelect name="lang" available="false"/>')
+
+        then: 'a locale outside the published list is still offered'
+        output.contains('value="fr"')
+    }
+
     void 'available="true" falls back to the current locale when nothing is published'() {
         when:
         String output = applyTemplate('<g:localeSelect name="lang" available="true"/>')

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectAvailableSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectAvailableSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.taglib
+
+import grails.testing.web.taglib.TagLibUnitTest
+import org.grails.plugins.web.taglib.FormTagLib
+import spock.lang.Specification
+
+/**
+ * Tests the {@code available="true"} mode of {@code g:localeSelect}, which restricts the options to
+ * the locales the i18n plugin publishes to the servlet context (the app's real translations) instead
+ * of every locale the JVM knows about.
+ */
+class LocaleSelectAvailableSpec extends Specification implements TagLibUnitTest<FormTagLib> {
+
+    void 'available="true" lists only the locales published to the servlet context'() {
+        given:
+        request.servletContext.setAttribute('availableLocales',
+                [Locale.forLanguageTag('en'), Locale.forLanguageTag('es')])
+
+        when:
+        String output = applyTemplate('<g:localeSelect name="lang" available="true"/>')
+
+        then: 'the two published locales are options'
+        output.contains('name="lang"')
+        output.contains('value="en"')
+        output.contains('value="es"')
+
+        and: 'a locale that has no bundle is not offered'
+        !output.contains('value="fr"')
+    }
+
+    void 'without available="true" the tag still lists every JVM locale'() {
+        when:
+        String output = applyTemplate('<g:localeSelect name="lang"/>')
+
+        then:
+        output.contains('value="fr"')
+    }
+
+    void 'available="true" falls back to the current locale when nothing is published'() {
+        when:
+        String output = applyTemplate('<g:localeSelect name="lang" available="true"/>')
+
+        then: 'no servlet-context attribute is present, so the select is not empty and not the full JVM list'
+        output.contains('<select')
+        !output.contains('value="fr"')
+    }
+
+    void 'the published list can drive a custom link dropdown like the create-app layout does'() {
+        given: 'the same servlet-context attribute the i18n plugin publishes and the create-app main.gsp reads'
+        request.servletContext.setAttribute('availableLocales',
+                [Locale.forLanguageTag('en'), Locale.forLanguageTag('es')])
+
+        when: 'the navbar snippet from the generated layout is rendered'
+        String output = applyTemplate('''
+            <g:set var="availableLocales" value="${application.getAttribute('availableLocales')}"/>
+            <g:if test="${availableLocales && availableLocales.size() > 1}">
+                <g:each in="${availableLocales}" var="availableLocale">
+                    <a href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
+                </g:each>
+            </g:if>
+        '''.stripIndent())
+
+        then: 'one ?lang= link per published locale is produced'
+        output.contains('href="?lang=en"')
+        output.contains('href="?lang=es"')
+    }
+}

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
@@ -50,8 +50,9 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  * scanned. When {@code includePluginBundles} is enabled, every {@code *.properties}
  * bundle on the classpath is considered, so locales contributed by plugins &mdash; whose
  * bundles are namespaced (e.g. {@code spring-security-core_fr.properties}) &mdash; are
- * included too. Candidate suffixes are validated against {@link Locale#getISOLanguages()}
- * so non-i18n properties files (e.g. {@code application.properties}) are ignored. See
+ * included too. Candidate suffixes are validated against the ISO language codes (and the ISO
+ * country codes when a country is present), so non-i18n properties files (e.g.
+ * {@code application.properties} or {@code foo_en_prod.properties}) are ignored. See
  * {@code grails.i18n.availableLocales.includePlugins}.
  *
  * @since 8.0.0
@@ -66,6 +67,8 @@ public class AvailableLocaleResolver {
     private static final String PROPERTIES_SUFFIX = ".properties";
 
     private static final Set<String> ISO_LANGUAGES = new HashSet<>(Arrays.asList(Locale.getISOLanguages()));
+
+    private static final Set<String> ISO_COUNTRIES = new HashSet<>(Arrays.asList(Locale.getISOCountries()));
 
     private final ResourcePatternResolver resourcePatternResolver;
 
@@ -151,7 +154,10 @@ public class AvailableLocaleResolver {
     /**
      * Extracts the locale a bundle filename encodes, or {@code null} if it is not a locale-specific
      * message bundle. The base name ends at the first underscore (matching Grails' own message-source
-     * convention, where plugin base names use hyphens), and the suffix must be a recognised language.
+     * convention, where plugin base names use hyphens). The suffix follows the resource-bundle
+     * convention {@code language(_COUNTRY(_variant))} &mdash; not BCP 47 &mdash; so the language must
+     * be an ISO language and, when present, the country an ISO country; anything else (e.g.
+     * {@code foo_en_prod.properties}) is rejected rather than misparsed as a script or region.
      */
     private static Locale localeFromBundleFilename(String filename) {
         if (filename == null || !filename.endsWith(PROPERTIES_SUFFIX)) {
@@ -162,12 +168,19 @@ public class AvailableLocaleResolver {
         if (underscore < 0) {
             return null;
         }
-        String code = base.substring(underscore + 1);
-        if (code.isEmpty()) {
+        String[] parts = base.substring(underscore + 1).split("_", 3);
+        String language = parts[0];
+        if (!ISO_LANGUAGES.contains(language)) {
             return null;
         }
-        Locale locale = Locale.forLanguageTag(code.replace('_', '-'));
-        return ISO_LANGUAGES.contains(locale.getLanguage()) ? locale : null;
+        if (parts.length == 1) {
+            return Locale.of(language);
+        }
+        String country = parts[1];
+        if (!ISO_COUNTRIES.contains(country)) {
+            return null;
+        }
+        return (parts.length == 2) ? Locale.of(language, country) : Locale.of(language, country, parts[2]);
     }
 
 }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
@@ -20,8 +20,10 @@ package org.grails.plugins.i18n;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -36,7 +38,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 
 /**
  * Discovers the locales an application is actually translated into by scanning the
- * classpath for {@code messages_*.properties} resource bundles.
+ * classpath for {@code <basename>_<locale>.properties} resource bundles.
  *
  * <p>Unlike {@link java.util.Locale#getAvailableLocales()} (which returns every locale
  * the JVM knows about), this returns only the locales that have a matching message
@@ -44,32 +46,56 @@ import org.springframework.core.io.support.ResourcePatternResolver;
  * selector. The result is sorted by each locale's display name in its own language and
  * cached; {@link #clearCache()} forces a re-scan (used when bundles change in development).
  *
+ * <p>By default only the application's own {@code messages_*.properties} bundles are
+ * scanned. When {@code includePluginBundles} is enabled, every {@code *.properties}
+ * bundle on the classpath is considered, so locales contributed by plugins &mdash; whose
+ * bundles are namespaced (e.g. {@code spring-security-core_fr.properties}) &mdash; are
+ * included too. Candidate suffixes are validated against {@link Locale#getISOLanguages()}
+ * so non-i18n properties files (e.g. {@code application.properties}) are ignored. See
+ * {@code grails.i18n.availableLocales.includePlugins}.
+ *
  * @since 8.0.0
  */
 public class AvailableLocaleResolver {
 
     private static final Logger log = LoggerFactory.getLogger(AvailableLocaleResolver.class);
 
-    private static final String MESSAGES_PREFIX = "messages_";
+    /** The base name of an application's own message bundles ({@code messages.properties}). */
+    public static final String DEFAULT_BASE_NAME = "messages";
 
     private static final String PROPERTIES_SUFFIX = ".properties";
 
-    private static final String LOCATION_PATTERN = "classpath*:" + MESSAGES_PREFIX + "*" + PROPERTIES_SUFFIX;
+    private static final Set<String> ISO_LANGUAGES = new HashSet<>(Arrays.asList(Locale.getISOLanguages()));
 
     private final ResourcePatternResolver resourcePatternResolver;
 
     private final Locale defaultLocale;
 
+    private final boolean includePluginBundles;
+
     private volatile List<Locale> cachedLocales;
 
     /**
+     * Scans only the application's own {@code messages_*.properties} bundles.
+     *
      * @param classLoader the class loader whose classpath is scanned for message bundles
      * @param defaultLocale the locale of the base {@code messages.properties} bundle,
      * always included in the result (may be {@code null} to include none)
      */
     public AvailableLocaleResolver(ClassLoader classLoader, Locale defaultLocale) {
+        this(classLoader, defaultLocale, false);
+    }
+
+    /**
+     * @param classLoader the class loader whose classpath is scanned for message bundles
+     * @param defaultLocale the locale of the base bundle, always included (may be {@code null})
+     * @param includePluginBundles whether to also consider plugin-contributed bundles (every
+     * {@code *.properties} on the classpath) rather than only the application's {@code messages}
+     */
+    public AvailableLocaleResolver(ClassLoader classLoader, Locale defaultLocale, boolean includePluginBundles) {
         this.resourcePatternResolver = new PathMatchingResourcePatternResolver(classLoader);
         this.defaultLocale = defaultLocale;
+        this.includePluginBundles = includePluginBundles;
     }
 
     /**
@@ -102,29 +128,46 @@ public class AvailableLocaleResolver {
         if (this.defaultLocale != null && !this.defaultLocale.getLanguage().isEmpty()) {
             locales.add(this.defaultLocale);
         }
+        String pattern = "classpath*:" + DEFAULT_BASE_NAME + "_*" + PROPERTIES_SUFFIX;
+        if (this.includePluginBundles) {
+            pattern = "classpath*:*" + PROPERTIES_SUFFIX;
+        }
         try {
-            for (Resource resource : this.resourcePatternResolver.getResources(LOCATION_PATTERN)) {
-                String filename = resource.getFilename();
-                if (filename == null || !filename.startsWith(MESSAGES_PREFIX) || !filename.endsWith(PROPERTIES_SUFFIX)) {
-                    continue;
-                }
-                String code = filename.substring(MESSAGES_PREFIX.length(), filename.length() - PROPERTIES_SUFFIX.length());
-                if (code.isEmpty()) {
-                    continue;
-                }
-                Locale locale = Locale.forLanguageTag(code.replace('_', '-'));
-                if (!locale.getLanguage().isEmpty()) {
+            for (Resource resource : this.resourcePatternResolver.getResources(pattern)) {
+                Locale locale = localeFromBundleFilename(resource.getFilename());
+                if (locale != null) {
                     locales.add(locale);
                 }
             }
         }
         catch (IOException ex) {
-            log.warn("Unable to resolve available locales from '{}*{}' message bundles: {}",
-                    MESSAGES_PREFIX, PROPERTIES_SUFFIX, ex.getMessage());
+            log.warn("Unable to resolve available locales from message bundles: {}", ex.getMessage());
         }
         List<Locale> sorted = new ArrayList<>(locales);
         sorted.sort(Comparator.comparing((Locale locale) -> locale.getDisplayName(locale)));
         return Collections.unmodifiableList(sorted);
+    }
+
+    /**
+     * Extracts the locale a bundle filename encodes, or {@code null} if it is not a locale-specific
+     * message bundle. The base name ends at the first underscore (matching Grails' own message-source
+     * convention, where plugin base names use hyphens), and the suffix must be a recognised language.
+     */
+    private static Locale localeFromBundleFilename(String filename) {
+        if (filename == null || !filename.endsWith(PROPERTIES_SUFFIX)) {
+            return null;
+        }
+        String base = filename.substring(0, filename.length() - PROPERTIES_SUFFIX.length());
+        int underscore = base.indexOf('_');
+        if (underscore < 0) {
+            return null;
+        }
+        String code = base.substring(underscore + 1);
+        if (code.isEmpty()) {
+            return null;
+        }
+        Locale locale = Locale.forLanguageTag(code.replace('_', '-'));
+        return ISO_LANGUAGES.contains(locale.getLanguage()) ? locale : null;
     }
 
 }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/AvailableLocaleResolver.java
@@ -1,0 +1,130 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.i18n;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+/**
+ * Discovers the locales an application is actually translated into by scanning the
+ * classpath for {@code messages_*.properties} resource bundles.
+ *
+ * <p>Unlike {@link java.util.Locale#getAvailableLocales()} (which returns every locale
+ * the JVM knows about), this returns only the locales that have a matching message
+ * bundle plus the configured default locale, making it suitable for driving a language
+ * selector. The result is sorted by each locale's display name in its own language and
+ * cached; {@link #clearCache()} forces a re-scan (used when bundles change in development).
+ *
+ * @since 8.0.0
+ */
+public class AvailableLocaleResolver {
+
+    private static final Logger log = LoggerFactory.getLogger(AvailableLocaleResolver.class);
+
+    private static final String MESSAGES_PREFIX = "messages_";
+
+    private static final String PROPERTIES_SUFFIX = ".properties";
+
+    private static final String LOCATION_PATTERN = "classpath*:" + MESSAGES_PREFIX + "*" + PROPERTIES_SUFFIX;
+
+    private final ResourcePatternResolver resourcePatternResolver;
+
+    private final Locale defaultLocale;
+
+    private volatile List<Locale> cachedLocales;
+
+    /**
+     * @param classLoader the class loader whose classpath is scanned for message bundles
+     * @param defaultLocale the locale of the base {@code messages.properties} bundle,
+     * always included in the result (may be {@code null} to include none)
+     */
+    public AvailableLocaleResolver(ClassLoader classLoader, Locale defaultLocale) {
+        this.resourcePatternResolver = new PathMatchingResourcePatternResolver(classLoader);
+        this.defaultLocale = defaultLocale;
+    }
+
+    /**
+     * @return an unmodifiable, display-name-sorted list of the locales the application is
+     * translated into. Computed once and cached until {@link #clearCache()} is called.
+     */
+    public List<Locale> getAvailableLocales() {
+        List<Locale> locales = this.cachedLocales;
+        if (locales == null) {
+            synchronized (this) {
+                locales = this.cachedLocales;
+                if (locales == null) {
+                    locales = computeAvailableLocales();
+                    this.cachedLocales = locales;
+                }
+            }
+        }
+        return locales;
+    }
+
+    /**
+     * Discards the cached list so the next {@link #getAvailableLocales()} re-scans the classpath.
+     */
+    public void clearCache() {
+        this.cachedLocales = null;
+    }
+
+    private List<Locale> computeAvailableLocales() {
+        Set<Locale> locales = new LinkedHashSet<>();
+        if (this.defaultLocale != null && !this.defaultLocale.getLanguage().isEmpty()) {
+            locales.add(this.defaultLocale);
+        }
+        try {
+            for (Resource resource : this.resourcePatternResolver.getResources(LOCATION_PATTERN)) {
+                String filename = resource.getFilename();
+                if (filename == null || !filename.startsWith(MESSAGES_PREFIX) || !filename.endsWith(PROPERTIES_SUFFIX)) {
+                    continue;
+                }
+                String code = filename.substring(MESSAGES_PREFIX.length(), filename.length() - PROPERTIES_SUFFIX.length());
+                if (code.isEmpty()) {
+                    continue;
+                }
+                Locale locale = Locale.forLanguageTag(code.replace('_', '-'));
+                if (!locale.getLanguage().isEmpty()) {
+                    locales.add(locale);
+                }
+            }
+        }
+        catch (IOException ex) {
+            log.warn("Unable to resolve available locales from '{}*{}' message bundles: {}",
+                    MESSAGES_PREFIX, PROPERTIES_SUFFIX, ex.getMessage());
+        }
+        List<Locale> sorted = new ArrayList<>(locales);
+        sorted.sort(Comparator.comparing((Locale locale) -> locale.getDisplayName(locale)));
+        return Collections.unmodifiableList(sorted);
+    }
+
+}

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
@@ -19,6 +19,8 @@
 
 package org.grails.plugins.i18n;
 
+import java.util.Locale;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -85,5 +87,22 @@ public class I18nAutoConfiguration {
             messageSource.setFileCacheSeconds(fileCacheSeconds);
         }
         return messageSource;
+    }
+
+    /**
+     * Discovers the locales the application is translated into (from {@code messages_*.properties}
+     * bundles on the classpath) so that a language selector can list only real translations rather
+     * than every JVM locale. Published to the servlet context by {@link I18nGrailsPlugin} and
+     * consumed by the {@code g:localeSelect available="true"} tag.
+     *
+     * @param defaultLocale the base {@code messages.properties} locale, always included
+     * ({@code grails.i18n.default.locale}, defaults to {@code en})
+     */
+    @Bean
+    @ConditionalOnMissingBean(AvailableLocaleResolver.class)
+    public AvailableLocaleResolver availableLocaleResolver(GrailsApplication grailsApplication,
+            @Value("${grails.i18n.default.locale:en}") String defaultLocale) {
+        return new AvailableLocaleResolver(grailsApplication.getClassLoader(),
+                Locale.forLanguageTag(defaultLocale.replace('_', '-')));
     }
 }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
@@ -90,19 +90,28 @@ public class I18nAutoConfiguration {
     }
 
     /**
-     * Discovers the locales the application is translated into (from {@code messages_*.properties}
+     * Discovers the locales the application is translated into (from {@code <basename>_<locale>.properties}
      * bundles on the classpath) so that a language selector can list only real translations rather
      * than every JVM locale. Published to the servlet context by {@link I18nGrailsPlugin} and
      * consumed by the {@code g:localeSelect available="true"} tag.
      *
+     * <p>By default every {@code *.properties} bundle on the classpath is considered, so locales
+     * contributed by plugins &mdash; whose bundles are namespaced (e.g.
+     * {@code spring-security-core_*.properties}) &mdash; are included alongside the application's own.
+     * Set {@code grails.i18n.availableLocales.includePlugins=false} to restrict discovery to the
+     * application's own {@code messages_*.properties} bundles.
+     *
      * @param defaultLocale the base {@code messages.properties} locale, always included
      * ({@code grails.i18n.default.locale}, defaults to {@code en})
+     * @param includePlugins whether to also scan plugin-contributed message bundles
+     * ({@code grails.i18n.availableLocales.includePlugins}, defaults to {@code true})
      */
     @Bean
     @ConditionalOnMissingBean(AvailableLocaleResolver.class)
     public AvailableLocaleResolver availableLocaleResolver(GrailsApplication grailsApplication,
-            @Value("${grails.i18n.default.locale:en}") String defaultLocale) {
+            @Value("${grails.i18n.default.locale:en}") String defaultLocale,
+            @Value("${grails.i18n.availableLocales.includePlugins:true}") boolean includePlugins) {
         return new AvailableLocaleResolver(grailsApplication.getClassLoader(),
-                Locale.forLanguageTag(defaultLocale.replace('_', '-')));
+                Locale.forLanguageTag(defaultLocale.replace('_', '-')), includePlugins);
     }
 }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nAutoConfiguration.java
@@ -143,17 +143,17 @@ public class I18nAutoConfiguration {
      * Set {@code grails.i18n.availableLocales.includePlugins=false} to restrict discovery to the
      * application's own {@code messages_*.properties} bundles.
      *
-     * @param defaultLocale the base {@code messages.properties} locale, always included
-     * ({@code grails.i18n.default.locale}, defaults to {@code en})
+     * <p>The base {@code messages.properties} locale is always included, resolved from
+     * {@code grails.i18n.default.locale} exactly like the rest of this class (falling back to the
+     * JVM default locale when the property is not set).
+     *
      * @param includePlugins whether to also scan plugin-contributed message bundles
      * ({@code grails.i18n.availableLocales.includePlugins}, defaults to {@code true})
      */
     @Bean
     @ConditionalOnMissingBean(AvailableLocaleResolver.class)
     public AvailableLocaleResolver availableLocaleResolver(GrailsApplication grailsApplication,
-            @Value("${grails.i18n.default.locale:en}") String defaultLocale,
             @Value("${grails.i18n.availableLocales.includePlugins:true}") boolean includePlugins) {
-        return new AvailableLocaleResolver(grailsApplication.getClassLoader(),
-                Locale.forLanguageTag(defaultLocale.replace('_', '-')), includePlugins);
+        return new AvailableLocaleResolver(grailsApplication.getClassLoader(), fixedLocale(), includePlugins);
     }
 }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
@@ -61,8 +61,13 @@ class I18nGrailsPlugin extends Plugin {
             return
         }
         def servletContext = ((WebApplicationContext) ctx).servletContext
-        if (servletContext != null && ctx.containsBean('availableLocaleResolver')) {
-            AvailableLocaleResolver resolver = ctx.getBean('availableLocaleResolver', AvailableLocaleResolver)
+        if (servletContext == null) {
+            return
+        }
+        // resolve by type, not name: the auto-configuration backs off by type, so a user-defined
+        // resolver registered under any bean name must still be published
+        AvailableLocaleResolver resolver = ctx.getBeanProvider(AvailableLocaleResolver).getIfAvailable()
+        if (resolver != null) {
             servletContext.setAttribute(AVAILABLE_LOCALES_ATTRIBUTE, resolver.availableLocales)
         }
     }
@@ -121,8 +126,9 @@ class I18nGrailsPlugin extends Plugin {
         }
 
         // A bundle may have been added/removed, so re-scan and re-publish the available locales.
-        if (ctx.containsBean('availableLocaleResolver')) {
-            ctx.getBean('availableLocaleResolver', AvailableLocaleResolver).clearCache()
+        AvailableLocaleResolver availableLocaleResolver = ctx.getBeanProvider(AvailableLocaleResolver).getIfAvailable()
+        if (availableLocaleResolver != null) {
+            availableLocaleResolver.clearCache()
             publishAvailableLocales()
         }
     }

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
@@ -24,6 +24,7 @@ import groovy.util.logging.Slf4j
 
 import org.springframework.context.support.ReloadableResourceBundleMessageSource
 import org.springframework.core.io.FileSystemResource
+import org.springframework.web.context.WebApplicationContext
 
 import grails.plugins.Plugin
 import grails.util.BuildSettings
@@ -41,6 +42,30 @@ class I18nGrailsPlugin extends Plugin {
     String baseDir = 'grails-app/i18n'
     String version = GrailsUtil.getGrailsVersion()
     String watchedResources = "file:./${baseDir}/**/*.properties".toString()
+
+    /**
+     * Publishes the discovered available locales to the servlet context so that views and the
+     * {@code g:localeSelect available="true"} tag can render a language selector. Reading a servlet
+     * context attribute keeps consumers decoupled from this module.
+     */
+    static final String AVAILABLE_LOCALES_ATTRIBUTE = 'availableLocales'
+
+    @Override
+    void doWithApplicationContext() {
+        publishAvailableLocales()
+    }
+
+    private void publishAvailableLocales() {
+        def ctx = applicationContext
+        if (!(ctx instanceof WebApplicationContext)) {
+            return
+        }
+        def servletContext = ((WebApplicationContext) ctx).servletContext
+        if (servletContext != null && ctx.containsBean('availableLocaleResolver')) {
+            AvailableLocaleResolver resolver = ctx.getBean('availableLocaleResolver', AvailableLocaleResolver)
+            servletContext.setAttribute(AVAILABLE_LOCALES_ATTRIBUTE, resolver.availableLocales)
+        }
+    }
 
     @Override
     void onChange(Map<String, Object> event) {
@@ -92,6 +117,12 @@ class I18nGrailsPlugin extends Plugin {
         def messageSource = ctx.getBean('messageSource')
         if (messageSource instanceof ReloadableResourceBundleMessageSource) {
             messageSource.clearCache()
+        }
+
+        // A bundle may have been added/removed, so re-scan and re-publish the available locales.
+        if (ctx.containsBean('availableLocaleResolver')) {
+            ctx.getBean('availableLocaleResolver', AvailableLocaleResolver).clearCache()
+            publishAvailableLocales()
         }
     }
 

--- a/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
+++ b/grails-i18n/src/main/groovy/org/grails/plugins/i18n/I18nGrailsPlugin.groovy
@@ -80,7 +80,8 @@ class I18nGrailsPlugin extends Plugin {
         def resourcesDir = BuildSettings.RESOURCES_DIR
         def classesDir = BuildSettings.CLASSES_DIR
 
-        if (resourcesDir.exists() && event.source instanceof FileSystemResource) {
+        // RESOURCES_DIR is null outside a Grails build (e.g. unit tests); nothing to copy then
+        if (resourcesDir?.exists() && event.source instanceof FileSystemResource) {
             // this MUST be getFile() because there's also a isFile() on this class
             File eventFile = (event.source as FileSystemResource).getFile().canonicalFile
             File i18nDir = eventFile.parentFile

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
@@ -41,6 +41,32 @@ class AvailableLocaleResolverSpec extends Specification {
         locales.contains(Locale.forLanguageTag('pt-BR'))
     }
 
+    void 'plugin-namespaced bundles are discovered only when plugin bundles are included'() {
+        given: 'a plugin ships spring-security-core_zu.properties (a locale no messages bundle has)'
+        Locale zulu = Locale.forLanguageTag('zu')
+
+        expect: 'a host-only scan does not see the plugin-namespaced locale'
+        !new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'), false)
+                .availableLocales.contains(zulu)
+
+        when: 'plugin bundles are included'
+        List<Locale> locales = new AvailableLocaleResolver(getClass().classLoader,
+                Locale.forLanguageTag('en'), true).availableLocales
+
+        then: 'the plugin locale is discovered, alongside the host messages locales'
+        locales.contains(zulu)
+        locales.contains(Locale.forLanguageTag('es'))
+    }
+
+    void 'non-i18n properties files on the classpath are ignored'() {
+        given:
+        List<String> isoLanguages = Locale.getISOLanguages() as List
+
+        expect: 'application.properties / logback.properties etc. never contribute a bogus locale'
+        new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'), true)
+                .availableLocales.every { it.language in isoLanguages }
+    }
+
     void 'sorts the discovered locales by their display name in their own language'() {
         given:
         List<Locale> expectedKnown = [

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
@@ -130,8 +130,8 @@ class AvailableLocaleResolverSpec extends Specification {
         locales == [Locale.forLanguageTag('en')]
     }
 
-    void 'bundles with no suffix, an empty suffix or a non-ISO suffix never contribute a locale'() {
-        given: 'deliberate fixtures: standalone.properties, messages_.properties and bogus-plugin_zz.properties'
+    void 'bundles with a malformed locale suffix never contribute a locale'() {
+        given: 'deliberate fixtures: standalone.properties (no suffix), messages_.properties (empty), bogus-plugin_zz.properties (non-ISO language) and report_en_prod.properties (non-ISO country)'
         List<Locale> locales = new AvailableLocaleResolver(getClass().classLoader, null, true).availableLocales
 
         expect: 'the scan saw sibling fixtures (a valid plugin-namespaced bundle is discovered)'
@@ -140,6 +140,15 @@ class AvailableLocaleResolverSpec extends Specification {
         and: 'none of the malformed fixtures produced a locale'
         locales.every { it.language && it.language in Locale.getISOLanguages() }
         !locales.any { it.language == 'zz' }
+
+        and: 'a non-ISO country is rejected rather than misparsed as a script or region (no en-Prod)'
+        !locales.any { it.toLanguageTag().toLowerCase().contains('prod') }
+    }
+
+    void 'a language_COUNTRY suffix is parsed by resource-bundle convention'() {
+        expect: 'the pt_BR fixture yields the pt-BR locale, with BR as the country'
+        Locale brazilian = newResolver().availableLocales.find { it.language == 'pt' }
+        brazilian.country == 'BR'
     }
 
     void 'caches the computed list until the cache is cleared'() {

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
@@ -96,6 +96,52 @@ class AvailableLocaleResolverSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
+    void 'a null default locale is simply not added'() {
+        when:
+        List<Locale> locales = newResolver(null).availableLocales
+
+        then: 'the scanned bundles are still discovered'
+        locales.contains(Locale.forLanguageTag('es'))
+        locales.contains(Locale.forLanguageTag('fr'))
+
+        and: 'no null or language-less entry is present'
+        locales.every { it != null && it.language }
+    }
+
+    void 'a language-less default locale (Locale.ROOT) is simply not added'() {
+        expect:
+        !newResolver(Locale.ROOT).availableLocales.contains(Locale.ROOT)
+    }
+
+    void 'falls back to just the default locale when classpath scanning fails'() {
+        given: 'a class loader whose resource enumeration always fails'
+        ClassLoader failingClassLoader = new ClassLoader(null) {
+
+            @Override
+            Enumeration<URL> getResources(String name) throws IOException {
+                throw new IOException('simulated classpath failure')
+            }
+        }
+
+        when:
+        List<Locale> locales = new AvailableLocaleResolver(failingClassLoader, Locale.forLanguageTag('en')).availableLocales
+
+        then: 'no exception escapes and only the default locale is offered'
+        locales == [Locale.forLanguageTag('en')]
+    }
+
+    void 'bundles with no suffix, an empty suffix or a non-ISO suffix never contribute a locale'() {
+        given: 'deliberate fixtures: standalone.properties, messages_.properties and bogus-plugin_zz.properties'
+        List<Locale> locales = new AvailableLocaleResolver(getClass().classLoader, null, true).availableLocales
+
+        expect: 'the scan saw sibling fixtures (a valid plugin-namespaced bundle is discovered)'
+        locales.contains(Locale.forLanguageTag('zu'))
+
+        and: 'none of the malformed fixtures produced a locale'
+        locales.every { it.language && it.language in Locale.getISOLanguages() }
+        !locales.any { it.language == 'zz' }
+    }
+
     void 'caches the computed list until the cache is cleared'() {
         given:
         AvailableLocaleResolver resolver = newResolver()

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/AvailableLocaleResolverSpec.groovy
@@ -1,0 +1,89 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.i18n
+
+import spock.lang.Specification
+
+/**
+ * Tests {@link AvailableLocaleResolver} against the {@code messages_*.properties} bundles on the
+ * test classpath ({@code src/test/resources}: es, fr, pt_BR, plus the base {@code messages.properties}).
+ */
+class AvailableLocaleResolverSpec extends Specification {
+
+    private AvailableLocaleResolver newResolver(Locale defaultLocale = Locale.forLanguageTag('en')) {
+        new AvailableLocaleResolver(getClass().classLoader, defaultLocale)
+    }
+
+    void 'discovers the locales that have a messages bundle plus the default locale'() {
+        when:
+        List<Locale> locales = newResolver().availableLocales
+
+        then:
+        locales.contains(Locale.forLanguageTag('en'))
+        locales.contains(Locale.forLanguageTag('es'))
+        locales.contains(Locale.forLanguageTag('fr'))
+        locales.contains(Locale.forLanguageTag('pt-BR'))
+    }
+
+    void 'sorts the discovered locales by their display name in their own language'() {
+        given:
+        List<Locale> expectedKnown = [
+                Locale.forLanguageTag('en'),
+                Locale.forLanguageTag('es'),
+                Locale.forLanguageTag('fr'),
+                Locale.forLanguageTag('pt-BR')
+        ].sort { it.getDisplayName(it) }
+
+        when: 'the discovered list is narrowed to the bundles this test controls'
+        List<Locale> actualKnown = newResolver().availableLocales.findAll { it in expectedKnown }
+
+        then: 'their relative order matches a display-name sort'
+        actualKnown == expectedKnown
+    }
+
+    void 'always includes the configured default locale even without a matching bundle'() {
+        expect:
+        newResolver(Locale.forLanguageTag('de')).availableLocales.contains(Locale.forLanguageTag('de'))
+    }
+
+    void 'returns an unmodifiable list'() {
+        when:
+        newResolver().availableLocales.add(Locale.forLanguageTag('zz'))
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    void 'caches the computed list until the cache is cleared'() {
+        given:
+        AvailableLocaleResolver resolver = newResolver()
+
+        expect: 'the same instance is returned while cached'
+        resolver.availableLocales.is(resolver.availableLocales)
+
+        when: 'the cache is cleared'
+        List<Locale> before = resolver.availableLocales
+        resolver.clearCache()
+        List<Locale> after = resolver.availableLocales
+
+        then: 'a freshly computed list is returned with equal contents'
+        !before.is(after)
+        before == after
+    }
+}

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nAutoConfigurationSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nAutoConfigurationSpec.groovy
@@ -159,9 +159,10 @@ class I18nAutoConfigurationSpec extends Specification {
         expect:
         contextRunner().run { context ->
             def resolver = context.getBean(AvailableLocaleResolver)
-            // the default locale defaults to en, and includePlugins defaults to true so the
+            // without grails.i18n.default.locale the JVM default is included (same fallback the
+            // fixed localeResolver uses), and includePlugins defaults to true so the
             // plugin-namespaced spring-security-core_zu.properties fixture is discovered
-            assert resolver.availableLocales.contains(Locale.forLanguageTag('en'))
+            assert resolver.availableLocales.contains(Locale.getDefault())
             assert resolver.availableLocales.contains(Locale.forLanguageTag('zu'))
         }
     }

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nAutoConfigurationSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nAutoConfigurationSpec.groovy
@@ -155,6 +155,46 @@ class I18nAutoConfigurationSpec extends Specification {
         parent.close()
     }
 
+    void 'the availableLocaleResolver bean registers by default and includes plugin bundles'() {
+        expect:
+        contextRunner().run { context ->
+            def resolver = context.getBean(AvailableLocaleResolver)
+            // the default locale defaults to en, and includePlugins defaults to true so the
+            // plugin-namespaced spring-security-core_zu.properties fixture is discovered
+            assert resolver.availableLocales.contains(Locale.forLanguageTag('en'))
+            assert resolver.availableLocales.contains(Locale.forLanguageTag('zu'))
+        }
+    }
+
+    void 'grails.i18n.default.locale and availableLocales.includePlugins drive the availableLocaleResolver'() {
+        expect:
+        contextRunner()
+                .withPropertyValues(
+                        'grails.i18n.default.locale=pt_BR',
+                        'grails.i18n.availableLocales.includePlugins=false')
+                .run { context ->
+                    def resolver = context.getBean(AvailableLocaleResolver)
+                    // the underscore form is normalised to a language tag
+                    assert resolver.availableLocales.contains(Locale.forLanguageTag('pt-BR'))
+                    // plugin-namespaced bundles are excluded when includePlugins=false
+                    assert !resolver.availableLocales.contains(Locale.forLanguageTag('zu'))
+                }
+    }
+
+    void 'a user-defined AvailableLocaleResolver bean makes the Grails availableLocaleResolver back off'() {
+        given:
+        AvailableLocaleResolver userResolver = new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'))
+        Supplier<AvailableLocaleResolver> userResolverSupplier = () -> userResolver
+
+        expect:
+        contextRunner()
+                .withBean('availableLocaleResolver', AvailableLocaleResolver, userResolverSupplier)
+                .run { context ->
+                    assert context.getBean(AvailableLocaleResolver).is(userResolver)
+                    assert context.getBeanNamesForType(AvailableLocaleResolver).length == 1
+                }
+    }
+
     void 'a user-defined messageSource bean makes the Grails messageSource back off'() {
         given:
         MessageSource userMessageSource = new StaticMessageSource()

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nGrailsPluginSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nGrailsPluginSpec.groovy
@@ -1,0 +1,122 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.i18n
+
+import grails.core.DefaultGrailsApplication
+
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.mock.web.MockServletContext
+import org.springframework.web.context.support.StaticWebApplicationContext
+
+import spock.lang.Specification
+
+/**
+ * Tests the available-locale publishing lifecycle of {@link I18nGrailsPlugin}: the discovered
+ * locales are published to the servlet context on startup and republished (after a re-scan)
+ * when a message bundle changes.
+ */
+class I18nGrailsPluginSpec extends Specification {
+
+    private static StaticWebApplicationContext webContext(AvailableLocaleResolver resolver = null) {
+        StaticWebApplicationContext ctx = new StaticWebApplicationContext()
+        ctx.servletContext = new MockServletContext()
+        if (resolver != null) {
+            ctx.beanFactory.registerSingleton('availableLocaleResolver', resolver)
+        }
+        // StaticApplicationContext already registers a StaticMessageSource under 'messageSource',
+        // which is what onChange() looks up
+        ctx.refresh()
+        ctx
+    }
+
+    private static I18nGrailsPlugin pluginFor(StaticWebApplicationContext ctx) {
+        I18nGrailsPlugin plugin = new I18nGrailsPlugin()
+        plugin.applicationContext = ctx
+        plugin.grailsApplication = new DefaultGrailsApplication()
+        plugin
+    }
+
+    void 'doWithApplicationContext publishes the available locales to the servlet context'() {
+        given:
+        AvailableLocaleResolver resolver = new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'))
+        StaticWebApplicationContext ctx = webContext(resolver)
+        I18nGrailsPlugin plugin = pluginFor(ctx)
+
+        when:
+        plugin.doWithApplicationContext()
+
+        then: 'views read the exact list the resolver computed'
+        ctx.servletContext.getAttribute('availableLocales').is(resolver.availableLocales)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void 'doWithApplicationContext is a no-op outside a web application context'() {
+        given:
+        GenericApplicationContext ctx = new GenericApplicationContext()
+        ctx.refresh()
+        I18nGrailsPlugin plugin = new I18nGrailsPlugin()
+        plugin.applicationContext = ctx
+
+        when:
+        plugin.doWithApplicationContext()
+
+        then:
+        notThrown(Exception)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void 'doWithApplicationContext publishes nothing when no availableLocaleResolver bean exists'() {
+        given:
+        StaticWebApplicationContext ctx = webContext()
+        I18nGrailsPlugin plugin = pluginFor(ctx)
+
+        when:
+        plugin.doWithApplicationContext()
+
+        then:
+        ctx.servletContext.getAttribute('availableLocales') == null
+
+        cleanup:
+        ctx.close()
+    }
+
+    void 'onChange re-scans and republishes the available locales when a bundle changes'() {
+        given: 'the locales have been published once and are cached'
+        AvailableLocaleResolver resolver = new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'))
+        StaticWebApplicationContext ctx = webContext(resolver)
+        I18nGrailsPlugin plugin = pluginFor(ctx)
+        plugin.doWithApplicationContext()
+        List<Locale> before = (List<Locale>) ctx.servletContext.getAttribute('availableLocales')
+
+        when: 'a bundle-change event arrives (a non-file source, so no bundle copying is attempted)'
+        plugin.onChange([source: 'messages_es.properties'] as Map<String, Object>)
+
+        then: 'a freshly computed list with the same contents is republished'
+        List<Locale> after = (List<Locale>) ctx.servletContext.getAttribute('availableLocales')
+        !after.is(before)
+        after == before
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nGrailsPluginSpec.groovy
+++ b/grails-i18n/src/test/groovy/org/grails/plugins/i18n/I18nGrailsPluginSpec.groovy
@@ -33,11 +33,12 @@ import spock.lang.Specification
  */
 class I18nGrailsPluginSpec extends Specification {
 
-    private static StaticWebApplicationContext webContext(AvailableLocaleResolver resolver = null) {
+    private static StaticWebApplicationContext webContext(AvailableLocaleResolver resolver = null,
+                                                          String beanName = 'availableLocaleResolver') {
         StaticWebApplicationContext ctx = new StaticWebApplicationContext()
         ctx.servletContext = new MockServletContext()
         if (resolver != null) {
-            ctx.beanFactory.registerSingleton('availableLocaleResolver', resolver)
+            ctx.beanFactory.registerSingleton(beanName, resolver)
         }
         // StaticApplicationContext already registers a StaticMessageSource under 'messageSource',
         // which is what onChange() looks up
@@ -62,6 +63,22 @@ class I18nGrailsPluginSpec extends Specification {
         plugin.doWithApplicationContext()
 
         then: 'views read the exact list the resolver computed'
+        ctx.servletContext.getAttribute('availableLocales').is(resolver.availableLocales)
+
+        cleanup:
+        ctx.close()
+    }
+
+    void 'a user-defined resolver under a custom bean name is still published (lookup is by type)'() {
+        given: 'the auto-configuration backs off by type, so the plugin must find the bean by type too'
+        AvailableLocaleResolver resolver = new AvailableLocaleResolver(getClass().classLoader, Locale.forLanguageTag('en'))
+        StaticWebApplicationContext ctx = webContext(resolver, 'myOwnLocaleResolver')
+        I18nGrailsPlugin plugin = pluginFor(ctx)
+
+        when:
+        plugin.doWithApplicationContext()
+
+        then:
         ctx.servletContext.getAttribute('availableLocales').is(resolver.availableLocales)
 
         cleanup:

--- a/grails-i18n/src/test/resources/bogus-plugin_zz.properties
+++ b/grails-i18n/src/test/resources/bogus-plugin_zz.properties
@@ -1,0 +1,1 @@
+fixture=a bundle whose suffix (zz) is not an ISO language; must never contribute a locale

--- a/grails-i18n/src/test/resources/messages.properties
+++ b/grails-i18n/src/test/resources/messages.properties
@@ -1,0 +1,1 @@
+default.greeting=Hello

--- a/grails-i18n/src/test/resources/messages_.properties
+++ b/grails-i18n/src/test/resources/messages_.properties
@@ -1,0 +1,1 @@
+fixture=a bundle with an empty locale suffix; must never contribute a locale

--- a/grails-i18n/src/test/resources/messages_es.properties
+++ b/grails-i18n/src/test/resources/messages_es.properties
@@ -1,0 +1,1 @@
+default.greeting=Hola

--- a/grails-i18n/src/test/resources/messages_fr.properties
+++ b/grails-i18n/src/test/resources/messages_fr.properties
@@ -1,0 +1,1 @@
+default.greeting=Bonjour

--- a/grails-i18n/src/test/resources/messages_pt_BR.properties
+++ b/grails-i18n/src/test/resources/messages_pt_BR.properties
@@ -1,0 +1,1 @@
+default.greeting=Olá

--- a/grails-i18n/src/test/resources/report_en_prod.properties
+++ b/grails-i18n/src/test/resources/report_en_prod.properties
@@ -1,0 +1,1 @@
+fixture=a bundle-like name whose suffix (en_prod) has a non-ISO country; must never contribute a locale

--- a/grails-i18n/src/test/resources/spring-security-core_zu.properties
+++ b/grails-i18n/src/test/resources/spring-security-core_zu.properties
@@ -1,0 +1,1 @@
+default.greeting=Sawubona

--- a/grails-i18n/src/test/resources/standalone.properties
+++ b/grails-i18n/src/test/resources/standalone.properties
@@ -1,0 +1,1 @@
+fixture=a properties file with no locale suffix; must never contribute a locale

--- a/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
@@ -16,6 +16,24 @@
         <a class="navbar-brand d-flex align-items-center" href="${request.contextPath}/">
             <asset:image class="w-75" src="grails.svg" alt="Grails Logo"/>
         </a>
+        <g:set var="availableLocales" value="${application.getAttribute('availableLocales')}"/>
+        <g:if test="${availableLocales && availableLocales.size() > 1}">
+            <g:set var="currentLocale" value="${org.springframework.web.servlet.support.RequestContextUtils.getLocale(request)}"/>
+            <ul class="navbar-nav ms-auto">
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="localeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="bi bi-globe me-1"></i>${currentLocale.getDisplayName(currentLocale)}
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
+                        <g:each in="${availableLocales}" var="availableLocale">
+                            <li>
+                                <a class="dropdown-item${availableLocale == currentLocale ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
+                            </li>
+                        </g:each>
+                    </ul>
+                </li>
+            </ul>
+        </g:if>
     </div>
 </nav>
 

--- a/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
@@ -28,7 +28,7 @@
                     <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
                         <g:each in="${availableLocales}" var="availableLocale">
                             <li>
-                                <a class="dropdown-item${availableLocale == currentLocale ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
+                                <a class="dropdown-item${availableLocale.language == currentLocale.language ? ' active' : ''}" href="?lang=${availableLocale.toLanguageTag()}">${availableLocale.getDisplayName(availableLocale)}</a>
                             </li>
                         </g:each>
                     </ul>


### PR DESCRIPTION
## Summary

Grails already ships the *switch-language* half of i18n — `I18nAutoConfiguration` wires a `SessionLocaleResolver` and a `?lang=`-driven `LocaleChangeInterceptor`, and `FormTagLib` has a `g:localeSelect`. What was missing was a way to discover **which locales an application is actually translated into** (`g:localeSelect` lists all ~150 `Locale.getAvailableLocales()`, which is not useful as a language switcher) and a ready-made selector in the generated app.

This PR adds that discovery to `grails-i18n` and surfaces a language dropdown in the default `create-app` layout. Because a generated web app already ships the `messages_*.properties` bundles (via the forge default plugins / the `base` profile skeleton), a freshly created app shows a fully-populated language switcher out of the box with no configuration.

## Changes

**`grails-i18n`**
- New `AvailableLocaleResolver` — scans the classpath for `messages_*.properties` and returns the translated locales (plus the configurable default locale, `grails.i18n.default.locale`, default `en`), sorted by display name and cached.
- `I18nAutoConfiguration` registers it as a bean (`@ConditionalOnMissingBean`).
- `I18nGrailsPlugin` publishes the list to the servlet context (`availableLocales`) on startup and re-scans on dev-mode bundle changes. Reading a servlet-context attribute keeps consumers decoupled from this module (no new compile dependency in `grails-gsp` / `grails-forge`).

**`grails-gsp`**
- `g:localeSelect` gains an `available="true"` attribute that lists only the translated locales instead of every JVM locale. Default behaviour is unchanged.

**Generated app (`grails-forge` template + classic `web` profile skeleton)**
- The default `main.gsp` navbar gets a Bootstrap language dropdown that iterates the published locales and switches via the existing `?lang=` interceptor. It renders only when more than one locale is available.

**Docs**
- `localeSelect` tag reference + the "Changing Locales" guide.

## Tests
- `AvailableLocaleResolverSpec` (resolver discovery, sorting, default locale, caching, immutability)
- `LocaleSelectAvailableSpec` (`available="true"` behaviour + a render test of the generated navbar snippet producing correct `?lang=` links)
- `GrailsGspSpec` gains a check that the generated layout contains the dropdown

All green.

## Update: plugin-contributed locales (default on)

`AvailableLocaleResolver` now discovers locales contributed by plugins too — their bundles are namespaced (e.g. `spring-security-core_fr.properties`) and were previously missed. When enabled it scans every root-level `*.properties` bundle on the classpath and validates each candidate suffix against `Locale.getISOLanguages()`, so non-i18n files (`application.properties`, etc.) are ignored.

Controlled by `grails.i18n.availableLocales.includePlugins`, **default `true`** — a selector lists every locale the app or its plugins provide out of the box. Set it to `false` to restrict discovery to the application's own `messages_*.properties`.
