### PR TITLE
Prevent multiple publishing from running at the same time

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -758,6 +758,12 @@ jobs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publish ]
     runs-on: ubuntu-24.04
+    # Documentation publishing targets a shared resource (the apache/grails-website repo).
+    # Share the static group used by the release documentation publish (release.yml) so only
+    # one documentation publish can run at a time across every branch; the rest queue.
+    concurrency:
+      group: grails-docs-publish
+      cancel-in-progress: false
     steps:
       - name: "⚙️ Maximize build space"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,6 +571,12 @@ jobs:
     name: "VOTE SUCCEEDED - Publish Documentation"
     needs: [ publish, source, upload, release ]
     runs-on: ubuntu-24.04
+    # Documentation publishing targets a shared resource (the apache/grails-website repo).
+    # Use a static, branch-independent group so only one documentation publish can run at a
+    # time across every branch and across the snapshot publish in gradle.yml; the rest queue.
+    concurrency:
+      group: grails-docs-publish
+      cancel-in-progress: false
     steps:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Instead of implementing https://github.com/apache/grails-github-actions/pull/98 - this adds an exclusive mutex so no 2 publishing jobs will run at the same time.  @jamesfredley 