### PR TITLE
Fix domainClass plugin being registered and loaded twice

### DIFF
--- a/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultPluginDiscovery.java
+++ b/grails-core/src/main/groovy/org/apache/grails/core/plugins/DefaultPluginDiscovery.java
@@ -483,12 +483,26 @@ public class DefaultPluginDiscovery implements PluginDiscovery {
     /**
      * Registers a plugin that is eligible to be loaded.
      *
-     * <p>This method skips disabled plugins, records eviction and observer relationships, and appends the
-     * plugin to the discovered load order.</p>
+     * <p>This method skips disabled plugins and plugins already registered under the same name (a plugin
+     * class may be declared by more than one {@code META-INF/grails-plugin.xml} descriptor on the
+     * classpath), records eviction and observer relationships, and appends the plugin to the discovered
+     * load order.</p>
      *
      * @param plugin the plugin to register
      */
     private void registerPlugin(PluginInfo plugin) {
+        var registeredPlugin = plugins.get(plugin.getName());
+        if (registeredPlugin != null) {
+            LOG.warn(
+                    "Grails plug-in [{}] with version [{}] is already registered; " +
+                            "skipping duplicate declaration with version [{}]",
+                    plugin.getName(),
+                    registeredPlugin.getPluginVersion(),
+                    plugin.getPluginVersion()
+            );
+            return;
+        }
+
         if (!plugin.getMetadata().canRegisterPlugin()) {
             if (LOG.isInfoEnabled()) {
                 LOG.info("Grails plugin {} is disabled and was not loaded", plugin);

--- a/grails-core/src/main/resources/META-INF/grails-plugin.xml
+++ b/grails-core/src/main/resources/META-INF/grails-plugin.xml
@@ -1,4 +1,3 @@
 <plugin name='core'>
   <type>org.grails.plugins.CoreGrailsPlugin</type>
-  <type>org.grails.plugins.domain.DomainClassGrailsPlugin</type>
 </plugin>

--- a/grails-core/src/test/groovy/org/apache/grails/core/plugins/PluginDiscoverySpec.groovy
+++ b/grails-core/src/test/groovy/org/apache/grails/core/plugins/PluginDiscoverySpec.groovy
@@ -18,6 +18,7 @@
  */
 package org.apache.grails.core.plugins
 
+import org.springframework.core.env.StandardEnvironment
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -299,6 +300,77 @@ class PluginDiscoverySpec extends Specification {
             PLUGIN_GROOVY_CONFIG == 'plugin.groovy'
             DEFAULT_CONFIG_IGNORE_LIST == ['dataSource', 'hibernate']
         }
+    }
+
+    def 'a plugin class declared in multiple classpath descriptors is registered only once'() {
+        given: 'a plugin class compiled by a Groovy class loader'
+        def gcl = new GroovyClassLoader()
+        gcl.parseClass('''
+class DuplicateDescriptorProbeGrailsPlugin {
+    def version = "1.0.0"
+}
+''')
+
+        and: 'two classpath roots each declaring the same plugin class in META-INF/grails-plugin.xml'
+        def tempDirs = (1..2).collect { index ->
+            def tempDir = File.createTempDir()
+            def metaInfDir = new File(tempDir, 'META-INF').tap { mkdirs() }
+            new File(metaInfDir, 'grails-plugin.xml').text = """<plugin name='descriptor${index}'>
+  <type>DuplicateDescriptorProbeGrailsPlugin</type>
+</plugin>"""
+            tempDir
+        }
+        def classLoader = new URLClassLoader(tempDirs*.toURI()*.toURL() as URL[], gcl)
+
+        and: 'the discovery resolves plugins from the thread context class loader'
+        def originalContextClassLoader = Thread.currentThread().contextClassLoader
+        Thread.currentThread().contextClassLoader = classLoader
+        def discovery = new DefaultPluginDiscovery()
+
+        when:
+        discovery.init(new StandardEnvironment())
+
+        then: 'the plugin is registered under its name'
+        discovery.hasPlugin('duplicateDescriptorProbe')
+
+        and: 'only one registration appears in the load order'
+        discovery.getPluginsInLoadOrder().count { it.name == 'duplicateDescriptorProbe' } == 1
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = originalContextClassLoader
+        tempDirs*.deleteDir()
+    }
+
+    def 'a plugin class supplied more than once is registered only once and skipping is logged at WARN'() {
+        given: 'a discovery bean supplied the same plugin class twice'
+        def gcl = new GroovyClassLoader()
+        def pluginClass = gcl.parseClass('''
+class RepeatedProbeGrailsPlugin {
+    def version = "1.0.0"
+}
+''')
+        def discovery = new DefaultPluginDiscovery(new Class<?>[]{pluginClass, pluginClass})
+        discovery.loadPluginsFromClasspath = false
+
+        and: 'standard error is captured to observe slf4j-simple output'
+        def originalErr = System.err
+        def captured = new ByteArrayOutputStream()
+        System.setErr(new PrintStream(captured, true))
+
+        when:
+        discovery.init(new StandardEnvironment())
+
+        then: 'only one registration appears in the load order'
+        discovery.hasPlugin('repeatedProbe')
+        discovery.getPluginsInLoadOrder().count { it.name == 'repeatedProbe' } == 1
+
+        and: 'the skipped duplicate is reported at WARN'
+        captured.toString().readLines().any {
+            it.contains('WARN') && it.contains('repeatedProbe') && it.contains('already registered')
+        }
+
+        cleanup:
+        System.setErr(originalErr)
     }
 }
 


### PR DESCRIPTION
Every Grails 8 application startup registers and loads the `domainClass` plugin twice (visible in M2, M3, and current SNAPSHOTs):

```
INFO ... g.plugins.DefaultGrailsPluginManager : Grails plug-in [domainClass] with version [8.0.0-M3] loaded successfully
...
INFO ... g.plugins.DefaultGrailsPluginManager : Grails plug-in [domainClass] with version [8.0.0-M3] loaded successfully
```

### Root cause

`org.grails.plugins.domain.DomainClassGrailsPlugin` is declared by **two** `META-INF/grails-plugin.xml` descriptors on every application classpath:

1. `grails-core.jar` — the hand-written descriptor declares `CoreGrailsPlugin` **and** `DomainClassGrailsPlugin`. This is a leftover from Grails 2.x, when the class still lived in grails-core; the class later moved to the `grails-domain-class` module but the entry was never removed.
2. `grails-domain-class.jar` — carries its own build-generated descriptor declaring the same class.

`ClasspathPluginFinder` creates one `PluginInfo` per *(descriptor, class)* pair and `DefaultPluginDiscovery.registerPlugin()` had no already-registered check, so both entries flow into the load order: the plugin is sorted, instantiated, and logged twice, with the second `plugins.put` silently overwriting the first instance.

### Fix

- Remove the stale `DomainClassGrailsPlugin` entry from grails-core's hand-written descriptor. This is safe: the generated descriptor is packaged inside the `grails-domain-class` jar, so the class and its descriptor always travel together — the stale entry could only ever produce a duplicate (jar present) or a class-not-found skip (jar absent).
- Defensively, `registerPlugin()` now skips a plugin whose name is already registered and logs a WARN including both versions, so a plugin accidentally declared by multiple descriptors can never double-load:

```
WARN ... Grails plug-in [domainClass] with version [8.0.0-M3] is already registered; skipping duplicate declaration with version [8.0.0-M3]
```

### Tests

Two new `PluginDiscoverySpec` features, exercised through public APIs only:

- the same plugin class declared in two classpath `grails-plugin.xml` descriptors (reproducing the actual bug via the thread-context class loader) registers exactly once
- the same plugin class supplied twice registers exactly once and the skipped duplicate is reported at WARN

Both tests were verified to fail against the previous code.

Note: the duplicate `domainClass` line is also visible in the startup output shown in #15969; the two PRs are independent and merge cleanly in either order (verified with `git merge-tree`).