### PR TITLE
Log plugin loaded successfully messages at DEBUG instead of INFO

### DIFF
--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -22,7 +22,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -155,6 +157,7 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
             return;
         }
 
+        List<String> loadedPlugins = new ArrayList<>();
         // Note: the environment is null here since the plugins should have always been populated in the bootstrap phase
         pluginDiscovery.getPluginsInLoadOrder().forEach(pluginInfo -> {
             GrailsPlugin plugin;
@@ -175,7 +178,13 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
             }
             plugin.setManager(this);
             plugins.put(plugin.getName(), plugin);
+            loadedPlugins.add(plugin.getName() + " (" + plugin.getVersion() + ")");
         });
+
+        if (LOG.isInfoEnabled()) {
+            LOG.info("Loaded " + loadedPlugins.size() + " Grails plugins in load order: [" +
+                    String.join(", ", loadedPlugins) + "]");
+        }
 
         initialised = true;
     }

--- a/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
+++ b/grails-core/src/main/groovy/grails/plugins/DefaultGrailsPluginManager.java
@@ -164,8 +164,8 @@ public class DefaultGrailsPluginManager extends AbstractGrailsPluginManager {
                 plugin = createBinaryGrailsPlugin(pluginInfo.getPluginClass(), pluginInfo.getPluginDescriptor());
             }
 
-            if (LOG.isInfoEnabled()) {
-                LOG.info("Grails plug-in [" + plugin.getName() + "] with version [" + plugin.getVersion() + "] loaded successfully");
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Grails plug-in [" + plugin.getName() + "] with version [" + plugin.getVersion() + "] loaded successfully");
             }
 
             // plugin is always ApplicationContextAware

--- a/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultPluginDiscovery.java
@@ -496,8 +496,8 @@ public class DefaultPluginDiscovery implements PluginDiscovery {
             return;
         }
 
-        if (LOG.isInfoEnabled()) {
-            LOG.info(
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
                     "Grails plug-in [{}] with version [{}] loaded successfully",
                     plugin.getName(),
                     plugin.getPluginVersion()

--- a/grails-core/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
+++ b/grails-core/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
@@ -18,10 +18,14 @@
  */
 package grails.plugins
 
+import grails.core.DefaultGrailsApplication
 import grails.core.GrailsApplication
+import org.apache.grails.core.plugins.DefaultPluginDiscovery
 import org.apache.grails.core.plugins.PluginInfo
 import org.apache.grails.core.plugins.PluginDiscovery
 import org.apache.grails.core.plugins.PluginUtils
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.core.env.StandardEnvironment
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -104,6 +108,41 @@ class DefaultGrailsPluginManagerSpec extends Specification {
         "7.0.5-M1"       | "7.0.3 > *"                || true
         "7.0.0-M1"       | "7.0.0-M1"                 || true
         "7.0.0-M2"       | "7.0.0-M1"                 || false
+    }
+
+    def "plugin loaded successfully message is not logged at INFO level"() {
+        given: 'a plugin manager backed by a discovery bean with a single plugin'
+        def gcl = new GroovyClassLoader()
+        def pluginClass = gcl.parseClass('''
+class LogLevelProbeGrailsPlugin {
+    def version = "1.0.0"
+}
+''')
+        def application = new DefaultGrailsApplication()
+        application.mainContext = new GenericApplicationContext()
+        def discovery = new DefaultPluginDiscovery(new Class<?>[]{pluginClass})
+        discovery.loadPluginsFromClasspath = false
+
+        and: 'standard error is captured to observe slf4j-simple output'
+        def originalErr = System.err
+        def captured = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(captured, true))
+
+        when:
+        discovery.init(new StandardEnvironment())
+        def manager = new DefaultGrailsPluginManager(application, discovery)
+        manager.loadPlugins()
+
+        then: 'the plugin is loaded'
+        manager.getGrailsPlugin('logLevelProbe') != null
+
+        and: 'the loaded-successfully message is not emitted at INFO'
+        captured.toString().readLines()
+                .findAll { it.contains('loaded successfully') && it.contains('logLevelProbe') }
+                .every { !it.contains('INFO') }
+
+        cleanup:
+        System.setErr(originalErr)
     }
 
     PluginInfo stubPluginWithGrailsVersion(String grailsVersion) {

--- a/grails-core/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
+++ b/grails-core/src/test/groovy/grails/plugins/DefaultGrailsPluginManagerSpec.groovy
@@ -110,17 +110,23 @@ class DefaultGrailsPluginManagerSpec extends Specification {
         "7.0.0-M2"       | "7.0.0-M1"                 || false
     }
 
-    def "plugin loaded successfully message is not logged at INFO level"() {
-        given: 'a plugin manager backed by a discovery bean with a single plugin'
+    def "per-plugin loaded messages are DEBUG and a single INFO summary reports the load order"() {
+        given: 'a discovery bean with two plugins registered in reverse of their load order'
         def gcl = new GroovyClassLoader()
-        def pluginClass = gcl.parseClass('''
-class LogLevelProbeGrailsPlugin {
+        def alphaClass = gcl.parseClass('''
+class AlphaProbeGrailsPlugin {
     def version = "1.0.0"
+}
+''')
+        def betaClass = gcl.parseClass('''
+class BetaProbeGrailsPlugin {
+    def version = "2.0.0"
+    def loadAfter = ['alphaProbe']
 }
 ''')
         def application = new DefaultGrailsApplication()
         application.mainContext = new GenericApplicationContext()
-        def discovery = new DefaultPluginDiscovery(new Class<?>[]{pluginClass})
+        def discovery = new DefaultPluginDiscovery(new Class<?>[]{betaClass, alphaClass})
         discovery.loadPluginsFromClasspath = false
 
         and: 'standard error is captured to observe slf4j-simple output'
@@ -133,13 +139,21 @@ class LogLevelProbeGrailsPlugin {
         def manager = new DefaultGrailsPluginManager(application, discovery)
         manager.loadPlugins()
 
-        then: 'the plugin is loaded'
-        manager.getGrailsPlugin('logLevelProbe') != null
+        then: 'both plugins are loaded'
+        manager.getGrailsPlugin('alphaProbe') != null
+        manager.getGrailsPlugin('betaProbe') != null
 
-        and: 'the loaded-successfully message is not emitted at INFO'
+        and: 'the per-plugin loaded-successfully messages are not emitted at INFO'
         captured.toString().readLines()
-                .findAll { it.contains('loaded successfully') && it.contains('logLevelProbe') }
+                .findAll { it.contains('loaded successfully') }
                 .every { !it.contains('INFO') }
+
+        and: 'a single INFO summary line reports the plugins in load order'
+        def summaryLines = captured.toString().readLines()
+                .findAll { it.contains('Grails plugins in load order') }
+        summaryLines.size() == 1
+        summaryLines[0].contains('INFO')
+        summaryLines[0].contains('Loaded 2 Grails plugins in load order: [alphaProbe (1.0.0), betaProbe (2.0.0)]')
 
         cleanup:
         System.setErr(originalErr)


### PR DESCRIPTION
The per-plugin "Grails plug-in [...] loaded successfully" messages from `DefaultGrailsPluginManager` and `DefaultPluginDiscovery` add 20+ INFO lines to every application startup:

```
2026-07-10T18:21:53.386-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [dataBinding] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.387-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [sitemesh3] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.387-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [restResponder] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.388-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [i18n] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.389-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [core] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.389-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [groovyPages] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.389-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [urlMappings] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.390-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [controllers] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.390-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [codecs] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.390-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [mimeTypes] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.390-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [dataSource] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.391-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [domainClass] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.392-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [assetPipeline] with version [5.1.0-M4] loaded successfully
2026-07-10T18:21:53.392-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [scaffolding] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.393-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [domainClass] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.393-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [converters] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.394-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [fields] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.395-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [hibernate] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.395-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [interceptors] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.395-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [services] with version [8.0.0-M2] loaded successfully
```

Another issue is appears domainClass is loaded 2x
```
2026-07-10T18:21:53.391-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [domainClass] with version [8.0.0-M2] loaded successfully
2026-07-10T18:21:53.391-07:00  INFO 17975 --- [  restartedMain] g.plugins.DefaultGrailsPluginManager     : Grails plug-in [domainClass] with version [8.0.0-M2] loaded successfully
```

This lowers both per-plugin emitters to DEBUG and replaces them with a **single INFO summary line** that lists every loaded plugin with its version, **in load order**:

```
INFO ... g.plugins.DefaultGrailsPluginManager : Loaded 20 Grails plugins in load order: [dataBinding (8.0.0-SNAPSHOT), restResponder (8.0.0-SNAPSHOT), i18n (8.0.0-SNAPSHOT), core (8.0.0-SNAPSHOT), ...]
```

This preserves the load-order diagnostics @jdaugherty relies on for support (the order and versions are still in every startup log at default levels — now on one line instead of 20+), while matching Spring Boot's convention that per-component assembly detail belongs at DEBUG. The per-plugin messages remain available via `logging.level.grails.plugins.DefaultGrailsPluginManager=DEBUG`.

The "plugin X is disabled and was not loaded" message stays at INFO since it is actionable.

Includes a regression test in `DefaultGrailsPluginManagerSpec` that loads two plugins (registered in reverse of their load order, ordered via `loadAfter`) through `DefaultPluginDiscovery` + `loadPlugins()` and asserts:
- the per-plugin message is no longer emitted at INFO
- exactly one INFO summary line is emitted, listing the plugins in load order with versions