### PR TITLE
Fix forge reproducibility issues

### DIFF
--- a/grails-forge/gradle.properties
+++ b/grails-forge/gradle.properties
@@ -30,6 +30,8 @@ antlr4Version=4.8-1!!
 asciidoctorGradleJvmVersion=4.0.5
 commonsCompressVersion=1.28.0
 gradleSdkvendorPluginVersion=3.0.0
+# minimum 4.0.32 - groovydoc output is non-deterministic before GROOVY-11954, breaking reproducible javadoc jars
+groovyVersion=4.0.32
 jacksonDatabindVersion=2.18.3
 # match the jansi version in grails-bom
 jansiVersion=2.4.2

--- a/grails-forge/gradle/groovy-version-pin.gradle
+++ b/grails-forge/gradle/groovy-version-pin.gradle
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+// Pin all Groovy modules to the version in gradle.properties instead of the
+// (older) version managed by the Micronaut platform BOM.
+configurations.configureEach {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (details.requested.group == 'org.apache.groovy') {
+            details.useVersion(groovyVersion)
+            details.because('groovydoc output is non-deterministic before GROOVY-11954, breaking reproducible javadoc jars')
+        }
+    }
+}

--- a/grails-forge/grails-forge-analytics-postgres/build.gradle
+++ b/grails-forge/grails-forge-analytics-postgres/build.gradle
@@ -116,4 +116,5 @@ tasks.named('dockerBuild') {
     images = [findProperty('dockerImageName') ?: 'grailsforge']
 }
 
+apply from: rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
 apply from: rootProject.layout.projectDirectory.file('gradle/code-style-config.gradle')

--- a/grails-forge/grails-forge-api/build.gradle
+++ b/grails-forge/grails-forge-api/build.gradle
@@ -74,6 +74,7 @@ dependencies {
 }
 
 apply {
+    from rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
     from rootProject.layout.projectDirectory.file('gradle/code-style-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/micronaut-openapi-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')

--- a/grails-forge/grails-forge-cli/build.gradle
+++ b/grails-forge/grails-forge-cli/build.gradle
@@ -119,6 +119,7 @@ rocker {
 }
 
 apply {
+    from rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
     from rootProject.layout.projectDirectory.file('gradle/code-style-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/doc-config.gradle')

--- a/grails-forge/grails-forge-core/build.gradle
+++ b/grails-forge/grails-forge-core/build.gradle
@@ -118,6 +118,7 @@ copyGrailsWrapper.configure { Sync it ->
 }
 
 apply {
+    from rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
     from rootProject.layout.projectDirectory.file('gradle/code-style-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
     from rootProject.layout.projectDirectory.file('gradle/doc-config.gradle')

--- a/grails-forge/grails-forge-web-netty/build.gradle
+++ b/grails-forge/grails-forge-web-netty/build.gradle
@@ -121,4 +121,5 @@ tasks.named('dockerBuild') {
     images = [findProperty('dockerImageName') ?: 'grailsforge']
 }
 
+apply from: rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
 apply from: rootProject.layout.projectDirectory.file('gradle/code-style-config.gradle')

--- a/grails-forge/test-core/build.gradle
+++ b/grails-forge/test-core/build.gradle
@@ -71,5 +71,6 @@ dependencies {
 }
 
 apply {
+    from rootProject.layout.projectDirectory.file('gradle/groovy-version-pin.gradle')
     from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
 }


### PR DESCRIPTION
Forge was updated to groovy 4, but not updated to 4.0.32 - it's running 4.0.28.  GROOVY-11954 fixed a reproducibility issue that we need to include to resolve our remaining 8.0.0-M3 reproducibility issue.