### PR TITLE
Honor EnvironmentAware application classes before early plugin registration

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/config/GrailsEarlyPluginRegistrationPostProcessor.java
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsEarlyPluginRegistrationPostProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.support.BeanRegistryAdapter;
 import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.EnvironmentAware;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.env.AbstractEnvironment;
@@ -120,6 +121,11 @@ public class GrailsEarlyPluginRegistrationPostProcessor
             return;
         }
 
+        // The application class may customize the environment (secrets, discovered endpoints, …);
+        // apply that before anything in this phase — plugin loading, the config snapshot, the
+        // doWithSpring drain — reads configuration.
+        customizeEnvironmentFromApplicationClasses(registry);
+
         // The initializing flag is a system property, so a leak on failure poisons every subsequent
         // context in the same JVM (test forks especially). Reset it if anything below throws; the
         // success path leaves it set and resets on refresh via the listener added at the end.
@@ -165,6 +171,45 @@ public class GrailsEarlyPluginRegistrationPostProcessor
         catch (RuntimeException | Error e) {
             Environment.setInitializing(false);
             throw e;
+        }
+    }
+
+    /**
+     * Honours the documented externalized-configuration pattern where the application class
+     * implements {@link EnvironmentAware} to contribute property sources (secrets, discovered
+     * endpoints, …). Before this early phase existed, the application configuration bean was
+     * instantiated — and received its {@code setEnvironment} callback — before plugin
+     * {@code doWithSpring} closures ran, so configuration read by plugins (for example GORM
+     * connection URLs) already included the contributed sources. The early phase now runs before
+     * any bean is created, so the contract is replayed here on a detached instance (mirroring
+     * {@link #scanApplicationSource}) before the config snapshot is built and the plugin runtime
+     * configuration is drained.
+     *
+     * <p>The application bean is still created by Spring later and receives the standard
+     * {@code setEnvironment} callback a second time, so implementations must be idempotent —
+     * contribute a <em>named</em> property source (re-adding a source with the same name replaces
+     * the earlier one) rather than accumulating state.
+     */
+    private void customizeEnvironmentFromApplicationClasses(BeanDefinitionRegistry registry) {
+        for (Class<?> source : resolveApplicationSourceClasses(registry)) {
+            boolean applicationClass = GrailsAutoConfiguration.class.isAssignableFrom(source) ||
+                    GrailsApplicationClass.class.isAssignableFrom(source);
+            if (!applicationClass || !EnvironmentAware.class.isAssignableFrom(source)) {
+                continue;
+            }
+            EnvironmentAware application;
+            try {
+                application = (EnvironmentAware) source.getDeclaredConstructor().newInstance();
+            } catch (Exception | LinkageError e) {
+                LOG.warn("Unable to instantiate [{}] to apply its EnvironmentAware environment customization " +
+                        "before plugin registration; plugins may read configuration the application has not " +
+                        "customized yet: {}", source.getName(), e.toString());
+                continue;
+            }
+            if (application instanceof GrailsAutoConfiguration grailsAutoConfiguration) {
+                grailsAutoConfiguration.setApplicationContext(applicationContext);
+            }
+            application.setEnvironment(applicationContext.getEnvironment());
         }
     }
 

--- a/grails-core/src/test/groovy/grails/boot/config/EarlyPluginRegistrationOrderingSpec.groovy
+++ b/grails-core/src/test/groovy/grails/boot/config/EarlyPluginRegistrationOrderingSpec.groovy
@@ -237,6 +237,36 @@ class EarlyPluginRegistrationOrderingSpec extends Specification {
             Environment.setInitializing(false)
     }
 
+    void 'an EnvironmentAware application class customizes the environment before plugin doWithSpring reads config'() {
+        given: 'a plugin that captures a config value when its runtime configuration is drained'
+            EarlyOrderingConfigReadingGrailsPlugin.CAPTURED_URL = null
+            EarlyOrderingEnvAwareApplication.INVOCATIONS.set(0)
+            def ctx = new AnnotationConfigApplicationContext()
+            registerDiscovery(ctx, EarlyOrderingConfigReadingGrailsPlugin)
+            new GrailsPluginLifecycleInitializer().initialize(ctx)
+
+        and: 'an EnvironmentAware application class registered and stashed as the application source, as GrailsApp does'
+            ctx.register(EarlyOrderingEnvAwareApplication)
+            ctx.beanFactory.registerSingleton(
+                    GrailsEarlyPluginRegistrationPostProcessor.APPLICATION_SOURCE_CLASSES_BEAN_NAME,
+                    [EarlyOrderingEnvAwareApplication] as Class<?>[])
+
+        when: 'the context refreshes'
+            ctx.refresh()
+
+        then: 'the plugin saw the value contributed by setEnvironment, not the yaml/default value'
+            EarlyOrderingConfigReadingGrailsPlugin.CAPTURED_URL == 'mongodb://real-host:27017/app'
+
+        and: 'the callback ran twice — early on a detached instance, then on the real bean — without duplicating the named source'
+            EarlyOrderingEnvAwareApplication.INVOCATIONS.get() == 2
+            ctx.environment.propertySources.get('earlyOrderingSecrets') != null
+
+        cleanup:
+            ctx.close()
+            Holders.clear()
+            Environment.setInitializing(false)
+    }
+
     void 'the initializing flag is reset when the early phase throws'() {
         given: 'a plugin whose doWithSpring throws while the early phase drains it'
             def ctx = new AnnotationConfigApplicationContext()
@@ -371,6 +401,35 @@ class EarlyOrderingThrowingGrailsPlugin extends Plugin {
 }
 
 class EarlyOrderingAppResolver {
+}
+
+class EarlyOrderingEnvAwareApplication extends GrailsAutoConfiguration implements org.springframework.context.EnvironmentAware {
+
+    static final AtomicInteger INVOCATIONS = new AtomicInteger()
+
+    @Override
+    void setEnvironment(org.springframework.core.env.Environment environment) {
+        INVOCATIONS.incrementAndGet()
+        // a named source is idempotent: re-adding replaces the earlier source of the same name
+        ((org.springframework.core.env.ConfigurableEnvironment) environment).propertySources.addFirst(
+                new org.springframework.core.env.MapPropertySource('earlyOrderingSecrets',
+                        ['test.datastore.url': 'mongodb://real-host:27017/app'] as Map<String, Object>))
+    }
+}
+
+class EarlyOrderingConfigReadingGrailsPlugin extends Plugin {
+
+    static volatile String CAPTURED_URL
+
+    def version = '1.0'
+
+    @Override
+    Closure doWithSpring() {
+        // read config when the runtime configuration is drained, exactly as GORM plugins
+        // resolve their connection settings inside doWithSpring
+        CAPTURED_URL = config.getProperty('test.datastore.url') ?: 'default-localhost'
+        return { -> }
+    }
 }
 
 class EarlyOrderingOverrideGrailsPlugin extends Plugin {


### PR DESCRIPTION
## This is currently a DRAFT because it involves a running `setEnvironment` 2x and I don't like that solution


### Problem

#15934 retimed plugin `doWithSpring` to run before Spring Boot auto-configuration — and therefore before any bean is created. An application class using the long-documented externalized-configuration pattern:

```groovy
class Application extends GrailsAutoConfiguration implements EnvironmentAware {
    void setEnvironment(Environment environment) {
        // fetch secrets / discover endpoints, addFirst a property source
    }
}
```

previously had `setEnvironment` invoked (when the application configuration bean was instantiated) *before* plugin bean registration ran. After the retiming, plugins that resolve settings inside `doWithSpring` read configuration the application has not customized yet. The GORM plugins resolve their connection URLs there — e.g. `MongodbGrailsPlugin.doWithSpring()` builds `MongoDbDataStoreSpringInitializer` from `config` at definition time — so an app that injects its production MongoDB URL from a secret manager in `setEnvironment` silently boots against the static yaml default (`localhost`) instead. Beans that read the `Environment` at creation time (Redis, Elasticsearch, `@Value`) are unaffected, which makes the failure look like a Mongo-specific mystery. This is a real-world regression observed in production on the re-staged 8.0.0-M3.

### Fix

Replay the contract at the start of `GrailsEarlyPluginRegistrationPostProcessor`: for each stashed application source class that is a `GrailsAutoConfiguration`/`GrailsApplicationClass` and implements `EnvironmentAware`, invoke `setEnvironment` on a detached instance — the same approach the phase already uses for artefact scanning (`scanApplicationSource`) — before plugin loading, the `PropertySourcesConfig` snapshot, and the `doWithSpring` drain.

The real application bean still receives the standard `EnvironmentAware` callback when Spring creates it later, so implementations must be idempotent: contribute a *named* property source (re-adding a source with the same name replaces the earlier one) rather than accumulate state. This is documented on the new method and asserted in the spec (`INVOCATIONS == 2`, no duplicated source).

### Testing

New test in `EarlyPluginRegistrationOrderingSpec`: a plugin that reads config in `doWithSpring` (as the GORM plugins do) observes the value contributed by the application's `setEnvironment`, not the default; the double-callback semantics are pinned. Full `:grails-core:test` and checkstyle pass.

Happy to add an upgrade-notes entry in grails-doc ("`setEnvironment` on `EnvironmentAware` application classes now runs twice; keep it idempotent") if wanted.
