### PR TITLE
ci: free runner disk space before the joint validation Grails build

### DIFF
--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -141,6 +141,18 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: "⚙️ Maximize build space"
+        run: |
+          echo "-- Dotnet"
+          sudo rm -rf /usr/share/dotnet
+          echo "-- Android"
+          sudo rm -rf /usr/local/lib/android
+          echo "-- Haskell"
+          sudo rm -rf /opt/ghc
+          echo "-- CodeQL"
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          df -h
       - name: "📥 Checkout project"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "☕️ Setup JDK"


### PR DESCRIPTION
Backport optimize build space for groovy joint workflow