### PR TITLE
ci: raise publish retry timeout to give slow Nexus uploads headroom (7.0.x)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -641,7 +641,7 @@ jobs:
           MAVEN_PUBLISH_USERNAME: ${{ secrets.NEXUS_USER }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.NEXUS_PW  }}
         with: 
-          timeout_seconds: 1200 # normal range 14min if build is not cached (no tests running)
+          timeout_seconds: 3600 # normal range ~14-25min uncached (no tests); generous headroom for slow Nexus uploads so a single attempt is not killed mid-publish
           max_attempts: 3 # Attempts to address: Could not write to resource 'https://repository.apache.org/content/repositories/snapshots/...' Read timed out
           retry_wait_seconds: 180
           command: ./gradlew publish aggregateChecksums aggregatePublishedArtifacts --no-build-cache --rerun-tasks


### PR DESCRIPTION
The `publish` job wraps `./gradlew publish ... --no-build-cache --rerun-tasks` in `nick-fields/retry` with a per-attempt `timeout_seconds: 1200` (20 min). That command does a full from-scratch recompile plus groovydoc/javadoc for 60+ modules and uploads to Apache Nexus, which legitimately runs ~14–25 min. On a cold build or with slow Nexus uploads, attempt 1 is killed on a pure timeout while making healthy progress, and the retry then succeeds only because attempt 1 already warmed the compile — so nearly every 7.0.x snapshot publish burns a wasted 20-minute attempt.

Example: run [28983551993 / job 86011906888](https://github.com/apache/grails-core/actions/runs/28983551993/job/86011906888) — `Attempt 1 failed. Reason: Timeout of 1200000ms hit`, attempt 2 succeeded (`Command completed after 2 attempt(s).`).

Raises `timeout_seconds` to 3600 (60 min) so a healthy attempt is never killed by the wrapper, keeping `max_attempts: 3` / `retry_wait_seconds: 180` for genuine transient Nexus read-timeouts. Worst case (3 × 60 min + 2 × 180 s waits) is ~186 min, still well under the GitHub Actions 6-hour job limit.

Note: 8.0.x was raised to 1800 in 82946a2ca8; when this merges forward it will conflict on that line — take 3600 (or bump 8.0.x to match).