### PR TITLE
Grant native access in CLI and wrapper start scripts

### DIFF
--- a/grails-forge/grails-cli/build.gradle
+++ b/grails-forge/grails-cli/build.gradle
@@ -149,6 +149,10 @@ tasks.named('assemble').configure {
     dependsOn(shadowJarTask)
 }
 
+// JLine loads a native terminal library via System::load, a restricted method under JEP 472;
+// without this grant JDK 24+ warns on every launch and a future JDK will refuse the call
+List<String> nativeAccessJvmOpts = ['--enable-native-access=ALL-UNNAMED']
+
 TaskProvider<CreateStartScripts> cliStartScripts = tasks.register('createCliStartScripts', CreateStartScripts)
 cliStartScripts.configure { CreateStartScripts t ->
     t.dependsOn jarTask, shadowJarTask
@@ -156,6 +160,7 @@ cliStartScripts.configure { CreateStartScripts t ->
     t.applicationName = 'grails'
     t.mainClass = project.findProperty('startMainClass') as String
     t.classpath = files(shadowJarTask)
+    t.defaultJvmOpts = nativeAccessJvmOpts
 }
 
 TaskProvider<CreateStartScripts> shellCliStartScripts = tasks.register('createShellCliStartScripts', CreateStartScripts)
@@ -165,6 +170,7 @@ shellCliStartScripts.configure { CreateStartScripts t ->
     t.applicationName = 'grails-shell-cli'
     t.mainClass = 'org.grails.cli.GrailsCli'
     t.classpath = files(shadowJarTask)
+    t.defaultJvmOpts = nativeAccessJvmOpts
 }
 
 TaskProvider<CreateStartScripts> forgeCliStartScripts = tasks.register('createForgeCliStartScripts', CreateStartScripts)
@@ -174,6 +180,7 @@ forgeCliStartScripts.configure { CreateStartScripts t ->
     t.applicationName = 'grails-forge-cli'
     t.mainClass = 'org.grails.forge.cli.Application'
     t.classpath = files(shadowJarTask)
+    t.defaultJvmOpts = nativeAccessJvmOpts
 }
 
 project.extensions.getByType(DistributionContainer).configureEach {

--- a/grails-wrapper/build.gradle
+++ b/grails-wrapper/build.gradle
@@ -74,6 +74,11 @@ startScripts.configure { CreateStartScripts t ->
     t.mainClass = project.findProperty('startMainClass') as String
     t.classpath = files(jarTask)
 
+    // the wrapper loads the downloaded CLI jar into this JVM, where JLine loads a native terminal
+    // library via System::load, a restricted method under JEP 472; without this grant JDK 24+
+    // warns on every launch and a future JDK will refuse the call
+    t.defaultJvmOpts = ['--enable-native-access=ALL-UNNAMED']
+
     // See gradle tickets such as for lib https://github.com/gradle/gradle/issues/7033
     doLast {
         t.unixScript.text = t.unixScript.text


### PR DESCRIPTION
### Problem

On JDK 24+ every launch of the CLI prints JEP 472 restricted-method warnings:

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.jline.nativ.JLineNativeLoader in an unnamed module (file:/.../grails-cli-8.0.0-M3-all.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

JLine loads its native terminal library via `System::load`, a restricted method under [JEP 472](https://openjdk.org/jeps/472). The generated start scripts launch the shadow jar on the classpath with `DEFAULT_JVM_OPTS=""`, so nothing grants native access. Today this is just noise, but a future JDK release will block the call outright, breaking interactive terminal support.

There is no way to avoid the grant: terminal control fundamentally requires native access (JLine's FFM provider hits the same restriction, and the `exec` provider degrades to a dumb terminal on Windows). JEP 472's prescribed remediation for classpath applications is exactly this flag in the launcher.

Relates to #15216, which reported the same symptom from `grailsw` on Java 25 (via hawtjni at the time; it is JLine's loader in 8.0.x) and only had a user-side workaround.

### Change

Set `defaultJvmOpts = ['--enable-native-access=ALL-UNNAMED']` on the four `CreateStartScripts` tasks:

- `grails`, `grails-shell-cli`, `grails-forge-cli` (`grails-forge/grails-cli/build.gradle`)
- `grailsw` (`grails-wrapper/build.gradle`) — the wrapper loads the downloaded CLI jar into its own JVM via `URLClassLoader`, so it needs the same grant

This bakes the flag into both the POSIX and Windows scripts shipped in the distributions.

### Verification

- Generated all four start scripts; each now contains `DEFAULT_JVM_OPTS='"--enable-native-access=ALL-UNNAMED"'` (and the `.bat` equivalent).
- Assembled a dist layout (`bin/grails` + `lib/grails-cli-8.0.0-SNAPSHOT-all.jar`) and ran `grails --version` on JDK 25.0.3: no warnings.
- Control run of the same jar without the flag reproduces all four warnings.