### PR TITLE
Upgrade SiteMesh to 3.3.0-M3

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -113,8 +113,8 @@ ext {
             'sitemesh.version'              : '2.6.0',
             'scribejava.version'            : '8.3.3',
             'spock.version'                 : '2.4-groovy-5.0',
-            'starter-sitemesh.version'      : '3.3.0-M2',
-            'spring-webmvc-sitemesh.version': '3.3.0-M2',
+            'starter-sitemesh.version'      : '3.3.0-M3',
+            'spring-webmvc-sitemesh.version': '3.3.0-M3',
             // Spring Boot 4 no longer manages spring-retry; pin it here so the
             // grails-shell-cli SpringRetryCompilerAutoConfiguration's unversioned
             // reference resolves and consumer apps using @Retryable get a known version.


### PR DESCRIPTION
Bumps `spring-boot-starter-sitemesh` / `spring-webmvc-sitemesh` from `3.3.0-M2` to `3.3.0-M3`.

### Why

**M3 fixes the response charset in the view-resolver integration.** Under M2, `SiteMeshView` stamped a charset-less `text/html` onto the real response before the inner view rendered. Grails GSP only applies its configured content type (`text/html;charset=UTF-8`) when none is set yet, so it backed off — and the response went out with the servlet container's locale-derived charset instead. Net effect: decorated pages served most non-English locales as **ISO-8859-1**, destroying all non-Latin-1 text (Cyrillic, Thai, Chinese, Czech, ...). Only locales whose container mapping happened to be UTF-8 rendered correctly.

M3 lets the inner view own the content type (`enableBuffering` is now the public API for unconditional buffering) and restores the `text/html` default only when the view declines to set one.

### Also in M3

- The invasive wrap-all default is replaced by a non-invasive delegating resolver — no `ViewResolver` bean is replaced or retyped. Grails' `bean-definition` / `bean-instance` integrations are unaffected and keep priority through the starter's extension contract (verified: single decoration pass).
- `SiteMeshViewResolver.decorate(View)` for views a handler resolves manually and returns directly.
- `SiteMeshViewContext` is created after the render, so custom content processors and decorator selectors observe the actual response content type.
- The starter's early post-processors bind `sitemesh.*` from the `Environment`, so `wrapMode=bean-definition` no longer ignores a configured `targetBeanName`.
- Decorator-chain parsing is centralized and whitespace-tolerant (`"inner, outer"` works in meta tags, request attributes, and configuration alike).

### Verification (against the released Central artifact)

- `:grails-sitemesh3:test` — green (forced rerun)
- `:grails-test-examples-gsp-sitemesh3:check` — 21 integration tests green (forced rerun), covering forced layouts, decorator chaining, JSP, plain text, and error-page decoration
- A generated application serves **all 18 bundled locales as `charset=UTF-8`** with strict byte-level validation of the translated content

Companion to #15974, which internationalizes the default welcome page — correct rendering of its non-Latin-1 locales depends on this upgrade.