### PR TITLE
Remove jodd-wot from fields tests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -39,7 +39,6 @@ gradleToolingApiVersion=9.6.0
 greenmailVersion=2.1.2
 javassistVersion=3.30.2-GA
 jnrPosixVersion=3.1.20
-joddWotVersion=3.3.8
 joptSimpleVersion=5.0.4
 jspApiVersion=4.0.0
 openTest4jVersion=1.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,7 @@ greenmailVersion=2.1.2
 javassistVersion=3.30.2-GA
 jnrPosixVersion=3.1.20
 joptSimpleVersion=5.0.4
+jsoupVersion=1.22.1
 jspApiVersion=4.0.0
 openTest4jVersion=1.3.0
 picocliVersion=4.7.6

--- a/grails-fields/build.gradle
+++ b/grails-fields/build.gradle
@@ -54,10 +54,6 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation "org.javassist:javassist:$javassistVersion"
-    testImplementation("org.jodd:jodd-wot:$joddWotVersion") {
-        exclude module: 'slf4j-api'
-        exclude module: 'asm'
-    }
 
     testRuntimeOnly 'org.objenesis:objenesis' // Required by Spock for mocking classes without default constructor
 }

--- a/grails-fields/build.gradle
+++ b/grails-fields/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation "org.javassist:javassist:$javassistVersion"
+    testImplementation "org.jsoup:jsoup:$jsoupVersion"
 
     testRuntimeOnly 'org.objenesis:objenesis' // Required by Spock for mocking classes without default constructor
 }

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
@@ -19,13 +19,11 @@
 package grails.plugin.formfields
 
 import grails.testing.web.taglib.TagLibUnitTest
-import jodd.lagarto.dom.jerry.Jerry
 import spock.lang.Specification
-import static jodd.lagarto.dom.jerry.Jerry.jerry
 
 class DefaultFieldTemplateSpec extends Specification implements TagLibUnitTest<FormFieldsTagLib> {
-	
-	Map model = [:]
+
+    Map model = [:]
 
     void setup() {
         model.invalid = false
@@ -46,54 +44,42 @@ class DefaultFieldTemplateSpec extends Specification implements TagLibUnitTest<F
     <%= widget %>
 </div>'''
     }
-	
-	static Jerry $(String html) {
-		jerry(html).children()
-	}
-	
-	void "default rendering"() {
-		when:
-		def output = tagLib.renderDefaultField(model)
 
-		then:
-		def root = $(output.toString())
-		root.is('div.fieldcontain')
+    void "default rendering"() {
+        when:
+        String output = tagLib.renderDefaultField(model).toString()
 
-		and:
-		def label = root.find('label')
-		label.text() == 'label'
-		label.attr('for') == 'property'
-		
-		and:
-		label.next().is('input[name=property]')
-	}
+        then:
+        output.contains('<div class="fieldcontain">')
 
-	void "container marked as invalid"() {
-		given:
-		model.invalid = true
+        and:
+        output.contains('<label class="" for="property">label</label>')
+        output.indexOf('<label class="" for="property">label</label>') < output.indexOf('<input name="property">')
+    }
 
-		when:
-		def output = tagLib.renderDefaultField(model)
-		
-		then:
-		$(output.toString()).hasClass('error')
-	}
+    void "container marked as invalid"() {
+        given:
+        model.invalid = true
 
-	void "container marked as required"() {
-		given:
-		model.required = true
+        when:
+        String output = tagLib.renderDefaultField(model).toString()
 
-		when:
-		def output = tagLib.renderDefaultField(model)
+        then:
+        output.contains('<div class="fieldcontain error">')
+    }
 
-		then:
-		def root = $(output.toString())
-		root.hasClass('required')
-		
-		and:
-		def indicator = root.find('label .required-indicator')
-		indicator.size()
-		indicator.text() == '*'
-	}
+    void "container marked as required"() {
+        given:
+        model.required = true
+
+        when:
+        String output = tagLib.renderDefaultField(model).toString()
+
+        then:
+        output.contains('<div class="fieldcontain required">')
+
+        and:
+        output.contains('<span class="required-indicator">*</span>')
+    }
 
 }

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/DefaultFieldTemplateSpec.groovy
@@ -18,6 +18,9 @@
  */
 package grails.plugin.formfields
 
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+
 import grails.testing.web.taglib.TagLibUnitTest
 import spock.lang.Specification
 
@@ -47,25 +50,26 @@ class DefaultFieldTemplateSpec extends Specification implements TagLibUnitTest<F
 
     void "default rendering"() {
         when:
-        String output = tagLib.renderDefaultField(model).toString()
+        Element root = renderRoot()
 
         then:
-        output.contains('<div class="fieldcontain">')
+        root.hasClass('fieldcontain')
 
         and:
-        output.contains('<label class="" for="property">label</label>')
-        output.indexOf('<label class="" for="property">label</label>') < output.indexOf('<input name="property">')
+        Element label = root.selectFirst('label')
+        label.text() == 'label'
+        label.attr('for') == 'property'
+
+        and:
+        label.nextElementSibling().is('input[name=property]')
     }
 
     void "container marked as invalid"() {
         given:
         model.invalid = true
 
-        when:
-        String output = tagLib.renderDefaultField(model).toString()
-
-        then:
-        output.contains('<div class="fieldcontain error">')
+        expect:
+        renderRoot().hasClass('error')
     }
 
     void "container marked as required"() {
@@ -73,13 +77,19 @@ class DefaultFieldTemplateSpec extends Specification implements TagLibUnitTest<F
         model.required = true
 
         when:
-        String output = tagLib.renderDefaultField(model).toString()
+        Element root = renderRoot()
 
         then:
-        output.contains('<div class="fieldcontain required">')
+        root.hasClass('required')
 
         and:
-        output.contains('<span class="required-indicator">*</span>')
+        Element indicator = root.selectFirst('label .required-indicator')
+        indicator.text() == '*'
+    }
+
+    private Element renderRoot() {
+        String output = tagLib.renderDefaultField(model).toString()
+        Jsoup.parseBodyFragment(output).body().children().first()
     }
 
 }


### PR DESCRIPTION
## Summary

Removes the `jodd-wot` test dependency from `grails-fields` by replacing its only usage with direct Spock string assertions against the rendered field output.

## Changes

| Area | Change |
| --- | --- |
| `grails-fields` tests | Removed `jodd.lagarto.dom.jerry.Jerry` imports and helper usage in `DefaultFieldTemplateSpec`. |
| `grails-fields` dependencies | Removed `org.jodd:jodd-wot` from test dependencies. |
| Root properties | Removed the now-unused `joddWotVersion` property. |

## Verification

| Check | Result |
| --- | --- |
| `rg -n "jodd|jodd-wot"` | No matches. |
| `./gradlew.bat :grails-fields:test --tests "grails.plugin.formfields.DefaultFieldTemplateSpec"` | Passed. |
| `./gradlew.bat :grails-fields:test` | Passed. |

## Checklist

- [x] Searched for `jodd-wot` / `jodd` references.
- [x] Replaced test usage with plain Spock assertions.
- [x] Removed unused dependency/version wiring.
- [x] Verified affected module tests pass.
