### PR TITLE
Simplify forge deployments to speed up release times

### DIFF
--- a/.github/workflows/forge-deploy-next.yml
+++ b/.github/workflows/forge-deploy-next.yml
@@ -16,34 +16,13 @@
 name: "Forge - Next GCP Deploy"
 on:
   workflow_dispatch:
+# The application code is already built and tested by the main CI (gradle.yml)
+# and by release verification, so these deploy workflows only build the native
+# image and ship it — no redundant full build or re-run of the forge tests.
 jobs:
-  build:
-    name: "Build project"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'liberica'
-          java-version: '21'
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
-      - name: "🔨 Build"
-        working-directory: grails-forge
-        run: ./gradlew build
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:next
     steps:
@@ -72,14 +51,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-api:test
-          grails-forge-web-netty:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -105,7 +76,6 @@ jobs:
   deployAnalytics:
     name: "Deploy analytics to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:next
     steps:
@@ -134,11 +104,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: ./gradlew grails-forge-analytics-postgres:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush

--- a/.github/workflows/forge-deploy-next.yml
+++ b/.github/workflows/forge-deploy-next.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -91,8 +89,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/forge-deploy-prev-snapshot.yml
+++ b/.github/workflows/forge-deploy-prev-snapshot.yml
@@ -16,34 +16,13 @@
 name: "Forge - Prev Snapshot GCP Deploy"
 on:
   workflow_dispatch:
+# The application code is already built and tested by the main CI (gradle.yml)
+# and by release verification, so these deploy workflows only build the native
+# image and ship it — no redundant full build or re-run of the forge tests.
 jobs:
-  build:
-    name: "Build project"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'liberica'
-          java-version: '21'
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
-      - name: "🔨 Build"
-        working-directory: grails-forge
-        run: ./gradlew build
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:prev-snapshot
     steps:
@@ -72,14 +51,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-api:test
-          grails-forge-web-netty:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -105,7 +76,6 @@ jobs:
   deployAnalytics:
     name: "Deploy analytics to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:prev-snapshot
     steps:
@@ -134,11 +104,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: ./gradlew grails-forge-analytics-postgres:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush

--- a/.github/workflows/forge-deploy-prev-snapshot.yml
+++ b/.github/workflows/forge-deploy-prev-snapshot.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -91,8 +89,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/forge-deploy-prev.yml
+++ b/.github/workflows/forge-deploy-prev.yml
@@ -16,34 +16,13 @@
 name: "Forge - Prev GCP Deploy"
 on:
   workflow_dispatch:
+# The application code is already built and tested by the main CI (gradle.yml)
+# and by release verification, so these deploy workflows only build the native
+# image and ship it — no redundant full build or re-run of the forge tests.
 jobs:
-  build:
-    name: "Build project"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'liberica'
-          java-version: '21'
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
-      - name: "🔨 Build"
-        working-directory: grails-forge
-        run: ./gradlew build
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:prev
     steps:
@@ -72,14 +51,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-api:test
-          grails-forge-web-netty:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush
@@ -105,7 +76,6 @@ jobs:
   deployAnalytics:
     name: "Deploy analytics to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:prev
     steps:
@@ -134,11 +104,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: ./gradlew grails-forge-analytics-postgres:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker image"
         working-directory: grails-forge
         # To deploy native executables built with GraalVM, replace dockerBuild with dockerBuildNative and dockerPush

--- a/.github/workflows/forge-deploy-prev.yml
+++ b/.github/workflows/forge-deploy-prev.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -91,8 +89,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/forge-deploy-release.yml
+++ b/.github/workflows/forge-deploy-release.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -91,8 +89,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:

--- a/.github/workflows/forge-deploy-release.yml
+++ b/.github/workflows/forge-deploy-release.yml
@@ -20,36 +20,13 @@ on:
       release:
         description: 'Release version'
         required: true
+# The application code is already built and tested by the main CI (gradle.yml)
+# and by release verification, so these deploy workflows only build the native
+# image and ship it — no redundant assemble or re-run of the forge tests.
 jobs:
-  build:
-    name: "Build project"
-    runs-on: ubuntu-24.04
-    outputs:
-      release_version: ${{ github.event.inputs.release }}
-    steps:
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'liberica'
-          java-version: '21'
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
-      - name: "🧩 Assemble"
-        working-directory: grails-forge
-        run: ./gradlew grails-cli:assemble
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -76,18 +53,10 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-api:test
-          grails-forge-web-netty:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         env:
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ github.event.inputs.release }}
           TEST_BUILD_REPRODUCIBLE: "true"
         run: >
           ./gradlew
@@ -95,13 +64,13 @@ jobs:
           -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ github.event.inputs.release }}
         run: |
           docker push ${{ env.IMAGE_NAME }}
       - name: "🚀 Deploy Docker image"
         env:
-          release_version: ${{ needs.build.outputs.release_version }}
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ needs.build.outputs.release_version }}
+          release_version: ${{ github.event.inputs.release }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:${{ github.event.inputs.release }}
         run: |
           gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-latest --image $IMAGE_NAME --region us-central1 --update-env-vars=HOSTNAME="latest.grails.org",CORS_ALLOWED_ORIGIN="https://start.grails.org",CORS_ALLOWED_ORIGIN_APACHE="https://grails.apache.org",GITHUB_OAUTH_APP_CLIENT_ID=${{ secrets.GH_OAUTH_LATEST_CLIENT_ID }},GITHUB_OAUTH_APP_CLIENT_SECRET=${{ secrets.GH_OAUTH_LATEST_CLIENT_SECRET }},GITHUB_USER_AGENT=${{ secrets.GH_USER_AGENT }},GITHUB_REDIRECT_URL=${{ secrets.GH_REDIRECT_URL }} --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}
           version="$(echo "${release_version//./}" | tr '[A-Z]' '[a-z]')"
@@ -109,7 +78,6 @@ jobs:
   deployAnalytics:
     name: "Deploy analytics to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -136,17 +104,10 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-analytics-postgres:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         env:
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ github.event.inputs.release }}
           TEST_BUILD_REPRODUCIBLE: "true"
         run: >
           ./gradlew
@@ -154,13 +115,13 @@ jobs:
           -PdockerImageName=${{ env.IMAGE_NAME }}
       - name: "📤 Push Container to Google Cloud Artifact Registry"
         env:
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ github.event.inputs.release }}
         run: |
           docker push ${{ env.IMAGE_NAME }}
       - name: "🚀 Deploy Docker image"
         env:
-          release_version: ${{ needs.build.outputs.release_version }}
-          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ needs.build.outputs.release_version }}
+          release_version: ${{ github.event.inputs.release }}
+          IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:${{ github.event.inputs.release }}
         run: |
           gcloud components install beta --quiet
           gcloud run deploy ${{ secrets.GCP_PROJECT_ID }}-analytics-latest --image $IMAGE_NAME --region us-central1 --platform managed --allow-unauthenticated --service-account=${{ secrets.GCLOUD_EMAIL }}

--- a/.github/workflows/forge-deploy-snapshot.yml
+++ b/.github/workflows/forge-deploy-snapshot.yml
@@ -16,34 +16,13 @@
 name: "Forge - Snapshot GCP Deploy"
 on:
   workflow_dispatch:
+# The application code is already built and tested by the main CI (gradle.yml)
+# and by release verification, so these deploy workflows only build the native
+# image and ship it — no redundant full build or re-run of the forge tests.
 jobs:
-  build:
-    name: "Build project"
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: 'liberica'
-          java-version: '21'
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
-      - name: "🔨 Build"
-        working-directory: grails-forge
-        run: ./gradlew build
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
   deploy:
     name: "Deploy to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}:snapshot
     steps:
@@ -72,14 +51,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: >
-          ./gradlew
-          grails-forge-api:test
-          grails-forge-web-netty:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         run: >
@@ -103,7 +74,6 @@ jobs:
   deployAnalytics:
     name: "Deploy analytics to Google Cloud Run"
     runs-on: ubuntu-24.04
-    needs: build
     env:
       IMAGE_NAME: us-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_APP_NAME }}/${{ secrets.GCP_APP_NAME }}-analytics:snapshot
     steps:
@@ -132,11 +102,6 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: "🐋 Configure Docker for Artifact Registry"
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
-      - name: "🏃 Run tests"
-        working-directory: grails-forge
-        run: ./gradlew grails-forge-analytics-postgres:test
-        env:
-          TEST_BUILD_REPRODUCIBLE: "true"
       - name: "🔨 Build Docker native image"
         working-directory: grails-forge
         run: >

--- a/.github/workflows/forge-deploy-snapshot.yml
+++ b/.github/workflows/forge-deploy-snapshot.yml
@@ -38,8 +38,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -89,8 +87,6 @@ jobs:
         with:
           cache-provider: basic # 'basic' uses the MIT-licensed, open-source cache provider; the default 'enhanced' provider (v6+) is proprietary (Gradle commercial Terms of Use)
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@d96a555133c275a00949d2cc77b70fe9a4242ebf # v1.9.2
       - name: "🔑 Login to Google Cloud"
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:


### PR DESCRIPTION
@jamesfredley we spoke about simplifying the forge workflows in one of the previous weekly meetings, this PR does that so releases can be quicker.