### PR TITLE
Fix generated logback-spring.xml hiding WARN and INFO messages

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/logging/template/logback.rocker.raw
@@ -22,43 +22,25 @@ under the License.
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <!-- Jansi is intentionally disabled. It replaces System.out globally, which is
-             incompatible with some reloading tools: after a Spring Boot DevTools restart
-             the replaced stream breaks console logging. Console colors are supplied by
-             Spring Boot's %clr converter via CONSOLE_LOG_PATTERN and do not need Jansi. -->
-        <withJansi>false</withJansi>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${CONSOLE_LOG_THRESHOLD}</level>
-        </filter>
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-            <charset>${CONSOLE_LOG_CHARSET}</charset>
-        </encoder>
-    </appender>
-
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" />
+        <logger name="StackTrace" level="ERROR"/>
 
 <!--        <logger name="@packageName" level="DEBUG"/>-->
 
 <!--        <logger name="org.hibernate.SQL" level="DEBUG"/>-->
 <!--        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>-->
 <!--        <logger name="org.springframework.security" level="TRACE"/>-->
-
-<!--        <root level="WARN"/>-->
     </springProfile>
 
-<!--    logging to a file-->
-<!--    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>-->
-<!--    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />-->
-<!--    <root level="ERROR">-->
-<!--        <appender-ref ref="FILE" />-->
+<!--    logging to a file: set logging.file.name in application.yml and include Spring Boot's file appender -->
+<!--    <include resource="org/springframework/boot/logging/logback/file-appender.xml"/>-->
+<!--    <root level="INFO">-->
+<!--        <appender-ref ref="FILE"/>-->
 <!--    </root>-->
-<!--    add logging.file.name to application.yml-->
 </configuration>

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/logging/LogbackSpec.groovy
@@ -54,14 +54,23 @@ class LogbackSpec extends ApplicationContextSpec implements CommandOutputFixture
     }
 
     @Unroll
-    void "test logback-spring.xml disables Jansi for #applicationType application"() {
+    void "test logback-spring.xml composes Spring Boot defaults with an INFO root level for #applicationType application"() {
         when:
         def output = generate(applicationType, new Options(DevelopmentReloading.DEVTOOLS))
 
-        then: "Jansi is disabled so its global System.out replacement does not break console logging after a Spring Boot DevTools restart (issue #15663)"
+        then: "the file reuses Spring Boot's own defaults and console appender instead of duplicating them"
         def logback = output.get("grails-app/conf/logback-spring.xml")
-        logback.contains("<withJansi>false</withJansi>")
-        !logback.contains("<withJansi>true</withJansi>")
+        logback.contains('<include resource="org/springframework/boot/logging/logback/defaults.xml"/>')
+        logback.contains('<include resource="org/springframework/boot/logging/logback/console-appender.xml"/>')
+        logback.contains('<root level="INFO">')
+        !logback.contains('<root level="ERROR">')
+
+        and: "environment-specific logging is configured via the development Spring profile"
+        logback.contains('<springProfile name="development">')
+        logback.contains('<logger name="StackTrace" level="ERROR"/>')
+
+        and: "Jansi is not used; its global System.out replacement breaks console logging after a Spring Boot DevTools restart (issue #15663)"
+        !logback.contains("withJansi")
 
         where:
         applicationType << ApplicationType.values().toList()

--- a/grails-profiles/base/skeleton/grails-app/conf/logback-spring.xml
+++ b/grails-profiles/base/skeleton/grails-app/conf/logback-spring.xml
@@ -1,39 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
 
-    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <withJansi>false</withJansi>
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${CONSOLE_LOG_THRESHOLD}</level>
-        </filter>
-        <encoder>
-            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
-            <charset>${CONSOLE_LOG_CHARSET}</charset>
-        </encoder>
-    </appender>
-
-    <root level="ERROR">
+    <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
 
     <springProfile name="development">
-        <logger name="StackTrace" level="ERROR" />
+        <logger name="StackTrace" level="ERROR"/>
 
-<!--        <logger name="Test38" level="DEBUG"/>-->
+<!--        <logger name="@grails.codegen.defaultPackage@" level="DEBUG"/>-->
 
 <!--        <logger name="org.hibernate.SQL" level="DEBUG"/>-->
 <!--        <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE"/>-->
 <!--        <logger name="org.springframework.security" level="TRACE"/>-->
-
-<!--        <root level="WARN"/>-->
     </springProfile>
 
-<!--    logging to a file-->
-<!--    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>-->
-<!--    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />-->
-<!--    <root level="ERROR">-->
-<!--        <appender-ref ref="FILE" />-->
+<!--    logging to a file: set logging.file.name in application.yml and include Spring Boot's file appender -->
+<!--    <include resource="org/springframework/boot/logging/logback/file-appender.xml"/>-->
+<!--    <root level="INFO">-->
+<!--        <appender-ref ref="FILE"/>-->
 <!--    </root>-->
-<!--    add logging.file.name to application.yml-->
 </configuration>


### PR DESCRIPTION
## Summary

The starter `grails-app/conf/logback-spring.xml` generated for new applications sets the root logger to `ERROR`, which suppresses the WARN and INFO output — including framework startup warnings — that Spring Boot shows by default.

This PR raises the root level to `INFO` and composes Spring Boot's own `defaults.xml` and `console-appender.xml` instead of duplicating the console appender, so the generated configuration matches Spring Boot's defaults. Jansi remains unused; Spring Boot's `%clr` converter supplies console colors (see #15663).

The change is applied to both generation paths so `create-app` and start.grails.org produce the same file:

- **Profile CLI**: `grails-profiles/base/skeleton/grails-app/conf/logback-spring.xml` (also fixes the commented development logger example to use the `@grails.codegen.defaultPackage@` placeholder instead of a hardcoded package name)
- **Grails Forge**: `grails-forge-core` `logback.rocker.raw` template, with `LogbackSpec` updated to assert the new content

This is the logback-spring.xml portion of #15757, extracted into its own PR. The opt-in zero-config Forge feature and documentation changes remain in #15757.

## Testing

- Full `grails-forge-core` test suite passes, including the updated `LogbackSpec` assertions (Spring Boot includes present, `INFO` root level, development `springProfile`, no Jansi) across all application types.