### PR TITLE
Make AutoTimestampEventListener temporary disabling thread-safe

### DIFF
--- a/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/eventsAutoTimestamping.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/eventsAutoTimestamping.adoc
@@ -408,3 +408,5 @@ autoTimestampEventListener.withoutTimestamps {
 ----
 
 WARNING: Because the timestamp handling is only disabled for the duration of the closure, you must flush the session during the closure execution!
+
+NOTE: The timestamp handling is only disabled for the thread executing the closure. Other threads persisting entities at the same time are unaffected and will continue to have their timestamps applied.

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +67,9 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     protected Map<String, Optional<Set<String>>> entitiesWithDateCreated = new ConcurrentHashMap<>();
     protected Map<String, Optional<Set<String>>> entitiesWithLastUpdated = new ConcurrentHashMap<>();
     protected Collection<String> uninitializedEntities = new ConcurrentLinkedQueue<>();
+
+    private final ThreadLocal<DisabledTimestamps> disabledDateCreated = new ThreadLocal<>();
+    private final ThreadLocal<DisabledTimestamps> disabledLastUpdated = new ThreadLocal<>();
 
     private TimestampProvider timestampProvider = new DefaultTimestampProvider();
 
@@ -158,11 +160,17 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     }
 
     protected Set<String> getLastUpdatedPropertyNames(String entityName) {
+        if (isDisabled(disabledLastUpdated, entityName)) {
+            return null;
+        }
         Optional<Set<String>> properties = entitiesWithLastUpdated.get(entityName);
         return properties == null ? null : properties.orElse(null);
     }
 
     protected Set<String> getDateCreatedPropertyNames(String entityName) {
+        if (isDisabled(disabledDateCreated, entityName)) {
+            return null;
+        }
         Optional<Set<String>> properties = entitiesWithDateCreated.get(entityName);
         return properties == null ? null : properties.orElse(null);
     }
@@ -231,53 +239,83 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
         this.timestampProvider = timestampProvider;
     }
 
-    private void processAllEntries(final Set<Map.Entry<String, Optional<Set<String>>>> entries, final Runnable runnable) {
-        Map<String, Optional<Set<String>>> originalValues = new LinkedHashMap<>();
-        for (Map.Entry<String, Optional<Set<String>>> entry: entries) {
-            originalValues.put(entry.getKey(), entry.getValue());
-            entry.setValue(Optional.empty());
+    private static boolean isDisabled(final ThreadLocal<DisabledTimestamps> disabledTimestamps, final String entityName) {
+        DisabledTimestamps disabled = disabledTimestamps.get();
+        return disabled != null && disabled.isDisabled(entityName);
+    }
+
+    private static DisabledTimestamps getOrCreateDisabled(final ThreadLocal<DisabledTimestamps> disabledTimestamps) {
+        DisabledTimestamps disabled = disabledTimestamps.get();
+        if (disabled == null) {
+            disabled = new DisabledTimestamps();
+            disabledTimestamps.set(disabled);
         }
-        runnable.run();
-        for (Map.Entry<String, Optional<Set<String>>> entry: entries) {
-            entry.setValue(originalValues.get(entry.getKey()));
+        return disabled;
+    }
+
+    private static void removeIfEmpty(final ThreadLocal<DisabledTimestamps> disabledTimestamps, final DisabledTimestamps disabled) {
+        if (disabled.isEmpty()) {
+            disabledTimestamps.remove();
         }
     }
 
-    private void processEntries(final List<Class> classes, Map<String, Optional<Set<String>>> entities, final Runnable runnable) {
-        Set<Map.Entry<String, Optional<Set<String>>>> entries = new HashSet<>();
-        final List<String> classNames = new ArrayList<>(classes.size());
-        for (Class clazz: classes) {
-            classNames.add(clazz.getName());
+    private static void runWithAllDisabled(final ThreadLocal<DisabledTimestamps> disabledTimestamps, final Runnable runnable) {
+        DisabledTimestamps disabled = getOrCreateDisabled(disabledTimestamps);
+        disabled.allDisabledDepth++;
+        try {
+            runnable.run();
+        } finally {
+            disabled.allDisabledDepth--;
+            removeIfEmpty(disabledTimestamps, disabled);
         }
-        for (Map.Entry<String, Optional<Set<String>>> entry: entities.entrySet()) {
-            if (classNames.contains(entry.getKey())) {
-                entries.add(entry);
+    }
+
+    private static void runWithDisabled(final ThreadLocal<DisabledTimestamps> disabledTimestamps, final List<Class> classes, final Runnable runnable) {
+        // only the names this scope newly disables may be re-enabled on exit; a name already
+        // disabled by an enclosing scope on this thread must survive this scope's finally
+        List<String> added = new ArrayList<>(classes.size());
+        DisabledTimestamps disabled = getOrCreateDisabled(disabledTimestamps);
+        try {
+            for (Class clazz : classes) {
+                String entityName = clazz.getName();
+                if (disabled.entityNames.add(entityName)) {
+                    added.add(entityName);
+                }
             }
+            runnable.run();
+        } finally {
+            disabled.entityNames.removeAll(added);
+            removeIfEmpty(disabledTimestamps, disabled);
         }
-        processAllEntries(entries, runnable);
     }
 
     /**
-     * Temporarily disables the last updated processing during the execution of the runnable
+     * Temporarily disables the last updated processing during the execution of the runnable.
+     * The processing is only disabled for the calling thread; concurrently executing threads
+     * are unaffected.
      *
      * @param runnable The code to execute while the last updated listener is disabled
      */
     public void withoutLastUpdated(final Runnable runnable) {
-        processAllEntries(entitiesWithLastUpdated.entrySet(), runnable);
+        runWithAllDisabled(disabledLastUpdated, runnable);
     }
 
     /**
-     * Temporarily disables the last updated processing only on the provided classes during the execution of the runnable
+     * Temporarily disables the last updated processing only on the provided classes during the
+     * execution of the runnable. The processing is only disabled for the calling thread;
+     * concurrently executing threads are unaffected.
      *
      * @param classes Which classes to disable the last updated processing for
      * @param runnable The code to execute while the last updated listener is disabled
      */
     public void withoutLastUpdated(final List<Class> classes, final Runnable runnable) {
-        processEntries(classes, entitiesWithLastUpdated, runnable);
+        runWithDisabled(disabledLastUpdated, classes, runnable);
     }
 
     /**
-     * Temporarily disables the last updated processing only on the provided class during the execution of the runnable
+     * Temporarily disables the last updated processing only on the provided class during the
+     * execution of the runnable. The processing is only disabled for the calling thread;
+     * concurrently executing threads are unaffected.
      *
      * @param clazz Which class to disable the last updated processing for
      * @param runnable The code to execute while the last updated listener is disabled
@@ -289,26 +327,32 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     }
 
     /**
-     * Temporarily disables the date created processing during the execution of the runnable
+     * Temporarily disables the date created processing during the execution of the runnable.
+     * The processing is only disabled for the calling thread; concurrently executing threads
+     * are unaffected.
      *
      * @param runnable The code to execute while the date created listener is disabled
      */
     public void withoutDateCreated(final Runnable runnable) {
-        processAllEntries(entitiesWithDateCreated.entrySet(), runnable);
+        runWithAllDisabled(disabledDateCreated, runnable);
     }
 
     /**
-     * Temporarily disables the date created processing only on the provided classes during the execution of the runnable
+     * Temporarily disables the date created processing only on the provided classes during the
+     * execution of the runnable. The processing is only disabled for the calling thread;
+     * concurrently executing threads are unaffected.
      *
      * @param classes Which classes to disable the date created processing for
      * @param runnable The code to execute while the date created listener is disabled
      */
     public void withoutDateCreated(final List<Class> classes, final Runnable runnable) {
-        processEntries(classes, entitiesWithDateCreated, runnable);
+        runWithDisabled(disabledDateCreated, classes, runnable);
     }
 
     /**
-     * Temporarily disables the date created processing only on the provided class during the execution of the runnable
+     * Temporarily disables the date created processing only on the provided class during the
+     * execution of the runnable. The processing is only disabled for the calling thread;
+     * concurrently executing threads are unaffected.
      *
      * @param clazz Which class to disable the date created processing for
      * @param runnable The code to execute while the date created listener is disabled
@@ -320,7 +364,9 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     }
 
     /**
-     * Temporarily disables the timestamp processing during the execution of the runnable
+     * Temporarily disables the timestamp processing during the execution of the runnable.
+     * The processing is only disabled for the calling thread; concurrently executing threads
+     * are unaffected.
      *
      * @param runnable The code to execute while the timestamp listeners are disabled
      */
@@ -329,7 +375,9 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     }
 
     /**
-     * Temporarily disables the timestamp processing only on the provided classes during the execution of the runnable
+     * Temporarily disables the timestamp processing only on the provided classes during the
+     * execution of the runnable. The processing is only disabled for the calling thread;
+     * concurrently executing threads are unaffected.
      *
      * @param classes Which classes to disable the timestamp processing for
      * @param runnable The code to execute while the timestamp listeners are disabled
@@ -339,13 +387,36 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
     }
 
     /**
-     * Temporarily disables the timestamp processing during the execution of the runnable
+     * Temporarily disables the timestamp processing during the execution of the runnable.
+     * The processing is only disabled for the calling thread; concurrently executing threads
+     * are unaffected.
      *
      * @param clazz Which class to disable the timestamp processing for
      * @param runnable The code to execute while the timestamp listeners are disabled
      */
     public void withoutTimestamps(final Class clazz, final Runnable runnable) {
         withoutDateCreated(clazz, () -> withoutLastUpdated(clazz, runnable));
+    }
+
+    /**
+     * The entities for which timestamp processing is temporarily disabled on the current thread.
+     * All entities are disabled while {@code allDisabledDepth} is greater than zero; otherwise
+     * only the entities named in {@code entityNames} are disabled.
+     */
+    private static final class DisabledTimestamps {
+
+        private int allDisabledDepth;
+
+        private final Set<String> entityNames = new HashSet<>();
+
+        private boolean isDisabled(String entityName) {
+            return allDisabledDepth > 0 || entityNames.contains(entityName);
+        }
+
+        private boolean isEmpty() {
+            return allDisabledDepth == 0 && entityNames.isEmpty();
+        }
+
     }
 
 }

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/timestamp/AutoTimestampEventListenerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/timestamp/AutoTimestampEventListenerSpec.groovy
@@ -19,270 +19,437 @@
 
 package org.grails.datastore.gorm.timestamp
 
+import java.util.concurrent.Callable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
+
 import groovy.transform.InheritConstructors
+import spock.lang.Specification
+
 import org.grails.datastore.gorm.events.AutoTimestampEventListener
 import org.grails.datastore.mapping.core.Datastore
+import org.grails.datastore.mapping.engine.EntityAccess
 import org.grails.datastore.mapping.model.MappingContext
-import spock.lang.Specification
+import org.grails.datastore.mapping.model.PersistentEntity
 
 class AutoTimestampEventListenerSpec extends Specification {
 
+    private static final Set<String> BOTH_TIMESTAMPS = ['dateCreated', 'lastUpdated'] as Set<String>
+    private static final Set<String> DATE_CREATED_ONLY = ['dateCreated'] as Set<String>
+    private static final Set<String> LAST_UPDATED_ONLY = ['lastUpdated'] as Set<String>
+
     TestEventListener listener
-    Map<String, Optional<Set<String>>> lastUpdatedBaseState = [:]
-    Map<String, Optional<Set<String>>> dateCreatedBaseState = [:]
 
     void setup() {
         listener = new TestEventListener(Stub(Datastore) {
             getMappingContext() >> null
         })
-        [Foo, Bar, FooBar].each {
-            lastUpdatedBaseState.put(it.getName(), Optional.of(['lastUpdated'] as Set<String>))
-            dateCreatedBaseState.put(it.getName(), Optional.of(['dateCreated'] as Set<String>))
-        }
     }
 
-    void updateBaseStates() {
-        listener.dateCreated.entrySet().each {
-            dateCreatedBaseState.put(it.key, it.value)
-        }
-        listener.lastUpdated.entrySet().each {
-            lastUpdatedBaseState.put(it.key, it.value)
-        }
+    void "timestamps are applied on insert and update by default"() {
+        expect:
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+        appliedOnUpdate(Foo).keySet() == LAST_UPDATED_ONLY
     }
 
-    void "test withoutLastUpdated"() {
+    void "withoutLastUpdated disables lastUpdated for all entities only while the closure runs"() {
+        given:
+        Map<String, Object> fooInsertInside = null
+        Map<String, Object> barUpdateInside = null
+
         when:
         listener.withoutLastUpdated {
-            updateBaseStates()
+            fooInsertInside = appliedOnInsert(Foo)
+            barUpdateInside = appliedOnUpdate(Bar)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isEmpty()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isEmpty()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        fooInsertInside.keySet() == DATE_CREATED_ONLY
+        barUpdateInside.isEmpty()
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and: 'timestamping resumes once the closure completes'
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+        appliedOnUpdate(Bar).keySet() == LAST_UPDATED_ONLY
     }
 
-    void "test withoutLastUpdated(Class)"() {
+    void "withoutLastUpdated(Class) only affects the given class"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutLastUpdated(Bar) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        barInside.keySet() == DATE_CREATED_ONLY
+        fooInside.keySet() == BOTH_TIMESTAMPS
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
     }
 
-    void "test withoutLastUpdated(Class[])"() {
+    void "withoutLastUpdated(List) only affects the given classes"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooBarInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutLastUpdated([Bar, FooBar]) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooBarInside = appliedOnInsert(FooBar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isEmpty()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        barInside.keySet() == DATE_CREATED_ONLY
+        fooBarInside.keySet() == DATE_CREATED_ONLY
+        fooInside.keySet() == BOTH_TIMESTAMPS
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
+        appliedOnInsert(FooBar).keySet() == BOTH_TIMESTAMPS
     }
 
-    void "test withoutDateCreated"() {
+    void "withoutDateCreated disables dateCreated for all entities only while the closure runs"() {
+        given:
+        Map<String, Object> fooInside = null
+        Map<String, Object> barInside = null
+
         when:
-        listener.withoutDateCreated() {
-            updateBaseStates()
+        listener.withoutDateCreated {
+            fooInside = appliedOnInsert(Foo)
+            barInside = appliedOnInsert(Bar)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isEmpty()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isEmpty()
+        fooInside.keySet() == LAST_UPDATED_ONLY
+        barInside.keySet() == LAST_UPDATED_ONLY
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
     }
 
-    void "test withoutDateCreated(Class)"() {
+    void "withoutDateCreated(Class) only affects the given class"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutDateCreated(Bar) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        barInside.keySet() == LAST_UPDATED_ONLY
+        fooInside.keySet() == BOTH_TIMESTAMPS
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
     }
 
-    void "test withoutDateCreated(Class[])"() {
+    void "withoutDateCreated(List) only affects the given classes"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooBarInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutDateCreated([Bar, FooBar]) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooBarInside = appliedOnInsert(FooBar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isEmpty()
+        barInside.keySet() == LAST_UPDATED_ONLY
+        fooBarInside.keySet() == LAST_UPDATED_ONLY
+        fooInside.keySet() == BOTH_TIMESTAMPS
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
+        appliedOnInsert(FooBar).keySet() == BOTH_TIMESTAMPS
     }
 
+    void "withoutTimestamps disables all timestamp handling only while the closure runs"() {
+        given:
+        Map<String, Object> fooInsertInside = null
+        Map<String, Object> fooUpdateInside = null
+        Map<String, Object> barInsertInside = null
 
-    void "test withoutTimestamps"() {
         when:
-        listener.withoutTimestamps() {
-            updateBaseStates()
+        listener.withoutTimestamps {
+            fooInsertInside = appliedOnInsert(Foo)
+            fooUpdateInside = appliedOnUpdate(Foo)
+            barInsertInside = appliedOnInsert(Bar)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isEmpty()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isEmpty()
-        dateCreatedBaseState[Foo.getName()].isEmpty()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isEmpty()
+        fooInsertInside.isEmpty()
+        fooUpdateInside.isEmpty()
+        barInsertInside.isEmpty()
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+        appliedOnUpdate(Foo).keySet() == LAST_UPDATED_ONLY
     }
 
-    void "test withoutTimestamps(Class)"() {
+    void "withoutTimestamps(Class) only affects the given class"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutTimestamps(Bar) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        barInside.isEmpty()
+        fooInside.keySet() == BOTH_TIMESTAMPS
 
-        when:
-        updateBaseStates()
-
-        then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
     }
 
-    void "test withoutTimestamps(Class[])"() {
+    void "withoutTimestamps(List) only affects the given classes"() {
+        given:
+        Map<String, Object> barInside = null
+        Map<String, Object> fooBarInside = null
+        Map<String, Object> fooInside = null
+
         when:
         listener.withoutTimestamps([Bar, FooBar]) {
-            updateBaseStates()
+            barInside = appliedOnInsert(Bar)
+            fooBarInside = appliedOnInsert(FooBar)
+            fooInside = appliedOnInsert(Foo)
         }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isEmpty()
-        lastUpdatedBaseState[FooBar.getName()].isEmpty()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isEmpty()
-        dateCreatedBaseState[FooBar.getName()].isEmpty()
+        barInside.isEmpty()
+        fooBarInside.isEmpty()
+        fooInside.keySet() == BOTH_TIMESTAMPS
+
+        and:
+        appliedOnInsert(Bar).keySet() == BOTH_TIMESTAMPS
+        appliedOnInsert(FooBar).keySet() == BOTH_TIMESTAMPS
+    }
+
+    void "nested disabling restores the enclosing scope"() {
+        given:
+        Map<String, Object> fooInner = null
+        Map<String, Object> fooOuter = null
+        Map<String, Object> barOuter = null
 
         when:
-        updateBaseStates()
+        listener.withoutLastUpdated(Foo) {
+            listener.withoutTimestamps {
+                fooInner = appliedOnInsert(Foo)
+            }
+            fooOuter = appliedOnInsert(Foo)
+            barOuter = appliedOnInsert(Bar)
+        }
+
+        then: 'everything is disabled inside the nested closure'
+        fooInner.isEmpty()
+
+        and: 'only the outer suppression remains after the nested closure completes'
+        fooOuter.keySet() == DATE_CREATED_ONLY
+        barOuter.keySet() == BOTH_TIMESTAMPS
+
+        and: 'all timestamping resumes after the outer closure completes'
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+    }
+
+    void "overlapping scopes disabling the same class restore the enclosing scope"() {
+        given:
+        Map<String, Object> fooInner = null
+        Map<String, Object> barInner = null
+        Map<String, Object> fooBetween = null
+        Map<String, Object> barBetween = null
+
+        when:
+        listener.withoutDateCreated(Foo) {
+            listener.withoutDateCreated([Foo, Bar]) {
+                fooInner = appliedOnInsert(Foo)
+                barInner = appliedOnInsert(Bar)
+            }
+            fooBetween = appliedOnInsert(Foo)
+            barBetween = appliedOnInsert(Bar)
+        }
+
+        then: 'both classes are disabled inside the inner scope'
+        fooInner.keySet() == LAST_UPDATED_ONLY
+        barInner.keySet() == LAST_UPDATED_ONLY
+
+        and: 'Foo stays disabled in the outer scope after the inner scope exits'
+        fooBetween.keySet() == LAST_UPDATED_ONLY
+        barBetween.keySet() == BOTH_TIMESTAMPS
+
+        and: 'everything is restored after the outer scope exits'
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+    }
+
+    void "no suppression remains when registering a class list fails part way"() {
+        when: 'the second element blows up after the first has already been registered'
+        listener.withoutTimestamps([Foo, null]) {
+            throw new IllegalStateException('never reached')
+        }
 
         then:
-        lastUpdatedBaseState[Foo.getName()].isPresent()
-        lastUpdatedBaseState[Bar.getName()].isPresent()
-        lastUpdatedBaseState[FooBar.getName()].isPresent()
-        dateCreatedBaseState[Foo.getName()].isPresent()
-        dateCreatedBaseState[Bar.getName()].isPresent()
-        dateCreatedBaseState[FooBar.getName()].isPresent()
+        thrown(NullPointerException)
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+        appliedOnUpdate(Foo).keySet() == LAST_UPDATED_ONLY
+    }
+
+    void "timestamp processing is restored when the closure throws"() {
+        when:
+        listener.withoutTimestamps {
+            throw new IllegalStateException('failure inside withoutTimestamps')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+        appliedOnUpdate(Foo).keySet() == LAST_UPDATED_ONLY
+    }
+
+    void "disabling timestamps on one thread does not affect other threads"() {
+        given:
+        CountDownLatch entered = new CountDownLatch(1)
+        CountDownLatch release = new CountDownLatch(1)
+        Thread worker = new Thread({
+            listener.withoutTimestamps {
+                entered.countDown()
+                release.await(10, TimeUnit.SECONDS)
+            }
+        })
+
+        when: 'this thread persists while the worker holds an open withoutTimestamps window'
+        worker.start()
+        boolean workerEntered = entered.await(10, TimeUnit.SECONDS)
+        Map<String, Object> insertApplied = appliedOnInsert(Foo)
+        Map<String, Object> updateApplied = appliedOnUpdate(Foo)
+        release.countDown()
+        worker.join(10000)
+
+        then:
+        workerEntered
+        insertApplied.keySet() == BOTH_TIMESTAMPS
+        updateApplied.keySet() == LAST_UPDATED_ONLY
+    }
+
+    void "overlapping windows on different threads restore independently"() {
+        given:
+        CountDownLatch aEntered = new CountDownLatch(1)
+        CountDownLatch bEntered = new CountDownLatch(1)
+        CountDownLatch aExited = new CountDownLatch(1)
+        Map<String, Object> insideB = null
+        Map<String, Object> insideBAfterAExited = null
+        Map<String, Object> afterA = null
+
+        Thread threadA = new Thread({
+            listener.withoutTimestamps(Foo) {
+                aEntered.countDown()
+                bEntered.await(10, TimeUnit.SECONDS)
+            }
+            afterA = appliedOnInsert(Foo)
+            aExited.countDown()
+        })
+        Thread threadB = new Thread({
+            aEntered.await(10, TimeUnit.SECONDS)
+            listener.withoutTimestamps(Foo) {
+                insideB = appliedOnInsert(Foo)
+                bEntered.countDown()
+                aExited.await(10, TimeUnit.SECONDS)
+                insideBAfterAExited = appliedOnInsert(Foo)
+            }
+        })
+
+        when:
+        threadA.start()
+        threadB.start()
+        threadA.join(15000)
+        threadB.join(15000)
+
+        then: 'thread B stays disabled for its whole window, even after thread A restores'
+        insideB.isEmpty()
+        insideBAfterAExited.isEmpty()
+
+        and: 'thread A is re-enabled as soon as its own window closes'
+        afterA.keySet() == BOTH_TIMESTAMPS
+
+        and: 'the test thread was never affected'
+        appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+    }
+
+    void "suppression stays thread local under concurrent use"() {
+        given:
+        int threadCount = 8
+        int iterations = 25
+        ExecutorService pool = Executors.newFixedThreadPool(threadCount)
+        CountDownLatch start = new CountDownLatch(1)
+
+        when:
+        List<Future<Boolean>> outcomes = (1..threadCount).collect { int n ->
+            pool.submit({
+                start.await(10, TimeUnit.SECONDS)
+                boolean consistent = true
+                iterations.times {
+                    if (n % 2 == 0) {
+                        listener.withoutTimestamps {
+                            consistent &= appliedOnInsert(Foo).isEmpty()
+                        }
+                        consistent &= appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+                    } else {
+                        consistent &= appliedOnInsert(Foo).keySet() == BOTH_TIMESTAMPS
+                        consistent &= appliedOnUpdate(Foo).keySet() == LAST_UPDATED_ONLY
+                    }
+                }
+                consistent
+            } as Callable<Boolean>)
+        }
+        start.countDown()
+        List<Boolean> results = outcomes.collect { it.get(30, TimeUnit.SECONDS) }
+
+        then:
+        results.every { it }
+
+        cleanup:
+        pool.shutdownNow()
+    }
+
+    private Map<String, Object> appliedOnInsert(Class clazz) {
+        Map<String, Object> applied = new ConcurrentHashMap<>()
+        listener.beforeInsert(entityFor(clazz), recordingAccess(applied))
+        applied
+    }
+
+    private Map<String, Object> appliedOnUpdate(Class clazz) {
+        Map<String, Object> applied = new ConcurrentHashMap<>()
+        listener.beforeUpdate(entityFor(clazz), recordingAccess(applied))
+        applied
+    }
+
+    private static PersistentEntity entityFor(Class clazz) {
+        [getName: { -> clazz.name }] as PersistentEntity
+    }
+
+    private static EntityAccess recordingAccess(Map<String, Object> applied) {
+        [
+                getPropertyValue: { String name -> null },
+                getPropertyType : { String name -> Date },
+                setProperty     : { String name, Object value -> applied.put(name, value) }
+        ] as EntityAccess
     }
 }
 
@@ -300,13 +467,6 @@ class FooBar {
 
 @InheritConstructors
 class TestEventListener extends AutoTimestampEventListener {
-
-    Map<String, Optional<Set<String>>> getDateCreated() {
-        this.entitiesWithDateCreated
-    }
-    Map<String, Optional<Set<String>>> getLastUpdated() {
-        this.entitiesWithLastUpdated
-    }
 
     protected void initForMappingContext(MappingContext mappingContext) {
         [Foo, Bar, FooBar].each {


### PR DESCRIPTION
Fixes #14510

### The bug

`withoutTimestamps`, `withoutDateCreated` and `withoutLastUpdated` disabled timestamping by mutating the listener-wide entity maps (capturing each entry and setting it to `Optional.empty()`, then restoring). That state is JVM-global, so overlapping windows on concurrent threads corrupt each other:

1. Thread A enters: captures ON, sets OFF
2. Thread B enters: captures OFF, sets OFF
3. Thread A exits: restores ON
4. Thread B's save now runs **with** timestamping — its historical `dateCreated`/`lastUpdated` values are silently clobbered

Reproduction: https://github.com/codeconsole/grails-autotimestamp-bug

A second facet: there was no `try`/`finally`, so an exception inside the closure left timestamping **permanently disabled** for the whole JVM.

### The fix

The shared metadata maps are no longer mutated. Suppression is tracked per thread: the property-name getters consult a `ThreadLocal` holding an all-entities nesting depth plus the set of entity names disabled by per-class scopes. Each scope only re-enables the names it added, so nested and overlapping scopes restore correctly; `try`/`finally` guarantees restoration when the closure throws; the `ThreadLocal` is removed when empty so nothing is retained on pooled threads.

Public API, protected fields and single-thread semantics are unchanged (binary and source compatible).

### Behavioral note

Disabling is now scoped to the calling thread. Threads spawned *inside* the closure are no longer affected — under the old global behavior they were (by accident). Code relying on that must call `withoutTimestamps` on each thread. The auto-timestamping guide now documents the thread scoping. Worth a mention in the release notes.

### Tests

The spec was rewritten to exercise the listener through the public `beforeInsert`/`beforeUpdate` API and extended with tests that reproduce the bug — written first and verified to fail on the old implementation:

* cross-thread isolation (the main #14510 repro)
* overlapping windows on different threads restoring independently (the interleaving above)
* nested and overlapping same-class scopes restoring the enclosing scope
* restoration when the closure throws, including a partial failure while registering a class list
* an 8-thread contention stress test

All 218 tests in `grails-datamapping-core` pass, as do the timestamp specs in `grails-datamapping-core-test`, `grails-data-hibernate5-core` and `grails-test-suite-uber`; Checkstyle and CodeNarc are clean.