### PR TITLE
Replace local StringBuffer usage with StringBuilder

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/jdbc/RelaxedNames.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/jdbc/RelaxedNames.java
@@ -142,7 +142,7 @@ final class RelaxedNames implements Iterable<String> {
             @Override
             public String apply(String value) {
                 Matcher matcher = CAMEL_CASE_PATTERN.matcher(value);
-                StringBuffer result = new StringBuffer();
+                StringBuilder result = new StringBuilder();
                 while (matcher.find()) {
                     matcher.appendReplacement(result, matcher.group(1) + '_' +
                             StringUtils.uncapitalize(matcher.group(2)));
@@ -156,7 +156,7 @@ final class RelaxedNames implements Iterable<String> {
             @Override
             public String apply(String value) {
                 Matcher matcher = CAMEL_CASE_PATTERN.matcher(value);
-                StringBuffer result = new StringBuffer();
+                StringBuilder result = new StringBuilder();
                 while (matcher.find()) {
                     matcher.appendReplacement(result, matcher.group(1) + '-' +
                             StringUtils.uncapitalize(matcher.group(2)));

--- a/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
+++ b/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
@@ -81,7 +81,7 @@ public class SpringIOUtils {
     /**
      * Convert a byte[] array to readable string format. This makes the "hex" readable!
      *
-     * @return result String buffer in String format
+     * @return result in String format
      * @param in
      *            byte[] buffer to convert to string format
      */

--- a/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
+++ b/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
@@ -92,7 +92,7 @@ public class SpringIOUtils {
             return null;
         }
 
-        StringBuffer out = new StringBuffer(in.length * 2);
+        StringBuilder out = new StringBuilder(in.length * 2);
 
         //CheckStyle:MagicNumber OFF
         for (int i = 0; i < in.length; i++) {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GrailsLayoutPreprocessor.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GrailsLayoutPreprocessor.java
@@ -41,14 +41,14 @@ public class GrailsLayoutPreprocessor {
     public static final String XML_CLOSING_FOR_EMPTY_TAG_ATTRIBUTE_NAME = "gsp_sm_xmlClosingForEmptyTag";
 
     public String addGspGrailsLayoutCapturing(String gspSource) {
-        StringBuffer sb = addHeadCapturing(gspSource);
+        StringBuilder sb = addHeadCapturing(gspSource);
         sb = addBodyCapturing(sb);
         sb = addContentCapturing(sb);
         return sb.toString();
     }
 
-    StringBuffer addHeadCapturing(String gspSource) {
-        StringBuffer sb = new StringBuffer((int) (gspSource.length() * 1.2));
+    StringBuilder addHeadCapturing(String gspSource) {
+        StringBuilder sb = new StringBuilder((int) (gspSource.length() * 1.2));
         Matcher m = headPattern.matcher(gspSource);
         if (m.find()) {
             m.appendReplacement(sb, "");
@@ -83,13 +83,13 @@ public class GrailsLayoutPreprocessor {
         return m.replaceAll("<grailsLayout:wrapTitleTag><grailsLayout:captureTitle$1>$2</grailsLayout:captureTitle></grailsLayout:wrapTitleTag>");
     }
 
-    StringBuffer addBodyCapturing(StringBuffer sb) {
+    StringBuilder addBodyCapturing(StringBuilder sb) {
         Matcher m = bodyPattern.matcher(sb);
-        return new StringBuffer(m.replaceAll("<grailsLayout:captureBody$1>$2</grailsLayout:captureBody>"));
+        return new StringBuilder(m.replaceAll("<grailsLayout:captureBody$1>$2</grailsLayout:captureBody>"));
     }
 
-    StringBuffer addContentCapturing(StringBuffer sb) {
+    StringBuilder addContentCapturing(StringBuilder sb) {
         Matcher m = contentPattern.matcher(sb);
-        return new StringBuffer(m.replaceAll("<grailsLayout:captureContent$1>$2</grailsLayout:captureContent>"));
+        return new StringBuilder(m.replaceAll("<grailsLayout:captureContent$1>$2</grailsLayout:captureContent>"));
     }
 }

--- a/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/json/JSONTokener.java
@@ -470,7 +470,7 @@ public class JSONTokener {
             endIndex = 19;
             appendDots = true;
         }
-        StringBuffer output = new StringBuffer(" at character " + this.myIndex + " of " + this.mySource.substring(0, endIndex));
+        StringBuilder output = new StringBuilder(" at character " + this.myIndex + " of " + this.mySource.substring(0, endIndex));
         if (appendDots) {
             output.append("...");
         }

--- a/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
+++ b/grails-web-url-mappings/src/main/groovy/org/grails/web/mapping/RegexUrlMapping.java
@@ -391,7 +391,7 @@ public class RegexUrlMapping extends AbstractUrlMapping {
             }
             m = DOUBLE_WILDCARD_PATTERN.matcher(token);
             if (m.find()) {
-                StringBuffer buf = new StringBuffer();
+                StringBuilder buf = new StringBuilder();
                 do {
                     ConstrainedProperty prop = constraints[paramIndex++];
                     String propName = prop.getPropertyName();


### PR DESCRIPTION
## Summary

- replace invocation-local StringBuffer instances with StringBuilder
- preserve output and public APIs while removing unnecessary synchronization
- keep the starter intentionally limited to five safe local conversions

## Verification

- :grails-web-url-mappings:test
- :grails-web-common:test
- :grails-datamapping-core:test
- :grails-gsp-core:test
- :grails-gradle-model:test

This is an AI-generated starting point for the broader legacy JDK type cleanup.
