### PR TITLE
Document continuous test mode

### DIFF
--- a/grails-doc/src/en/guide/testing/runningTests/withGrailsCli.adoc
+++ b/grails-doc/src/en/guide/testing/runningTests/withGrailsCli.adoc
@@ -59,6 +59,25 @@ open test-report
 You can also run your unit tests from within most IDEs.
 
 
+==== Running Tests Continuously
+
+
+For a local edit-and-test loop in the Grails interactive CLI, start continuous testing:
+
+
+[source,groovy]
+----
+grails
+grails> test-app -continuous
+----
+
+
+Grails starts its `DirectoryWatcher` and reruns the selected tests after a `.groovy` or `.java` file is created or changed in `grails-app`, `src/main/groovy`, `src/test/groovy`, or `src/integration-test/groovy`. It does not run tests immediately. Combine `-continuous` with test name patterns or `-unit` and `-integration` to keep the same test selection for each rerun.
+
+
+The watcher is part of Grails, not Gradle `--continuous`, and Grails doesn't pass Gradle's continuous option to the build. It doesn't watch files outside those directories, including `src/main/java`, and `--watch` isn't an alias. Keep the interactive CLI open while using this mode, then exit the CLI or press Ctrl+C to stop it. A one-off `grails test-app -continuous` invocation exits immediately because `DirectoryWatcher` runs on a daemon thread.
+
+
 ==== Targeting Tests
 
 

--- a/grails-doc/src/en/ref/Command Line/test-app.adoc
+++ b/grails-doc/src/en/ref/Command Line/test-app.adoc
@@ -45,7 +45,7 @@ grails test-app Foo Bar
 Usage:
 [source,groovy]
 ----
-grails <<environment>>* test-app <<names>>* [-unit|-integration] [-continuous]
+grails <<environment>>* test-app <<names>>* [-unit] [-integration] [-continuous]
 ----
 
 Fired Events:

--- a/grails-doc/src/en/ref/Command Line/test-app.adoc
+++ b/grails-doc/src/en/ref/Command Line/test-app.adoc
@@ -45,7 +45,7 @@ grails test-app Foo Bar
 Usage:
 [source,groovy]
 ----
-grails <<environment>>* test-app <<names>>* [-unit|-integration]
+grails <<environment>>* test-app <<names>>* [-unit|-integration] [-continuous]
 ----
 
 Fired Events:
@@ -71,11 +71,18 @@ grails test-app -unit
 grails test-app -integration
 ----
 
-If you only wish to re-run failed tests use the -rerun flag
+=== Continuous Testing
 
 [source,groovy]
 ----
-grails test-app -rerun
+grails
+grails> test-app -continuous
 ----
+
+The `-continuous` option starts Grails' `DirectoryWatcher`. It watches `.groovy` and `.java` files in `grails-app`, `src/main/groovy`, `src/test/groovy`, and `src/integration-test/groovy`. Creating or changing a watched file reruns the tests selected by the command options and test name patterns.
+
+Continuous mode does not run tests when it starts. It is intended for the Grails interactive CLI, where the watcher remains active until you exit the CLI. A one-off `grails test-app -continuous` command exits immediately because `DirectoryWatcher` runs on a daemon thread. Stop interactive continuous testing by exiting the CLI or pressing Ctrl+C.
+
+This is not Gradle's `--continuous` mode. Grails does not pass `--continuous` to Gradle, and `--watch` is not an alias for `-continuous`. Files outside the watched directories, including Java source directories such as `src/main/java`, do not trigger a rerun.
 
 See the link:{guidePath}testing.html[Testing] section for examples on how to combine the different options to target tests.


### PR DESCRIPTION
## Summary

- document the existing `grails test-app -continuous` continuous test mode
- cover the watched source directories, .groovy/.java triggers, no initial run, and interactive-CLI lifecycle/termination
- show the correct interactive sequence (start `grails`, then `test-app -continuous` at the prompt) and explain why a one-off invocation exits immediately
- distinguish the Grails DirectoryWatcher from Gradle --continuous; synopsis lists -continuous as an independent optional flag

## Verification

- :grails-doc:publishGuide -x aggregateGroovydoc
- git diff --check

This is an AI-generated starting point documenting existing continuous test behavior.
