### PR TITLE
Compile-time check for GORM query strings flattened from GString (alternative to #15968)

### DIFF
--- a/grails-common/src/main/groovy/org/apache/grails/common/compiler/GroovyTransformOrder.groovy
+++ b/grails-common/src/main/groovy/org/apache/grails/common/compiler/GroovyTransformOrder.groovy
@@ -98,9 +98,15 @@ interface GroovyTransformOrder {
     static final int FINDER_ORDER = WHERE_ORDER + DECREMENT_PRIORITY
 
     /**
+     * Detects GORM query strings that were GString-interpolated but coerced to a plain String
+     * before reaching a query method, losing GORM's automatic parameter binding
+     */
+    static final int QUERY_SAFETY_ORDER = FINDER_ORDER + DECREMENT_PRIORITY
+
+    /**
      * Grails allows applying transforms by artefact type, this transformation is what implements that
      */
-    static final int GLOBAL_GRAILS_TRANSFORM_ORDER = FINDER_ORDER + DECREMENT_PRIORITY
+    static final int GLOBAL_GRAILS_TRANSFORM_ORDER = QUERY_SAFETY_ORDER + DECREMENT_PRIORITY
 
     /**
      * Similar to Groovy's @Delegate AST transform but instead assumes the first

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
@@ -1,0 +1,57 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.query.transform;
+
+import java.util.List;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.ASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+import org.codehaus.groovy.transform.TransformWithPriority;
+
+import org.apache.grails.common.compiler.GroovyTransformOrder;
+
+/**
+ * Global version of {@link GormQuerySafetyTransformer} - runs automatically against every class
+ * in every Grails application that has {@code grails-datamapping-core} on its compile classpath,
+ * with no developer configuration required.
+ *
+ * @since 8.1
+ */
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class GlobalGormQuerySafetyASTTransformation implements ASTTransformation, TransformWithPriority {
+
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        GormQuerySafetyTransformer transformer = new GormQuerySafetyTransformer(source);
+        ModuleNode ast = source.getAST();
+        List<ClassNode> classes = ast.getClasses();
+        for (ClassNode aClass : classes) {
+            transformer.visitClass(aClass);
+        }
+    }
+
+    @Override
+    public int priority() {
+        return GroovyTransformOrder.QUERY_SAFETY_ORDER;
+    }
+}

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
@@ -36,12 +36,31 @@ import org.apache.grails.common.compiler.GroovyTransformOrder;
  * in every Grails application that has {@code grails-datamapping-core} on its compile classpath,
  * with no developer configuration required.
  *
+ * <p>Since this check is intraprocedural and does not cover every possible way query text can be
+ * built (see {@link GormQuerySafetyTransformer}'s documented limitations), a build that hits a
+ * false positive it can't otherwise work around may need to disable it entirely rather than per
+ * call site. Setting the {@value #PROTECT_SQL_INJECTION_ATTACKS_PROPERTY} system property to
+ * {@code false} skips this transformation for the whole compilation unit - this is a global kill
+ * switch of last resort, not a substitute for {@link GormQuerySafetyTransformer#SUPPRESS_WARNINGS_VALUE}.
+ *
  * @since 8.1
  */
 @GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
 public class GlobalGormQuerySafetyASTTransformation implements ASTTransformation, TransformWithPriority {
 
+    /**
+     * System property that enables this check; defaults to {@code true}. There is no fully
+     * accurate way to guarantee protection against SQL/HQL/Cypher injection at compile time (this
+     * check has documented gaps), so the name describes intent, not a guarantee. Set to
+     * {@code false} only as a last resort, e.g. a false positive blocking a build with no other
+     * workaround.
+     */
+    public static final String PROTECT_SQL_INJECTION_ATTACKS_PROPERTY = "protectSqlInjectionAttacks";
+
     public void visit(ASTNode[] nodes, SourceUnit source) {
+        if (!Boolean.parseBoolean(System.getProperty(PROTECT_SQL_INJECTION_ATTACKS_PROPERTY, "true"))) {
+            return;
+        }
         GormQuerySafetyTransformer transformer = new GormQuerySafetyTransformer(source);
         ModuleNode ast = source.getAST();
         List<ClassNode> classes = ast.getClasses();

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformation.java
@@ -43,7 +43,7 @@ import org.apache.grails.common.compiler.GroovyTransformOrder;
  * {@code false} skips this transformation for the whole compilation unit - this is a global kill
  * switch of last resort, not a substitute for {@link GormQuerySafetyTransformer#SUPPRESS_WARNINGS_VALUE}.
  *
- * @since 8.1
+ * @since 8.0
  */
 @GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
 public class GlobalGormQuerySafetyASTTransformation implements ASTTransformation, TransformWithPriority {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
@@ -32,6 +32,7 @@ import org.codehaus.groovy.ast.AnnotationNode;
 import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
 import org.codehaus.groovy.ast.ClassHelper;
 import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
 import org.codehaus.groovy.ast.MethodNode;
 import org.codehaus.groovy.ast.expr.ArgumentListExpression;
 import org.codehaus.groovy.ast.expr.BinaryExpression;
@@ -43,9 +44,13 @@ import org.codehaus.groovy.ast.expr.Expression;
 import org.codehaus.groovy.ast.expr.GStringExpression;
 import org.codehaus.groovy.ast.expr.ListExpression;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.PropertyExpression;
 import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
 import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.ast.stmt.IfStatement;
 import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.control.messages.WarningMessage;
+import org.codehaus.groovy.syntax.Token;
 import org.codehaus.groovy.syntax.Types;
 
 import org.grails.datastore.mapping.reflect.AstUtils;
@@ -77,15 +82,42 @@ import org.grails.datastore.mapping.reflect.AstUtils;
  * Book.executeQuery(q)
  * }</pre>
  *
- * <p><strong>Known limitations (deliberate v1 scope):</strong>
+ * <p>This is a build-breaking error for the local-variable case above, because the detection is
+ * precise: every flattening point is visible in the method being compiled. Two related patterns
+ * are lower-confidence and instead reported as compile-time <em>warnings</em>, which do not fail
+ * the build:
+ *
+ * <ul>
+ *     <li><strong>Fields.</strong> A {@code String}-typed field initialized from an interpolated
+ *     {@code GString}, or assigned one via {@code this.field = ...}, that later reaches a query
+ *     method through {@code this.field}. Unlike locals, a field can be reassigned from a
+ *     constructor, another method, or a subclass that this check never visits, so it is flagged
+ *     rather than failed.</li>
+ *     <li><strong>String concatenation.</strong> Query text built with {@code +} from a
+ *     non-constant value and no {@code GString} involved at all, e.g.
+ *     {@code "select ... " + userInput}. This is a real injection shape, but concatenation is
+ *     common enough for benign, non-query purposes that a hard failure would be too blunt an
+ *     instrument. Concatenating a {@code GString} with anything else (e.g.
+ *     {@code "...${x}..." + " order by title"}) is a different matter - {@code GString.plus}
+ *     returns a plain {@code String}, so this flattens the interpolation immediately and is
+ *     reported as the build-breaking error above, not this warning.</li>
+ * </ul>
+ *
+ * <p>Both warnings share the same {@link #SUPPRESS_WARNINGS_VALUE} suppression as the error case.
+ *
+ * <p><strong>Known limitations (deliberate scope):</strong>
  * <ul>
  *     <li>Intraprocedural only — a flattened {@code String} built inside a helper method and
  *     returned to the caller is invisible to this check.</li>
- *     <li>Reassignment tracking is last-write-wins, not full branch-sensitive dataflow.</li>
- *     <li>Only local variables are tracked, not fields.</li>
- *     <li>Does not detect plain string concatenation with no {@code GString} involved at all, raw
- *     JDBC via {@code groovy.sql.Sql}, or any datastore whose query methods use names outside
- *     {@link #CANDIDATE_METHODS}.</li>
+ *     <li>Reassignment tracking for locals is branch-sensitive across a single {@code if}/{@code
+ *     else} (a variable unsafe after either branch stays unsafe after the statement), but not
+ *     across loops, {@code switch}, or {@code try}/{@code catch} - and is last-write-wins for
+ *     fields, which are not branch-sensitive at all.</li>
+ *     <li>Field tracking only recognizes a directly-interpolated {@code GString} initializer or
+ *     {@code this.field = ...} assignment - it does not follow aliasing chains or
+ *     {@code .toString()}/cast coercions the way local tracking does.</li>
+ *     <li>Does not detect raw JDBC via {@code groovy.sql.Sql}, or any datastore whose query
+ *     methods use names outside {@link #CANDIDATE_METHODS}.</li>
  * </ul>
  *
  * @since 8.1
@@ -96,17 +128,31 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
      * What a tracked local variable currently holds, from this check's point of view.
      */
     private enum Origin {
-        /** Not derived from an interpolated GString at all - nothing to track. */
+        /** Not derived from an interpolated GString or unsafe concatenation - nothing to track. */
         NONE,
         /** Still a real {@link groovy.lang.GString} - safe if passed directly to a query method. */
         LIVE_GSTRING,
         /** Already coerced to a plain {@code String} - unsafe if it reaches a query method. */
-        FLATTENED
+        FLATTENED,
+        /** Built via {@code +} concatenation of a non-constant value, no GString involved. */
+        CONCATENATED
     }
 
     /**
-     * The {@code @SuppressWarnings} value that silences this check on the enclosing method (or,
-     * for calls outside any method, the enclosing class).
+     * What kind of unsafe query argument was found at a candidate call site, and therefore how
+     * severely (and with what message) to report it.
+     */
+    private enum Finding {
+        NONE,
+        FLATTENED_GSTRING,
+        FLATTENED_FIELD,
+        UNSAFE_CONCATENATION
+    }
+
+    /**
+     * The {@code @SuppressWarnings} value that silences this check (both the error and the two
+     * warnings below) on the enclosing method (or, for calls outside any method, the enclosing
+     * class).
      */
     public static final String SUPPRESS_WARNINGS_VALUE = "GormUnsafeQueryString";
 
@@ -133,6 +179,8 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
     private final SourceUnit sourceUnit;
     private final Map<String, ASTNode> flattenedStringVars = new HashMap<>();
     private final Map<String, ASTNode> liveGStringVars = new HashMap<>();
+    private final Map<String, ASTNode> concatenatedStringVars = new HashMap<>();
+    private final Map<String, ASTNode> flattenedFields = new HashMap<>();
     private ClassNode currentClassNode;
     private MethodNode currentMethodNode;
 
@@ -149,10 +197,16 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
     public void visitClass(ClassNode node) {
         try {
             this.currentClassNode = node;
+            // Pre-scan field initializers so a field flattened here is already tracked no matter
+            // which order the base class visits fields vs. methods in.
+            for (FieldNode field : node.getFields()) {
+                trackFieldInitializer(field);
+            }
             super.visitClass(node);
         } finally {
             this.currentClassNode = null;
             clearTracking();
+            flattenedFields.clear();
         }
     }
 
@@ -170,6 +224,7 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
     private void clearTracking() {
         flattenedStringVars.clear();
         liveGStringVars.clear();
+        concatenatedStringVars.clear();
     }
 
     @Override
@@ -185,12 +240,96 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
 
     @Override
     public void visitBinaryExpression(BinaryExpression expression) {
-        if (expression.getOperation().getType() == Types.ASSIGN &&
-                expression.getLeftExpression() instanceof VariableExpression) {
-            VariableExpression leftVariable = (VariableExpression) expression.getLeftExpression();
-            track(leftVariable.getName(), expression.getRightExpression(), leftVariable.getType(), expression);
+        if (expression.getOperation().getType() == Types.ASSIGN) {
+            Expression left = expression.getLeftExpression();
+            if (left instanceof VariableExpression) {
+                VariableExpression leftVariable = (VariableExpression) left;
+                track(leftVariable.getName(), expression.getRightExpression(), leftVariable.getType(), expression);
+            }
+            else if (isThisFieldReference(left)) {
+                trackField(fieldNameOf(left), expression.getRightExpression(), expression);
+            }
         }
         super.visitBinaryExpression(expression);
+    }
+
+    /**
+     * Visits an {@code if}/{@code else} branch-sensitively: each branch is walked from the same
+     * starting state, and the two resulting states are merged pessimistically afterwards - a
+     * variable unsafe at the end of either branch stays unsafe after the statement, since we
+     * don't know at compile time which branch will actually run. Without this, whichever branch
+     * happens to be visited last would silently win, e.g. a variable flattened only in the
+     * {@code if} branch would be forgotten if the {@code else} branch reassigns it safely.
+     */
+    @Override
+    public void visitIfElse(IfStatement ifElse) {
+        ifElse.getBooleanExpression().visit(this);
+
+        TrackingSnapshot beforeBranches = snapshot();
+
+        ifElse.getIfBlock().visit(this);
+        TrackingSnapshot afterIf = snapshot();
+
+        restore(beforeBranches);
+        ifElse.getElseBlock().visit(this);
+        TrackingSnapshot afterElse = snapshot();
+
+        restore(mergePessimistically(afterIf, afterElse));
+    }
+
+    private TrackingSnapshot snapshot() {
+        return new TrackingSnapshot(flattenedStringVars, liveGStringVars, concatenatedStringVars);
+    }
+
+    private void restore(TrackingSnapshot state) {
+        flattenedStringVars.clear();
+        flattenedStringVars.putAll(state.flattened);
+        liveGStringVars.clear();
+        liveGStringVars.putAll(state.live);
+        concatenatedStringVars.clear();
+        concatenatedStringVars.putAll(state.concatenated);
+    }
+
+    private TrackingSnapshot mergePessimistically(TrackingSnapshot a, TrackingSnapshot b) {
+        Set<String> names = new HashSet<>();
+        names.addAll(a.flattened.keySet());
+        names.addAll(a.live.keySet());
+        names.addAll(a.concatenated.keySet());
+        names.addAll(b.flattened.keySet());
+        names.addAll(b.live.keySet());
+        names.addAll(b.concatenated.keySet());
+
+        Map<String, ASTNode> mergedFlattened = new HashMap<>();
+        Map<String, ASTNode> mergedLive = new HashMap<>();
+        Map<String, ASTNode> mergedConcatenated = new HashMap<>();
+
+        for (String name : names) {
+            // Unsafe states win pessimistically: if either branch leaves this variable unsafe,
+            // that state survives past the if/else regardless of which branch actually runs.
+            if (a.flattened.containsKey(name) || b.flattened.containsKey(name)) {
+                mergedFlattened.put(name, a.flattened.containsKey(name) ? a.flattened.get(name) : b.flattened.get(name));
+            }
+            else if (a.concatenated.containsKey(name) || b.concatenated.containsKey(name)) {
+                mergedConcatenated.put(name, a.concatenated.containsKey(name) ? a.concatenated.get(name) : b.concatenated.get(name));
+            }
+            else if (a.live.containsKey(name) || b.live.containsKey(name)) {
+                mergedLive.put(name, a.live.containsKey(name) ? a.live.get(name) : b.live.get(name));
+            }
+        }
+        return new TrackingSnapshot(mergedFlattened, mergedLive, mergedConcatenated);
+    }
+
+    private static final class TrackingSnapshot {
+
+        final Map<String, ASTNode> flattened;
+        final Map<String, ASTNode> live;
+        final Map<String, ASTNode> concatenated;
+
+        TrackingSnapshot(Map<String, ASTNode> flattened, Map<String, ASTNode> live, Map<String, ASTNode> concatenated) {
+            this.flattened = new HashMap<>(flattened);
+            this.live = new HashMap<>(live);
+            this.concatenated = new HashMap<>(concatenated);
+        }
     }
 
     /**
@@ -200,21 +339,24 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
      * {@code String}-typed variable.
      */
     private void track(String variableName, Expression rightExpression, ClassNode declaredType, ASTNode locationNode) {
-        switch (classify(rightExpression, declaredType)) {
+        Origin origin = classify(rightExpression, declaredType);
+        // Any reassignment first clears prior tracking under all three categories - last write
+        // wins for what follows, then the switch below re-establishes tracking if still unsafe.
+        flattenedStringVars.remove(variableName);
+        liveGStringVars.remove(variableName);
+        concatenatedStringVars.remove(variableName);
+        switch (origin) {
             case FLATTENED:
                 flattenedStringVars.put(variableName, locationNode);
-                liveGStringVars.remove(variableName);
                 break;
             case LIVE_GSTRING:
                 liveGStringVars.put(variableName, locationNode);
-                flattenedStringVars.remove(variableName);
+                break;
+            case CONCATENATED:
+                concatenatedStringVars.put(variableName, locationNode);
                 break;
             case NONE:
             default:
-                // Any other (safe) reassignment clears prior tracking - last write wins,
-                // not full branch-sensitive dataflow. See class Javadoc.
-                flattenedStringVars.remove(variableName);
-                liveGStringVars.remove(variableName);
                 break;
         }
     }
@@ -230,6 +372,9 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
             String name = ((VariableExpression) expression).getName();
             if (flattenedStringVars.containsKey(name)) {
                 return Origin.FLATTENED; // already a plain String - stays unsafe regardless of declaredType
+            }
+            if (concatenatedStringVars.containsKey(name)) {
+                return Origin.CONCATENATED; // already a plain String - stays unsafe regardless of declaredType
             }
             if (liveGStringVars.containsKey(name)) {
                 return ClassHelper.STRING_TYPE.equals(declaredType) ? Origin.FLATTENED : Origin.LIVE_GSTRING;
@@ -251,6 +396,28 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
             if ("toString".equals(call.getMethodAsString()) && isUnsafeSource(call.getObjectExpression())) {
                 return Origin.FLATTENED; // .toString() always yields a String, regardless of declaredType
             }
+            return Origin.NONE;
+        }
+        return classifyConcatenation(expression);
+    }
+
+    /**
+     * Classifies a {@code +} concatenation. One built from a {@link GStringExpression} anywhere in
+     * the tree is {@link Origin#FLATTENED}, not merely {@link Origin#CONCATENATED} - concatenating
+     * a GString with anything else immediately converts it to a plain {@code String} at runtime
+     * (Groovy's {@code GString.plus} returns {@code String}), the same irreversible coercion a
+     * {@code .toString()} call causes. A concatenation with no GString at all, but at least one
+     * non-constant operand, is the lower-confidence {@link Origin#CONCATENATED} case.
+     */
+    private Origin classifyConcatenation(Expression expression) {
+        if (!isConcatenation(expression)) {
+            return Origin.NONE;
+        }
+        if (containsGString(expression)) {
+            return Origin.FLATTENED;
+        }
+        if (hasNonConstantOperand(expression)) {
+            return Origin.CONCATENATED;
         }
         return Origin.NONE;
     }
@@ -275,14 +442,88 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
         return expression instanceof GStringExpression && !((GStringExpression) expression).getValues().isEmpty();
     }
 
+    private boolean isConcatenation(Expression expression) {
+        return expression instanceof BinaryExpression &&
+                ((BinaryExpression) expression).getOperation().getType() == Types.PLUS;
+    }
+
+    private boolean hasNonConstantOperand(Expression expression) {
+        if (expression instanceof ConstantExpression) {
+            return false;
+        }
+        if (isConcatenation(expression)) {
+            BinaryExpression binary = (BinaryExpression) expression;
+            return hasNonConstantOperand(binary.getLeftExpression()) || hasNonConstantOperand(binary.getRightExpression());
+        }
+        return true;
+    }
+
+    private boolean containsGString(Expression expression) {
+        if (expression instanceof GStringExpression) {
+            return true;
+        }
+        if (expression instanceof BinaryExpression) {
+            BinaryExpression binary = (BinaryExpression) expression;
+            return containsGString(binary.getLeftExpression()) || containsGString(binary.getRightExpression());
+        }
+        return false;
+    }
+
+    /**
+     * Seeds {@link #flattenedFields} from a field's own initializer, e.g.
+     * {@code String query = "...${x}..."} declared directly on the class. Unlike local tracking,
+     * this only recognises a bare interpolated GString initializer - not a {@code .toString()} or
+     * cast coercion - to keep the (already lower-confidence) field check simple.
+     */
+    private void trackFieldInitializer(FieldNode field) {
+        Expression initial = field.getInitialValueExpression();
+        if (initial != null && isInterpolatedGString(initial) && ClassHelper.STRING_TYPE.equals(field.getType())) {
+            flattenedFields.put(field.getName(), field);
+        }
+    }
+
+    /**
+     * Records a {@code this.field = ...} assignment. A safe reassignment clears prior tracking
+     * for that field - last-write-wins, with no branch-sensitivity (see class Javadoc).
+     */
+    private void trackField(String fieldName, Expression rightExpression, ASTNode locationNode) {
+        ClassNode fieldType = fieldDeclaredType(fieldName);
+        if (isInterpolatedGString(rightExpression) && ClassHelper.STRING_TYPE.equals(fieldType)) {
+            flattenedFields.put(fieldName, locationNode);
+        }
+        else {
+            flattenedFields.remove(fieldName);
+        }
+    }
+
+    private ClassNode fieldDeclaredType(String fieldName) {
+        if (currentClassNode == null) {
+            return null;
+        }
+        FieldNode field = currentClassNode.getField(fieldName);
+        return field != null ? field.getType() : null;
+    }
+
+    private boolean isThisFieldReference(Expression expression) {
+        if (!(expression instanceof PropertyExpression)) {
+            return false;
+        }
+        PropertyExpression property = (PropertyExpression) expression;
+        return property.getObjectExpression() instanceof VariableExpression &&
+                ((VariableExpression) property.getObjectExpression()).isThisExpression() &&
+                property.getPropertyAsString() != null;
+    }
+
+    private String fieldNameOf(Expression expression) {
+        return ((PropertyExpression) expression).getPropertyAsString();
+    }
+
     @Override
     public void visitMethodCallExpression(MethodCallExpression call) {
         String methodName = call.getMethodAsString();
         if (methodName != null && CANDIDATE_METHODS.contains(methodName) &&
-                isFlattenedQueryArgument(methodName, call.getArguments()) &&
-                isGormReceiver(call.getObjectExpression()) &&
-                !isSuppressed()) {
-            reportUnsafeQuery(call, methodName);
+                isGormReceiver(call.getObjectExpression()) && !isSuppressed()) {
+            report(findUnsafeArgument(methodName, call.getArguments()), call, methodName);
         }
         super.visitMethodCallExpression(call);
     }
@@ -291,10 +532,8 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
     public void visitStaticMethodCallExpression(StaticMethodCallExpression call) {
         String methodName = call.getMethod();
         if (CANDIDATE_METHODS.contains(methodName) &&
-                isFlattenedQueryArgument(methodName, call.getArguments()) &&
-                AstUtils.isDomainClass(call.getOwnerType()) &&
-                !isSuppressed()) {
-            reportUnsafeQuery(call, methodName);
+                AstUtils.isDomainClass(call.getOwnerType()) && !isSuppressed()) {
+            report(findUnsafeArgument(methodName, call.getArguments()), call, methodName);
         }
         super.visitStaticMethodCallExpression(call);
     }
@@ -309,17 +548,55 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
         return false;
     }
 
-    private boolean isFlattenedQueryArgument(String methodName, Expression arguments) {
+    private Finding findUnsafeArgument(String methodName, Expression arguments) {
         if (!(arguments instanceof ArgumentListExpression)) {
-            return false;
+            return Finding.NONE;
         }
         List<Expression> args = ((ArgumentListExpression) arguments).getExpressions();
-        int index = QUERY_ARGUMENT_INDEX.get(methodName);
-        if (args.size() <= index || !(args.get(index) instanceof VariableExpression)) {
-            return false;
+        Integer index = QUERY_ARGUMENT_INDEX.get(methodName);
+        if (index == null || args.size() <= index) {
+            return Finding.NONE;
         }
-        String variableName = ((VariableExpression) args.get(index)).getName();
-        return flattenedStringVars.containsKey(variableName);
+        Expression argument = args.get(index);
+
+        if (argument instanceof VariableExpression) {
+            String name = ((VariableExpression) argument).getName();
+            if (flattenedStringVars.containsKey(name)) {
+                return Finding.FLATTENED_GSTRING;
+            }
+            if (concatenatedStringVars.containsKey(name)) {
+                return Finding.UNSAFE_CONCATENATION;
+            }
+            return Finding.NONE;
+        }
+        if (isThisFieldReference(argument) && flattenedFields.containsKey(fieldNameOf(argument))) {
+            return Finding.FLATTENED_FIELD;
+        }
+        Origin concatOrigin = classifyConcatenation(argument);
+        if (concatOrigin == Origin.FLATTENED) {
+            return Finding.FLATTENED_GSTRING;
+        }
+        if (concatOrigin == Origin.CONCATENATED) {
+            return Finding.UNSAFE_CONCATENATION;
+        }
+        return Finding.NONE;
+    }
+
+    private void report(Finding finding, ASTNode node, String methodName) {
+        switch (finding) {
+            case FLATTENED_GSTRING:
+                reportUnsafeQuery(node, methodName);
+                break;
+            case FLATTENED_FIELD:
+                reportFlattenedFieldQuery(node, methodName);
+                break;
+            case UNSAFE_CONCATENATION:
+                reportUnsafeConcatenation(node, methodName);
+                break;
+            case NONE:
+            default:
+                break;
+        }
     }
 
     private boolean isSuppressed() {
@@ -363,5 +640,39 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
                 "safe call site, add @SuppressWarnings(\"" + SUPPRESS_WARNINGS_VALUE + "\") to the " +
                 "enclosing method.";
         sourceUnit.getErrorCollector().addErrorAndContinue(message, node, sourceUnit);
+    }
+
+    private void reportFlattenedFieldQuery(ASTNode node, String methodName) {
+        String message = "[GORM] The query string passed to '" + methodName + "' was built from a " +
+                "field that was assigned a GString-interpolated value coerced to a plain String, " +
+                "so any interpolated values may be embedded as raw, unescaped text - this is a " +
+                "query injection risk if that field can be influenced by user input. This is a " +
+                "warning rather than a build failure because field assignments outside this method " +
+                "(other methods, constructors, subclasses) aren't visible to this check. Prefer " +
+                "keeping the value as a GString or passing named/positional parameters; to " +
+                "suppress, add @SuppressWarnings(\"" + SUPPRESS_WARNINGS_VALUE + "\") to the " +
+                "enclosing method.";
+        reportWarning(node, message);
+    }
+
+    private void reportUnsafeConcatenation(ASTNode node, String methodName) {
+        String message = "[GORM] The query string passed to '" + methodName + "' is built using " +
+                "'+' string concatenation with a non-constant value, so no automatic parameter " +
+                "binding is possible - this is a query injection risk if that value can be " +
+                "influenced by user input. Prefer a GString (GORM binds interpolated values " +
+                "automatically) or named/positional parameters. To suppress, add " +
+                "@SuppressWarnings(\"" + SUPPRESS_WARNINGS_VALUE + "\") to the enclosing method.";
+        reportWarning(node, message);
+    }
+
+    /**
+     * Emits a compile-time warning (not a build failure) located at {@code node}.
+     * {@link org.codehaus.groovy.control.ErrorCollector#addWarning} predates {@link ASTNode} and
+     * still takes the older {@link org.codehaus.groovy.syntax.CSTNode} for location, so a minimal
+     * {@link Token} carrying just the line/column is built to satisfy it.
+     */
+    private void reportWarning(ASTNode node, String message) {
+        Token location = new Token(Types.UNKNOWN, "", node.getLineNumber(), node.getColumnNumber());
+        sourceUnit.getErrorCollector().addWarning(WarningMessage.LIKELY_ERRORS, message, location, sourceUnit);
     }
 }

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
@@ -1,0 +1,291 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.query.transform;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
+import org.codehaus.groovy.ast.ClassHelper;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.CastExpression;
+import org.codehaus.groovy.ast.expr.ClassExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.DeclarationExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.GStringExpression;
+import org.codehaus.groovy.ast.expr.ListExpression;
+import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.syntax.Types;
+
+import org.grails.datastore.mapping.reflect.AstUtils;
+
+/**
+ * {@link ClassCodeVisitorSupport} that detects GORM HQL/Cypher query text built from a
+ * {@link GStringExpression} that Groovy coerced to a plain {@code String} <em>before</em> it
+ * reaches a GORM query method, e.g.:
+ *
+ * <pre>{@code
+ * String query = "from Book where name = ${userInput}"   // coerced to String right here
+ * Book.executeQuery(query)                                // -> raw, unescaped text, no binding
+ * }</pre>
+ *
+ * <p>When a {@link groovy.lang.GString} is passed directly to a GORM query method, GORM binds
+ * each interpolated value as a query parameter — safe. Once the {@code GString} has been coerced
+ * to a {@code String} (an explicit {@code String}-typed local, a {@code .toString()} call, or an
+ * {@code as String}/cast coercion), that information is gone: a {@code String} carries no trace
+ * of ever having been a {@code GString}, so this can only be caught here, before the coercion
+ * erases it — a runtime check at the query boundary is structurally blind to this case.
+ *
+ * <p><strong>Known limitations (deliberate v1 scope):</strong>
+ * <ul>
+ *     <li>Intraprocedural only — a flattened {@code String} built inside a helper method and
+ *     returned to the caller is invisible to this check.</li>
+ *     <li>Reassignment tracking is last-write-wins, not full branch-sensitive dataflow.</li>
+ *     <li>Only local variables are tracked, not fields.</li>
+ *     <li>Does not detect plain string concatenation with no {@code GString} involved at all, raw
+ *     JDBC via {@code groovy.sql.Sql}, or any datastore whose query methods use names outside
+ *     {@link #CANDIDATE_METHODS}.</li>
+ * </ul>
+ *
+ * @since 8.1
+ */
+public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
+
+    /**
+     * The {@code @SuppressWarnings} value that silences this check on the enclosing method (or,
+     * for calls outside any method, the enclosing class).
+     */
+    public static final String SUPPRESS_WARNINGS_VALUE = "GormUnsafeQueryString";
+
+    private static final Set<String> CANDIDATE_METHODS = new HashSet<>(Arrays.asList(
+            "find", "findAll", "executeQuery", "executeUpdate",
+            "findAllWithSql", "cypherStatic", "findPath", "findPathTo"));
+
+    /**
+     * The positional index of the query argument for each candidate method. Every candidate
+     * method takes the query as its first argument except Neo4j's
+     * {@code findPathTo(Class type, CharSequence query, Map params)}.
+     */
+    private static final Map<String, Integer> QUERY_ARGUMENT_INDEX = buildQueryArgumentIndex();
+
+    private static Map<String, Integer> buildQueryArgumentIndex() {
+        Map<String, Integer> indexes = new HashMap<>();
+        for (String method : CANDIDATE_METHODS) {
+            indexes.put(method, 0);
+        }
+        indexes.put("findPathTo", 1);
+        return Collections.unmodifiableMap(indexes);
+    }
+
+    private final SourceUnit sourceUnit;
+    private final Map<String, ASTNode> flattenedStringVars = new HashMap<>();
+    private ClassNode currentClassNode;
+    private MethodNode currentMethodNode;
+
+    public GormQuerySafetyTransformer(SourceUnit sourceUnit) {
+        this.sourceUnit = sourceUnit;
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        return this.sourceUnit;
+    }
+
+    @Override
+    public void visitClass(ClassNode node) {
+        try {
+            this.currentClassNode = node;
+            super.visitClass(node);
+        } finally {
+            this.currentClassNode = null;
+            this.flattenedStringVars.clear();
+        }
+    }
+
+    @Override
+    public void visitMethod(MethodNode node) {
+        this.currentMethodNode = node;
+        try {
+            super.visitMethod(node);
+        } finally {
+            this.currentMethodNode = null;
+            this.flattenedStringVars.clear();
+        }
+    }
+
+    @Override
+    public void visitDeclarationExpression(DeclarationExpression expression) {
+        // getVariableExpression() is null for multiple-assignment declarations, e.g. def (a, b) = [...]
+        VariableExpression variableExpression = expression.isMultipleAssignmentDeclaration() ?
+                null : expression.getVariableExpression();
+        if (variableExpression != null &&
+                isUnsafeGStringCoercion(expression.getRightExpression(), variableExpression.getType())) {
+            flattenedStringVars.put(variableExpression.getName(), expression);
+        }
+        super.visitDeclarationExpression(expression);
+    }
+
+    @Override
+    public void visitBinaryExpression(BinaryExpression expression) {
+        if (expression.getOperation().getType() == Types.ASSIGN &&
+                expression.getLeftExpression() instanceof VariableExpression) {
+            VariableExpression leftVariable = (VariableExpression) expression.getLeftExpression();
+            String variableName = leftVariable.getName();
+            if (isUnsafeGStringCoercion(expression.getRightExpression(), leftVariable.getType())) {
+                flattenedStringVars.put(variableName, expression);
+            } else {
+                // Any other (safe) reassignment clears prior unsafe tracking - last write wins,
+                // not full branch-sensitive dataflow. See class Javadoc.
+                flattenedStringVars.remove(variableName);
+            }
+        }
+        super.visitBinaryExpression(expression);
+    }
+
+    /**
+     * True when {@code expression} is the moment a {@code GString} becomes an ordinary
+     * {@code String}: either a bare interpolated {@link GStringExpression} assigned to a
+     * {@code String}-typed variable ({@code declaredType}), or an explicit
+     * {@code .toString()}/cast/{@code as String} coercion of one (which loses the binding
+     * regardless of what the result is then declared as).
+     */
+    private boolean isUnsafeGStringCoercion(Expression expression, ClassNode declaredType) {
+        if (isInterpolatedGString(expression)) {
+            return ClassHelper.STRING_TYPE.equals(declaredType);
+        }
+        if (expression instanceof CastExpression) {
+            CastExpression cast = (CastExpression) expression;
+            return ClassHelper.STRING_TYPE.equals(cast.getType()) && isInterpolatedGString(cast.getExpression());
+        }
+        if (expression instanceof MethodCallExpression) {
+            MethodCallExpression call = (MethodCallExpression) expression;
+            return "toString".equals(call.getMethodAsString()) && isInterpolatedGString(call.getObjectExpression());
+        }
+        return false;
+    }
+
+    private boolean isInterpolatedGString(Expression expression) {
+        return expression instanceof GStringExpression && !((GStringExpression) expression).getValues().isEmpty();
+    }
+
+    @Override
+    public void visitMethodCallExpression(MethodCallExpression call) {
+        String methodName = call.getMethodAsString();
+        if (methodName != null && CANDIDATE_METHODS.contains(methodName) &&
+                isFlattenedQueryArgument(methodName, call.getArguments()) &&
+                isGormReceiver(call.getObjectExpression()) &&
+                !isSuppressed()) {
+            reportUnsafeQuery(call, methodName);
+        }
+        super.visitMethodCallExpression(call);
+    }
+
+    @Override
+    public void visitStaticMethodCallExpression(StaticMethodCallExpression call) {
+        String methodName = call.getMethod();
+        if (CANDIDATE_METHODS.contains(methodName) &&
+                isFlattenedQueryArgument(methodName, call.getArguments()) &&
+                AstUtils.isDomainClass(call.getOwnerType()) &&
+                !isSuppressed()) {
+            reportUnsafeQuery(call, methodName);
+        }
+        super.visitStaticMethodCallExpression(call);
+    }
+
+    private boolean isGormReceiver(Expression objectExpression) {
+        if (objectExpression instanceof ClassExpression) {
+            return AstUtils.isDomainClass(((ClassExpression) objectExpression).getType());
+        }
+        if (objectExpression instanceof VariableExpression && ((VariableExpression) objectExpression).isThisExpression()) {
+            return currentClassNode != null && AstUtils.isDomainClass(currentClassNode);
+        }
+        return false;
+    }
+
+    private boolean isFlattenedQueryArgument(String methodName, Expression arguments) {
+        if (!(arguments instanceof ArgumentListExpression)) {
+            return false;
+        }
+        List<Expression> args = ((ArgumentListExpression) arguments).getExpressions();
+        int index = QUERY_ARGUMENT_INDEX.get(methodName);
+        if (args.size() <= index || !(args.get(index) instanceof VariableExpression)) {
+            return false;
+        }
+        String variableName = ((VariableExpression) args.get(index)).getName();
+        return flattenedStringVars.containsKey(variableName);
+    }
+
+    private boolean isSuppressed() {
+        if (currentMethodNode != null && isSuppressedNode(currentMethodNode)) {
+            return true;
+        }
+        return currentClassNode != null && isSuppressedNode(currentClassNode);
+    }
+
+    private boolean isSuppressedNode(AnnotatedNode node) {
+        for (AnnotationNode annotation : node.getAnnotations(ClassHelper.make(SuppressWarnings.class))) {
+            Expression value = annotation.getMember("value");
+            if (containsSuppressionValue(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean containsSuppressionValue(Expression value) {
+        if (value instanceof ConstantExpression) {
+            return SUPPRESS_WARNINGS_VALUE.equals(((ConstantExpression) value).getValue());
+        }
+        if (value instanceof ListExpression) {
+            for (Expression element : ((ListExpression) value).getExpressions()) {
+                if (containsSuppressionValue(element)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void reportUnsafeQuery(ASTNode node, String methodName) {
+        String message = "[GORM] The query string passed to '" + methodName + "' was built from a " +
+                "GString that Groovy already coerced to a plain String, so any interpolated " +
+                "values are now embedded as raw, unescaped text - this is a query injection " +
+                "risk. Keep the value as a GString when calling '" + methodName + "' (GORM turns " +
+                "GString interpolations into bound query parameters automatically), or pass " +
+                "named/positional parameters explicitly. To suppress this check for a reviewed, " +
+                "safe call site, add @SuppressWarnings(\"" + SUPPRESS_WARNINGS_VALUE + "\") to the " +
+                "enclosing method.";
+        sourceUnit.getErrorCollector().addErrorAndContinue(message, node, sourceUnit);
+    }
+}

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
@@ -120,7 +120,7 @@ import org.grails.datastore.mapping.reflect.AstUtils;
  *     methods use names outside {@link #CANDIDATE_METHODS}.</li>
  * </ul>
  *
- * @since 8.1
+ * @since 8.0
  */
 public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
 
@@ -571,6 +571,18 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
         }
         if (isThisFieldReference(argument) && flattenedFields.containsKey(fieldNameOf(argument))) {
             return Finding.FLATTENED_FIELD;
+        }
+        if (argument instanceof CastExpression) {
+            CastExpression cast = (CastExpression) argument;
+            if (ClassHelper.STRING_TYPE.equals(cast.getType()) && isUnsafeSource(cast.getExpression())) {
+                return Finding.FLATTENED_GSTRING;
+            }
+        }
+        if (argument instanceof MethodCallExpression) {
+            MethodCallExpression flatteningCall = (MethodCallExpression) argument;
+            if ("toString".equals(flatteningCall.getMethodAsString()) && isUnsafeSource(flatteningCall.getObjectExpression())) {
+                return Finding.FLATTENED_GSTRING;
+            }
         }
         Origin concatOrigin = classifyConcatenation(argument);
         if (concatOrigin == Origin.FLATTENED) {

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformer.java
@@ -67,6 +67,16 @@ import org.grails.datastore.mapping.reflect.AstUtils;
  * of ever having been a {@code GString}, so this can only be caught here, before the coercion
  * erases it — a runtime check at the query boundary is structurally blind to this case.
  *
+ * <p>A {@code GString} does not have to be flattened directly at the call site to be unsafe —
+ * aliasing it through one or more intermediate variables still loses the binding the moment it is
+ * assigned to a {@code String}-typed variable, however many hops away that happens:
+ *
+ * <pre>{@code
+ * def g = "from Book where name = ${userInput}"   // g: still a live GString
+ * String q = g                                     // flattened HERE, not at the executeQuery call
+ * Book.executeQuery(q)
+ * }</pre>
+ *
  * <p><strong>Known limitations (deliberate v1 scope):</strong>
  * <ul>
  *     <li>Intraprocedural only — a flattened {@code String} built inside a helper method and
@@ -81,6 +91,18 @@ import org.grails.datastore.mapping.reflect.AstUtils;
  * @since 8.1
  */
 public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
+
+    /**
+     * What a tracked local variable currently holds, from this check's point of view.
+     */
+    private enum Origin {
+        /** Not derived from an interpolated GString at all - nothing to track. */
+        NONE,
+        /** Still a real {@link groovy.lang.GString} - safe if passed directly to a query method. */
+        LIVE_GSTRING,
+        /** Already coerced to a plain {@code String} - unsafe if it reaches a query method. */
+        FLATTENED
+    }
 
     /**
      * The {@code @SuppressWarnings} value that silences this check on the enclosing method (or,
@@ -110,6 +132,7 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
 
     private final SourceUnit sourceUnit;
     private final Map<String, ASTNode> flattenedStringVars = new HashMap<>();
+    private final Map<String, ASTNode> liveGStringVars = new HashMap<>();
     private ClassNode currentClassNode;
     private MethodNode currentMethodNode;
 
@@ -129,7 +152,7 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
             super.visitClass(node);
         } finally {
             this.currentClassNode = null;
-            this.flattenedStringVars.clear();
+            clearTracking();
         }
     }
 
@@ -140,8 +163,13 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
             super.visitMethod(node);
         } finally {
             this.currentMethodNode = null;
-            this.flattenedStringVars.clear();
+            clearTracking();
         }
+    }
+
+    private void clearTracking() {
+        flattenedStringVars.clear();
+        liveGStringVars.clear();
     }
 
     @Override
@@ -149,9 +177,8 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
         // getVariableExpression() is null for multiple-assignment declarations, e.g. def (a, b) = [...]
         VariableExpression variableExpression = expression.isMultipleAssignmentDeclaration() ?
                 null : expression.getVariableExpression();
-        if (variableExpression != null &&
-                isUnsafeGStringCoercion(expression.getRightExpression(), variableExpression.getType())) {
-            flattenedStringVars.put(variableExpression.getName(), expression);
+        if (variableExpression != null) {
+            track(variableExpression.getName(), expression.getRightExpression(), variableExpression.getType(), expression);
         }
         super.visitDeclarationExpression(expression);
     }
@@ -161,36 +188,85 @@ public class GormQuerySafetyTransformer extends ClassCodeVisitorSupport {
         if (expression.getOperation().getType() == Types.ASSIGN &&
                 expression.getLeftExpression() instanceof VariableExpression) {
             VariableExpression leftVariable = (VariableExpression) expression.getLeftExpression();
-            String variableName = leftVariable.getName();
-            if (isUnsafeGStringCoercion(expression.getRightExpression(), leftVariable.getType())) {
-                flattenedStringVars.put(variableName, expression);
-            } else {
-                // Any other (safe) reassignment clears prior unsafe tracking - last write wins,
-                // not full branch-sensitive dataflow. See class Javadoc.
-                flattenedStringVars.remove(variableName);
-            }
+            track(leftVariable.getName(), expression.getRightExpression(), leftVariable.getType(), expression);
         }
         super.visitBinaryExpression(expression);
     }
 
     /**
-     * True when {@code expression} is the moment a {@code GString} becomes an ordinary
-     * {@code String}: either a bare interpolated {@link GStringExpression} assigned to a
-     * {@code String}-typed variable ({@code declaredType}), or an explicit
-     * {@code .toString()}/cast/{@code as String} coercion of one (which loses the binding
-     * regardless of what the result is then declared as).
+     * Records what {@code variableName} now holds after being assigned {@code rightExpression},
+     * resolving through any variable aliasing so a {@code GString} tracked several assignments
+     * earlier is still recognised as unsafe once it (or an alias of it) reaches a
+     * {@code String}-typed variable.
      */
-    private boolean isUnsafeGStringCoercion(Expression expression, ClassNode declaredType) {
+    private void track(String variableName, Expression rightExpression, ClassNode declaredType, ASTNode locationNode) {
+        switch (classify(rightExpression, declaredType)) {
+            case FLATTENED:
+                flattenedStringVars.put(variableName, locationNode);
+                liveGStringVars.remove(variableName);
+                break;
+            case LIVE_GSTRING:
+                liveGStringVars.put(variableName, locationNode);
+                flattenedStringVars.remove(variableName);
+                break;
+            case NONE:
+            default:
+                // Any other (safe) reassignment clears prior tracking - last write wins,
+                // not full branch-sensitive dataflow. See class Javadoc.
+                flattenedStringVars.remove(variableName);
+                liveGStringVars.remove(variableName);
+                break;
+        }
+    }
+
+    /**
+     * Determines what {@code expression} evaluates to, from this check's point of view, resolving
+     * one level of variable reference against the current tracking state so aliasing chains
+     * (however many hops long) are followed correctly - each hop was itself already classified
+     * when its own assignment was visited.
+     */
+    private Origin classify(Expression expression, ClassNode declaredType) {
+        if (expression instanceof VariableExpression) {
+            String name = ((VariableExpression) expression).getName();
+            if (flattenedStringVars.containsKey(name)) {
+                return Origin.FLATTENED; // already a plain String - stays unsafe regardless of declaredType
+            }
+            if (liveGStringVars.containsKey(name)) {
+                return ClassHelper.STRING_TYPE.equals(declaredType) ? Origin.FLATTENED : Origin.LIVE_GSTRING;
+            }
+            return Origin.NONE;
+        }
         if (isInterpolatedGString(expression)) {
-            return ClassHelper.STRING_TYPE.equals(declaredType);
+            return ClassHelper.STRING_TYPE.equals(declaredType) ? Origin.FLATTENED : Origin.LIVE_GSTRING;
         }
         if (expression instanceof CastExpression) {
             CastExpression cast = (CastExpression) expression;
-            return ClassHelper.STRING_TYPE.equals(cast.getType()) && isInterpolatedGString(cast.getExpression());
+            if (ClassHelper.STRING_TYPE.equals(cast.getType()) && isUnsafeSource(cast.getExpression())) {
+                return Origin.FLATTENED;
+            }
+            return Origin.NONE;
         }
         if (expression instanceof MethodCallExpression) {
             MethodCallExpression call = (MethodCallExpression) expression;
-            return "toString".equals(call.getMethodAsString()) && isInterpolatedGString(call.getObjectExpression());
+            if ("toString".equals(call.getMethodAsString()) && isUnsafeSource(call.getObjectExpression())) {
+                return Origin.FLATTENED; // .toString() always yields a String, regardless of declaredType
+            }
+        }
+        return Origin.NONE;
+    }
+
+    /**
+     * True when {@code expression} is itself a live GString, or a variable reference already
+     * tracked as a live GString or an already-flattened String - i.e. anything a cast or
+     * {@code .toString()} applied on top of would still be unsafe to hand to a query method.
+     */
+    private boolean isUnsafeSource(Expression expression) {
+        if (isInterpolatedGString(expression)) {
+            return true;
+        }
+        if (expression instanceof VariableExpression) {
+            String name = ((VariableExpression) expression).getName();
+            return flattenedStringVars.containsKey(name) || liveGStringVars.containsKey(name);
         }
         return false;
     }

--- a/grails-datamapping-core/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
+++ b/grails-datamapping-core/src/main/resources/META-INF/services/org.codehaus.groovy.transform.ASTTransformation
@@ -1,2 +1,3 @@
 org.grails.datastore.gorm.query.transform.GlobalDetachedCriteriaASTTransformation
 org.grails.compiler.gorm.GlobalJpaEntityTransform
+org.grails.datastore.gorm.query.transform.GlobalGormQuerySafetyASTTransformation

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformationSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformationSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.query.transform
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+
+import spock.lang.Specification
+
+class GlobalGormQuerySafetyASTTransformationSpec extends Specification {
+
+    private static final String UNSAFE_CLASS_SOURCE = '''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        String q = "from Book where title = ${title}"
+        executeQuery(q)
+    }
+}
+'''
+
+    void cleanup() {
+        System.clearProperty(GlobalGormQuerySafetyASTTransformation.PROTECT_SQL_INJECTION_ATTACKS_PROPERTY)
+    }
+
+    void "check runs by default with no system property set"() {
+        given:
+        System.clearProperty(GlobalGormQuerySafetyASTTransformation.PROTECT_SQL_INJECTION_ATTACKS_PROPERTY)
+
+        when:
+        new GroovyClassLoader().parseClass(UNSAFE_CLASS_SOURCE)
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+    }
+
+    void "check runs when protectSqlInjectionAttacks is explicitly true"() {
+        given:
+        System.setProperty(GlobalGormQuerySafetyASTTransformation.PROTECT_SQL_INJECTION_ATTACKS_PROPERTY, 'true')
+
+        when:
+        new GroovyClassLoader().parseClass(UNSAFE_CLASS_SOURCE)
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+    }
+
+    void "check is skipped entirely when protectSqlInjectionAttacks is false"() {
+        given:
+        System.setProperty(GlobalGormQuerySafetyASTTransformation.PROTECT_SQL_INJECTION_ATTACKS_PROPERTY, 'false')
+
+        when:
+        Class<?> book = new GroovyClassLoader().parseClass(UNSAFE_CLASS_SOURCE)
+
+        then:
+        noExceptionThrown()
+        book != null
+    }
+}

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformationSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GlobalGormQuerySafetyASTTransformationSpec.groovy
@@ -21,7 +21,9 @@ package org.grails.datastore.gorm.query.transform
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
 
 import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
 
+@RestoreSystemProperties
 class GlobalGormQuerySafetyASTTransformationSpec extends Specification {
 
     private static final String UNSAFE_CLASS_SOURCE = '''
@@ -37,10 +39,6 @@ class Book {
     }
 }
 '''
-
-    void cleanup() {
-        System.clearProperty(GlobalGormQuerySafetyASTTransformation.PROTECT_SQL_INJECTION_ATTACKS_PROPERTY)
-    }
 
     void "check runs by default with no system property set"() {
         given:

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
@@ -18,12 +18,22 @@
  */
 package org.grails.datastore.gorm.query.transform
 
+import org.codehaus.groovy.control.CompilationUnit
 import org.codehaus.groovy.control.MultipleCompilationErrorsException
+import org.codehaus.groovy.control.Phases
+import org.codehaus.groovy.control.messages.WarningMessage
 
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class GormQuerySafetyTransformerSpec extends Specification {
+
+    private List<WarningMessage> compileAndCollectWarnings(String source) {
+        CompilationUnit unit = new CompilationUnit(new GroovyClassLoader())
+        def sourceUnit = unit.addSource("Book.groovy", source)
+        unit.compile(Phases.CANONICALIZATION)
+        sourceUnit.getErrorCollector().getWarnings() ?: []
+    }
 
     void "test String query flattened from an interpolated GString before executeQuery fails to compile"() {
         when:
@@ -103,6 +113,83 @@ class Book {
         '.toString() on an alias'        | 'def g = "from Book where title = ${title}"\nString q = g.toString()'
         'a two-hop alias chain'          | 'def g = "from Book where title = ${title}"\ndef h = g\nString q = h'
         'assigning an already-flattened alias' | 'String p = "from Book where title = ${title}"\nString q = p'
+    }
+
+    void "test a variable flattened in only one branch of an if/else still fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Book byTitle(String title, boolean condition) {
+        String q
+        if (condition) {
+            q = "from Book where title = ${title}"
+        } else {
+            q = "from Book"
+        }
+        find(q)
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+    }
+
+    void "test a variable flattened only in the else branch still fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Book byTitle(String title, boolean condition) {
+        String q
+        if (condition) {
+            q = "from Book"
+        } else {
+            q = "from Book where title = ${title}"
+        }
+        find(q)
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+    }
+
+    void "test if/else where both branches build a safe query compiles cleanly"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Book byTitle(String title, boolean condition) {
+        String q
+        if (condition) {
+            q = "from Book where title = :title"
+        } else {
+            q = "from Book"
+        }
+        find(q, [title: title])
+    }
+}
+''')
+
+        then:
+        bookClass != null
     }
 
     void "test aliasing a plain non-interpolated variable compiles cleanly"() {
@@ -273,5 +360,157 @@ class Book {
         then:
         def e = thrown(MultipleCompilationErrorsException)
         e.message.contains('GormUnsafeQueryString')
+    }
+
+    void "test a field flattened via its own GString initializer warns but still compiles"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+    String cachedQuery = "from Book where title = ${title}"
+
+    List loadCached() {
+        executeQuery(this.cachedQuery)
+    }
+}
+''')
+
+        then:
+        warnings.size() == 1
+        warnings[0].message.contains('GormUnsafeQueryString')
+        warnings[0].message.contains("passed to 'executeQuery'")
+    }
+
+    void "test a field flattened via this.field assignment warns but still compiles"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+    String cachedQuery
+
+    void prepare(String title) {
+        this.cachedQuery = "from Book where title = ${title}"
+    }
+
+    List loadCached() {
+        executeQuery(this.cachedQuery)
+    }
+}
+''')
+
+        then:
+        warnings.size() == 1
+        warnings[0].message.contains('GormUnsafeQueryString')
+    }
+
+    void "test a field safely reassigned does not warn"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+    String cachedQuery = "from Book"
+
+    List loadCached() {
+        this.cachedQuery = "from Book where title = :title"
+        executeQuery(this.cachedQuery, [title: title])
+    }
+}
+''')
+
+        then:
+        warnings.empty
+    }
+
+    void "test string concatenation with a non-constant value warns but still compiles"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        String q = "from Book where title = " + title
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        warnings.size() == 1
+        warnings[0].message.contains('GormUnsafeQueryString')
+        warnings[0].message.contains("passed to 'executeQuery'")
+    }
+
+    void "test string concatenation passed directly as the query argument warns but still compiles"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        executeQuery("from Book where title = " + title)
+    }
+}
+''')
+
+        then:
+        warnings.size() == 1
+        warnings[0].message.contains('GormUnsafeQueryString')
+    }
+
+    void "test concatenating two constant strings does not warn"() {
+        when:
+        List<WarningMessage> warnings = compileAndCollectWarnings('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List all() {
+        String q = "from " + "Book"
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        warnings.empty
+    }
+
+    void "test concatenating a GString with more text fails to compile as flattening, not as a lesser concatenation warning"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        String q = "from Book where title = ${title}" + " order by title"
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+        e.message.contains("passed to 'executeQuery'")
     }
 }

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
@@ -87,6 +87,33 @@ class Book {
     }
 
     @Unroll
+    void "test inline #description at the call site fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass("""
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        executeQuery($argument)
+    }
+}
+""")
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+
+        where:
+        description     | argument
+        '.toString()'   | '"from Book where title = ${title}".toString()'
+        '(String) cast' | '(String) "from Book where title = ${title}"'
+        'as String'     | '("from Book where title = ${title}" as String)'
+    }
+
+    @Unroll
     void "test aliasing via #description before find fails to compile"() {
         when:
         new GroovyClassLoader().parseClass("""

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
@@ -1,0 +1,227 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.query.transform
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class GormQuerySafetyTransformerSpec extends Specification {
+
+    void "test String query flattened from an interpolated GString before executeQuery fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        String q = "from Book where title = ${title}"
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+        e.message.contains("passed to 'executeQuery'")
+    }
+
+    @Unroll
+    void "test flattening via #description before find fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass("""
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Book byTitle(String title) {
+        $declaration
+        find(q)
+    }
+}
+""")
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+
+        where:
+        description        | declaration
+        '.toString()'      | 'def q = "from Book where title = ${title}".toString()'
+        'as String'        | 'String q = ("from Book where title = ${title}" as String)'
+        '(String) cast'    | 'String q = (String) "from Book where title = ${title}"'
+        'reassignment'     | 'String q; q = "from Book where title = ${title}"'
+    }
+
+    void "test a GString literal passed directly compiles cleanly"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List byTitle(String title) {
+        executeQuery("from Book where title = ${title}")
+    }
+}
+''')
+
+        then:
+        bookClass != null
+    }
+
+    void "test a plain non-interpolated String compiles cleanly"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List all() {
+        String q = "from Book"
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        bookClass != null
+    }
+
+    void "test a flattened query suppressed with @SuppressWarnings compiles cleanly"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    @SuppressWarnings("GormUnsafeQueryString")
+    static List byTitle(String title) {
+        String q = "from Book where title = ${title}"
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        bookClass != null
+    }
+
+    void "test a non-domain class with its own find/findAll(String) methods does not false-positive"() {
+        when:
+        Class<?> planClass = new GroovyClassLoader().parseClass('''
+class Plan {
+    String find(String query) {
+        return query
+    }
+
+    List findAll(String query) {
+        return [query]
+    }
+
+    static String byName(String name) {
+        String q = "plan ${name}"
+        new Plan().find(q)
+    }
+}
+''')
+
+        then:
+        planClass != null
+    }
+
+    void "test Collection.find/.findAll with a closure argument does not false-positive"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Object pickOne(List titles, String target) {
+        String q = "picking ${target}"
+        titles.find { it == q }
+        titles.findAll { it == q }
+    }
+}
+''')
+
+        then:
+        bookClass != null
+    }
+
+    void "test findPathTo detects a flattened query at argument index 1, not 0"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Object toOther(Class other, String title) {
+        String q = "MATCH (b:Book)-[*]->(o) WHERE b.title = ${title} RETURN o"
+        findPathTo(other, q, [:])
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+        e.message.contains("passed to 'findPathTo'")
+    }
+
+    void "test a flattened variable referenced inside a nested closure still fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static void byTitles(List titles) {
+        titles.each { String title ->
+            String q = "from Book where title = ${title}"
+            executeQuery(q)
+        }
+    }
+}
+''')
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+    }
+}

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/query/transform/GormQuerySafetyTransformerSpec.groovy
@@ -76,6 +76,56 @@ class Book {
         'reassignment'     | 'String q; q = "from Book where title = ${title}"'
     }
 
+    @Unroll
+    void "test aliasing via #description before find fails to compile"() {
+        when:
+        new GroovyClassLoader().parseClass("""
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static Book byTitle(String title) {
+        $declaration
+        find(q)
+    }
+}
+""")
+
+        then:
+        def e = thrown(MultipleCompilationErrorsException)
+        e.message.contains('GormUnsafeQueryString')
+
+        where:
+        description                      | declaration
+        'a variable holding a GString'   | 'def g = "from Book where title = ${title}"\nString q = g'
+        '.toString() on an alias'        | 'def g = "from Book where title = ${title}"\nString q = g.toString()'
+        'a two-hop alias chain'          | 'def g = "from Book where title = ${title}"\ndef h = g\nString q = h'
+        'assigning an already-flattened alias' | 'String p = "from Book where title = ${title}"\nString q = p'
+    }
+
+    void "test aliasing a plain non-interpolated variable compiles cleanly"() {
+        when:
+        Class<?> bookClass = new GroovyClassLoader().parseClass('''
+import grails.gorm.annotation.Entity
+
+@Entity
+class Book {
+    String title
+
+    static List all() {
+        def g = "from Book"
+        String q = g
+        executeQuery(q)
+    }
+}
+''')
+
+        then:
+        bookClass != null
+    }
+
     void "test a GString literal passed directly compiles cleanly"() {
         when:
         Class<?> bookClass = new GroovyClassLoader().parseClass('''

--- a/grails-doc/src/en/guide/security/securingAgainstAttacks.adoc
+++ b/grails-doc/src/en/guide/security/securingAgainstAttacks.adoc
@@ -89,6 +89,32 @@ def reviewedAndSafe() {
 
 This check runs automatically against every Grails application that has `grails-datamapping-core` on its compile classpath — no configuration is required, and it covers every GORM implementation whose query methods follow this convention (Hibernate and Neo4j today).
 
+===== Compile-time warnings for lower-confidence patterns
+
+Two related patterns are detected by the same check but reported as compile-time *warnings* rather than build failures, because the detection is less certain than the local-variable case above:
+
+[source,groovy]
+----
+class Book {
+    String title
+    String cachedQuery = "from Book where title = ${title}"  // <1>
+
+    def loadCached() {
+        executeQuery(this.cachedQuery)                         // <2>
+    }
+
+    def vulnerable(String title) {
+        String query = "from Book where title = " + title      // <3>
+        executeQuery(query)
+    }
+}
+----
+<1> A field initialized from an interpolated `GString` — unlike a local variable, a field can be reassigned from a constructor, another method, or a subclass that this check never sees, so this is flagged rather than failed.
+<2> Reading that field later through `this.cachedQuery` in a query call.
+<3> Query text built with `+` from a non-constant value and no `GString` involved at all. This is a real injection shape, but string concatenation is common enough for benign, non-query purposes that a hard build failure would be too blunt an instrument.
+
+Both warnings identify the call site and suppress the same way as the error above, with `@SuppressWarnings("GormUnsafeQueryString")` on the enclosing method. Concatenating a `GString` with additional text (e.g. `"...${title}..." + " order by title"`) is *not* one of these warnings — Groovy's `GString.plus` returns a plain `String`, so this flattens the interpolation immediately and is reported as the build-breaking error instead.
+
 
 ==== Phishing
 

--- a/grails-doc/src/en/guide/security/securingAgainstAttacks.adoc
+++ b/grails-doc/src/en/guide/security/securingAgainstAttacks.adoc
@@ -18,6 +18,7 @@ under the License.
 ////
 
 
+[[sqlInjection]]
 ==== SQL injection
 
 
@@ -58,6 +59,35 @@ def safe() {
                           [title: params.title])
 }
 ----
+
+===== Compile-time detection of flattened GString queries
+
+Passing a `GString` *directly* to a GORM query method such as `find`, `findAll`, `executeQuery`, or `executeUpdate` is safe: GORM converts each interpolated value into a bound query parameter rather than embedding it as text. The risk is a subtler pattern that looks harmless:
+
+[source,groovy]
+----
+def vulnerable() {
+    String query = "from Book as b where b.title = ${params.title}"  // <1>
+    def books = Book.executeQuery(query)                              // <2>
+}
+----
+<1> Groovy coerces the `GString` to a plain `String` right here, because `query` is declared as `String`.
+<2> By the time `executeQuery` receives it, it is an ordinary `String` with no trace of ever having been a `GString` — the interpolated value is now raw, unescaped text, and this call is genuinely vulnerable to HQL injection.
+
+This is dangerous precisely because it can't be caught at runtime: once a `GString` is flattened to a `String`, there is nothing left to distinguish it from HQL text that was always safe. Grails detects this pattern at *compile time* instead, and fails the build with an error identifying the call site. To fix it, keep the value as a `GString` (recommended) or pass named/positional parameters explicitly, as shown above.
+
+If a flagged call site has been reviewed and is genuinely safe, suppress the check on the enclosing method:
+
+[source,groovy]
+----
+@SuppressWarnings("GormUnsafeQueryString")
+def reviewedAndSafe() {
+    String query = "from Book as b where b.title = ${params.title}"
+    def books = Book.executeQuery(query)
+}
+----
+
+This check runs automatically against every Grails application that has `grails-datamapping-core` on its compile classpath — no configuration is required, and it covers every GORM implementation whose query methods follow this convention (Hibernate and Neo4j today).
 
 
 ==== Phishing

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1513,4 +1513,23 @@ Both hooks may be used on the same plugin during migration; when a registrar and
 
 **Bean-definition overriding edge case.** Grails defaults `spring.main.allow-bean-definition-overriding` to `true`, and under that default nothing changes: an application bean (from the application class, `resources.groovy` or `resources.xml`) that uses the same name as a plugin bean still replaces the plugin's bean. However, because plugin beans now register earlier and application beans register in a separate, later step, an application that explicitly sets `spring.main.allow-bean-definition-overriding` to `false` will see a `BeanDefinitionOverrideException` for an application bean that shadows a plugin bean — in previous releases the two definitions were merged before a single registry write, so the shadowing was silent even with overriding disabled.
 
+
+==== 34. Compile-Time GORM Query Safety Check
+
+Grails 8 adds a compile-time check that can **break existing builds**: passing a GORM query method (`find`, `findAll`, `executeQuery`, `executeUpdate`, and the Neo4j Cypher equivalents) a `String`-typed variable that was built from an interpolated `GString` is now a compile error, not just a discouraged pattern.
+
+[source,groovy]
+----
+def vulnerable() {
+    String query = "from Book as b where b.title = ${params.title}"  // fails to compile
+    def books = Book.executeQuery(query)
+}
+----
+
+This is flagged because passing the `GString` *directly* to `executeQuery` is safe — GORM binds the interpolated value as a query parameter — but assigning it to a `String`-typed local first causes Groovy to coerce it to a plain `String` at that point, silently discarding the safe binding; the interpolated value is then embedded as raw, unescaped query text. See <<sqlInjection,SQL injection>> for the full explanation and examples.
+
+If your application has this pattern, fix it by keeping the query a `GString` all the way to the call, or by using named/positional parameters instead. For a call site that has been reviewed and is genuinely safe, add `@SuppressWarnings("GormUnsafeQueryString")` to the enclosing method rather than restructuring the code.
+
+This check runs automatically wherever `grails-datamapping-core` is on the compile classpath — no opt-in configuration is required or possible beyond the per-call-site suppression above.
+
 **Most applications and plugins need no action.** Behavior only changes where a plugin bean and a conditional Boot bean competed for the same name or type — the plugin bean now wins, which is almost always the intended outcome.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1532,4 +1532,6 @@ If your application has this pattern, fix it by keeping the query a `GString` al
 
 This check runs automatically wherever `grails-datamapping-core` is on the compile classpath — no opt-in configuration is required or possible beyond the per-call-site suppression above.
 
+The same check also emits (non-build-breaking) **compile-time warnings**, not errors, for two related but lower-confidence patterns: a `String`-typed field assigned an interpolated `GString` and later read through `this.field` in a query call, and query text built with `+` concatenation from a non-constant value with no `GString` involved. Neither of these fails the build, but both are worth reviewing — see <<sqlInjection,SQL injection>> for examples of both.
+
 **Most applications and plugins need no action.** Behavior only changes where a plugin bean and a conditional Boot bean competed for the same name or type — the plugin bean now wins, which is almost always the intended outcome.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1530,7 +1530,7 @@ This is flagged because passing the `GString` *directly* to `executeQuery` is sa
 
 If your application has this pattern, fix it by keeping the query a `GString` all the way to the call, or by using named/positional parameters instead. For a call site that has been reviewed and is genuinely safe, add `@SuppressWarnings("GormUnsafeQueryString")` to the enclosing method rather than restructuring the code.
 
-This check runs automatically wherever `grails-datamapping-core` is on the compile classpath — no opt-in configuration is required or possible beyond the per-call-site suppression above.
+This check runs automatically wherever `grails-datamapping-core` is on the compile classpath, with no opt-in configuration required. If it produces a false positive with no workaround, the whole check can be disabled by setting the `protectSqlInjectionAttacks` system property to `false` (it defaults to `true`) — this is a last-resort, build-wide kill switch, not a substitute for the per-call-site `@SuppressWarnings` above.
 
 The same check also emits (non-build-breaking) **compile-time warnings**, not errors, for two related but lower-confidence patterns: a `String`-typed field assigned an interpolated `GString` and later read through `this.field` in a query call, and query text built with `+` concatenation from a non-constant value with no `GString` involved. Neither of these fails the build, but both are worth reviewing — see <<sqlInjection,SQL injection>> for examples of both.
 


### PR DESCRIPTION
## Background

While reviewing #15968 ("Warn once on GString-interpolated GORM HQL queries"), GitHub's Copilot reviewer left a comment on `HibernateGormStaticApi.groovy` noting that the new runtime warning had no test verifying it actually fires through the real Hibernate static API call path — only through the isolated `GormQuerySafetyWarnings` helper spec. That comment was the starting point for a deeper investigation (with Claude) into whether the warning mechanism actually closes the gap it claims to.

That investigation found:

1. **The warning does fire correctly when a `GString` is passed directly** to `find`/`findAll`/`executeQuery` — confirmed empirically by adding a log-capturing assertion to the existing `HibernateGormStaticApiSpec` "injection-safe" test and running it against #15968's branch. GORM binds the interpolated value as a real query parameter in this case; it is not exploitable.
2. **#15968 only wires the warning into one of three GORM implementations with the identical code path.** `grails-data-hibernate5`'s `AbstractHibernateGormStaticApi` and `grails-data-neo4j`'s `Neo4jGormStaticApi` have the same `instanceof GString` / `buildNamedParameterQueryFromGString` pattern (Neo4j's error message still literally says "HQL injection" even though it's building Cypher) — neither references the new warning helper at all.
3. **The actual dangerous case is structurally invisible to any runtime check.** GORM's own safe-binding mechanism only engages when the query argument is *still* a `GString` at the point of the call. The extremely common Groovy pattern
   ```groovy
   String query = "from Book where name = ${userInput}"   // GString -> String, right here
   Book.executeQuery(query)
   ```
   causes Groovy to coerce the `GString` to a plain `String` at the assignment, because `query` is declared `String`. By the time this reaches GORM's query builder, `instanceof GString` is `false`, and the interpolated value is used as raw, unescaped query text — a genuine injection vector. A `java.lang.String` carries no trace of ever having been a `GString`, so no amount of runtime checking at the query boundary can distinguish this from a safely hand-written HQL string. The information needed to tell them apart only exists at the source-code level, before compilation erases it.

That third point is the actual finding this PR addresses: a warning that fires on the already-safe case and stays silent on the actually-dangerous case is backwards from what a risk-reduction mechanism should do, regardless of whether it warns or (as considered and rejected) throws at runtime.

## What this PR does

Adds a **global, compile-time Groovy AST transformation** (`GormQuerySafetyTransformer` / `GlobalGormQuerySafetyASTTransformation`, in `grails-datamapping-core`) that detects the flattened-`String` pattern above and fails the build with a clear, actionable error — before the type information that would let a runtime check catch it is lost.

Because the check is syntactic (method name + argument shape), not tied to a specific datastore's runtime class, **one transform covers Hibernate5, Hibernate7, and Neo4j simultaneously**, with zero changes to any of those three modules and zero configuration required from application developers — it runs automatically wherever `grails-datamapping-core` is on the compile classpath, the same way `@GrailsCompileStatic` and domain-class enhancement already apply themselves invisibly.

### Detection algorithm

- Tracks local variables (declarations and reassignments) that go from a live, interpolated `GString` to a plain `String` — via explicit `String` typing, `.toString()`, `(String)` cast, or `as String`.
- Flags a call to `find` / `findAll` / `executeQuery` / `executeUpdate` / `findAllWithSql` / `cypherStatic` / `findPath` / `findPathTo` whose query argument is one of those flattened variables.
- Gates on the receiver looking like a GORM domain class (reusing the existing `AstUtils.isDomainClass`, the same utility `DetachedCriteriaTransformer`'s `where{}` rewriting already relies on) to avoid false positives on unrelated methods.
- A direct `GString` literal argument (`Book.executeQuery("... ${x} ...")`) is never flagged — that path is already safe.

### Corner cases handled (with test coverage)

- **`.toString()` / `(String)` cast / `as String`** coercions of an interpolated `GString` — all flagged, not just plain `String`-typed declarations.
- **Reassignment**, not just declaration (`String q; q = "...${x}..."`) — tracked via `visitBinaryExpression`, with a safe reassignment clearing prior unsafe tracking (last-write-wins; see limitations below).
- **`Collection.find` / `Collection.findAll`** (GDK methods present on nearly every `Iterable`) never collide with the GORM methods of the same name — they take a `Closure`, and the flagged argument must be a tracked `String` variable, so the two shapes can't overlap.
- **Non-domain classes that happen to define their own `find`/`findAll(String)`** methods do not false-positive, because of the `isDomainClass` receiver gate.
- **Closures capture the flattened state correctly** — a variable flattened in an enclosing method and referenced inside a nested closure (`.each { ... executeQuery(q) }`) still triggers, since closures are walked as part of their enclosing method's traversal.
- **Neo4j's `findPathTo(Class type, CharSequence query, Map params)`** has the query as its *second* argument, not first — handled as a special case in the argument-index map, with a dedicated test.
- **Suppression**: a reviewed, genuinely safe call site can opt out per-call-site with `@SuppressWarnings("GormUnsafeQueryString")` on the enclosing method — a deliberate, auditable exception rather than a global kill switch.
- **Multiple-assignment declarations** (`def (a, b) = [...]`) don't crash the transform — `DeclarationExpression.getVariableExpression()` returns `null` for these and is guarded.

### Known, deliberate limitations (documented in the class Javadoc and the upgrade guide)

This is intentionally scoped, not a general SQL-injection solution:

- **Intraprocedural only** — a flattened `String` built inside a helper method and returned is invisible to this check.
- **Last-write-wins reassignment tracking**, not full branch-sensitive dataflow.
- **Locals only, not fields**, in this first version.
- **Does not catch plain string concatenation with no `GString` involved at all** (`"select * ... " + userInput`) — arguably the more classic injection shape, and untouched by this or #15968's runtime check, since there's no `GStringExpression` node to detect.
- **Does not cover raw JDBC via `groovy.sql.Sql`**, which is outside GORM's static API entirely.
- **Does not apply to MongoDB** — its GORM API has no `CharSequence`-based raw query method at all (it inherits `GormStaticApi.executeQuery()`, which just throws `unsupported('executeQuery')`), so it isn't vulnerable to this specific pattern in the first place.

## Verification

- New `GormQuerySafetyTransformerSpec` — 12 tests, covering every case above (error cases assert `MultipleCompilationErrorsException` with the expected message; safe/suppressed/non-domain cases assert clean compilation).
- Full `grails-datamapping-core` test suite: pass.
- Full `grails-data-hibernate7-core` suite (2988 tests) and `grails-data-hibernate5-core` suite: zero failures, confirming the global transform introduces no false positives against real GORM/query source in either module.
- `codeStyle` (Checkstyle + CodeNarc) clean on touched modules.
- Doc build (`publishGuide`) verified to render correctly, including the new cross-reference between the upgrade guide and the security guide.

## Why this is opinionated, on purpose

Grails' own stated philosophy is "sensible defaults" — convention over configuration, with escape hatches for the cases that genuinely need them. Not permitting query-string injection by default is exactly that kind of sensible default: an application shouldn't have to opt in to safety, and a framework that discovers it's silently coercing a safely-parameterizable query into raw unescaped text has an obligation to say so loudly, not log it once and move on. That's why this fails the build rather than warning: for a compile-time check, the "pre-prod environment" every responsible team already runs *is* the build itself — failing to compile has no live-traffic blast radius, unlike a runtime throw would. Teams that hit a false positive on a reviewed-safe call get an explicit, auditable, per-call-site escape hatch (`@SuppressWarnings("GormUnsafeQueryString")`) rather than a single switch that quietly reopens the whole risk surface.

This is offered as an alternative to the runtime-only, single-module approach in #15968 — happy to discuss reconciling the two (e.g. keeping #15968's docs/warning as a softer signal for the cases this transform's intraprocedural limits can't reach, while this closes the case that matters most).
