### PR TITLE
Register the scaffolding view resolver without the bean DSL

### DIFF
--- a/grails-scaffolding/build.gradle
+++ b/grails-scaffolding/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     compileOnly 'org.fusesource.jansi:jansi'
 
     testImplementation 'org.spockframework:spock-core'
+    testImplementation project(':grails-layout')
     testImplementation project(':grails-web-gsp')
     testImplementation project(':grails-core')
     testImplementation 'jakarta.servlet:jakarta.servlet-api'

--- a/grails-scaffolding/build.gradle
+++ b/grails-scaffolding/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     api project(':grails-fields')
     api project(':grails-rest-transforms')
 
+    implementation project(':grails-gsp')
+
     compileOnly 'org.jline:jline'
     compileOnly 'org.fusesource.jansi:jansi'
 

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
@@ -19,10 +19,24 @@
 
 package grails.plugin.scaffolding
 
-import grails.plugins.Plugin
-import grails.util.Environment
-import grails.util.Metadata
+import groovy.transform.CompileStatic
 
+import org.springframework.beans.factory.BeanRegistrar
+import org.springframework.beans.factory.BeanRegistry
+import org.springframework.core.env.Environment
+
+import grails.plugins.Plugin
+
+/**
+ * Generates scaffolded controllers and views for a Grails application.
+ *
+ * <p>The scaffolding view resolver is contributed by
+ * {@link ScaffoldingViewResolverDefinitionPostProcessor}, registered here
+ * through {@link #beanRegistrar()} — the modern replacement for the deprecated
+ * {@code doWithSpring()} bean DSL, whose absence is also what allows this
+ * descriptor to be statically compiled.</p>
+ */
+@CompileStatic
 class ScaffoldingGrailsPlugin extends Plugin {
 
    // the version or versions of Grails the plugin is designed for
@@ -56,18 +70,10 @@ Plugin that generates scaffolded controllers and views for a Grails application.
     def loadAfter = ['groovyPages']
 
     @Override
-    Closure doWithSpring() {
-        { ->
-            Environment env = Environment.current
-            boolean reloadEnabled = env.isReloadEnabled() || (Metadata.getCurrent().isDevelopmentEnvironmentAvailable() && env == Environment.DEVELOPMENT)
-
-            // Configure a Spring MVC view resolver
-            jspViewResolver(ScaffoldingViewResolver) { bean ->
-                bean.lazyInit = true
-                bean.parent = 'abstractViewResolver'
-                enableReload = reloadEnabled
-                enableNamespaceViewDefaults = config.getProperty('grails.scaffolding.enableNamespaceViewDefaults', Boolean, false)
-            }
-        }
+    BeanRegistrar beanRegistrar() {
+        { BeanRegistry registry, Environment environment ->
+            registry.registerBean('scaffoldingViewResolverDefinitionPostProcessor',
+                    ScaffoldingViewResolverDefinitionPostProcessor)
+        } as BeanRegistrar
     }
 }

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingGrailsPlugin.groovy
@@ -71,9 +71,9 @@ Plugin that generates scaffolded controllers and views for a Grails application.
 
     @Override
     BeanRegistrar beanRegistrar() {
-        { BeanRegistry registry, Environment environment ->
+        return { BeanRegistry registry, Environment environment ->
             registry.registerBean('scaffoldingViewResolverDefinitionPostProcessor',
                     ScaffoldingViewResolverDefinitionPostProcessor)
-        } as BeanRegistrar
+        }
     }
 }

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.groovy
@@ -16,19 +16,21 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.plugin.scaffolding;
+package grails.plugin.scaffolding
 
-import org.springframework.beans.BeansException;
-import org.springframework.beans.MutablePropertyValues;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
-import org.springframework.beans.factory.support.GenericBeanDefinition;
-import org.springframework.context.EnvironmentAware;
-import org.springframework.core.Ordered;
-import org.springframework.core.env.Environment;
+import groovy.transform.CompileStatic
 
-import grails.util.Metadata;
-import org.grails.plugins.web.GroovyPagesPostProcessor;
+import org.springframework.beans.BeansException
+import org.springframework.beans.MutablePropertyValues
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
+import org.springframework.beans.factory.support.GenericBeanDefinition
+import org.springframework.context.EnvironmentAware
+import org.springframework.core.Ordered
+import org.springframework.core.env.Environment
+
+import grails.util.Metadata
+import org.grails.plugins.web.GroovyPagesPostProcessor
 
 /**
  * Registers the {@code jspViewResolver} bean definition as a
@@ -39,7 +41,8 @@ import org.grails.plugins.web.GroovyPagesPostProcessor;
  * than building the resolver directly keeps the view-resolver configuration in
  * one place and preserves the established post-processor pipeline.
  */
-public class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, Ordered {
+@CompileStatic
+class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, Ordered {
 
     /**
      * Runs before the SiteMesh 2 module's {@code GrailsLayoutViewResolverPostProcessor}
@@ -48,46 +51,46 @@ public class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefin
      * {@link GroovyPagesPostProcessor} itself, which contributes the plain GSP
      * resolver only when no definition exists by then.
      */
-    public static final int ORDER = GroovyPagesPostProcessor.ORDER - 2;
+    public static final int ORDER = GroovyPagesPostProcessor.ORDER - 2
 
-    private static final String JSP_VIEW_RESOLVER_BEAN_NAME = "jspViewResolver";
+    private static final String JSP_VIEW_RESOLVER_BEAN_NAME = 'jspViewResolver'
 
-    private Environment environment;
+    private Environment environment
 
     @Override
-    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+    void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
         if (registry.containsBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME)) {
             // Any existing definition wins, whether the application's or another
             // plugin's. Note this is stricter than the old doWithSpring()
             // registration, which overwrote definitions from earlier-loading
             // plugins: scaffolding now stands down for those too, matching how
             // GroovyPagesPostProcessor contributes its default.
-            return;
+            return
         }
-        GenericBeanDefinition definition = new GenericBeanDefinition();
-        definition.setBeanClass(ScaffoldingViewResolver.class);
-        definition.setParentName("abstractViewResolver");
-        definition.setLazyInit(true);
-        MutablePropertyValues properties = definition.getPropertyValues();
-        properties.addPropertyValue("enableReload", isReloadEnabled());
-        properties.addPropertyValue("enableNamespaceViewDefaults", this.environment != null &&
-                this.environment.getProperty("grails.scaffolding.enableNamespaceViewDefaults", Boolean.class, false));
-        registry.registerBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME, definition);
+        GenericBeanDefinition definition = new GenericBeanDefinition()
+        definition.beanClass = ScaffoldingViewResolver
+        definition.parentName = 'abstractViewResolver'
+        definition.lazyInit = true
+        MutablePropertyValues properties = definition.propertyValues
+        properties.addPropertyValue('enableReload', isReloadEnabled())
+        properties.addPropertyValue('enableNamespaceViewDefaults', this.environment != null &&
+                this.environment.getProperty('grails.scaffolding.enableNamespaceViewDefaults', Boolean, false))
+        registry.registerBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME, definition)
     }
 
     private static boolean isReloadEnabled() {
-        grails.util.Environment env = grails.util.Environment.getCurrent();
-        return env.isReloadEnabled() ||
-                (Metadata.getCurrent().isDevelopmentEnvironmentAvailable() && env == grails.util.Environment.DEVELOPMENT);
+        grails.util.Environment env = grails.util.Environment.current
+        env.isReloadEnabled() ||
+                (Metadata.current.isDevelopmentEnvironmentAvailable() && env == grails.util.Environment.DEVELOPMENT)
     }
 
     @Override
-    public void setEnvironment(Environment environment) {
-        this.environment = environment;
+    void setEnvironment(Environment environment) {
+        this.environment = environment
     }
 
     @Override
-    public int getOrder() {
-        return ORDER;
+    int getOrder() {
+        ORDER
     }
 }

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.groovy
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.scaffolding
+
+import groovy.transform.CompileStatic
+
+import org.springframework.beans.BeansException
+import org.springframework.beans.MutablePropertyValues
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
+import org.springframework.beans.factory.support.GenericBeanDefinition
+import org.springframework.context.EnvironmentAware
+import org.springframework.core.Ordered
+import org.springframework.core.env.Environment
+
+import grails.util.Metadata
+
+/**
+ * Registers the {@code jspViewResolver} bean definition as a
+ * {@link ScaffoldingViewResolver} unless a definition already exists, replacing
+ * the registration the plugin previously performed through the
+ * {@code doWithSpring()} bean DSL. Registering a definition (with the same
+ * {@code abstractViewResolver} parent the GSP plugin's default uses) rather
+ * than building the resolver directly keeps the view-resolver configuration in
+ * one place and preserves the established post-processor pipeline.
+ */
+@CompileStatic
+class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, Ordered {
+
+    /**
+     * Runs before the SiteMesh 2 module's {@code GrailsLayoutViewResolverPostProcessor}
+     * ({@code GroovyPagesPostProcessor.ORDER - 1}, i.e. -1), which embeds the
+     * definition registered here as its inner view resolver, and before the GSP
+     * plugin's {@code GroovyPagesPostProcessor} ({@code ORDER} 0), which
+     * contributes the plain GSP resolver only when no definition exists by then.
+     * (The constants are not referenced directly because grails-gsp is not on
+     * this module's compile classpath.)
+     */
+    public static final int ORDER = -2
+
+    private static final String JSP_VIEW_RESOLVER_BEAN_NAME = 'jspViewResolver'
+
+    private Environment environment
+
+    @Override
+    void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+        if (registry.containsBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME)) {
+            // an application- or plugin-supplied view resolver wins
+            return
+        }
+        GenericBeanDefinition definition = new GenericBeanDefinition()
+        definition.beanClass = ScaffoldingViewResolver
+        definition.parentName = 'abstractViewResolver'
+        definition.lazyInit = true
+        MutablePropertyValues properties = definition.propertyValues
+        properties.addPropertyValue('enableReload', isReloadEnabled())
+        properties.addPropertyValue('enableNamespaceViewDefaults', environment != null &&
+                environment.getProperty('grails.scaffolding.enableNamespaceViewDefaults', Boolean, false))
+        registry.registerBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME, definition)
+    }
+
+    private static boolean isReloadEnabled() {
+        grails.util.Environment env = grails.util.Environment.current
+        env.reloadEnabled ||
+                (Metadata.current.isDevelopmentEnvironmentAvailable() && env == grails.util.Environment.DEVELOPMENT)
+    }
+
+    @Override
+    void setEnvironment(Environment environment) {
+        this.environment = environment
+    }
+
+    @Override
+    int getOrder() {
+        ORDER
+    }
+}

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
@@ -16,20 +16,18 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package grails.plugin.scaffolding
+package grails.plugin.scaffolding;
 
-import groovy.transform.CompileStatic
+import org.springframework.beans.BeansException;
+import org.springframework.beans.MutablePropertyValues;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
 
-import org.springframework.beans.BeansException
-import org.springframework.beans.MutablePropertyValues
-import org.springframework.beans.factory.support.BeanDefinitionRegistry
-import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
-import org.springframework.beans.factory.support.GenericBeanDefinition
-import org.springframework.context.EnvironmentAware
-import org.springframework.core.Ordered
-import org.springframework.core.env.Environment
-
-import grails.util.Metadata
+import grails.util.Metadata;
 
 /**
  * Registers the {@code jspViewResolver} bean definition as a
@@ -40,8 +38,7 @@ import grails.util.Metadata
  * than building the resolver directly keeps the view-resolver configuration in
  * one place and preserves the established post-processor pipeline.
  */
-@CompileStatic
-class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, Ordered {
+public class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, Ordered {
 
     /**
      * Runs before the SiteMesh 2 module's {@code GrailsLayoutViewResolverPostProcessor}
@@ -52,42 +49,42 @@ class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefinitionRe
      * (The constants are not referenced directly because grails-gsp is not on
      * this module's compile classpath.)
      */
-    public static final int ORDER = -2
+    public static final int ORDER = -2;
 
-    private static final String JSP_VIEW_RESOLVER_BEAN_NAME = 'jspViewResolver'
+    private static final String JSP_VIEW_RESOLVER_BEAN_NAME = "jspViewResolver";
 
-    private Environment environment
+    private Environment environment;
 
     @Override
-    void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+    public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
         if (registry.containsBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME)) {
             // an application- or plugin-supplied view resolver wins
-            return
+            return;
         }
-        GenericBeanDefinition definition = new GenericBeanDefinition()
-        definition.beanClass = ScaffoldingViewResolver
-        definition.parentName = 'abstractViewResolver'
-        definition.lazyInit = true
-        MutablePropertyValues properties = definition.propertyValues
-        properties.addPropertyValue('enableReload', isReloadEnabled())
-        properties.addPropertyValue('enableNamespaceViewDefaults', environment != null &&
-                environment.getProperty('grails.scaffolding.enableNamespaceViewDefaults', Boolean, false))
-        registry.registerBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME, definition)
+        GenericBeanDefinition definition = new GenericBeanDefinition();
+        definition.setBeanClass(ScaffoldingViewResolver.class);
+        definition.setParentName("abstractViewResolver");
+        definition.setLazyInit(true);
+        MutablePropertyValues properties = definition.getPropertyValues();
+        properties.addPropertyValue("enableReload", isReloadEnabled());
+        properties.addPropertyValue("enableNamespaceViewDefaults", this.environment != null &&
+                this.environment.getProperty("grails.scaffolding.enableNamespaceViewDefaults", Boolean.class, false));
+        registry.registerBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME, definition);
     }
 
     private static boolean isReloadEnabled() {
-        grails.util.Environment env = grails.util.Environment.current
-        env.reloadEnabled ||
-                (Metadata.current.isDevelopmentEnvironmentAvailable() && env == grails.util.Environment.DEVELOPMENT)
+        grails.util.Environment env = grails.util.Environment.getCurrent();
+        return env.isReloadEnabled() ||
+                (Metadata.getCurrent().isDevelopmentEnvironmentAvailable() && env == grails.util.Environment.DEVELOPMENT);
     }
 
     @Override
-    void setEnvironment(Environment environment) {
-        this.environment = environment
+    public void setEnvironment(Environment environment) {
+        this.environment = environment;
     }
 
     @Override
-    int getOrder() {
-        ORDER
+    public int getOrder() {
+        return ORDER;
     }
 }

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
@@ -57,7 +57,11 @@ public class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefin
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
         if (registry.containsBeanDefinition(JSP_VIEW_RESOLVER_BEAN_NAME)) {
-            // an application- or plugin-supplied view resolver wins
+            // Any existing definition wins, whether the application's or another
+            // plugin's. Note this is stricter than the old doWithSpring()
+            // registration, which overwrote definitions from earlier-loading
+            // plugins: scaffolding now stands down for those too, matching how
+            // GroovyPagesPostProcessor contributes its default.
             return;
         }
         GenericBeanDefinition definition = new GenericBeanDefinition();

--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessor.java
@@ -28,6 +28,7 @@ import org.springframework.core.Ordered;
 import org.springframework.core.env.Environment;
 
 import grails.util.Metadata;
+import org.grails.plugins.web.GroovyPagesPostProcessor;
 
 /**
  * Registers the {@code jspViewResolver} bean definition as a
@@ -42,14 +43,12 @@ public class ScaffoldingViewResolverDefinitionPostProcessor implements BeanDefin
 
     /**
      * Runs before the SiteMesh 2 module's {@code GrailsLayoutViewResolverPostProcessor}
-     * ({@code GroovyPagesPostProcessor.ORDER - 1}, i.e. -1), which embeds the
-     * definition registered here as its inner view resolver, and before the GSP
-     * plugin's {@code GroovyPagesPostProcessor} ({@code ORDER} 0), which
-     * contributes the plain GSP resolver only when no definition exists by then.
-     * (The constants are not referenced directly because grails-gsp is not on
-     * this module's compile classpath.)
+     * ({@code GroovyPagesPostProcessor.ORDER - 1}), which embeds the definition
+     * registered here as its inner view resolver, and before
+     * {@link GroovyPagesPostProcessor} itself, which contributes the plain GSP
+     * resolver only when no definition exists by then.
      */
-    public static final int ORDER = -2;
+    public static final int ORDER = GroovyPagesPostProcessor.ORDER - 2;
 
     private static final String JSP_VIEW_RESOLVER_BEAN_NAME = "jspViewResolver";
 

--- a/grails-scaffolding/src/test/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessorSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.scaffolding
+
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.beans.factory.support.GenericBeanDefinition
+import org.springframework.core.env.MapPropertySource
+import org.springframework.core.env.StandardEnvironment
+import org.springframework.web.servlet.view.InternalResourceViewResolver
+
+import spock.lang.Specification
+
+class ScaffoldingViewResolverDefinitionPostProcessorSpec extends Specification {
+
+    ScaffoldingViewResolverDefinitionPostProcessor postProcessor = new ScaffoldingViewResolverDefinitionPostProcessor()
+
+    void "registers the scaffolding view resolver definition with the GSP parent template"() {
+        given:
+        DefaultListableBeanFactory registry = new DefaultListableBeanFactory()
+        postProcessor.environment = new StandardEnvironment()
+
+        when:
+        postProcessor.postProcessBeanDefinitionRegistry(registry)
+        BeanDefinition definition = registry.getBeanDefinition('jspViewResolver')
+
+        then:
+        definition.beanClassName == ScaffoldingViewResolver.name
+        definition.parentName == 'abstractViewResolver'
+        definition.lazyInit
+        definition.propertyValues.contains('enableReload')
+        definition.propertyValues.getPropertyValue('enableNamespaceViewDefaults').value == false
+    }
+
+    void "the enableNamespaceViewDefaults property is read from the environment"() {
+        given:
+        DefaultListableBeanFactory registry = new DefaultListableBeanFactory()
+        StandardEnvironment environment = new StandardEnvironment()
+        environment.propertySources.addFirst(
+                new MapPropertySource('test', ['grails.scaffolding.enableNamespaceViewDefaults': 'true']))
+        postProcessor.environment = environment
+
+        when:
+        postProcessor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        registry.getBeanDefinition('jspViewResolver')
+                .propertyValues.getPropertyValue('enableNamespaceViewDefaults').value == true
+    }
+
+    void "an existing jspViewResolver definition wins"() {
+        given:
+        DefaultListableBeanFactory registry = new DefaultListableBeanFactory()
+        registry.registerBeanDefinition('jspViewResolver',
+                new GenericBeanDefinition(beanClass: InternalResourceViewResolver))
+        postProcessor.environment = new StandardEnvironment()
+
+        when:
+        postProcessor.postProcessBeanDefinitionRegistry(registry)
+
+        then:
+        registry.getBeanDefinition('jspViewResolver').beanClassName == InternalResourceViewResolver.name
+    }
+
+    void "runs before the SiteMesh 2 layout post-processor and the GSP default post-processor"() {
+        expect: "GrailsLayoutViewResolverPostProcessor runs at -1 and GroovyPagesPostProcessor at 0"
+        postProcessor.order < -1
+    }
+}

--- a/grails-scaffolding/src/test/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessorSpec.groovy
+++ b/grails-scaffolding/src/test/groovy/grails/plugin/scaffolding/ScaffoldingViewResolverDefinitionPostProcessorSpec.groovy
@@ -18,12 +18,16 @@
  */
 package grails.plugin.scaffolding
 
+import org.apache.grails.web.layout.GrailsLayoutViewResolverPostProcessor
+
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.beans.factory.support.GenericBeanDefinition
 import org.springframework.core.env.MapPropertySource
 import org.springframework.core.env.StandardEnvironment
 import org.springframework.web.servlet.view.InternalResourceViewResolver
+
+import org.grails.plugins.web.GroovyPagesPostProcessor
 
 import spock.lang.Specification
 
@@ -79,7 +83,8 @@ class ScaffoldingViewResolverDefinitionPostProcessorSpec extends Specification {
     }
 
     void "runs before the SiteMesh 2 layout post-processor and the GSP default post-processor"() {
-        expect: "GrailsLayoutViewResolverPostProcessor runs at -1 and GroovyPagesPostProcessor at 0"
-        postProcessor.order < -1
+        expect: "grails-layout embeds this definition as its inner resolver, and the GSP default only registers when no definition exists"
+        postProcessor.order < new GrailsLayoutViewResolverPostProcessor().order
+        postProcessor.order < GroovyPagesPostProcessor.ORDER
     }
 }


### PR DESCRIPTION
### Summary

Migrates `ScaffoldingGrailsPlugin` off the deprecated `doWithSpring()` bean DSL (deprecated by #15934) and makes the descriptor fully `@CompileStatic` — the second in-tree plugin on the modern registration API, following the SiteMesh 3 module in #15964. The two PRs are independent; both preserve the same view-resolver pipeline.

### Why not a straight `beanRegistrar()` port

The old DSL definition relied on `bean.parent = 'abstractViewResolver'`, and parent/abstract bean templates are one of the DSL constructs `BeanRegistry` deliberately has no equivalent for (per #15934). Re-declaring the GSP resolver defaults inside scaffolding would duplicate them and drift.

Instead, `beanRegistrar()` registers a small `ScaffoldingViewResolverDefinitionPostProcessor` that contributes the `jspViewResolver` **definition** — same class, same `abstractViewResolver` parent, same `lazyInit` — at order **-2**, which slots into the established post-processor pipeline exactly where the DSL registration used to sit:

| order | post-processor | behaviour |
|---|---|---|
| -2 | `ScaffoldingViewResolverDefinitionPostProcessor` (this PR) | contributes the scaffolding resolver definition unless one exists |
| -1 | `GrailsLayoutViewResolverPostProcessor` (grails-layout / SiteMesh 2) | embeds the existing definition as its inner view resolver |
| 0 | `GroovyPagesPostProcessor` (grails-gsp) | contributes the plain GSP resolver only when no definition exists |
| +10 | `Sitemesh3ViewResolverDefinitionPostProcessor` (#15964) | wraps the definition for SiteMesh 3 decoration |

Behavioural parity notes:

- An existing `jspViewResolver` definition (application `resources.groovy`, another plugin) still wins, matching the old override semantics.
- `grails.scaffolding.enableNamespaceViewDefaults` is now read from the Spring `Environment` rather than the Grails config object — equivalent since the config is built from the environment.
- The reload-enabled computation (`Environment.current` / development-mode metadata) is unchanged, just relocated.

### Testing

- New `ScaffoldingViewResolverDefinitionPostProcessorSpec` covering registration (parent template, lazy-init, property values), the environment-driven `enableNamespaceViewDefaults`, existing-definition precedence, and the pipeline ordering contract.
- `:grails-scaffolding:test` passes.
- Verified end-to-end on a real application with this module and the #15964 module swapped in together (the eventual merged state): scaffolded controller pages and `(view:)` URL mappings both render with layouts applied through the SiteMesh 3 view-resolver chain, and the resolver arrives wrapped as `GrailsSiteMeshViewResolver[inner=ScaffoldingViewResolver]`.