### PR TITLE
Forge - Grails 8 Updates around Grails Data

### DIFF
--- a/grails-doc/src/en/guide/commandLine/creatingProject.adoc
+++ b/grails-doc/src/en/guide/commandLine/creatingProject.adoc
@@ -51,7 +51,7 @@ After generating a project with Forge, switch to the created directory and use t
 [none]
 * -jdk, --java-version
 * -s, --servlet
-* -g, --gorm
+* -d, --data (-g, --gorm are legacy aliases)
 * -t, --test
 * -f, --features
 * -i, --inplace
@@ -61,7 +61,7 @@ After generating a project with Forge, switch to the created directory and use t
 ./grails -t forge create-app \
     --servlet=tomcat \
     --jdk=11 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --test=spock \
     --features=github-workflow-java-ci \
     com.example.demo
@@ -73,7 +73,7 @@ After generating a project with Forge, switch to the created directory and use t
 [none]
 * -jdk, --java-version
 * -s, --servlet
-* -g, --gorm
+* -d, --data (-g, --gorm are legacy aliases)
 * -t, --test
 * -f, --features
 * -i, --inplace
@@ -83,7 +83,7 @@ After generating a project with Forge, switch to the created directory and use t
 ./grails -t forge create-restapi \
     --servlet=tomcat \
     --jdk=11 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --test=spock \
     --features=github-workflow-java-ci \
     com.example.demo
@@ -95,7 +95,7 @@ After generating a project with Forge, switch to the created directory and use t
 [none]
 * -jdk, --java-version
 * -s, --servlet
-* -g, --gorm
+* -d, --data (-g, --gorm are legacy aliases)
 * -t, --test
 * -f, --features
 * -i, --inplace
@@ -105,7 +105,7 @@ After generating a project with Forge, switch to the created directory and use t
 ./grails -t forge create-plugin \
     --servlet=tomcat \
     --jdk=11 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --test=spock \
     --features=github-workflow-java-ci \
     com.example.demo
@@ -117,7 +117,7 @@ After generating a project with Forge, switch to the created directory and use t
 [none]
 * -jdk, --java-version
 * -s, --servlet
-* -g, --gorm
+* -d, --data (-g, --gorm are legacy aliases)
 * -t, --test
 * -f, --features
 * -i, --inplace
@@ -127,7 +127,7 @@ After generating a project with Forge, switch to the created directory and use t
 ./grails -t forge create-web-plugin \
     --servlet=tomcat \
     --jdk=11 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --test=spock \
     --features=github-workflow-java-ci \
     com.example.demo
@@ -136,7 +136,7 @@ After generating a project with Forge, switch to the created directory and use t
 
 === The `create-` command flags
 
-The "create-*" commands are used to produce a fundamental Grails project, allowing for the inclusion of optional flags to select additional features, to customize GORM settings, an embedded servlet, the test framework, and the Java version.
+The "create-*" commands are used to produce a fundamental Grails project, allowing for the inclusion of optional flags to select additional features, to customize Grails Data settings, an embedded servlet, the test framework, and the Java version.
 
 [cols="4,8,6a"]
 |===
@@ -158,12 +158,12 @@ The "create-*" commands are used to produce a fundamental Grails project, allowi
 --servlet=tomcat
 ----
 
-| -g, --gorm
-| Which GORM Implementation to configure. Possible values: hibernate, hibernate7, mongodb.
+| -d, --data (-g, --gorm are legacy aliases)
+| Which Grails Data implementation to configure. Possible values: hibernate5, hibernate7, mongodb. The value hibernate is accepted as a legacy alias for hibernate5.
 |
 [source,shell]
 ----
---gorm hibernate
+--data hibernate5
 ----
 
 | -t, --test

--- a/grails-doc/src/en/guide/commandLine/creatingProject.adoc
+++ b/grails-doc/src/en/guide/commandLine/creatingProject.adoc
@@ -159,7 +159,7 @@ The "create-*" commands are used to produce a fundamental Grails project, allowi
 ----
 
 | -g, --gorm
-| Which GORM Implementation to configure. Possible values: hibernate, mongodb, neo4j.
+| Which GORM Implementation to configure. Possible values: hibernate, hibernate7, mongodb.
 |
 [source,shell]
 ----
@@ -175,7 +175,7 @@ The "create-*" commands are used to produce a fundamental Grails project, allowi
 ----
 
 | -f, --features
-| The features to use. Possible values: h2, gorm-hibernate5, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties
+| The features to use. Possible values: h2, gorm-hibernate5, gorm-hibernate7, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties
 |
 [source,shell]
 ----

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc
@@ -20,7 +20,7 @@ under the License.
 The `create-app` command is available in both the Grails Shell CLI and the Forge CLI.
 
 - Use `grails create-app myapp` to generate a default project using the Grails Shell CLI. This is the most common usage.
-- Use `grails -t forge create-app myapp` to access advanced application generation options such as `--jdk`, `--gorm`, and other Forge-only flags.
+- Use `grails -t forge create-app myapp` to access advanced application generation options such as `--jdk`, `--data`, and other Forge-only flags.
 
 The example below assumes you are using the Forge CLI, which is solely intended for **application generation**. It does not support running, building, or managing a Grails application.
 

--- a/grails-doc/src/en/guide/commandLine/interactiveMode.adoc
+++ b/grails-doc/src/en/guide/commandLine/interactiveMode.adoc
@@ -75,9 +75,9 @@ Creates an application
                           grails-console, views-markup, asset-pipeline-grails, views-json,
                           gorm-neo4j, asciidoctor, grails-web-console,
                           logbackGroovy, mongo-sync, shade, geb, properties
-  -g, --gorm=GORM Implementation
-                        Which GORM Implementation to configure. Possible values: hibernate,
-                          mongodb, neo4j.
+  -d, --data, -g, --gorm=Grails Data Implementation
+                        Which Grails Data implementation to configure (-g, --gorm are legacy
+                          aliases). Possible values: hibernate5, hibernate7, mongodb.
   -h, --help            Show this help message and exit.
   -i, --inplace         Create a service using the current directory
       --jdk, --java-version=<javaVersion>

--- a/grails-doc/src/en/guide/commandLine/interactiveMode.adoc
+++ b/grails-doc/src/en/guide/commandLine/interactiveMode.adoc
@@ -61,13 +61,13 @@ You can access general usage information for Grails commands using the help flag
 [source,shell]
 ----
 grails> create-app -h
-Usage: grails create-app [-hivVx] [--list-features] [-g=GORM Implementation] [--jdk=<javaVersion>]
+Usage: grails create-app [-hivVx] [--list-features] [-d=Grails Data Implementation] [--jdk=<javaVersion>]
                          [-s=Servlet Implementation] [-t=TEST] [-f=FEATURE[,FEATURE...]]... [NAME]
 Creates an application
       [NAME]            The name of the application to create.
   -f, --features=FEATURE[,FEATURE...]
                         The features to use. Possible values: h2, scaffolding, gorm-hibernate5,
-                          spring-boot-starter-jetty, spring-boot-starter-tomcat,
+                          gorm-hibernate7, spring-boot-starter-jetty, spring-boot-starter-tomcat,
                           micronaut-http-client, cache-ehcache, hibernate-validator, postgres,
                           mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb,
                           assertj, mockito, spring-boot-starter-undertow,
@@ -116,8 +116,9 @@ Available Features
 
   Database
   database-migration                  Adds support for Liquibase database migrations. The Database Migration plugin helps you manage database changes while developing Grails applications.
-  gorm-hibernate5 (+)                 Adds support for Hibernate5 using GORM
-  gorm-mongodb                        Configures GORM for MongoDB for Groovy applications
+  gorm-hibernate5 (+)                 Configure Grails Data for using Hibernate 5.
+  gorm-hibernate7                     Configure Grails Data for using Hibernate 7.
+  gorm-mongodb                        Configure Grails Data for using MongoDB.
   gorm-neo4j                          Configures GORM for Neo4j for Groovy applications
   h2 (+)                              Adds the H2 driver and default config
   mongo-sync                          Adds support for the MongoDB Synchronous Driver

--- a/grails-doc/src/en/guide/introduction/whatsNew.adoc
+++ b/grails-doc/src/en/guide/introduction/whatsNew.adoc
@@ -39,6 +39,20 @@ This brings the Spring Boot 4 modular artifact layout, Spring Framework 7 API re
 
 The Grails 8 upgrade guide calls out the major application-impacting changes and links to the Spring Boot 4.0 migration guide, Spring Boot 4.1 release notes and Spring Framework 7.0 release notes.
 
+==== Hibernate 7 Application Generation
+
+Grails Forge can now generate applications configured for Grails Data with Hibernate 7.
+The `create-*` commands also accept a new `-d, --data` option (the previous `-g` and `--gorm` flags remain supported as legacy aliases) with the values `hibernate5`, `hibernate7`, and `mongodb`; the legacy value `hibernate` is still accepted and selects Hibernate 5:
+
+[source,console]
+----
+grails -t forge create-app --data=hibernate7 com.example.demo
+----
+
+Applications generated for Hibernate 7 consume `grails-hibernate7-bom` — or `grails-hibernate7-micronaut-bom` when combined with the `grails-micronaut` feature — consistently across the application dependencies, the buildscript classpath, and `buildSrc`.
+This avoids the dependency resolution conflicts that occur when an application generated for Hibernate 5 is manually switched to `grails-data-hibernate7` while the default `grails-bom` remains on the build classpath.
+The `database-migration` feature also selects the matching `grails-data-hibernate7-dbmigration` plugin automatically.
+
 ==== GSP Tag Library Improvements
 
 Grails {grailsMajorVersion} continues the move toward method-based TagLib handlers while preserving compatibility with existing closure-based tags.

--- a/grails-doc/src/en/ref/Command Line/create-app.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-app.adoc
@@ -29,7 +29,7 @@ In Grails {grailsMajorVersion}, `create-app` is available in both the **Grails S
 
 - Most users should use the **Grails Shell CLI** by default (`grails create-app bookstore`). This version supports core development commands and project lifecycle management, and includes basic `create-*` flags like `--inplace`, `--features`, and `--profile`.
 
-- The **Forge CLI** (`grails -t forge create-app bookstore`) is intended solely for **application generation** with extended configuration flags such as `--jdk`, `--gorm`, and `--servlet`.
+- The **Forge CLI** (`grails -t forge create-app bookstore`) is intended solely for **application generation** with extended configuration flags such as `--jdk`, `--data`, and `--servlet`.
 
 Forge-specific flags will result in an error if used with the Shell CLI.
 ====
@@ -50,7 +50,7 @@ This uses the **Forge CLI** to generate an application with extended configurati
 ----
 $ grails -t forge create-app bookstore \
     --jdk=17 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --servlet=tomcat \
     --test=spock \
     --features=asciidoctor,github-workflow-java-ci
@@ -62,7 +62,7 @@ These options are available only when using `grails -t forge`:
 
 - `NAME`: The desired name for the application.
 - `-f, --features=FEATURE[,FEATURE...]`: Enable features like `gorm-hibernate5`, `postgres`, `asciidoctor`, `grails-gsp`, etc.
-- `-g, --gorm=GORM Implementation`: Choose GORM implementation: `hibernate`, `mongodb`, `neo4j`.
+- `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Choose the Grails Data implementation: `hibernate5`, `hibernate7`, `mongodb`.
 - `--jdk=<javaVersion>`: Target JDK version (e.g., 11 or 17).
 - `-s, --servlet=Servlet Implementation`: Choose embedded servlet: `tomcat`, `jetty`, `undertow`, `none`.
 - `-t, --test=TEST`: Select test framework: `spock`, `junit`.
@@ -83,7 +83,7 @@ Available flags:
 - `--features` _(limited support depending on profile)_
 - `--profile`
 
-Forge-only options such as `--jdk`, `--gorm`, or `--servlet` are **not supported** in the Shell CLI.
+Forge-only options such as `--jdk`, `--data`, or `--servlet` are **not supported** in the Shell CLI.
 
 === Examples
 
@@ -101,7 +101,7 @@ $ cd bookstore
 ----
 $ grails -t forge create-app bookstore \
     --jdk=17 \
-    --gorm=hibernate \
+    --data=hibernate5 \
     --features=asciidoctor,grails-gsp
 ----
 

--- a/grails-doc/src/en/ref/Command Line/create-app.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-app.adoc
@@ -61,7 +61,7 @@ $ grails -t forge create-app bookstore \
 These options are available only when using `grails -t forge`:
 
 - `NAME`: The desired name for the application.
-- `-f, --features=FEATURE[,FEATURE...]`: Enable features like `gorm-hibernate5`, `postgres`, `asciidoctor`, `grails-gsp`, etc.
+- `-f, --features=FEATURE[,FEATURE...]`: Enable features like `gorm-hibernate5`, `gorm-hibernate7`, `postgres`, `asciidoctor`, `grails-gsp`, etc.
 - `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Choose the Grails Data implementation: `hibernate5`, `hibernate7`, `mongodb`.
 - `--jdk=<javaVersion>`: Target JDK version (e.g., 11 or 17).
 - `-s, --servlet=Servlet Implementation`: Choose embedded servlet: `tomcat`, `jetty`, `undertow`, `none`.

--- a/grails-doc/src/en/ref/Command Line/create-plugin.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-plugin.adoc
@@ -64,13 +64,13 @@ grails create-plugin [OPTIONS] NAME
 
 - `NAME`: The desired name for the Grails plugin.
 
-Options include specifying features, configuring the GORM implementation, selecting a servlet implementation, choosing a test framework, setting the JDK version, and more. You can tailor your Grails plugin to your specific requirements using these options.
+Options include specifying features, configuring the Grails Data implementation, selecting a servlet implementation, choosing a test framework, setting the JDK version, and more. You can tailor your Grails plugin to your specific requirements using these options.
 
 === Options
 
 Here are the available options for the create-plugin command:
 
-- -f, --features=FEATURE[,FEATURE...]: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow,  github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
+- -f, --features=FEATURE[,FEATURE...]: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, gorm-hibernate7, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow,  github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
 - -d, --data=Grails Data Implementation (-g, --gorm are legacy aliases): Specifies the Grails Data implementation to configure for the plugin. Possible values are hibernate5, hibernate7, mongodb.
 - -h, --help: Displays the help message and exits.
 - -i, --inplace: Creates a service within the current directory.
@@ -109,7 +109,7 @@ This command will create a Grails plugin project named "minimal-plugin" with the
 grails create-plugin mongodb-plugin --data=mongodb
 ----
 +
-This command will generate a Grails plugin project named "mongodb-plugin" configured to use MongoDB as the GORM implementation.
+This command will generate a Grails plugin project named "mongodb-plugin" configured to use MongoDB as the Grails Data implementation.
 
 3. Create a plugin with embedded H2 database and view support:
 
@@ -121,4 +121,4 @@ grails create-plugin h2-views-plugin --features h2,views-markup
 +
 This command will create a Grails plugin project named "h2-views-plugin" with the H2 database and views markup feature enabled, making it useful for projects that require an embedded database and view rendering capabilities.
 
-These additional examples showcase different use cases for the `create-plugin` command, such as creating minimal plugins, customizing GORM implementations, and enabling specific features to meet project requirements.
+These additional examples showcase different use cases for the `create-plugin` command, such as creating minimal plugins, customizing Grails Data implementations, and enabling specific features to meet project requirements.

--- a/grails-doc/src/en/ref/Command Line/create-plugin.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-plugin.adoc
@@ -71,7 +71,7 @@ Options include specifying features, configuring the GORM implementation, select
 Here are the available options for the create-plugin command:
 
 - -f, --features=FEATURE[,FEATURE...]: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow,  github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
-- -g, --gorm=GORM Implementation: Specifies the GORM Implementation to configure for the plugin. Possible values are hibernate, mongodb, neo4j.
+- -d, --data=Grails Data Implementation (-g, --gorm are legacy aliases): Specifies the Grails Data implementation to configure for the plugin. Possible values are hibernate5, hibernate7, mongodb.
 - -h, --help: Displays the help message and exits.
 - -i, --inplace: Creates a service within the current directory.
 - --jdk=<javaVersion>: Specifies the JDK version the project should target.
@@ -106,7 +106,7 @@ This command will create a Grails plugin project named "minimal-plugin" with the
 +
 [source,shell]
 ----
-grails create-plugin mongodb-plugin --gorm=mongodb
+grails create-plugin mongodb-plugin --data=mongodb
 ----
 +
 This command will generate a Grails plugin project named "mongodb-plugin" configured to use MongoDB as the GORM implementation.

--- a/grails-doc/src/en/ref/Command Line/create-restapi.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-restapi.adoc
@@ -40,7 +40,7 @@ The `create-restapi` command accepts the following options:
 
 - `NAME`: The desired name for the REST API application.
 
-- `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include. Available options include h2, scaffolding, gorm-hibernate5, spring-boot-starter-jetty, spring-boot-starter-tomcat, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, asset-pipeline-grails, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, geb, properties.
+- `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include. Available options include h2, scaffolding, gorm-hibernate5, gorm-hibernate7, spring-boot-starter-jetty, spring-boot-starter-tomcat, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, asset-pipeline-grails, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, geb, properties.
 
 - `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Specifies the Grails Data implementation to configure, with options hibernate5, hibernate7, mongodb.
 

--- a/grails-doc/src/en/ref/Command Line/create-restapi.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-restapi.adoc
@@ -42,7 +42,7 @@ The `create-restapi` command accepts the following options:
 
 - `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include. Available options include h2, scaffolding, gorm-hibernate5, spring-boot-starter-jetty, spring-boot-starter-tomcat, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, asset-pipeline-grails, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, geb, properties.
 
-- `-g, --gorm=GORM Implementation`: Specifies the GORM Implementation to configure, with options like hibernate, mongodb, neo4j.
+- `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Specifies the Grails Data implementation to configure, with options hibernate5, hibernate7, mongodb.
 
 - `-h, --help`: Displays the help message and exits.
 

--- a/grails-doc/src/en/ref/Command Line/create-web-plugin.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-web-plugin.adoc
@@ -40,7 +40,7 @@ Here are the available options for the `create-web-plugin` command:
 
 - `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
 
-- `-g, --gorm=GORM Implementation`: Specifies the GORM Implementation to configure for the plugin. Possible values are hibernate, mongodb, neo4j.
+- `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Specifies the Grails Data implementation to configure for the plugin. Possible values are hibernate5, hibernate7, mongodb.
 
 - `-h, --help`: Displays the help message and exits.
 

--- a/grails-doc/src/en/ref/Command Line/create-web-plugin.adoc
+++ b/grails-doc/src/en/ref/Command Line/create-web-plugin.adoc
@@ -38,7 +38,7 @@ grails create-web-plugin [OPTIONS] NAME
 
 Here are the available options for the `create-web-plugin` command:
 
-- `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
+- `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include in the plugin. Available options include h2, gorm-hibernate5, gorm-hibernate7, spring-boot-starter-jetty, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, views-json, gorm-neo4j, asciidoctor, grails-web-console, logbackGroovy, mongo-sync, shade, properties.
 
 - `-d, --data=Grails Data Implementation` (`-g`, `--gorm` are legacy aliases): Specifies the Grails Data implementation to configure for the plugin. Possible values are hibernate5, hibernate7, mongodb.
 

--- a/grails-doc/src/en/ref/Command Line/help.adoc
+++ b/grails-doc/src/en/ref/Command Line/help.adoc
@@ -134,13 +134,13 @@ NOTE: To access help for Forge-only options such as `--features`, `--jdk`, or `-
 [source,shell]
 ----
 grails> create-app --help
-Usage: grails create-app [-hivVx] [--list-features] [-g=GORM Implementation] [--jdk=<javaVersion>]
+Usage: grails create-app [-hivVx] [--list-features] [-d=Grails Data Implementation] [--jdk=<javaVersion>]
                          [-s=Servlet Implementation] [-t=TEST] [-f=FEATURE[,FEATURE...]]... [NAME]
 Creates an application
       [NAME]            The name of the application to create.
   -f, --features=FEATURE[,FEATURE...]
                         The features to use. Possible values: h2, scaffolding, gorm-hibernate5,
-                          spring-boot-starter-jetty, spring-boot-starter-tomcat,
+                          gorm-hibernate7, spring-boot-starter-jetty, spring-boot-starter-tomcat,
                           micronaut-http-client, cache-ehcache, hibernate-validator, postgres,
                           mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb,
                           assertj, mockito, spring-boot-starter-undertow,

--- a/grails-doc/src/en/ref/Command Line/help.adoc
+++ b/grails-doc/src/en/ref/Command Line/help.adoc
@@ -148,9 +148,9 @@ Creates an application
                           grails-console, views-markup, asset-pipeline-grails, views-json,
                           gorm-neo4j, asciidoctor, grails-web-console,
                           logbackGroovy, mongo-sync, shade, geb, properties
-  -g, --gorm=GORM Implementation
-                        Which GORM Implementation to configure. Possible values: hibernate,
-                          mongodb, neo4j.
+  -d, --data, -g, --gorm=Grails Data Implementation
+                        Which Grails Data implementation to configure (-g, --gorm are legacy
+                          aliases). Possible values: hibernate5, hibernate7, mongodb.
   -h, --help            Show this help message and exit.
   -i, --inplace         Create a service using the current directory
       --jdk, --java-version=<javaVersion>

--- a/grails-doc/src/en/ref/Command Line/list-features.adoc
+++ b/grails-doc/src/en/ref/Command Line/list-features.adoc
@@ -65,8 +65,9 @@ Available Features
 
   Database
   database-migration                  Adds support for Liquibase database migrations. The Database Migration plugin helps you manage database changes while developing Grails applications.
-  gorm-hibernate5 (+)                 Adds support for Hibernate5 using GORM
-  gorm-mongodb                        Configures GORM for MongoDB for Groovy applications
+  gorm-hibernate5 (+)                 Configure Grails Data for using Hibernate 5.
+  gorm-hibernate7                     Configure Grails Data for using Hibernate 7.
+  gorm-mongodb                        Configure Grails Data for using MongoDB.
   gorm-neo4j                          Configures GORM for Neo4j for Groovy applications
   h2 (+)                              Adds the H2 driver and default config
   mongo-sync                          Adds support for the MongoDB Synchronous Driver

--- a/grails-forge/grails-forge-analytics-postgres/src/test/groovy/org/grails/forge/analytics/postgres/StoreGeneratedProjectStatsSpec.groovy
+++ b/grails-forge/grails-forge-analytics-postgres/src/test/groovy/org/grails/forge/analytics/postgres/StoreGeneratedProjectStatsSpec.groovy
@@ -73,7 +73,7 @@ class StoreGeneratedProjectStatsSpec extends Specification implements TestProper
         given:
         def generated = new Generated(
                 ApplicationType.WEB,
-                GormImpl.HIBERNATE,
+                GormImpl.HIBERNATE5,
                 ServletImpl.TOMCAT,
                 DevelopmentReloading.DEVTOOLS,
                 JdkVersion.DEFAULT_OPTION

--- a/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/GormImplDTO.java
+++ b/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/GormImplDTO.java
@@ -85,7 +85,7 @@ public class GormImplDTO extends Linkable implements Named, Described, Selectabl
 
     @NonNull
     @Override
-    @Schema(description = "A description of the GORM Implementation")
+    @Schema(description = "A description of the Grails Data implementation")
     public String getDescription() {
         return description;
     }
@@ -98,13 +98,13 @@ public class GormImplDTO extends Linkable implements Named, Described, Selectabl
     }
 
     @Override
-    @Schema(description = "The value of the GORM Implementation for select options")
+    @Schema(description = "The value of the Grails Data implementation for select options")
     public GormImpl getValue() {
         return value;
     }
 
     @Override
-    @Schema(description = "The label of the GORM Implementation for select options")
+    @Schema(description = "The label of the Grails Data implementation for select options")
     public String getLabel() {
         return value.getLabel();
     }

--- a/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/SelectOptionsDTO.java
+++ b/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/SelectOptionsDTO.java
@@ -90,7 +90,7 @@ public class SelectOptionsDTO {
         return reloading;
     }
 
-    @Schema(description = "supported options for GORM Implementation")
+    @Schema(description = "supported options for the Grails Data implementation")
     public GormImplSelectOptions getGorm() {
         return gorm;
     }

--- a/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/ServletImplDTO.java
+++ b/grails-forge/grails-forge-api/src/main/java/org/grails/forge/api/ServletImplDTO.java
@@ -74,7 +74,7 @@ public class ServletImplDTO extends Linkable implements Named, Described, Select
 
     @NonNull
     @Override
-    @Schema(description = "A description of the GORM Implementation")
+    @Schema(description = "A description of the Servlet implementation")
     public String getDescription() {
         return description;
     }

--- a/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/FeatureControllerSpec.groovy
+++ b/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/FeatureControllerSpec.groovy
@@ -21,9 +21,7 @@ package org.grails.forge.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.http.HttpRequest
-import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject

--- a/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/FeatureControllerSpec.groovy
+++ b/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/FeatureControllerSpec.groovy
@@ -21,7 +21,9 @@ package org.grails.forge.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -173,9 +175,8 @@ class FeatureControllerSpec extends Specification {
 
     void "test feature filter - invalid option as query parameter"() {
         when:
-        String response = httpClient.toBlocking().withCloseable { client ->
-            client.exchange(HttpRequest.GET('/application-types/' + ApplicationType.WEB.name + '/features?javaVersion=invalid'), String.class).body()
-        }
+        String response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/application-types/' + ApplicationType.WEB.name + '/features?javaVersion=invalid'), String.class).body()
 
         then:
         response
@@ -185,5 +186,28 @@ class FeatureControllerSpec extends Specification {
         def map = mapper.readValue(response, Map)
 
         map.features.collect { it -> it.name }.find { it == 'gorm-mongodb'}
+    }
+
+    void "test feature filter - Grails Data implementation as query parameter"() {
+        when: 'a valid Grails Data implementation is accepted'
+        String response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/application-types/' + ApplicationType.WEB.name + '/features?gorm=hibernate7'), String.class).body()
+
+        then:
+        response
+
+        when: 'the legacy hibernate value is accepted'
+        response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/application-types/' + ApplicationType.WEB.name + '/features?gorm=hibernate'), String.class).body()
+
+        then:
+        response
+
+        when: 'an invalid value falls back to the default like other filter options'
+        response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/application-types/' + ApplicationType.WEB.name + '/features?gorm=invalid'), String.class).body()
+
+        then:
+        response
     }
 }

--- a/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/ZipCreateControllerSpec.groovy
+++ b/grails-forge/grails-forge-api/src/test/groovy/org/grails/forge/api/ZipCreateControllerSpec.groovy
@@ -21,7 +21,10 @@ package org.grails.forge.api
 
 
 import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -35,6 +38,10 @@ class ZipCreateControllerSpec extends Specification {
 
     @Inject
     CreateClient client
+
+    @Inject
+    @Client("/")
+    HttpClient httpClient
 
     @Inject
     MyEventListener eventListener
@@ -110,5 +117,29 @@ class ZipCreateControllerSpec extends Specification {
 
         then:
         ZipUtil.containsFileWithContents(bytes, "test/build.gradle", "spring-boot-devtools")
+    }
+
+    void "test create app with an invalid Grails Data implementation is rejected"() {
+        when:
+        httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/create/web/test?gorm=invalid'), byte[].class)
+
+        then:
+        def e = thrown(HttpClientResponseException)
+        e.status == HttpStatus.BAD_REQUEST
+
+        when: 'a valid Grails Data implementation is accepted'
+        def response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/create/web/test?gorm=hibernate7'), byte[].class)
+
+        then:
+        ZipUtil.isZip(response.body())
+
+        when: 'the legacy hibernate value is accepted'
+        response = httpClient.toBlocking()
+                .exchange(HttpRequest.GET('/create/web/test?gorm=hibernate'), byte[].class)
+
+        then:
+        ZipUtil.isZip(response.body())
     }
 }

--- a/grails-forge/grails-forge-cli/src/main/java/org/grails/forge/cli/command/CreateCommand.java
+++ b/grails-forge/grails-forge-cli/src/main/java/org/grails/forge/cli/command/CreateCommand.java
@@ -50,7 +50,7 @@ public abstract class CreateCommand extends BaseCommand implements Callable<Inte
     DevelopmentReloading reloading;
 
     @ReflectiveAccess
-    @CommandLine.Option(names = {"-g", "--gorm"}, paramLabel = "GORM Implementation", description = "Which GORM Implementation to configure. Possible values: ${COMPLETION-CANDIDATES}.", completionCandidates = GormImplCandidates.class, converter = GormImplConverter.class)
+    @CommandLine.Option(names = {"-d", "--data", "-g", "--gorm"}, paramLabel = "Grails Data Implementation", description = "Which Grails Data implementation to configure (-g, --gorm are legacy aliases). Possible values: ${COMPLETION-CANDIDATES}.", completionCandidates = GormImplCandidates.class, converter = GormImplConverter.class)
     GormImpl gormImpl;
 
     @ReflectiveAccess

--- a/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/command/CreateAppCommandSpec.groovy
+++ b/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/command/CreateAppCommandSpec.groovy
@@ -64,7 +64,72 @@ class CreateAppCommandSpec extends CommandSpec implements CommandFixture {
 
         then:
         noExceptionThrown()
-        baos.toString().contains("Invalid GORM implementation selection: xyz")
+        baos.toString().contains("Invalid Grails Data implementation selection: xyz")
+    }
+
+    void "test creating a project with the data switch"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(CreateAppCommand, ctx, "dataswitch", "--data", "hibernate7")
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Application created")
+    }
+
+    void "test creating a project with the -d short alias"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(CreateAppCommand, ctx, "dshort", "-d", "hibernate7")
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Application created")
+    }
+
+    void "test creating a project with the legacy -g short alias"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(CreateAppCommand, ctx, "gshort", "-g", "hibernate5")
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Application created")
+    }
+
+    void "test creating a project with the legacy hibernate gorm value"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(CreateAppCommand, ctx, "legacygorm", "--gorm", "hibernate")
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Application created")
+    }
+
+    void "test creating a project with the hibernate5 gorm value"() {
+        given:
+        ByteArrayOutputStream out = new ByteArrayOutputStream()
+        System.setOut(new PrintStream(out))
+
+        when:
+        PicocliRunner.run(CreateAppCommand, ctx, "hib5gorm", "--gorm", "hibernate5")
+
+        then:
+        noExceptionThrown()
+        out.toString().contains("Application created")
     }
 
     void "community and preview features are labelled as such"() {

--- a/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/command/CreateAppCommandSpec.groovy
+++ b/grails-forge/grails-forge-cli/src/test/groovy/org/grails/forge/cli/command/CreateAppCommandSpec.groovy
@@ -41,6 +41,19 @@ class CreateAppCommandSpec extends CommandSpec implements CommandFixture {
     @AutoCleanup
     ApplicationContext beanContext = ApplicationContext.run()
 
+    PrintStream originalOut
+    PrintStream originalErr
+
+    void setup() {
+        originalOut = System.out
+        originalErr = System.err
+    }
+
+    void cleanup() {
+        System.setOut(originalOut)
+        System.setErr(originalErr)
+    }
+
     void "test creating project with defaults"() {
         given:
         ByteArrayOutputStream out = new ByteArrayOutputStream()
@@ -135,7 +148,6 @@ class CreateAppCommandSpec extends CommandSpec implements CommandFixture {
     void "community and preview features are labelled as such"() {
         given:
         ByteArrayOutputStream baos = new ByteArrayOutputStream()
-        PrintStream old = System.out
         System.setOut(new PrintStream(baos))
 
         and:
@@ -152,8 +164,5 @@ class CreateAppCommandSpec extends CommandSpec implements CommandFixture {
         //baos.toString().contains("$previewFeature.name [PREVIEW]")
         communityFeature == null
         //baos.toString().contains("$communityFeature.name [COMMUNITY]")
-
-        cleanup:
-        System.setOut(old)
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/analytics/Generated.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/analytics/Generated.java
@@ -47,7 +47,7 @@ public class Generated {
             @NonNull DevelopmentReloading reloading,
             @NonNull JdkVersion jdkVersion) {
         this.type = Objects.requireNonNull(type, "Type cannot be null");
-        this.gorm = Objects.requireNonNull(gorm, "GORM cannot be null");
+        this.gorm = Objects.requireNonNull(gorm, "Grails Data implementation cannot be null");
         this.servlet = Objects.requireNonNull(servlet, "Embedded Servlet cannot be null");
         this.reloading = Objects.requireNonNull(reloading, "Development reloading cannot be null");
         this.jdkVersion = Objects.requireNonNull(jdkVersion, "JDK version cannot be null");

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/build/gradle/templates/buildSrcBuildGradle.rocker.raw
@@ -51,7 +51,15 @@ repositories {
 }
 
 dependencies {
+@if (features.contains("gorm-hibernate7") && features.contains("grails-micronaut")) {
+    implementation platform("org.apache.grails:grails-hibernate7-micronaut-bom:$grailsVersion")
+} else if (features.contains("grails-micronaut")) {
+    implementation platform("org.apache.grails:grails-micronaut-bom:$grailsVersion")
+} else if (features.contains("gorm-hibernate7")) {
+    implementation platform("org.apache.grails:grails-hibernate7-bom:$grailsVersion")
+} else {
     implementation platform("org.apache.grails:grails-bom:$grailsVersion")
+}
 @for (GradleDependency dependency : gradleBuild.getBuildSrcDependencies()) {
     @dependency.toSnippet()
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -28,7 +28,7 @@ import static org.grails.forge.feature.config.ConfigurationFeature.TEST_ENVIRONM
 import static org.grails.forge.feature.config.ConfigurationFeature.PROD_ENVIRONMENT_KEY;
 import static org.grails.forge.feature.config.ConfigurationFeature.ENVIRONMENTS_KEY;
 import static org.grails.forge.feature.config.ConfigurationFeature.PROPERTIES_KEY;
-import static org.grails.forge.feature.database.HibernateGorm.PREFIX;
+import static org.grails.forge.feature.database.GrailsDataHibernate5.PREFIX;
 
 /**
  * A feature that configures a datasource with a driver

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverConfigurationFeature.java
@@ -28,12 +28,13 @@ import static org.grails.forge.feature.config.ConfigurationFeature.TEST_ENVIRONM
 import static org.grails.forge.feature.config.ConfigurationFeature.PROD_ENVIRONMENT_KEY;
 import static org.grails.forge.feature.config.ConfigurationFeature.ENVIRONMENTS_KEY;
 import static org.grails.forge.feature.config.ConfigurationFeature.PROPERTIES_KEY;
-import static org.grails.forge.feature.database.GrailsDataHibernate5.PREFIX;
 
 /**
  * A feature that configures a datasource with a driver
  */
 public interface DatabaseDriverConfigurationFeature extends Feature {
+
+    String DATASOURCE_PREFIX = "dataSource.";
 
     String getUrlKey();
 
@@ -64,6 +65,6 @@ public interface DatabaseDriverConfigurationFeature extends Feature {
     }
 
     default void addProductionDataSourceProperties(Map<String, Object> config, String key, Object value) {
-        config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + PREFIX + PROPERTIES_KEY + "." + key, value);
+        config.put(ENVIRONMENTS_KEY + "." + PROD_ENVIRONMENT_KEY + "." + DATASOURCE_PREFIX + PROPERTIES_KEY + "." + key, value);
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -29,15 +29,15 @@ import java.util.Map;
 public abstract class DatabaseDriverFeature implements OneOfFeature {
 
     private final TestContainers testContainers;
-    private final HibernateGorm hibernateGorm;
+    private final GrailsDataHibernate5 grailsDataHibernate5;
 
     public DatabaseDriverFeature() {
         this.testContainers = null;
-        this.hibernateGorm = null;
+        this.grailsDataHibernate5 = null;
     }
 
-    public DatabaseDriverFeature(HibernateGorm hibernateGorm, TestContainers testContainers) {
-        this.hibernateGorm = hibernateGorm;
+    public DatabaseDriverFeature(GrailsDataHibernate5 grailsDataHibernate5, TestContainers testContainers) {
+        this.grailsDataHibernate5 = grailsDataHibernate5;
         this.testContainers = testContainers;
     }
 
@@ -56,8 +56,8 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
         if (!featureContext.isPresent(TestContainers.class) && testContainers != null) {
             featureContext.addFeature(testContainers);
         }
-        if (!featureContext.isPresent(HibernateGorm.class) && hibernateGorm != null) {
-            featureContext.addFeature(hibernateGorm);
+        if (!featureContext.isPresent(GrailsDataHibernate5.class) && grailsDataHibernate5 != null) {
+            featureContext.addFeature(grailsDataHibernate5);
         }
     }
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -56,7 +56,7 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
         if (!featureContext.isPresent(TestContainers.class) && testContainers != null) {
             featureContext.addFeature(testContainers);
         }
-        if (!featureContext.isPresent(GrailsDataHibernate5.class) && grailsDataHibernate5 != null) {
+        if (!featureContext.isPresent(GormFeature.class) && grailsDataHibernate5 != null) {
             featureContext.addFeature(grailsDataHibernate5);
         }
     }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/DatabaseDriverFeature.java
@@ -56,7 +56,7 @@ public abstract class DatabaseDriverFeature implements OneOfFeature {
         if (!featureContext.isPresent(TestContainers.class) && testContainers != null) {
             featureContext.addFeature(testContainers);
         }
-        if (!featureContext.isPresent(GormFeature.class) && grailsDataHibernate5 != null) {
+        if (!featureContext.isPresent(DatabaseDriverConfigurationFeature.class) && grailsDataHibernate5 != null) {
             featureContext.addFeature(grailsDataHibernate5);
         }
     }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
@@ -33,7 +33,7 @@ import java.util.Set;
 
 @Primary
 @Singleton
-public class HibernateGorm extends GormFeature implements DatabaseDriverConfigurationFeature {
+public class GrailsDataHibernate5 extends GormFeature implements DatabaseDriverConfigurationFeature {
 
     static final String PREFIX = "dataSource.";
     private static final String URL_KEY = PREFIX + "url";
@@ -44,7 +44,7 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
 
     private final DatabaseDriverFeature defaultDbFeature;
 
-    public HibernateGorm(DatabaseDriverFeature defaultDbFeature) {
+    public GrailsDataHibernate5(DatabaseDriverFeature defaultDbFeature) {
         this.defaultDbFeature = defaultDbFeature;
     }
 
@@ -123,6 +123,8 @@ public class HibernateGorm extends GormFeature implements DatabaseDriverConfigur
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().anyMatch(f -> f instanceof HibernateGorm) || options.getGormImpl() == GormImpl.HIBERNATE;
+        return selectedFeatures.stream().anyMatch(f -> f instanceof GrailsDataHibernate5)
+                || (options.getGormImpl() == GormImpl.HIBERNATE
+                        && selectedFeatures.stream().noneMatch(GrailsDataHibernate7.class::isInstance));
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
@@ -55,12 +55,12 @@ public class GrailsDataHibernate5 extends GormFeature implements DatabaseDriverC
 
     @Override
     public String getTitle() {
-        return "GORM for Hibernate 5";
+        return "Grails Data for Hibernate 5";
     }
 
     @Override
     public String getDescription() {
-        return "Configure GORM for using Hibernate 5.";
+        return "Configure Grails Data for using Hibernate 5.";
     }
 
     @Override
@@ -124,7 +124,7 @@ public class GrailsDataHibernate5 extends GormFeature implements DatabaseDriverC
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
         return selectedFeatures.stream().anyMatch(f -> f instanceof GrailsDataHibernate5)
-                || (options.getGormImpl() == GormImpl.HIBERNATE
+                || (options.getGormImpl() == GormImpl.HIBERNATE5
                         && selectedFeatures.stream().noneMatch(GrailsDataHibernate7.class::isInstance));
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate5.java
@@ -35,12 +35,11 @@ import java.util.Set;
 @Singleton
 public class GrailsDataHibernate5 extends GormFeature implements DatabaseDriverConfigurationFeature {
 
-    static final String PREFIX = "dataSource.";
-    private static final String URL_KEY = PREFIX + "url";
-    private static final String DRIVER_KEY = PREFIX + "driverClassName";
-    private static final String USERNAME_KEY = PREFIX + "username";
-    private static final String PASSWORD_KEY = PREFIX + "password";
-    private static final String DB_CREATE_KEY = PREFIX + "dbCreate";
+    private static final String URL_KEY = DATASOURCE_PREFIX + "url";
+    private static final String DRIVER_KEY = DATASOURCE_PREFIX + "driverClassName";
+    private static final String USERNAME_KEY = DATASOURCE_PREFIX + "username";
+    private static final String PASSWORD_KEY = DATASOURCE_PREFIX + "password";
+    private static final String DB_CREATE_KEY = DATASOURCE_PREFIX + "dbCreate";
 
     private final DatabaseDriverFeature defaultDbFeature;
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
@@ -33,12 +33,11 @@ import java.util.Set;
 @Singleton
 public class GrailsDataHibernate7 extends GormFeature implements DatabaseDriverConfigurationFeature {
 
-    static final String PREFIX = "dataSource.";
-    private static final String URL_KEY = PREFIX + "url";
-    private static final String DRIVER_KEY = PREFIX + "driverClassName";
-    private static final String USERNAME_KEY = PREFIX + "username";
-    private static final String PASSWORD_KEY = PREFIX + "password";
-    private static final String DB_CREATE_KEY = PREFIX + "dbCreate";
+    private static final String URL_KEY = DATASOURCE_PREFIX + "url";
+    private static final String DRIVER_KEY = DATASOURCE_PREFIX + "driverClassName";
+    private static final String USERNAME_KEY = DATASOURCE_PREFIX + "username";
+    private static final String PASSWORD_KEY = DATASOURCE_PREFIX + "password";
+    private static final String DB_CREATE_KEY = DATASOURCE_PREFIX + "dbCreate";
 
     private final DatabaseDriverFeature defaultDbFeature;
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
@@ -53,12 +53,12 @@ public class GrailsDataHibernate7 extends GormFeature implements DatabaseDriverC
 
     @Override
     public String getTitle() {
-        return "GORM for Hibernate 7";
+        return "Grails Data for Hibernate 7";
     }
 
     @Override
     public String getDescription() {
-        return "Configure GORM for using Hibernate 7.";
+        return "Configure Grails Data for using Hibernate 7.";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernate7.java
@@ -1,0 +1,126 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.forge.feature.database;
+
+import jakarta.inject.Singleton;
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.application.generator.GeneratorContext;
+import org.grails.forge.build.dependencies.Dependency;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.FeatureContext;
+import org.grails.forge.options.GormImpl;
+import org.grails.forge.options.Options;
+
+import java.util.Map;
+import java.util.Set;
+
+@Singleton
+public class GrailsDataHibernate7 extends GormFeature implements DatabaseDriverConfigurationFeature {
+
+    static final String PREFIX = "dataSource.";
+    private static final String URL_KEY = PREFIX + "url";
+    private static final String DRIVER_KEY = PREFIX + "driverClassName";
+    private static final String USERNAME_KEY = PREFIX + "username";
+    private static final String PASSWORD_KEY = PREFIX + "password";
+    private static final String DB_CREATE_KEY = PREFIX + "dbCreate";
+
+    private final DatabaseDriverFeature defaultDbFeature;
+
+    public GrailsDataHibernate7(DatabaseDriverFeature defaultDbFeature) {
+        this.defaultDbFeature = defaultDbFeature;
+    }
+
+    @Override
+    public String getName() {
+        return "gorm-hibernate7";
+    }
+
+    @Override
+    public String getTitle() {
+        return "GORM for Hibernate 7";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Configure GORM for using Hibernate 7.";
+    }
+
+    @Override
+    public void processSelectedFeatures(FeatureContext featureContext) {
+        if (!featureContext.isPresent(DatabaseDriverFeature.class)) {
+            featureContext.addFeature(defaultDbFeature);
+        }
+    }
+
+    @Override
+    public void apply(GeneratorContext generatorContext) {
+        Map<String, Object> config = generatorContext.getConfiguration();
+        DatabaseDriverFeature dbFeature = generatorContext.getRequiredFeature(DatabaseDriverFeature.class);
+        applyDefaultConfig(dbFeature, config);
+        applyDefaultGormConfig(config);
+        config.put("dataSource.pooled", true);
+        config.put("dataSource.jmxExport", true);
+        config.put("hibernate.cache.queries", false);
+        config.put("hibernate.cache.use_second_level_cache", false);
+        config.put("hibernate.cache.use_query_cache", false);
+
+        generatorContext.addBuildscriptDependency(Dependency.builder()
+                .groupId("org.apache.grails")
+                .artifactId("grails-data-hibernate7")
+                .buildSrc());
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("org.apache.grails")
+                .artifactId("grails-data-hibernate7")
+                .implementation());
+        generatorContext.addDependency(Dependency.builder()
+                .groupId("com.zaxxer")
+                .artifactId("HikariCP")
+                .runtimeOnly());
+    }
+
+    @Override
+    public String getUrlKey() {
+        return URL_KEY;
+    }
+
+    @Override
+    public String getDriverKey() {
+        return DRIVER_KEY;
+    }
+
+    @Override
+    public String getUsernameKey() {
+        return USERNAME_KEY;
+    }
+
+    @Override
+    public String getPasswordKey() {
+        return PASSWORD_KEY;
+    }
+
+    @Override
+    public String getDbCreateKey() {
+        return DB_CREATE_KEY;
+    }
+
+    @Override
+    public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
+        return selectedFeatures.stream().anyMatch(GrailsDataHibernate7.class::isInstance) || options.getGormImpl() == GormImpl.HIBERNATE7;
+    }
+}

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
@@ -34,7 +34,7 @@ public class GrailsDataHibernateValidator implements FeatureValidator {
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
         if (features.stream().anyMatch(GrailsDataHibernate5.class::isInstance)
                 && features.stream().anyMatch(GrailsDataHibernate7.class::isInstance)) {
-            throw new IllegalArgumentException("Only one GORM for Hibernate implementation can be selected: gorm-hibernate5 or gorm-hibernate7");
+            throw new IllegalArgumentException("Only one Grails Data for Hibernate implementation can be selected: gorm-hibernate5 or gorm-hibernate7");
         }
     }
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
@@ -32,14 +32,18 @@ public class GrailsDataHibernateValidator implements FeatureValidator {
 
     @Override
     public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
-        if (features.stream().anyMatch(GrailsDataHibernate5.class::isInstance)
-                && features.stream().anyMatch(GrailsDataHibernate7.class::isInstance)) {
-            throw new IllegalArgumentException("Only one Grails Data for Hibernate implementation can be selected: gorm-hibernate5 or gorm-hibernate7");
-        }
+        validateOnlyOneHibernateImplementation(features);
     }
 
     @Override
     public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        validateOnlyOneHibernateImplementation(features);
+    }
 
+    private static void validateOnlyOneHibernateImplementation(Set<Feature> features) {
+        if (features.stream().anyMatch(GrailsDataHibernate5.class::isInstance)
+                && features.stream().anyMatch(GrailsDataHibernate7.class::isInstance)) {
+            throw new IllegalArgumentException("Only one Grails Data for Hibernate implementation can be selected: gorm-hibernate5 or gorm-hibernate7");
+        }
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataHibernateValidator.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.forge.feature.database;
+
+import java.util.Set;
+
+import jakarta.inject.Singleton;
+
+import org.grails.forge.application.ApplicationType;
+import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.validation.FeatureValidator;
+import org.grails.forge.options.Options;
+
+@Singleton
+public class GrailsDataHibernateValidator implements FeatureValidator {
+
+    @Override
+    public void validatePreProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+        if (features.stream().anyMatch(GrailsDataHibernate5.class::isInstance)
+                && features.stream().anyMatch(GrailsDataHibernate7.class::isInstance)) {
+            throw new IllegalArgumentException("Only one GORM for Hibernate implementation can be selected: gorm-hibernate5 or gorm-hibernate7");
+        }
+    }
+
+    @Override
+    public void validatePostProcessing(Options options, ApplicationType applicationType, Set<Feature> features) {
+
+    }
+}

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataMongoDB.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataMongoDB.java
@@ -32,11 +32,11 @@ import java.util.Map;
 import java.util.Set;
 
 @Singleton
-public class MongoGorm extends GormOneOfFeature {
+public class GrailsDataMongoDB extends GormOneOfFeature {
 
     private final TestContainers testContainers;
 
-    public MongoGorm(TestContainers testContainers) {
+    public GrailsDataMongoDB(TestContainers testContainers) {
         this.testContainers = testContainers;
     }
 
@@ -76,7 +76,7 @@ public class MongoGorm extends GormOneOfFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return selectedFeatures.stream().anyMatch(f -> f instanceof MongoGorm) || options.getGormImpl() == GormImpl.MONGODB;
+        return selectedFeatures.stream().anyMatch(f -> f instanceof GrailsDataMongoDB) || options.getGormImpl() == GormImpl.MONGODB;
     }
 
     @Nullable

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataMongoDB.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GrailsDataMongoDB.java
@@ -47,12 +47,12 @@ public class GrailsDataMongoDB extends GormOneOfFeature {
 
     @Override
     public String getTitle() {
-        return "GORM for MongoDB";
+        return "Grails Data for MongoDB";
     }
 
     @Override
     public String getDescription() {
-        return "Configure GORM for using MongoDB.";
+        return "Configure Grails Data for using MongoDB.";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GraphqlGorm.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GraphqlGorm.java
@@ -52,12 +52,12 @@ public class GraphqlGorm implements Feature {
 
     @Override
     public String getTitle() {
-        return "GORM for GraphQL";
+        return "Grails Data for GraphQL";
     }
 
     @Override
     public String getDescription() {
-        return "Generates a GraphQL schema based on entities in GORM.";
+        return "Generates a GraphQL schema based on entities in Grails Data.";
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GraphqlGorm.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/GraphqlGorm.java
@@ -31,18 +31,18 @@ import org.grails.forge.feature.FeatureContext;
  * Adds the {@code grails-data-graphql} plugin to the generated application.
  *
  * <p>GraphQL is a layer on top of GORM rather than a GORM implementation, so
- * this feature is selectable in addition to (not instead of) {@link HibernateGorm}
- * or {@link MongoGorm}. If the user opts into GraphQL without explicitly
+ * this feature is selectable in addition to (not instead of) {@link GrailsDataHibernate5}
+ * or {@link GrailsDataMongoDB}. If the user opts into GraphQL without explicitly
  * selecting a GORM persistence layer, Hibernate is added as a sensible default
  * via {@link #processSelectedFeatures(FeatureContext)}.</p>
  */
 @Singleton
 public class GraphqlGorm implements Feature {
 
-    private final HibernateGorm hibernateGorm;
+    private final GrailsDataHibernate5 grailsDataHibernate5;
 
-    public GraphqlGorm(HibernateGorm hibernateGorm) {
-        this.hibernateGorm = hibernateGorm;
+    public GraphqlGorm(GrailsDataHibernate5 grailsDataHibernate5) {
+        this.grailsDataHibernate5 = grailsDataHibernate5;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class GraphqlGorm implements Feature {
         // GraphQL needs a GORM implementation to introspect; default to Hibernate
         // when the user has not explicitly chosen a GORM provider.
         if (!featureContext.isPresent(GormFeature.class) && !featureContext.isPresent(GormOneOfFeature.class)) {
-            featureContext.addFeature(hibernateGorm);
+            featureContext.addFeature(grailsDataHibernate5);
         }
     }
 

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
@@ -100,7 +100,7 @@ public class H2 extends DatabaseDriverFeature implements DefaultFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return (options.getGormImpl() == GormImpl.HIBERNATE || options.getGormImpl() == GormImpl.HIBERNATE7) &&
+        return (options.getGormImpl() == GormImpl.HIBERNATE5 || options.getGormImpl() == GormImpl.HIBERNATE7) &&
                 selectedFeatures.stream().noneMatch(f -> f instanceof DatabaseDriverFeature);
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/H2.java
@@ -25,6 +25,7 @@ import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
+import org.grails.forge.options.GormImpl;
 import org.grails.forge.options.Options;
 
 import java.util.Set;
@@ -99,7 +100,7 @@ public class H2 extends DatabaseDriverFeature implements DefaultFeature {
 
     @Override
     public boolean shouldApply(ApplicationType applicationType, Options options, Set<Feature> selectedFeatures) {
-        return options.getGormImpl().getName().equals("gorm-hibernate5") &&
+        return (options.getGormImpl() == GormImpl.HIBERNATE || options.getGormImpl() == GormImpl.HIBERNATE7) &&
                 selectedFeatures.stream().noneMatch(f -> f instanceof DatabaseDriverFeature);
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/MySQL.java
@@ -26,8 +26,8 @@ import org.grails.forge.build.dependencies.Dependency;
 @Singleton
 public class MySQL extends DatabaseDriverFeature {
 
-    public MySQL(HibernateGorm hibernateGorm, TestContainers testContainers) {
-        super(hibernateGorm, testContainers);
+    public MySQL(GrailsDataHibernate5 grailsDataHibernate5, TestContainers testContainers) {
+        super(grailsDataHibernate5, testContainers);
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/PostgreSQL.java
@@ -26,8 +26,8 @@ import org.grails.forge.build.dependencies.Dependency;
 @Singleton
 public class PostgreSQL extends DatabaseDriverFeature {
 
-    public PostgreSQL(HibernateGorm hibernateGorm, TestContainers testContainers) {
-        super(hibernateGorm, testContainers);
+    public PostgreSQL(GrailsDataHibernate5 grailsDataHibernate5, TestContainers testContainers) {
+        super(grailsDataHibernate5, testContainers);
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/SQLServer.java
@@ -26,8 +26,8 @@ import org.grails.forge.build.dependencies.Dependency;
 @Singleton
 public class SQLServer extends DatabaseDriverFeature {
 
-    public SQLServer(HibernateGorm hibernateGorm, TestContainers testContainers) {
-        super(hibernateGorm, testContainers);
+    public SQLServer(GrailsDataHibernate5 grailsDataHibernate5, TestContainers testContainers) {
+        super(grailsDataHibernate5, testContainers);
     }
 
     @Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/TestContainers.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/database/TestContainers.java
@@ -82,7 +82,7 @@ public class TestContainers implements Feature {
             generatorContext.addDependency(testContainerTestDependency("testcontainers-spock"));
         }
 
-        if (generatorContext.isFeaturePresent(MongoFeature.class) || generatorContext.isFeaturePresent(MongoGorm.class)) {
+        if (generatorContext.isFeaturePresent(MongoFeature.class) || generatorContext.isFeaturePresent(GrailsDataMongoDB.class)) {
             generatorContext.addDependency(testContainerTestDependency("testcontainers-mongodb"));
         }
     }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/grails/GrailsBase.java
@@ -24,6 +24,7 @@ import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
 import org.grails.forge.feature.DefaultFeature;
 import org.grails.forge.feature.Feature;
+import org.grails.forge.feature.database.GrailsDataHibernate7;
 import org.grails.forge.feature.micronaut.GrailsMicronaut;
 import org.grails.forge.options.Options;
 import org.grails.forge.template.URLTemplate;
@@ -56,10 +57,18 @@ public class GrailsBase implements DefaultFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
 
-        // When Micronaut is used, the application must consume grails-micronaut-bom as an
-        // enforcedPlatform so the Micronaut platform cannot override grails-bom
+        // When Micronaut is used, the application must consume the Micronaut BOM variant as an
+        // enforcedPlatform so the Micronaut platform cannot override the Grails BOM. The
+        // Hibernate 7 BOM variants pin the Hibernate 7 dependency versions (e.g. jandex) that
+        // conflict with the default (Hibernate 5) grails-bom - see grails-core issue #15942.
         boolean useMicronautBom = generatorContext.isFeaturePresent(GrailsMicronaut.class);
-        String bomArtifactId = useMicronautBom ? "grails-micronaut-bom" : "grails-bom";
+        boolean useHibernate7Bom = generatorContext.isFeaturePresent(GrailsDataHibernate7.class);
+        String bomArtifactId;
+        if (useMicronautBom) {
+            bomArtifactId = useHibernate7Bom ? "grails-hibernate7-micronaut-bom" : "grails-micronaut-bom";
+        } else {
+            bomArtifactId = useHibernate7Bom ? "grails-hibernate7-bom" : "grails-bom";
+        }
 
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.grails")
@@ -71,7 +80,7 @@ public class GrailsBase implements DefaultFeature {
 
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.apache.grails")
-                .artifactId("grails-bom")
+                .artifactId(bomArtifactId)
                 .pom(true)
                 .version("$grailsVersion")
                 .classpath());

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/migration/DatabaseMigrationPlugin.java
@@ -21,6 +21,7 @@ package org.grails.forge.feature.migration;
 import jakarta.inject.Singleton;
 import org.grails.forge.application.generator.GeneratorContext;
 import org.grails.forge.build.dependencies.Dependency;
+import org.grails.forge.feature.database.GrailsDataHibernate7;
 import org.grails.forge.feature.migration.templates.dbMigrationGradle;
 import org.grails.forge.template.RockerWritable;
 import org.grails.forge.template.URLTemplate;
@@ -57,14 +58,17 @@ public class DatabaseMigrationPlugin implements MigrationFeature {
     @Override
     public void apply(GeneratorContext generatorContext) {
         final String srcDirPath = getSrcDirPath();
+        final String dbMigrationArtifactId = generatorContext.isFeaturePresent(GrailsDataHibernate7.class)
+                ? "grails-data-hibernate7-dbmigration"
+                : "grails-data-hibernate5-dbmigration";
         generatorContext.addBuildscriptDependency(Dependency.builder()
                 .groupId("org.apache.grails")
-                .artifactId("grails-data-hibernate5-dbmigration")
+                .artifactId(dbMigrationArtifactId)
                 .buildSrc()
                 .extension(new RockerWritable(dbMigrationGradle.template(srcDirPath))));
         generatorContext.addDependency(Dependency.builder()
                 .groupId("org.apache.grails")
-                .artifactId("grails-data-hibernate5-dbmigration")
+                .artifactId(dbMigrationArtifactId)
                 .implementation());
 
         final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImpl.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImpl.java
@@ -19,14 +19,19 @@
 package org.grails.forge.options;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 
 public enum GormImpl {
 
-    HIBERNATE("gorm-hibernate5", "Hibernate 5"),
+    HIBERNATE5("gorm-hibernate5", "Hibernate 5"),
     HIBERNATE7("gorm-hibernate7", "Hibernate 7"),
     MONGODB("gorm-mongodb", "MongoDB");
 
-    public static final GormImpl DEFAULT_OPTION = HIBERNATE;
+    public static final GormImpl DEFAULT_OPTION = HIBERNATE5;
+
+    // Selection value accepted before HIBERNATE5 replaced the HIBERNATE constant
+    private static final String LEGACY_HIBERNATE_VALUE = "hibernate";
+
     private final String featureName;
     private final String label;
 
@@ -43,6 +48,29 @@ public enum GormImpl {
     @NonNull
     public String getLabel() {
         return label;
+    }
+
+    /**
+     * Resolves a user-supplied selection value to a {@link GormImpl}.
+     *
+     * @param value the selection value (case-insensitive), e.g. {@code hibernate5};
+     *              the legacy value {@code hibernate} resolves to {@link #HIBERNATE5}
+     * @return the matching implementation, or {@code null} when the value is unknown
+     */
+    @Nullable
+    public static GormImpl parse(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        if (LEGACY_HIBERNATE_VALUE.equalsIgnoreCase(value)) {
+            return HIBERNATE5;
+        }
+        for (GormImpl impl : values()) {
+            if (value.equalsIgnoreCase(impl.name())) {
+                return impl;
+            }
+        }
+        return null;
     }
 
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImpl.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImpl.java
@@ -23,6 +23,7 @@ import io.micronaut.core.annotation.NonNull;
 public enum GormImpl {
 
     HIBERNATE("gorm-hibernate5", "Hibernate 5"),
+    HIBERNATE7("gorm-hibernate7", "Hibernate 7"),
     MONGODB("gorm-mongodb", "MongoDB");
 
     public static final GormImpl DEFAULT_OPTION = HIBERNATE;

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
@@ -22,8 +22,6 @@ import java.util.Optional;
 
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
-import io.micronaut.core.convert.exceptions.ConversionErrorException;
-import io.micronaut.core.type.Argument;
 import jakarta.inject.Singleton;
 
 /**
@@ -40,8 +38,9 @@ public class GormImplTypeConverter implements TypeConverter<CharSequence, GormIm
         }
         GormImpl gormImpl = GormImpl.parse(object.toString());
         if (gormImpl == null) {
-            throw new ConversionErrorException(Argument.of(GormImpl.class),
+            context.reject(object,
                     new IllegalArgumentException("Invalid Grails Data implementation selection: " + object));
+            return Optional.empty();
         }
         return Optional.of(gormImpl);
     }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.TypeConverter;
+import io.micronaut.core.convert.exceptions.ConversionErrorException;
+import io.micronaut.core.type.Argument;
 import jakarta.inject.Singleton;
 
 /**
@@ -36,6 +38,11 @@ public class GormImplTypeConverter implements TypeConverter<CharSequence, GormIm
         if (object == null) {
             return Optional.empty();
         }
-        return Optional.ofNullable(GormImpl.parse(object.toString()));
+        GormImpl gormImpl = GormImpl.parse(object.toString());
+        if (gormImpl == null) {
+            throw new ConversionErrorException(Argument.of(GormImpl.class),
+                    new IllegalArgumentException("Invalid Grails Data implementation selection: " + object));
+        }
+        return Optional.of(gormImpl);
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
@@ -16,24 +16,23 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.grails.forge.cli.command;
+package org.grails.forge.options;
 
-import io.micronaut.core.annotation.Introspected;
-import org.grails.forge.options.GormImpl;
-import picocli.CommandLine;
+import java.util.Optional;
 
-@Introspected
-public class GormImplConverter implements CommandLine.ITypeConverter<GormImpl> {
+import io.micronaut.core.convert.ConversionContext;
+import io.micronaut.core.convert.TypeConverter;
+import jakarta.inject.Singleton;
+
+/**
+ * Converts user-supplied selection values (including the legacy {@code hibernate}
+ * value) to {@link GormImpl} for HTTP parameter binding.
+ */
+@Singleton
+public class GormImplTypeConverter implements TypeConverter<CharSequence, GormImpl> {
 
     @Override
-    public GormImpl convert(String value) throws Exception {
-        if (value == null) {
-            return GormImpl.DEFAULT_OPTION;
-        }
-        GormImpl impl = GormImpl.parse(value);
-        if (impl != null) {
-            return impl;
-        }
-        throw new CommandLine.TypeConversionException("Invalid Grails Data implementation selection: " + value);
+    public Optional<GormImpl> convert(CharSequence object, Class<GormImpl> targetType, ConversionContext context) {
+        return Optional.ofNullable(GormImpl.parse(object.toString()));
     }
 }

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/options/GormImplTypeConverter.java
@@ -33,6 +33,9 @@ public class GormImplTypeConverter implements TypeConverter<CharSequence, GormIm
 
     @Override
     public Optional<GormImpl> convert(CharSequence object, Class<GormImpl> targetType, ConversionContext context) {
+        if (object == null) {
+            return Optional.empty();
+        }
         return Optional.ofNullable(GormImpl.parse(object.toString()));
     }
 }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate5Spec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate5Spec.groovy
@@ -31,7 +31,7 @@ import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
 import org.grails.forge.options.TestFramework
 
-class HibernateGormSpec extends ApplicationContextSpec implements CommandOutputFixture{
+class GrailsDataHibernate5Spec extends ApplicationContextSpec implements CommandOutputFixture{
 
     void "test hibernate gorm features"() {
         when:

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
@@ -167,7 +167,7 @@ class GrailsDataHibernate7Spec extends ApplicationContextSpec implements Command
 
         then:
         IllegalArgumentException e = thrown()
-        e.message.contains('Only one GORM for Hibernate implementation can be selected')
+        e.message.contains('Only one Grails Data for Hibernate implementation can be selected')
     }
 
     void "test config"() {

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
@@ -48,6 +48,27 @@ class GrailsDataHibernate7Spec extends ApplicationContextSpec implements Command
         !features.contains("gorm-hibernate5")
     }
 
+    void "test a database driver feature does not add hibernate 5 when hibernate 7 is selected"() {
+        when:
+        Features features = getFeatures(['gorm-hibernate7', 'postgres'])
+
+        then:
+        features.contains("postgres")
+        features.contains("gorm-hibernate7")
+        !features.contains("gorm-hibernate5")
+    }
+
+    void "test a database driver feature dependencies with hibernate 7 for gradle"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7", "postgres"])
+                .render()
+
+        then:
+        template.contains('implementation "org.apache.grails:grails-data-hibernate7"')
+        !template.contains('grails-data-hibernate5')
+    }
+
     void "test dependencies are present for gradle"() {
         when:
         final String template = new BuildBuilder(beanContext)

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataHibernate7Spec.groovy
@@ -1,0 +1,199 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.forge.feature.database
+
+import groovy.yaml.YamlSlurper
+import org.grails.forge.ApplicationContextSpec
+import org.grails.forge.BuildBuilder
+import org.grails.forge.application.ApplicationType
+import org.grails.forge.application.generator.GeneratorContext
+import org.grails.forge.feature.Features
+import org.grails.forge.fixture.CommandOutputFixture
+import org.grails.forge.options.DevelopmentReloading
+import org.grails.forge.options.GormImpl
+import org.grails.forge.options.JdkVersion
+import org.grails.forge.options.Options
+import org.grails.forge.options.ServletImpl
+
+class GrailsDataHibernate7Spec extends ApplicationContextSpec implements CommandOutputFixture {
+
+    private static Options hibernate7Options() {
+        new Options(DevelopmentReloading.DEVTOOLS, GormImpl.HIBERNATE7, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+    }
+
+    void "test hibernate 7 gorm features"() {
+        when:
+        Features features = getFeatures(['gorm-hibernate7'])
+
+        then:
+        features.contains("h2")
+        features.contains("gorm-hibernate7")
+        !features.contains("gorm-hibernate5")
+    }
+
+    void "test dependencies are present for gradle"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7"])
+                .render()
+
+        then:
+        template.contains('implementation "org.apache.grails:grails-data-hibernate7"')
+        template.contains('runtimeOnly "com.zaxxer:HikariCP"')
+        template.contains('runtimeOnly "com.h2database:h2"')
+        !template.contains('grails-data-hibernate5')
+    }
+
+    void "test hibernate 7 bom is used for gradle"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7"])
+                .render()
+
+        then:
+        template.contains('org.apache.grails:grails-hibernate7-bom')
+        !template.contains('org.apache.grails:grails-bom')
+    }
+
+    void "test hibernate 7 micronaut bom is used when micronaut is added"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7", "grails-micronaut"])
+                .jdkVersion(JdkVersion.JDK_25)
+                .render()
+
+        then: 'the application consumes the Hibernate 7 Micronaut BOM variant as an enforced platform'
+        template.contains('implementation enforcedPlatform("org.apache.grails:grails-hibernate7-micronaut-bom:$grailsVersion")')
+        !template.contains('org.apache.grails:grails-micronaut-bom')
+
+        and: 'the buildscript classpath uses the Hibernate 7 Micronaut BOM variant'
+        template.contains('classpath platform("org.apache.grails:grails-hibernate7-micronaut-bom:$grailsVersion")')
+        !template.contains('org.apache.grails:grails-hibernate7-bom:')
+    }
+
+    void "test buildSrc uses the hibernate 7 micronaut bom when micronaut is added"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7", "grails-micronaut"])
+                .jdkVersion(JdkVersion.JDK_25)
+                .renderBuildSrc()
+
+        then:
+        template.contains('implementation platform("org.apache.grails:grails-hibernate7-micronaut-bom:$grailsVersion")')
+        !template.contains('org.apache.grails:grails-hibernate7-bom:')
+        !template.contains('org.apache.grails:grails-bom:')
+    }
+
+    void "test buildSrc uses the micronaut bom when micronaut is added without hibernate 7"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate5", "grails-micronaut"])
+                .jdkVersion(JdkVersion.JDK_25)
+                .renderBuildSrc()
+
+        then:
+        template.contains('implementation platform("org.apache.grails:grails-micronaut-bom:$grailsVersion")')
+        !template.contains('grails-hibernate7-micronaut-bom')
+        !template.contains('org.apache.grails:grails-bom:')
+    }
+
+    void "test hibernate 5 micronaut bom is used when micronaut is added without hibernate 7"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate5", "grails-micronaut"])
+                .jdkVersion(JdkVersion.JDK_25)
+                .render()
+
+        then:
+        template.contains('org.apache.grails:grails-micronaut-bom')
+        !template.contains('grails-hibernate7-micronaut-bom')
+    }
+
+    void "test dependencies are present for buildSrc"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7"])
+                .renderBuildSrc()
+
+        then:
+        template.contains('implementation platform("org.apache.grails:grails-hibernate7-bom:$grailsVersion")')
+        template.contains('implementation "org.apache.grails:grails-data-hibernate7"')
+        !template.contains('org.apache.grails:grails-bom')
+        !template.contains('grails-data-hibernate5')
+    }
+
+    void "test buildSrc is present for buildscript dependencies"() {
+        given:
+        final def output = generate(ApplicationType.WEB, hibernate7Options())
+        final def buildGradle = output["build.gradle"]
+
+        expect:
+        buildGradle != null
+        buildGradle.contains("classpath \"org.apache.grails:grails-data-hibernate7\"")
+        !buildGradle.contains("grails-data-hibernate5")
+    }
+
+    void "test database migration uses the hibernate 7 artifact"() {
+        when:
+        final String template = new BuildBuilder(beanContext)
+                .features(["gorm-hibernate7", "database-migration"])
+                .render()
+
+        then:
+        template.contains('grails-data-hibernate7-dbmigration')
+        !template.contains('grails-data-hibernate5-dbmigration')
+    }
+
+    void "test selecting both hibernate implementations is rejected"() {
+        when:
+        getFeatures(['gorm-hibernate5', 'gorm-hibernate7'])
+
+        then:
+        IllegalArgumentException e = thrown()
+        e.message.contains('Only one GORM for Hibernate implementation can be selected')
+    }
+
+    void "test config"() {
+        when:
+        GeneratorContext ctx = buildGeneratorContext(['gorm-hibernate7'])
+
+        then:
+        ctx.configuration.containsKey("dataSource.pooled")
+        ctx.configuration.containsKey("dataSource.jmxExport")
+        ctx.configuration.containsKey("hibernate.cache.queries")
+        ctx.configuration.containsKey("hibernate.cache.use_second_level_cache")
+        ctx.configuration.containsKey("hibernate.cache.use_query_cache")
+    }
+
+    void "test match values of datasource config"() {
+        when:
+        final def output = generate(ApplicationType.WEB, hibernate7Options())
+        final String applicationYaml = output["grails-app/conf/application.yml"]
+        def config = new YamlSlurper().parseText(applicationYaml)
+
+        then:
+        config.environments.development.dataSource.dbCreate == 'create-drop'
+        config.environments.test.dataSource.dbCreate == 'update'
+        config.environments.production.dataSource.dbCreate == 'none'
+        config.environments.development.dataSource.url == 'jdbc:h2:mem:devDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.test.dataSource.url == 'jdbc:h2:mem:testDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+        config.environments.production.dataSource.url == 'jdbc:h2:./prodDb;LOCK_TIMEOUT=10000;DB_CLOSE_ON_EXIT=FALSE'
+    }
+}

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataMongoDBSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataMongoDBSpec.groovy
@@ -24,6 +24,11 @@ import org.grails.forge.BuildBuilder
 import org.grails.forge.application.generator.GeneratorContext
 import org.grails.forge.feature.Features
 import org.grails.forge.fixture.CommandOutputFixture
+import org.grails.forge.options.DevelopmentReloading
+import org.grails.forge.options.GormImpl
+import org.grails.forge.options.JdkVersion
+import org.grails.forge.options.Options
+import org.grails.forge.options.ServletImpl
 
 class GrailsDataMongoDBSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
@@ -61,5 +66,36 @@ class GrailsDataMongoDBSpec extends ApplicationContextSpec implements CommandOut
         ctx.configuration.containsKey("grails.mongodb.url")
     }
 
+    void "test a SQL driver combined with MongoDB still adds Hibernate 5 as the default SQL implementation"() {
+        given:
+        Options options = new Options(DevelopmentReloading.DEFAULT_OPTION, GormImpl.MONGODB, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+
+        when:
+        Features features = getFeatures(['gorm-mongodb', 'postgres'], options)
+
+        then:
+        features.contains("gorm-mongodb")
+        features.contains("postgres")
+        features.contains("gorm-hibernate5")
+        !features.contains("gorm-hibernate7")
+
+        when:
+        String template = new BuildBuilder(beanContext)
+                .features(['gorm-mongodb', 'postgres'])
+                .gormImpl(GormImpl.MONGODB)
+                .render()
+
+        then:
+        template.contains("implementation \"org.apache.grails:grails-data-mongodb\"")
+        template.contains("implementation \"org.apache.grails:grails-data-hibernate5\"")
+        template.contains("runtimeOnly \"org.postgresql:postgresql\"")
+
+        when:
+        GeneratorContext ctx = buildGeneratorContext(['gorm-mongodb', 'postgres'], options)
+
+        then:
+        ctx.configuration.containsKey("grails.mongodb.url")
+        ctx.configuration.get("dataSource.driverClassName") == 'org.postgresql.Driver'
+    }
 
 }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataMongoDBSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/database/GrailsDataMongoDBSpec.groovy
@@ -25,7 +25,7 @@ import org.grails.forge.application.generator.GeneratorContext
 import org.grails.forge.feature.Features
 import org.grails.forge.fixture.CommandOutputFixture
 
-class MongoGormSpec extends ApplicationContextSpec implements CommandOutputFixture {
+class GrailsDataMongoDBSpec extends ApplicationContextSpec implements CommandOutputFixture {
 
     void "test Mongo gorm features"() {
         when:

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/options/GormImplSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/options/GormImplSpec.groovy
@@ -16,24 +16,33 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package org.grails.forge.cli.command;
 
-import io.micronaut.core.annotation.Introspected;
-import org.grails.forge.options.GormImpl;
-import picocli.CommandLine;
+package org.grails.forge.options
 
-@Introspected
-public class GormImplConverter implements CommandLine.ITypeConverter<GormImpl> {
+import spock.lang.Specification
+import spock.lang.Unroll
 
-    @Override
-    public GormImpl convert(String value) throws Exception {
-        if (value == null) {
-            return GormImpl.DEFAULT_OPTION;
-        }
-        GormImpl impl = GormImpl.parse(value);
-        if (impl != null) {
-            return impl;
-        }
-        throw new CommandLine.TypeConversionException("Invalid Grails Data implementation selection: " + value);
+class GormImplSpec extends Specification {
+
+    @Unroll
+    void "parse resolves #value to #expected"() {
+        expect:
+        GormImpl.parse(value) == expected
+
+        where:
+        value        | expected
+        'hibernate5' | GormImpl.HIBERNATE5
+        'HIBERNATE5' | GormImpl.HIBERNATE5
+        'hibernate'  | GormImpl.HIBERNATE5
+        'HIBERNATE'  | GormImpl.HIBERNATE5
+        'hibernate7' | GormImpl.HIBERNATE7
+        'mongodb'    | GormImpl.MONGODB
+        'neo4j'      | null
+        null         | null
+    }
+
+    void "the default option is Hibernate 5"() {
+        expect:
+        GormImpl.DEFAULT_OPTION == GormImpl.HIBERNATE5
     }
 }


### PR DESCRIPTION
 ## Description

  Fixes #15942.

  Grails 8.0.0-M2 users following the documented migration path (create an app, then swap
  `grails-data-hibernate5` → `grails-data-hibernate7` in `build.gradle`) hit an unresolvable
  dependency error:

  Conflicting constraints detected: Cannot find a version of 'io.smallrye:jandex' that satisfies the version constraints

  The root cause is that a manually-migrated app ends up with **two conflicting BOMs** on the same
  classpath: the default `grails-bom` (generated into `buildSrc`/`buildscript` regardless of the data
  implementation) and `grails-hibernate7-bom` (pulled transitively by `grails-data-hibernate7`).
  `grails-hibernate7-bom` strictly pins `io.smallrye:jandex:3.2.3` while `hibernate-core` endorses
  `hibernate-platform`, which requires jandex `3.3.2` — an irreconcilable strict-constraint conflict.
  Notably, `grails-data-hibernate7` resolves fine when the *matching* Hibernate 7 BOM variant is the
  only Grails BOM in the graph.

  Rather than requiring users to hand-edit BOMs, this PR adds first-class Hibernate 7 support to
  Grails Forge so generated apps consume a consistent set of BOMs from the start:

  - **New `gorm-hibernate7` feature** (`GrailsDataHibernate7`) and `GormImpl.HIBERNATE7`, selectable
    via `create-app --data hibernate7` or `--features gorm-hibernate7`.
  - **BOM selection matrix** applied consistently to the app dependencies, the `buildscript`
    classpath, and the generated `buildSrc`:
    | Data implementation | Without Micronaut | With Micronaut |
    |---|---|---|
    | Hibernate 5 | `grails-bom` | `grails-micronaut-bom` (enforced) |
    | Hibernate 7 | `grails-hibernate7-bom` | `grails-hibernate7-micronaut-bom` (enforced) |
  - **`database-migration`** now emits `grails-data-hibernate7-dbmigration` for Hibernate 7 apps.
  - **Guard rail**: selecting both `gorm-hibernate5` and `gorm-hibernate7` is rejected with a clear
    error (`GrailsDataHibernateValidator`).
  - **CLI switch renamed** to `-d, --data` with `-g, --gorm` retained as legacy aliases.
    `GormImpl.HIBERNATE` was migrated to `HIBERNATE5`; the selection values are now `hibernate5`,
    `hibernate7`, `mongodb`, and the legacy value `hibernate` is still accepted (handled in both the
    picocli converter and a new Micronaut `TypeConverter` for the Forge HTTP API).
  - **Naming cleanup in Forge**: feature classes renamed to match their artifacts
    (`GrailsDataHibernate5`, `GrailsDataHibernate7`, `GrailsDataMongoDB`) and user-facing "GORM"
    text updated to "Grails Data" (feature titles/descriptions, CLI help and error messages, OpenAPI
    schema descriptions). Feature names (`gorm-hibernate5`, etc.) are unchanged for compatibility.
  - **Documentation**: `creatingProject.adoc`, the `create-*` command reference pages, and the sample
    help output updated for the new switch, values, and legacy aliases (also fixes stale
    `hibernate, mongodb, neo4j` value lists).

  ### Testing

  - New `GrailsDataHibernate7Spec` (12 tests): dependencies, all four BOM combinations across
    `build.gradle` and `buildSrc`, dbmigration artifact switch, mutual-exclusion validation, and
    datasource config.
  - New `GormImplSpec` covering `GormImpl.parse`, including legacy and unknown values.
  - `CreateAppCommandSpec` extended for `--data`, `-d`, legacy `-g`/`--gorm`, legacy `hibernate`
    value, and the updated invalid-value error.
  - Full `grails-forge` `check` passes, except `CreateControllerCommandSpec."test app with controller"`,
    which requires a running Docker daemon (Testcontainers) and fails identically without this change
  when Docker is unavailable.

## Contributor Checklist

### Issue and Scope

- [x] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. (#15942)
- [x] This PR addresses the **complete scope** of the linked issue.
- [x] This PR contains a **single, focused change**.
- [x] This PR targets the **correct branch** for the type of change. (`8.0.x` — new Forge feature and CLI switch rename)

### Code Quality

- [x] I have **added or updated tests** that cover the changes introduced in this PR.
- [ ] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`.
      <!-- forge core/api/web/cli suites pass; full root rerun not yet executed -->
- [x] My code follows the project's **code style** guidelines.
- [x] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring
      unless it was **explicitly approved** in the linked issue. (Forge feature-class renames were
      requested as part of this change.)
- [x] If generative AI tooling was used in preparing this contribution, a quality model was used to
      ensure contributions are **consistent with the project's quality standards**.

### Licensing and Attribution

- [x] All contributed code is provided under the Apache License 2.0, and new source files include
      the appropriate **Apache license header**.
- [x] I have the necessary rights to submit this contribution and confirm it is my own original work.
- [x] If generative AI tooling was used in preparing this contribution, I have followed the ASF
      policy on generative tooling and have properly attributed its use.
      (Prepared with assistance from Claude Code; reviewed and directed by the author.)

### Documentation

- [x] If this PR introduces user-facing changes, I have included or updated the relevant documentation.
- [x] If this PR adds a new feature, I have updated the **What's New** section of the Grails Guide.
- [x] If this PR introduces breaking changes or changes that require user action during an upgrade,
      I have updated the **Upgrade Notes** for the corresponding version in the Grails Guide.
      (No user action required: `-g`, `--gorm`, and the `hibernate` value remain supported as legacy aliases.)
- [x] The PR description clearly explains **what** was changed and **why**.