### PR TITLE
docs: fix broken external and internal links in Groovydocs

### DIFF
--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
@@ -27,24 +27,17 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
- * A task that repairs malformed navigation links in generated Groovydocs.
+ * A task that audits generated Groovydocs for malformed navigation links.
  * Specifically targets 'phantom' links and relative path issues in navigation files
  * like overview-summary.html, deprecated-list.html, and help-doc.html.
  */
-abstract class FixGroovydocLinksTask extends DefaultTask {
-    
-    /**
-     * If true, the task will fail the build if any malformed links are found.
-     * If false, the task will attempt to repair the links (patching mode).
-     */
-    @org.gradle.api.tasks.Input
-    boolean auditMode = false
+abstract class AuditGroovydocLinksTask extends DefaultTask {
 
     @InputDirectory
     abstract DirectoryProperty getApiDocsDir()
 
     @TaskAction
-    void fixLinks() {
+    void auditLinks() {
         File apiDir = apiDocsDir.get().asFile
         if (!apiDir.exists()) {
             logger.warn "API documentation directory does not exist: ${apiDir.absolutePath}"
@@ -59,24 +52,20 @@ abstract class FixGroovydocLinksTask extends DefaultTask {
             (Pattern.compile(/href='([^']+?)\/overview-summary\.html'/)): "href='overview-summary.html'"
         ]
 
-        int totalFixes = 0
         List<String> violations = []
 
         apiDir.eachFileRecurse { File file ->
             if (file.name.endsWith(".html")) {
                 String content = file.text
-                boolean changed = false
                 
                 replacements.each { pattern, replacement ->
                     Matcher matcher = pattern.matcher(content)
                     if (matcher.find()) {
-                        content = matcher.replaceAll(replacement)
-                        changed = true
-                        violations << "Malformed nav link in ${file.name}"
+                        violations << "Malformed nav link in ${file.name}: ${matcher.group(0)}"
                     }
                 }
                 
-                // Fix specific inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
+                // Check specific inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
                 Pattern innerClassPattern = Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
                 Matcher innerMatcher = innerClassPattern.matcher(content)
                 while (innerMatcher.find()) {
@@ -88,30 +77,16 @@ abstract class FixGroovydocLinksTask extends DefaultTask {
                     Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
                     
                     if (Files.exists(targetPath)) {
-                        String newHref = "href='${relPath}/${outer}.${inner}'"
-                        content = content.replace(innerMatcher.group(0), newHref)
-                        changed = true
-                        violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)} -> ${newHref}"
-                    }
-                }
-
-                if (changed) {
-                    totalFixes++
-                    if (!auditMode) {
-                        file.text = content
+                        violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)}"
                     }
                 }
             }
         }
         
-        if (totalFixes > 0) {
-            if (auditMode) {
-                violations.take(10).each { logger.error(it) }
-                if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")
-                throw new org.gradle.api.GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
-            } else {
-                logger.lifecycle "Repaired ${totalFixes} HTML files in ${apiDir.absolutePath}"
-            }
+        if (!violations.isEmpty()) {
+            violations.take(10).each { logger.error(it) }
+            if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")
+            throw new org.gradle.api.GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
         } else {
             logger.lifecycle "No malformed Groovydoc links found in ${apiDir.absolutePath}"
         }

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
@@ -22,9 +22,6 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
-import java.nio.file.*
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 /**
  * A task that audits generated Groovydocs for malformed navigation links.
@@ -44,45 +41,8 @@ abstract class AuditGroovydocLinksTask extends DefaultTask {
             return
         }
 
-        // Patterns common to Groovydoc navigation failures
-        Map<Pattern, String> replacements = [
-            (Pattern.compile(/href='([^']+?)\/deprecated-list\.html'/)): "href='deprecated-list.html'",
-            (Pattern.compile(/href='([^']+?)\/help-doc\.html'/)): "href='help-doc.html'",
-            (Pattern.compile(/href='([^']+?)\/index-all\.html'/)): "href='index-all.html'",
-            (Pattern.compile(/href='([^']+?)\/overview-summary\.html'/)): "href='overview-summary.html'"
-        ]
+        List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
 
-        List<String> violations = []
-
-        apiDir.eachFileRecurse { File file ->
-            if (file.name.endsWith(".html")) {
-                String content = file.text
-                
-                replacements.each { pattern, replacement ->
-                    Matcher matcher = pattern.matcher(content)
-                    if (matcher.find()) {
-                        violations << "Malformed nav link in ${file.name}: ${matcher.group(0)}"
-                    }
-                }
-                
-                // Check specific inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
-                Pattern innerClassPattern = Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
-                Matcher innerMatcher = innerClassPattern.matcher(content)
-                while (innerMatcher.find()) {
-                    String relPath = innerMatcher.group(1)
-                    String outer = innerMatcher.group(2)
-                    String inner = innerMatcher.group(3)
-                    
-                    Path currentPath = file.toPath().parent
-                    Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
-                    
-                    if (Files.exists(targetPath)) {
-                        violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)}"
-                    }
-                }
-            }
-        }
-        
         if (!violations.isEmpty()) {
             violations.take(10).each { logger.error(it) }
             if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
@@ -21,33 +21,67 @@ package org.grails.doc.gradle
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task that audits generated Groovydocs for malformed inner-class links, where a
- * slash-separated 'phantom' path (e.g. {@code Outer/Inner.html}) was emitted instead
- * of the dotted Groovydoc naming convention ({@code Outer.Inner.html}).
+ * A task that audits generated Groovydocs for relative links that resolve to a page which
+ * was never generated. Links that Groovydoc itself is responsible for are reported as
+ * warnings; links that this repository can fix - by putting the type on the Groovydoc
+ * classpath or mapping its package to an external javadoc site - fail the build.
  *
  * @see GroovydocLinkAuditor
  */
 abstract class AuditGroovydocLinksTask extends DefaultTask {
 
+    private static final int MAX_REPORTED = 25
+
     @InputDirectory
     abstract DirectoryProperty getApiDocsDir()
+
+    /**
+     * Package prefixes with no published javadoc to link to. Links into these are reported
+     * as neither a warning nor a violation.
+     */
+    @Input
+    abstract SetProperty<String> getUnmappedPackages()
 
     @TaskAction
     void auditLinks() {
         File apiDir = apiDocsDir.get().asFile
 
-        List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir, unmappedPackages.get())
 
-        if (!violations.isEmpty()) {
-            violations.take(10).each { logger.error(it) }
-            if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")
-            throw new GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
-        } else {
-            logger.lifecycle "No malformed Groovydoc links found in ${apiDir.absolutePath}"
+        for (Map.Entry<GroovydocLinkAuditor.Category, List<String>> warning : result.warnings) {
+            report(warning.key, warning.value, false)
+        }
+
+        List<String> violations = result.violations
+        if (violations.isEmpty()) {
+            logger.lifecycle "No unresolvable Groovydoc links found in ${apiDir.absolutePath}"
+            return
+        }
+
+        report(GroovydocLinkAuditor.Category.UNMAPPED_TYPE, violations, true)
+        throw new GradleException("Found ${violations.size()} Groovydoc links to types that were neither " +
+                'generated nor mapped to an external javadoc site. Add the type to the Groovydoc classpath ' +
+                "or map its package in the 'links' configuration; see the log for details.")
+    }
+
+    private void report(GroovydocLinkAuditor.Category category, List<String> messages, boolean error) {
+        List<String> lines = ["Groovydoc: ${messages.size()} x ${category.description}".toString()]
+        messages.take(MAX_REPORTED).each { lines << "  ${it}".toString() }
+        if (messages.size() > MAX_REPORTED) {
+            lines << "  ... and ${messages.size() - MAX_REPORTED} more".toString()
+        }
+        for (String line : lines) {
+            if (error) {
+                logger.error(line)
+            } else {
+                logger.warn(line)
+            }
         }
     }
 }

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/AuditGroovydocLinksTask.groovy
@@ -19,14 +19,17 @@
 package org.grails.doc.gradle
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task that audits generated Groovydocs for malformed navigation links.
- * Specifically targets 'phantom' links and relative path issues in navigation files
- * like overview-summary.html, deprecated-list.html, and help-doc.html.
+ * A task that audits generated Groovydocs for malformed inner-class links, where a
+ * slash-separated 'phantom' path (e.g. {@code Outer/Inner.html}) was emitted instead
+ * of the dotted Groovydoc naming convention ({@code Outer.Inner.html}).
+ *
+ * @see GroovydocLinkAuditor
  */
 abstract class AuditGroovydocLinksTask extends DefaultTask {
 
@@ -36,17 +39,13 @@ abstract class AuditGroovydocLinksTask extends DefaultTask {
     @TaskAction
     void auditLinks() {
         File apiDir = apiDocsDir.get().asFile
-        if (!apiDir.exists()) {
-            logger.warn "API documentation directory does not exist: ${apiDir.absolutePath}"
-            return
-        }
 
         List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
 
         if (!violations.isEmpty()) {
             violations.take(10).each { logger.error(it) }
             if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")
-            throw new org.gradle.api.GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
+            throw new GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
         } else {
             logger.lifecycle "No malformed Groovydoc links found in ${apiDir.absolutePath}"
         }

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/FixGroovydocLinksTask.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/FixGroovydocLinksTask.groovy
@@ -1,0 +1,119 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.doc.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.nio.file.*
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * A task that repairs malformed navigation links in generated Groovydocs.
+ * Specifically targets 'phantom' links and relative path issues in navigation files
+ * like overview-summary.html, deprecated-list.html, and help-doc.html.
+ */
+abstract class FixGroovydocLinksTask extends DefaultTask {
+    
+    /**
+     * If true, the task will fail the build if any malformed links are found.
+     * If false, the task will attempt to repair the links (patching mode).
+     */
+    @org.gradle.api.tasks.Input
+    boolean auditMode = false
+
+    @InputDirectory
+    abstract DirectoryProperty getApiDocsDir()
+
+    @TaskAction
+    void fixLinks() {
+        File apiDir = apiDocsDir.get().asFile
+        if (!apiDir.exists()) {
+            logger.warn "API documentation directory does not exist: ${apiDir.absolutePath}"
+            return
+        }
+
+        // Patterns common to Groovydoc navigation failures
+        Map<Pattern, String> replacements = [
+            (Pattern.compile(/href='([^']+?)\/deprecated-list\.html'/)): "href='deprecated-list.html'",
+            (Pattern.compile(/href='([^']+?)\/help-doc\.html'/)): "href='help-doc.html'",
+            (Pattern.compile(/href='([^']+?)\/index-all\.html'/)): "href='index-all.html'",
+            (Pattern.compile(/href='([^']+?)\/overview-summary\.html'/)): "href='overview-summary.html'"
+        ]
+
+        int totalFixes = 0
+        List<String> violations = []
+
+        apiDir.eachFileRecurse { File file ->
+            if (file.name.endsWith(".html")) {
+                String content = file.text
+                boolean changed = false
+                
+                replacements.each { pattern, replacement ->
+                    Matcher matcher = pattern.matcher(content)
+                    if (matcher.find()) {
+                        content = matcher.replaceAll(replacement)
+                        changed = true
+                        violations << "Malformed nav link in ${file.name}"
+                    }
+                }
+                
+                // Fix specific inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
+                Pattern innerClassPattern = Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
+                Matcher innerMatcher = innerClassPattern.matcher(content)
+                while (innerMatcher.find()) {
+                    String relPath = innerMatcher.group(1)
+                    String outer = innerMatcher.group(2)
+                    String inner = innerMatcher.group(3)
+                    
+                    Path currentPath = file.toPath().parent
+                    Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
+                    
+                    if (Files.exists(targetPath)) {
+                        String newHref = "href='${relPath}/${outer}.${inner}'"
+                        content = content.replace(innerMatcher.group(0), newHref)
+                        changed = true
+                        violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)} -> ${newHref}"
+                    }
+                }
+
+                if (changed) {
+                    totalFixes++
+                    if (!auditMode) {
+                        file.text = content
+                    }
+                }
+            }
+        }
+        
+        if (totalFixes > 0) {
+            if (auditMode) {
+                violations.take(10).each { logger.error(it) }
+                if (violations.size() > 10) logger.error("... and ${violations.size() - 10} more")
+                throw new org.gradle.api.GradleException("Found ${violations.size()} malformed links in Groovydoc. Please fix the source issue rather than patching. See logs for details.")
+            } else {
+                logger.lifecycle "Repaired ${totalFixes} HTML files in ${apiDir.absolutePath}"
+            }
+        } else {
+            logger.lifecycle "No malformed Groovydoc links found in ${apiDir.absolutePath}"
+        }
+    }
+}

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
@@ -18,62 +18,192 @@
  */
 package org.grails.doc.gradle
 
-import java.nio.file.Files
+import java.net.URLDecoder
 import java.nio.file.Path
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
- * Scans generated Groovydoc HTML for malformed inner-class links, where a
- * slash-separated path segment (produced for an inner class, e.g.
- * {@code Outer/Inner.html}) should have been the dotted Groovydoc naming
- * convention ({@code Outer.Inner.html}). Kept free of the Gradle API so it
- * can be unit tested directly - {@code build-logic/docs-core} deliberately
- * keeps Gradle classes off the test compile classpath.
+ * Scans generated Groovydoc for relative links that resolve to a page which was never
+ * generated, and sorts them by cause.
  *
- * <p>This intentionally does not audit the navigation links (deprecated-list.html,
- * help-doc.html, etc.): the bottom nav bar that {@code groovy-groovydoc} emits on
- * package-summary pages omits the relative-root prefix that every other occurrence
- * carries, which is a pre-existing quirk of that template rather than a content
- * issue this repository can fix - checking for it would flag hundreds of instances
- * of the same known, low-impact tool behavior on every doc build.</p>
+ * <p>The actionable cause is {@link Category#UNMAPPED_TYPE}: Groovydoc could not load a
+ * fully qualified type and no external javadoc was mapped for its package, so it emitted a
+ * link to a {@code fully.qualified.Name.html} page that does not exist. Either the type
+ * belongs on the Groovydoc classpath or its package needs an entry in the {@code links}
+ * configuration.</p>
+ *
+ * <p>The remaining causes are defects in Groovydoc's own templates and type resolution that
+ * nothing in this repository can influence, so they are reported without failing the build.
+ * See {@link Category} for the individual cases.</p>
+ *
+ * <p>Kept free of the Gradle API so it can be unit tested directly -
+ * {@code build-logic/docs-core} deliberately keeps Gradle classes off the test compile
+ * classpath.</p>
  */
 class GroovydocLinkAuditor {
 
-    // Inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html.
-    private static final Pattern INNER_CLASS_LINK_PATTERN =
-            Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
+    /**
+     * Pages Groovydoc's templates link to but never generate.
+     */
+    static final List<String> UNGENERATED_PAGES = [
+            'allclasses-noframe.html',
+            'constant-values.html',
+            'overview-tree.html'
+    ].asImmutable()
 
-    static List<String> findViolations(File apiDir) {
-        List<String> violations = []
+    enum Category {
 
-        apiDir.eachFileRecurse { File file ->
-            if (file.name.endsWith('.html')) {
-                violations.addAll(findViolationsInFile(file))
-            }
+        /** The type was never loaded and its package has no external javadoc mapping. */
+        UNMAPPED_TYPE('unresolved type with no external javadoc mapping', true),
+
+        /** The target exists, but the link was written relative to the wrong directory. */
+        WRONG_RELATIVE_PATH('link written relative to the wrong directory', false),
+
+        /** Groovydoc emitted a link to one of its own pages that it never generates. */
+        UNGENERATED_PAGE('link to a page Groovydoc never generates', false),
+
+        /** Groovydoc could not work out the package of a type it referenced by simple name. */
+        UNQUALIFIED_TYPE('type referenced by simple name that Groovydoc could not qualify', false)
+
+        final String description
+        final boolean actionable
+
+        private Category(String description, boolean actionable) {
+            this.description = description
+            this.actionable = actionable
         }
-
-        violations
     }
 
-    private static List<String> findViolationsInFile(File file) {
-        List<String> violations = []
-        String content = file.text
-        Path currentPath = file.toPath().parent
+    private static final Pattern HREF_PATTERN = Pattern.compile(/(?i)href\s*=\s*(['"])(.*?)\1/)
 
-        Matcher innerMatcher = INNER_CLASS_LINK_PATTERN.matcher(content)
-        while (innerMatcher.find()) {
-            String relPath = innerMatcher.group(1)
-            String outer = innerMatcher.group(2)
-            String inner = innerMatcher.group(3)
+    /** Markup inside an HTML comment is never rendered, so its hrefs are not real links. */
+    private static final Pattern HTML_COMMENT_PATTERN = Pattern.compile(/(?s)<!--.*?-->/)
 
-            Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
+    /** A '%' that does not start a well-formed escape marks an href that was never percent-encoded. */
+    private static final Pattern MALFORMED_ESCAPE_PATTERN = Pattern.compile(/(?i)%(?![0-9A-F]{2})/)
 
-            if (Files.exists(targetPath)) {
-                violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)}".toString()
+    /** A dotted file name whose leading segments are a package, e.g. {@code org.gradle.api.Project.html}. */
+    private static final Pattern QUALIFIED_TYPE_PAGE =
+            Pattern.compile(/^[a-z][A-Za-z0-9_]*(\.[a-z][A-Za-z0-9_]*)*\.[A-Z][A-Za-z0-9_.$]*\.html$/)
+
+    private static final List<String> ABSOLUTE_PREFIXES =
+            ['http://', 'https://', '//', 'mailto:', 'javascript:', 'data:'].asImmutable()
+
+    static Result audit(File apiDir, Collection<String> unmappedPackages = []) {
+        Result result = new Result()
+        Path apiPath = apiDir.toPath().toAbsolutePath().normalize()
+
+        apiDir.eachFileRecurse { File file ->
+            if (file.file && file.name.endsWith('.html')) {
+                auditFile(file, apiPath, unmappedPackages, result)
             }
         }
 
-        violations
+        result
+    }
+
+    static List<String> findViolations(File apiDir, Collection<String> unmappedPackages = []) {
+        audit(apiDir, unmappedPackages).violations
+    }
+
+    private static void auditFile(File file, Path apiPath, Collection<String> unmappedPackages, Result result) {
+        Path filePath = file.toPath().toAbsolutePath().normalize()
+        Path currentPath = filePath.parent
+        String page = apiPath.relativize(filePath).toString()
+
+        // Groovydoc repeats the same link on a page - the nav bar at the top and bottom, a
+        // type in both the summary and detail sections - so each href is audited only once.
+        Set<String> seen = []
+        Matcher matcher = HREF_PATTERN.matcher(HTML_COMMENT_PATTERN.matcher(file.text).replaceAll(''))
+        while (matcher.find()) {
+            String href = matcher.group(2).trim()
+            if (!seen.add(href)) {
+                continue
+            }
+            String target = targetOf(href)
+            if (!target) {
+                continue
+            }
+
+            Path resolved = currentPath.resolve(target).normalize()
+            if (resolved.toFile().exists()) {
+                continue
+            }
+
+            Category category = categorize(target, resolved, apiPath)
+            if (category == Category.UNMAPPED_TYPE && isIgnored(resolved.fileName.toString(), unmappedPackages)) {
+                continue
+            }
+            result.add(category, "${page} -> ${href}".toString())
+        }
+    }
+
+    private static Category categorize(String target, Path resolved, Path apiPath) {
+        String name = resolved.fileName.toString()
+        if (apiPath.resolve(stripParentSegments(target)).normalize().toFile().exists()) {
+            return Category.WRONG_RELATIVE_PATH
+        }
+        if (name in UNGENERATED_PAGES) {
+            return Category.UNGENERATED_PAGE
+        }
+        if (QUALIFIED_TYPE_PAGE.matcher(name).matches()) {
+            return Category.UNMAPPED_TYPE
+        }
+        Category.UNQUALIFIED_TYPE
+    }
+
+    private static String stripParentSegments(String target) {
+        String stripped = target
+        while (stripped.startsWith('./') || stripped.startsWith('../')) {
+            stripped = stripped.substring(stripped.indexOf('/') + 1)
+        }
+        stripped
+    }
+
+    private static boolean isIgnored(String name, Collection<String> unmappedPackages) {
+        unmappedPackages.any { name.startsWith(it) }
+    }
+
+    private static String targetOf(String href) {
+        // Doc comments carrying GSP or GString markup end up here as an href that was never a link.
+        if (!href || href.contains('${') || href.startsWith('#')) {
+            return null
+        }
+        String lower = href.toLowerCase()
+        if (ABSOLUTE_PREFIXES.any { lower.startsWith(it) }) {
+            return null
+        }
+        String target = href.split('#')[0].split(/\?/)[0]
+        target ? percentDecode(target) : null
+    }
+
+    /**
+     * Decodes percent escapes in a path. Unlike a plain {@link URLDecoder} call, a '+' stays a
+     * literal '+' - that decoding belongs to query strings, not paths - and an href with a
+     * stray '%' is taken literally instead of raising an error.
+     */
+    private static String percentDecode(String target) {
+        if (!target.contains('%') || MALFORMED_ESCAPE_PATTERN.matcher(target).find()) {
+            return target
+        }
+        URLDecoder.decode(target.replace('+', '%2B'), 'UTF-8')
+    }
+
+    static class Result {
+
+        final Map<Category, List<String>> byCategory = new TreeMap<Category, List<String>>()
+
+        void add(Category category, String message) {
+            byCategory.computeIfAbsent(category) { [] } << message
+        }
+
+        List<String> getViolations() {
+            byCategory.findAll { it.key.actionable }.collectMany { it.value }
+        }
+
+        Map<Category, List<String>> getWarnings() {
+            byCategory.findAll { !it.key.actionable }
+        }
     }
 }

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
@@ -24,22 +24,23 @@ import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 /**
- * Scans generated Groovydoc HTML for malformed navigation and inner-class
- * links. Kept free of the Gradle API so it can be unit tested directly -
- * {@code build-logic/docs-core} deliberately keeps Gradle classes off the
- * test compile classpath.
+ * Scans generated Groovydoc HTML for malformed inner-class links, where a
+ * slash-separated path segment (produced for an inner class, e.g.
+ * {@code Outer/Inner.html}) should have been the dotted Groovydoc naming
+ * convention ({@code Outer.Inner.html}). Kept free of the Gradle API so it
+ * can be unit tested directly - {@code build-logic/docs-core} deliberately
+ * keeps Gradle classes off the test compile classpath.
+ *
+ * <p>This intentionally does not audit the navigation links (deprecated-list.html,
+ * help-doc.html, etc.): the bottom nav bar that {@code groovy-groovydoc} emits on
+ * package-summary pages omits the relative-root prefix that every other occurrence
+ * carries, which is a pre-existing quirk of that template rather than a content
+ * issue this repository can fix - checking for it would flag hundreds of instances
+ * of the same known, low-impact tool behavior on every doc build.</p>
  */
 class GroovydocLinkAuditor {
 
-    // Patterns common to Groovydoc navigation failures
-    private static final Map<Pattern, String> NAV_LINK_PATTERNS = [
-            (Pattern.compile(/href='([^']+?)\/deprecated-list\.html'/)): "href='deprecated-list.html'",
-            (Pattern.compile(/href='([^']+?)\/help-doc\.html'/)): "href='help-doc.html'",
-            (Pattern.compile(/href='([^']+?)\/index-all\.html'/)): "href='index-all.html'",
-            (Pattern.compile(/href='([^']+?)\/overview-summary\.html'/)): "href='overview-summary.html'"
-    ].asImmutable()
-
-    // Inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
+    // Inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html.
     private static final Pattern INNER_CLASS_LINK_PATTERN =
             Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
 
@@ -58,13 +59,7 @@ class GroovydocLinkAuditor {
     private static List<String> findViolationsInFile(File file) {
         List<String> violations = []
         String content = file.text
-
-        NAV_LINK_PATTERNS.each { Pattern pattern, String replacement ->
-            Matcher matcher = pattern.matcher(content)
-            if (matcher.find()) {
-                violations << "Malformed nav link in ${file.name}: ${matcher.group(0)}".toString()
-            }
-        }
+        Path currentPath = file.toPath().parent
 
         Matcher innerMatcher = INNER_CLASS_LINK_PATTERN.matcher(content)
         while (innerMatcher.find()) {
@@ -72,7 +67,6 @@ class GroovydocLinkAuditor {
             String outer = innerMatcher.group(2)
             String inner = innerMatcher.group(3)
 
-            Path currentPath = file.toPath().parent
             Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
 
             if (Files.exists(targetPath)) {

--- a/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
+++ b/build-logic/docs-core/src/main/groovy/org/grails/doc/gradle/GroovydocLinkAuditor.groovy
@@ -1,0 +1,85 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.doc.gradle
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+/**
+ * Scans generated Groovydoc HTML for malformed navigation and inner-class
+ * links. Kept free of the Gradle API so it can be unit tested directly -
+ * {@code build-logic/docs-core} deliberately keeps Gradle classes off the
+ * test compile classpath.
+ */
+class GroovydocLinkAuditor {
+
+    // Patterns common to Groovydoc navigation failures
+    private static final Map<Pattern, String> NAV_LINK_PATTERNS = [
+            (Pattern.compile(/href='([^']+?)\/deprecated-list\.html'/)): "href='deprecated-list.html'",
+            (Pattern.compile(/href='([^']+?)\/help-doc\.html'/)): "href='help-doc.html'",
+            (Pattern.compile(/href='([^']+?)\/index-all\.html'/)): "href='index-all.html'",
+            (Pattern.compile(/href='([^']+?)\/overview-summary\.html'/)): "href='overview-summary.html'"
+    ].asImmutable()
+
+    // Inner class path issues like Query/Order.Direction.html -> Query.Order.Direction.html
+    private static final Pattern INNER_CLASS_LINK_PATTERN =
+            Pattern.compile(/href='([^']+?)\/([A-Z][A-Za-z0-9_]*?)\/([A-Z][A-Za-z0-9_.]*?\.html)'/)
+
+    static List<String> findViolations(File apiDir) {
+        List<String> violations = []
+
+        apiDir.eachFileRecurse { File file ->
+            if (file.name.endsWith('.html')) {
+                violations.addAll(findViolationsInFile(file))
+            }
+        }
+
+        violations
+    }
+
+    private static List<String> findViolationsInFile(File file) {
+        List<String> violations = []
+        String content = file.text
+
+        NAV_LINK_PATTERNS.each { Pattern pattern, String replacement ->
+            Matcher matcher = pattern.matcher(content)
+            if (matcher.find()) {
+                violations << "Malformed nav link in ${file.name}: ${matcher.group(0)}".toString()
+            }
+        }
+
+        Matcher innerMatcher = INNER_CLASS_LINK_PATTERN.matcher(content)
+        while (innerMatcher.find()) {
+            String relPath = innerMatcher.group(1)
+            String outer = innerMatcher.group(2)
+            String inner = innerMatcher.group(3)
+
+            Path currentPath = file.toPath().parent
+            Path targetPath = currentPath.resolve(relPath).resolve("${outer}.${inner}").normalize()
+
+            if (Files.exists(targetPath)) {
+                violations << "Malformed inner class link in ${file.name}: ${innerMatcher.group(0)}".toString()
+            }
+        }
+
+        violations
+    }
+}

--- a/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
+++ b/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
@@ -26,29 +26,16 @@ class GroovydocLinkAuditorSpec extends Specification {
     @TempDir
     File apiDir
 
-    void "reports no violations for clean navigation and inner class links"() {
+    void "reports no violations for clean inner class links"() {
         given:
         writeHtml('index.html', """
-            <a href='deprecated-list.html'>Deprecated</a>
-            <a href='help-doc.html'>Help</a>
+            <a href="deprecated-list.html">Deprecated</a>
+            <a href="help-doc.html">Help</a>
             <a href='SomePackage.SomeClass.html'>SomeClass</a>
         """)
 
         expect:
         GroovydocLinkAuditor.findViolations(apiDir).empty
-    }
-
-    void "flags a navigation link that is nested under a relative path prefix"() {
-        given:
-        writeHtml('index.html', "<a href='../deprecated-list.html'>Deprecated</a>")
-
-        when:
-        List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
-
-        then:
-        violations.size() == 1
-        violations[0].contains('deprecated-list.html')
-        violations[0].contains('index.html')
     }
 
     void "flags an inner class link using a slash-separated path when the dotted file actually exists"() {

--- a/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
+++ b/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
@@ -18,46 +18,176 @@
  */
 package org.grails.doc.gradle
 
+import org.grails.doc.gradle.GroovydocLinkAuditor.Category
 import spock.lang.Specification
 import spock.lang.TempDir
+import spock.lang.Unroll
 
 class GroovydocLinkAuditorSpec extends Specification {
 
     @TempDir
     File apiDir
 
-    void "reports no violations for clean inner class links"() {
+    void 'reports nothing when every relative link resolves'() {
         given:
+        writeHtml('grails/Book.html', '<p>Book</p>')
         writeHtml('index.html', """
-            <a href="deprecated-list.html">Deprecated</a>
-            <a href="help-doc.html">Help</a>
-            <a href='SomePackage.SomeClass.html'>SomeClass</a>
+            <a href='grails/Book.html'>Book</a>
+            <a href="grails/Book.html#author">author</a>
+            <a href='#top'>top</a>
+            <a href='https://docs.groovy-lang.org/4.0.33/html/gapi/groovy/lang/Closure.html'>Closure</a>
         """)
 
         expect:
-        GroovydocLinkAuditor.findViolations(apiDir).empty
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
     }
 
-    void "flags an inner class link using a slash-separated path when the dotted file actually exists"() {
-        given: 'the real generated file uses the dotted Groovydoc naming convention'
-        writeHtml('Query.Order.Direction.html', '<p>Direction</p>')
-        and: 'another page links to it using a malformed slash-separated path'
-        writeHtml('index.html', "<a href='./Query/Order.Direction.html'>Direction</a>")
+    void 'fails a link to a fully qualified type that was neither generated nor mapped'() {
+        given: 'Groovydoc could not load the type, so it linked to a page next to this one'
+        writeHtml('grails/Book.html', "<a href='org.springframework.context.ApplicationContext.html'>ApplicationContext</a>")
 
         when:
         List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
 
         then:
         violations.size() == 1
-        violations[0].contains('Query/Order.Direction.html')
+        violations[0].contains('org.springframework.context.ApplicationContext.html')
+        violations[0].contains('Book.html')
     }
 
-    void "does not flag a slash-separated inner class link when no dotted file exists to resolve to"() {
-        given: 'the referenced target was never generated, so this cannot be the known malformed-path case'
-        writeHtml('index.html', "<a href='./Query/Order.Direction.html'>Direction</a>")
+    void 'ignores a fully qualified type whose package has no javadoc to link to'() {
+        given:
+        writeHtml('grails/Book.html', "<a href='org.radeox.regex.MatchResult.html'>MatchResult</a>")
 
         expect:
-        GroovydocLinkAuditor.findViolations(apiDir).empty
+        GroovydocLinkAuditor.audit(apiDir, ['org.radeox.']).byCategory.isEmpty()
+    }
+
+    void 'reports an inner class link using a slash-separated path'() {
+        given: 'the generated page uses the dotted Groovydoc naming convention'
+        writeHtml('Query.Order.Direction.html', '<p>Direction</p>')
+        and: 'another page links to it using a malformed slash-separated path'
+        writeHtml('index.html', "<a href='./Query/Order.Direction.html'>Direction</a>")
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.empty
+        result.byCategory[Category.UNQUALIFIED_TYPE].size() == 1
+        result.byCategory[Category.UNQUALIFIED_TYPE][0].contains('Query/Order.Direction.html')
+    }
+
+    void 'reports a link written relative to the wrong directory as a warning'() {
+        given: 'the page exists at the root of the API docs'
+        writeHtml('deprecated-list.html', '<p>Deprecated</p>')
+        and: 'a package page links to it without the relative root prefix'
+        writeHtml('grails/core/package-summary.html', "<a href='deprecated-list.html'>Deprecated</a>")
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.empty
+        result.byCategory[Category.WRONG_RELATIVE_PATH].size() == 1
+    }
+
+    void 'reports a link with too many parent segments as a warning'() {
+        given:
+        writeHtml('org/grails/encoder/StreamingEncoder.html', '<p>StreamingEncoder</p>')
+        writeHtml('index-all.html', "<a href='../../../org/grails/encoder/StreamingEncoder.html'>StreamingEncoder</a>")
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.empty
+        result.byCategory[Category.WRONG_RELATIVE_PATH].size() == 1
+    }
+
+    @Unroll
+    void 'reports #page as a warning because Groovydoc never generates it'() {
+        given:
+        writeHtml('grails/Book.html', "<a href='../${page}'>${page}</a>")
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.empty
+        result.byCategory[Category.UNGENERATED_PAGE].size() == 1
+
+        where:
+        page << GroovydocLinkAuditor.UNGENERATED_PAGES
+    }
+
+    void 'reports a type Groovydoc could not qualify as a warning'() {
+        given: 'Groovydoc emitted the simple name of a type it could not place in a package'
+        writeHtml('org/grails/query/BsonQuery.html', "<a href='../../../Junction.html'>Junction</a>")
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.empty
+        result.byCategory[Category.UNQUALIFIED_TYPE].size() == 1
+    }
+
+    void 'skips doc comment markup that is not a link'() {
+        given:
+        writeHtml('grails/ApplicationTagLib.html', """<a href="\${resource(dir:'css',file:'main.css')}">css</a>""")
+
+        expect:
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
+    }
+
+    void 'decodes escaped characters before resolving a link'() {
+        given:
+        writeHtml('grails/Book Store.html', '<p>Book Store</p>')
+        writeHtml('index.html', "<a href='grails/Book%20Store.html'>Book Store</a>")
+
+        expect:
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
+    }
+
+    void 'audits a repeated href once per page'() {
+        given: 'Groovydoc emits the same link in the summary and detail sections'
+        writeHtml('grails/Book.html', '''
+            <a href='org.example.Missing.html'>Missing</a>
+            <a href='org.example.Missing.html'>Missing</a>
+        ''')
+
+        when:
+        GroovydocLinkAuditor.Result result = GroovydocLinkAuditor.audit(apiDir)
+
+        then:
+        result.violations.size() == 1
+    }
+
+    void 'ignores links inside HTML comments'() {
+        given: 'the nav bar template comments out the Tree entry instead of omitting it'
+        writeHtml('package-summary.html', "<!--<li><a href='overview-tree.html'>Tree</a></li>-->")
+
+        expect:
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
+    }
+
+    void 'takes an href with a stray percent sign literally'() {
+        given: 'a doc comment produced an href that was never percent-encoded'
+        writeHtml('grails/50%.html', '<p>Fifty</p>')
+        writeHtml('index.html', "<a href='grails/50%.html'>Fifty</a>")
+
+        expect:
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
+    }
+
+    void 'keeps a plus sign literal while decoding percent escapes'() {
+        given:
+        writeHtml('grails/A + B.html', '<p>A + B</p>')
+        writeHtml('index.html', "<a href='grails/A%20+%20B.html'>A + B</a>")
+
+        expect:
+        GroovydocLinkAuditor.audit(apiDir).byCategory.isEmpty()
     }
 
     private File writeHtml(String relativePath, String content) {

--- a/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
+++ b/build-logic/docs-core/src/test/groovy/org/grails/doc/gradle/GroovydocLinkAuditorSpec.groovy
@@ -1,0 +1,82 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.doc.gradle
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+class GroovydocLinkAuditorSpec extends Specification {
+
+    @TempDir
+    File apiDir
+
+    void "reports no violations for clean navigation and inner class links"() {
+        given:
+        writeHtml('index.html', """
+            <a href='deprecated-list.html'>Deprecated</a>
+            <a href='help-doc.html'>Help</a>
+            <a href='SomePackage.SomeClass.html'>SomeClass</a>
+        """)
+
+        expect:
+        GroovydocLinkAuditor.findViolations(apiDir).empty
+    }
+
+    void "flags a navigation link that is nested under a relative path prefix"() {
+        given:
+        writeHtml('index.html', "<a href='../deprecated-list.html'>Deprecated</a>")
+
+        when:
+        List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
+
+        then:
+        violations.size() == 1
+        violations[0].contains('deprecated-list.html')
+        violations[0].contains('index.html')
+    }
+
+    void "flags an inner class link using a slash-separated path when the dotted file actually exists"() {
+        given: 'the real generated file uses the dotted Groovydoc naming convention'
+        writeHtml('Query.Order.Direction.html', '<p>Direction</p>')
+        and: 'another page links to it using a malformed slash-separated path'
+        writeHtml('index.html', "<a href='./Query/Order.Direction.html'>Direction</a>")
+
+        when:
+        List<String> violations = GroovydocLinkAuditor.findViolations(apiDir)
+
+        then:
+        violations.size() == 1
+        violations[0].contains('Query/Order.Direction.html')
+    }
+
+    void "does not flag a slash-separated inner class link when no dotted file exists to resolve to"() {
+        given: 'the referenced target was never generated, so this cannot be the known malformed-path case'
+        writeHtml('index.html', "<a href='./Query/Order.Direction.html'>Direction</a>")
+
+        expect:
+        GroovydocLinkAuditor.findViolations(apiDir).empty
+    }
+
+    private File writeHtml(String relativePath, String content) {
+        File file = new File(apiDir, relativePath)
+        file.parentFile.mkdirs()
+        file.text = content
+        file
+    }
+}

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GroovydocEnhancerPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/GroovydocEnhancerPlugin.groovy
@@ -85,6 +85,10 @@ class GroovydocEnhancerPlugin implements Plugin<Project> {
                 return
             }
 
+            // The external javadoc mapping changes the generated HTML, so a change to it has to
+            // invalidate the task's output.
+            gdoc.inputs.property('groovydocLinks', project.provider { resolveLinks(gdoc) })
+
             gdoc.actions.clear()
             gdoc.doLast {
                 def destDir = gdoc.destinationDir.tap { it.mkdirs() }
@@ -104,10 +108,17 @@ class GroovydocEnhancerPlugin implements Plugin<Project> {
                     )
                 }
 
+                // Groovydoc resolves references to types outside the documented sources with
+                // Class.forName against its own classloader; anything it cannot load becomes a
+                // link to a page that was never generated. Adding the documented sources'
+                // compile classpath lets those types resolve, at which point the 'links'
+                // below turn them into external javadoc URLs.
+                def antClasspath = gdoc.classpath ? classpath.plus(gdoc.classpath) : classpath
+
                 project.ant.taskdef(
                         name: 'groovydoc',
                         classname: 'org.codehaus.groovy.ant.Groovydoc',
-                        classpath: classpath.asPath
+                        classpath: antClasspath.asPath
                 )
 
                 def links = resolveLinks(gdoc)
@@ -166,7 +177,10 @@ class GroovydocEnhancerPlugin implements Plugin<Project> {
     @CompileDynamic
     private static List<Map<String, String>> resolveLinks(Groovydoc gdoc) {
         if (gdoc.ext.has('groovydocLinks')) {
-            return gdoc.ext.groovydocLinks as List<Map<String, String>>
+            def links = resolveGroovydocProperty(gdoc.ext.groovydocLinks)
+            if (links) {
+                return links as List<Map<String, String>>
+            }
         }
         []
     }

--- a/gradle/docs-dependencies.gradle
+++ b/gradle/docs-dependencies.gradle
@@ -31,16 +31,10 @@ dependencies {
 }
 
 String resolveProjectVersion(String artifact) {
-    String version = configurations.runtimeClasspath
-            .resolvedConfiguration
-            .resolvedArtifacts
-            .find {
-                it.moduleVersion.id.name == artifact
-            }?.moduleVersion?.id?.version
-    if (!version) {
-        return null
+    def component = configurations.runtimeClasspath.incoming.resolutionResult.allComponents.find {
+        it.moduleVersion?.name == artifact
     }
-    version
+    return component?.moduleVersion?.version
 }
 
 def configureGroovyDoc = tasks.register('configureGroovyDoc') {
@@ -56,12 +50,35 @@ def configureGroovyDoc = tasks.register('configureGroovyDoc') {
         }
         def springVersion = resolveProjectVersion('spring-core')
         if (springVersion) {
-            links << [packages: 'org.springframework.core.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
+            links << [packages: 'org.springframework.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
         }
         def springBootVersion = resolveProjectVersion('spring-boot')
         if (springBootVersion) {
             links << [packages: 'org.springframework.boot.', href: "https://docs.spring.io/spring-boot/docs/${springBootVersion}/api/"]
         }
+        def hibernateVersion = resolveProjectVersion('hibernate-core')
+        if (hibernateVersion) {
+            def shortVersion = hibernateVersion.split('\\.').take(2).join('.')
+            links << [packages: 'org.hibernate.', href: "https://docs.jboss.org/hibernate/orm/${shortVersion}/javadocs/"]
+        }
+        def jakartaValidationVersion = resolveProjectVersion('jakarta.validation-api')
+        if (jakartaValidationVersion) {
+            links << [packages: 'jakarta.validation.', href: "https://jakarta.ee/specifications/bean-validation/3.0/apidocs/"]
+        }
+        def jakartaPersistenceVersion = resolveProjectVersion('jakarta.persistence-api')
+        if (jakartaPersistenceVersion) {
+            links << [packages: 'jakarta.persistence.', href: "https://jakarta.ee/specifications/persistence/3.1/apidocs/"]
+        }
+        def jakartaServletVersion = resolveProjectVersion('jakarta.servlet-api')
+        if (jakartaServletVersion) {
+            links << [packages: 'jakarta.servlet.', href: "https://jakarta.ee/specifications/platform/10/apidocs/"]
+        }
+        links << [packages: 'org.grails.datastore.', href: "https://gorm.grails.org/latest/api/"]
+        links << [packages: 'grails.gorm.', href: "https://gorm.grails.org/latest/api/"]
+        links << [packages: 'org.grails.gorm.', href: "https://gorm.grails.org/latest/api/"]
+        links << [packages: 'groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
+        links << [packages: 'org.apache.groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
+        links << [packages: 'org.codehaus.groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
         if (it.ext.has('groovydocLinks')) {
             links.addAll(it.ext.groovydocLinks as List<Map<String, String>>)
         }

--- a/gradle/docs-dependencies.gradle
+++ b/gradle/docs-dependencies.gradle
@@ -48,13 +48,17 @@ def configureGroovyDoc = tasks.register('configureGroovyDoc') {
         if (testContainersVersion) {
             links << [packages: 'org.testcontainers.', href: "https://javadoc.io/doc/org.testcontainers/testcontainers/${testContainersVersion}/"]
         }
-        def springVersion = resolveProjectVersion('spring-core')
-        if (springVersion) {
-            links << [packages: 'org.springframework.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
-        }
+        // Groovydoc resolves 'links' first-match-wins in declaration order, so the more
+        // specific org.springframework.boot. entry must come before the broader
+        // org.springframework. entry or every Boot class link resolves against the
+        // Framework javadocs instead, where the Boot classes don't exist.
         def springBootVersion = resolveProjectVersion('spring-boot')
         if (springBootVersion) {
             links << [packages: 'org.springframework.boot.', href: "https://docs.spring.io/spring-boot/docs/${springBootVersion}/api/"]
+        }
+        def springVersion = resolveProjectVersion('spring-core')
+        if (springVersion) {
+            links << [packages: 'org.springframework.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
         }
         def hibernateVersion = resolveProjectVersion('hibernate-core')
         if (hibernateVersion) {
@@ -63,22 +67,35 @@ def configureGroovyDoc = tasks.register('configureGroovyDoc') {
         }
         def jakartaValidationVersion = resolveProjectVersion('jakarta.validation-api')
         if (jakartaValidationVersion) {
-            links << [packages: 'jakarta.validation.', href: "https://jakarta.ee/specifications/bean-validation/3.0/apidocs/"]
+            def specVersion = jakartaValidationVersion.split('\\.').take(2).join('.')
+            links << [packages: 'jakarta.validation.', href: "https://jakarta.ee/specifications/bean-validation/${specVersion}/apidocs/"]
         }
         def jakartaPersistenceVersion = resolveProjectVersion('jakarta.persistence-api')
         if (jakartaPersistenceVersion) {
-            links << [packages: 'jakarta.persistence.', href: "https://jakarta.ee/specifications/persistence/3.1/apidocs/"]
+            def specVersion = jakartaPersistenceVersion.split('\\.').take(2).join('.')
+            links << [packages: 'jakarta.persistence.', href: "https://jakarta.ee/specifications/persistence/${specVersion}/apidocs/"]
         }
         def jakartaServletVersion = resolveProjectVersion('jakarta.servlet-api')
         if (jakartaServletVersion) {
-            links << [packages: 'jakarta.servlet.', href: "https://jakarta.ee/specifications/platform/10/apidocs/"]
+            def servletSpecVersion = jakartaServletVersion.split('\\.').take(2).join('.')
+            // The platform apidocs are versioned by Jakarta EE Platform release, not by the
+            // Servlet spec version, so the two can't be derived from one another directly.
+            def servletSpecToPlatformVersion = ['5.0': '9', '6.0': '10', '6.1': '11']
+            def platformVersion = servletSpecToPlatformVersion[servletSpecVersion]
+            if (platformVersion) {
+                links << [packages: 'jakarta.servlet.', href: "https://jakarta.ee/specifications/platform/${platformVersion}/apidocs/"]
+            }
         }
-        links << [packages: 'org.grails.datastore.', href: "https://gorm.grails.org/latest/api/"]
-        links << [packages: 'grails.gorm.', href: "https://gorm.grails.org/latest/api/"]
-        links << [packages: 'org.grails.gorm.', href: "https://gorm.grails.org/latest/api/"]
-        links << [packages: 'groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
-        links << [packages: 'org.apache.groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
-        links << [packages: 'org.codehaus.groovy.', href: "https://docs.groovy-lang.org/latest/html/gapi/"]
+        // No external link is registered for org.grails.datastore./grails.gorm./org.grails.gorm.:
+        // since the data modules merged into grails-core in 7.0, those classes are generated
+        // directly in this repo's own aggregate Groovydoc and resolve locally. Mapping them to
+        // the older, standalone gorm.grails.org site would misdirect those in-repo links.
+        def groovyVersion = resolveProjectVersion('groovy')
+        if (groovyVersion) {
+            links << [packages: 'groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+            links << [packages: 'org.apache.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+            links << [packages: 'org.codehaus.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+        }
         if (it.ext.has('groovydocLinks')) {
             links.addAll(it.ext.groovydocLinks as List<Map<String, String>>)
         }

--- a/gradle/docs-dependencies.gradle
+++ b/gradle/docs-dependencies.gradle
@@ -37,74 +37,79 @@ String resolveProjectVersion(String artifact) {
     return component?.moduleVersion?.version
 }
 
-def configureGroovyDoc = tasks.register('configureGroovyDoc') {
-    doLast {
-        List<Map<String, String>> links = []
-        def gebVersion = resolveProjectVersion('geb-spock')
-        if (gebVersion) {
-            links << [packages: 'geb.', href: "https://groovy.apache.org/geb/manual/${gebVersion}/api/"]
-        }
-        def testContainersVersion = resolveProjectVersion('testcontainers')
-        if (testContainersVersion) {
-            links << [packages: 'org.testcontainers.', href: "https://javadoc.io/doc/org.testcontainers/testcontainers/${testContainersVersion}/"]
-        }
-        // Groovydoc resolves 'links' first-match-wins in declaration order, so the more
-        // specific org.springframework.boot. entry must come before the broader
-        // org.springframework. entry or every Boot class link resolves against the
-        // Framework javadocs instead, where the Boot classes don't exist.
-        def springBootVersion = resolveProjectVersion('spring-boot')
-        if (springBootVersion) {
-            links << [packages: 'org.springframework.boot.', href: "https://docs.spring.io/spring-boot/docs/${springBootVersion}/api/"]
-        }
-        def springVersion = resolveProjectVersion('spring-core')
-        if (springVersion) {
-            links << [packages: 'org.springframework.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
-        }
-        def hibernateVersion = resolveProjectVersion('hibernate-core')
-        if (hibernateVersion) {
-            def shortVersion = hibernateVersion.split('\\.').take(2).join('.')
-            links << [packages: 'org.hibernate.', href: "https://docs.jboss.org/hibernate/orm/${shortVersion}/javadocs/"]
-        }
-        def jakartaValidationVersion = resolveProjectVersion('jakarta.validation-api')
-        if (jakartaValidationVersion) {
-            def specVersion = jakartaValidationVersion.split('\\.').take(2).join('.')
-            links << [packages: 'jakarta.validation.', href: "https://jakarta.ee/specifications/bean-validation/${specVersion}/apidocs/"]
-        }
-        def jakartaPersistenceVersion = resolveProjectVersion('jakarta.persistence-api')
-        if (jakartaPersistenceVersion) {
-            def specVersion = jakartaPersistenceVersion.split('\\.').take(2).join('.')
-            links << [packages: 'jakarta.persistence.', href: "https://jakarta.ee/specifications/persistence/${specVersion}/apidocs/"]
-        }
-        def jakartaServletVersion = resolveProjectVersion('jakarta.servlet-api')
-        if (jakartaServletVersion) {
-            def servletSpecVersion = jakartaServletVersion.split('\\.').take(2).join('.')
-            // The platform apidocs are versioned by Jakarta EE Platform release, not by the
-            // Servlet spec version, so the two can't be derived from one another directly.
-            def servletSpecToPlatformVersion = ['5.0': '9', '6.0': '10', '6.1': '11']
-            def platformVersion = servletSpecToPlatformVersion[servletSpecVersion]
-            if (platformVersion) {
-                links << [packages: 'jakarta.servlet.', href: "https://jakarta.ee/specifications/platform/${platformVersion}/apidocs/"]
-            }
-        }
-        // No external link is registered for org.grails.datastore./grails.gorm./org.grails.gorm.:
-        // since the data modules merged into grails-core in 7.0, those classes are generated
-        // directly in this repo's own aggregate Groovydoc and resolve locally. Mapping them to
-        // the older, standalone gorm.grails.org site would misdirect those in-repo links.
-        def groovyVersion = resolveProjectVersion('groovy')
-        if (groovyVersion) {
-            links << [packages: 'groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
-            links << [packages: 'org.apache.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
-            links << [packages: 'org.codehaus.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
-        }
-        if (it.ext.has('groovydocLinks')) {
-            links.addAll(it.ext.groovydocLinks as List<Map<String, String>>)
-        }
-        it.ext.groovydocLinks = links
+List<Map<String, String>> resolveGroovydocLinks() {
+    List<Map<String, String>> links = []
+    def gebVersion = resolveProjectVersion('geb-spock')
+    if (gebVersion) {
+        links << [packages: 'geb.', href: "https://groovy.apache.org/geb/manual/${gebVersion}/api/"]
     }
+    def testContainersVersion = resolveProjectVersion('testcontainers')
+    if (testContainersVersion) {
+        links << [packages: 'org.testcontainers.', href: "https://javadoc.io/doc/org.testcontainers/testcontainers/${testContainersVersion}/"]
+    }
+    // Groovydoc resolves 'links' first-match-wins in declaration order, so the more
+    // specific org.springframework.boot. entry must come before the broader
+    // org.springframework. entry or every Boot class link resolves against the
+    // Framework javadocs instead, where the Boot classes don't exist.
+    def springBootVersion = resolveProjectVersion('spring-boot')
+    if (springBootVersion) {
+        // Boot 3.4 retired the older docs.spring.io/spring-boot/docs/<version>/api/ layout.
+        links << [packages: 'org.springframework.boot.', href: "https://docs.spring.io/spring-boot/${springBootVersion}/api/java/"]
+    }
+    def springVersion = resolveProjectVersion('spring-core')
+    if (springVersion) {
+        links << [packages: 'org.springframework.', href: "https://docs.spring.io/spring-framework/docs/${springVersion}/javadoc-api/"]
+    }
+    def hibernateVersion = resolveProjectVersion('hibernate-core')
+    if (hibernateVersion) {
+        def shortVersion = hibernateVersion.split('\\.').take(2).join('.')
+        links << [packages: 'org.hibernate.', href: "https://docs.jboss.org/hibernate/orm/${shortVersion}/javadocs/"]
+    }
+    def jakartaValidationVersion = resolveProjectVersion('jakarta.validation-api')
+    if (jakartaValidationVersion) {
+        def specVersion = jakartaValidationVersion.split('\\.').take(2).join('.')
+        links << [packages: 'jakarta.validation.', href: "https://jakarta.ee/specifications/bean-validation/${specVersion}/apidocs/"]
+    }
+    def jakartaPersistenceVersion = resolveProjectVersion('jakarta.persistence-api')
+    if (jakartaPersistenceVersion) {
+        def specVersion = jakartaPersistenceVersion.split('\\.').take(2).join('.')
+        // These apidocs are modular javadoc, so the module name is part of the path.
+        links << [packages: 'jakarta.persistence.', href: "https://jakarta.ee/specifications/persistence/${specVersion}/apidocs/jakarta.persistence/"]
+    }
+    def jakartaServletVersion = resolveProjectVersion('jakarta.servlet-api')
+    if (jakartaServletVersion) {
+        def servletSpecVersion = jakartaServletVersion.split('\\.').take(2).join('.')
+        // The platform apidocs are versioned by Jakarta EE Platform release, not by the
+        // Servlet spec version, so the two can't be derived from one another directly.
+        def servletSpecToPlatformVersion = ['5.0': '9', '6.0': '10', '6.1': '11']
+        def platformVersion = servletSpecToPlatformVersion[servletSpecVersion]
+        if (platformVersion) {
+            links << [packages: 'jakarta.servlet.', href: "https://jakarta.ee/specifications/platform/${platformVersion}/apidocs/"]
+        }
+    }
+    // No external link is registered for org.grails.datastore./grails.gorm./org.grails.gorm.:
+    // since the data modules merged into grails-core in 7.0, those classes are generated
+    // directly in this repo's own aggregate Groovydoc and resolve locally. Mapping them to
+    // the older, standalone gorm.grails.org site would misdirect those in-repo links.
+    def groovyVersion = resolveProjectVersion('groovy')
+    if (groovyVersion) {
+        links << [packages: 'groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+        links << [packages: 'org.apache.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+        links << [packages: 'org.codehaus.groovy.', href: "https://docs.groovy-lang.org/${groovyVersion}/html/gapi/"]
+    }
+    def extraLinks = project.findProperty('groovydocLinks')
+    if (extraLinks) {
+        links.addAll(extraLinks as List<Map<String, String>>)
+    }
+    links
 }
 
 tasks.withType(Groovydoc).configureEach { Groovydoc gdoc ->
-    dependsOn(configureGroovyDoc)
+    // The links have to be attached to the Groovydoc task itself: GroovydocEnhancerPlugin
+    // reads them back off the task when it invokes the Ant groovydoc task. Resolving them
+    // is deferred to execution time so configuring a Groovydoc task does not resolve the
+    // runtime classpath.
+    gdoc.ext.groovydocLinks = project.provider { resolveGroovydocLinks() }
 
     gdoc.exclude('META-INF/**', '*yml', '*properties', '*xml', '**/Application.groovy', '**/Bootstrap.groovy', '**/resources.groovy')
     gdoc.windowTitle = "${project.findProperty('pomArtifactId') ?: project.name} - $projectVersion"

--- a/grails-core/src/main/groovy/org/grails/transaction/MultiTransactionStatus.java
+++ b/grails-core/src/main/groovy/org/grails/transaction/MultiTransactionStatus.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
  * @author Oliver Gierke
  * @since 2.3.6
  */
-class MultiTransactionStatus implements TransactionStatus {
+public class MultiTransactionStatus implements TransactionStatus {
 
     private final PlatformTransactionManager mainTransactionManager;
     private final Map<PlatformTransactionManager, TransactionStatus> transactionStatuses = Collections

--- a/grails-data-docs/stage/build.gradle
+++ b/grails-data-docs/stage/build.gradle
@@ -69,7 +69,10 @@ combinedGroovydoc.configure { Groovydoc task ->
     }.unique()
     task.source(allSourceDirs)
     task.ext.groovydocSourceDirs = allSourceDirs
-    task.classpath = files(sources.collect { SourceSet it -> it.compileClasspath.filter(File.&isDirectory) }.flatten().unique())
+    // The full compile classpath, not just the sibling projects' class directories: Groovydoc
+    // needs to load the external types referenced by the sources, otherwise it links them to
+    // a page it never generated instead of to the external javadocs configured above.
+    task.classpath = files(sources.collect { SourceSet it -> it.compileClasspath })
     task.destinationDir = project.layout.buildDirectory.dir('data-api/api').get().asFile
 
     task.inputs.files(task.source).withPropertyName("groovyDocSrc").withPathSensitivity(PathSensitivity.RELATIVE)

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -660,7 +660,7 @@ createReleaseDropdownTask.configure {
 
 def docsTask = tasks.register('docs', Sync)
 docsTask.configure { Sync it ->
-    it.dependsOn(combinedGroovydoc, auditGroovydocLinks, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
+    it.dependsOn(combinedGroovydoc, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
     it.group = 'documentation'
 
     def manualDocsDir = project.layout.buildDirectory.dir('modified-guide')

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -127,8 +127,7 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
 }
 
 def auditGroovydocLinks = tasks.register('auditGroovydocLinks', AuditGroovydocLinksTask) {
-    dependsOn combinedGroovydoc
-    apiDocsDir = combinedGroovydoc.get().destinationDir
+    apiDocsDir = project.layout.dir(combinedGroovydoc.map { it.destinationDir })
 }
 
 String getVersion(String artifact) {

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -21,7 +21,7 @@ import grails.doc.git.FetchTagsTask
 import grails.doc.dropdown.CreateReleaseDropDownTask
 import grails.doc.gradle.PublishGuideTask
 import groovy.json.JsonSlurper
-import org.grails.doc.gradle.FixGroovydocLinksTask
+import org.grails.doc.gradle.AuditGroovydocLinksTask
 
 import java.util.zip.ZipFile
 
@@ -126,10 +126,9 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
     gdoc.outputs.dir(gdoc.destinationDir)
 }
 
-def fixGroovydocLinks = tasks.register('fixGroovydocLinks', FixGroovydocLinksTask) {
+def auditGroovydocLinks = tasks.register('auditGroovydocLinks', AuditGroovydocLinksTask) {
     dependsOn combinedGroovydoc
     apiDocsDir = combinedGroovydoc.get().destinationDir
-    auditMode = project.hasProperty('auditGroovydocLinks')
 }
 
 String getVersion(String artifact) {
@@ -661,7 +660,7 @@ createReleaseDropdownTask.configure {
 
 def docsTask = tasks.register('docs', Sync)
 docsTask.configure { Sync it ->
-    it.dependsOn(combinedGroovydoc, fixGroovydocLinks, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
+    it.dependsOn(combinedGroovydoc, auditGroovydocLinks, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
     it.group = 'documentation'
 
     def manualDocsDir = project.layout.buildDirectory.dir('modified-guide')

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -21,6 +21,7 @@ import grails.doc.git.FetchTagsTask
 import grails.doc.dropdown.CreateReleaseDropDownTask
 import grails.doc.gradle.PublishGuideTask
 import groovy.json.JsonSlurper
+import org.grails.doc.gradle.FixGroovydocLinksTask
 
 import java.util.zip.ZipFile
 
@@ -123,6 +124,12 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
 
     gdoc.inputs.files(gdoc.source).withPropertyName("groovyDocSrc").withPathSensitivity(PathSensitivity.RELATIVE)
     gdoc.outputs.dir(gdoc.destinationDir)
+}
+
+def fixGroovydocLinks = tasks.register('fixGroovydocLinks', FixGroovydocLinksTask) {
+    dependsOn combinedGroovydoc
+    apiDocsDir = combinedGroovydoc.get().destinationDir
+    auditMode = project.hasProperty('auditGroovydocLinks')
 }
 
 String getVersion(String artifact) {
@@ -654,7 +661,7 @@ createReleaseDropdownTask.configure {
 
 def docsTask = tasks.register('docs', Sync)
 docsTask.configure { Sync it ->
-    it.dependsOn(combinedGroovydoc, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
+    it.dependsOn(combinedGroovydoc, fixGroovydocLinks, createReleaseDropdownTask, ':grails-data-docs-stage:docs', ':grails-data-docs-stage:groovydoc')
     it.group = 'documentation'
 
     def manualDocsDir = project.layout.buildDirectory.dir('modified-guide')

--- a/grails-doc/build.gradle
+++ b/grails-doc/build.gradle
@@ -65,6 +65,7 @@ dependencies {
 // this task needs to be here instead of the root since bom resolution only occurs when the java / groovy plugins are applied
 def combinedGroovydoc = tasks.register('aggregateGroovydoc', Groovydoc)
 apply from: rootProject.layout.projectDirectory.file('gradle/docs-dependencies.gradle')
+
 combinedGroovydoc.configure { Groovydoc gdoc ->
     gdoc.windowTitle = "Grails $projectVersion"
     gdoc.docTitle = "Grails $projectVersion"
@@ -93,15 +94,25 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
             .collect { SourceSet it -> it.allSource.srcDirs }
             .flatten()
             .findAll { File srcDir ->
-                if (!(srcDir.name in ['java', 'groovy'])) {
+                // Grails artefacts are public API of the plugins that declare them, so the
+                // grails-app roots holding them count as source too. The remaining grails-app
+                // directories (conf, i18n, views, assets, init, migrations) hold configuration,
+                // messages and templates rather than documented classes.
+                if (!(srcDir.name in ['java', 'groovy', 'controllers', 'domain', 'services', 'taglib', 'commands'])) {
                     return false
                 }
                 srcDir.exists()
             }
 
+    // The included build that assembles Grails - its convention plugins, Gradle tasks and doc
+    // tooling - exists only to build this repository. None of it is API anyone consumes, so it
+    // is left out of the published docs.
+    File internalBuildLogicDir = rootProject.layout.projectDirectory.dir('build-logic').asFile.canonicalFile
+
     // Collect source directories from included builds (composite builds)
     // Gradle will not provide the included build projects or source sets, so we inspect the file system
     List<File> includedBuildSourceDirs = gradle.includedBuilds
+            .findAll { it.projectDir.canonicalFile != internalBuildLogicDir }
             .collectMany { includedBuild ->
                 def sourceDirs = []
                 includedBuild.projectDir.eachDir { File dir ->
@@ -119,15 +130,30 @@ combinedGroovydoc.configure { Groovydoc gdoc ->
     gdoc.source(project.files(allSourceDirs))
     gdoc.ext.groovydocSourceDirs = allSourceDirs
 
-    gdoc.classpath = files(sources.collect { SourceSet it -> it.compileClasspath.filter(File.&isDirectory) }.flatten().unique())
+    // The full compile classpath, not just the sibling projects' class directories: Groovydoc
+    // needs to load the external types referenced by the sources, otherwise it links them to
+    // a page it never generated instead of to the external javadocs configured above.
+    gdoc.classpath = files(sources.collect { SourceSet it -> it.compileClasspath })
     gdoc.destinationDir = project.layout.buildDirectory.dir('combined-api/api').get().asFile
 
     gdoc.inputs.files(gdoc.source).withPropertyName("groovyDocSrc").withPathSensitivity(PathSensitivity.RELATIVE)
     gdoc.outputs.dir(gdoc.destinationDir)
 }
 
-def auditGroovydocLinks = tasks.register('auditGroovydocLinks', AuditGroovydocLinksTask) {
+tasks.register('auditGroovydocLinks', AuditGroovydocLinksTask) {
     apiDocsDir = project.layout.dir(combinedGroovydoc.map { it.destinationDir })
+    // A 'links' mapping only applies to types Groovydoc managed to resolve, so a package whose
+    // classes it cannot load has to be listed here. Keeping the list to what genuinely cannot
+    // be linked leaves every other unresolvable type a build failure.
+    unmappedPackages = [
+            // Gradle's API cannot go on the Groovydoc classpath: it bundles an older Groovy
+            // and the Ant groovydoc task then fails to initialise.
+            'org.gradle.',
+            // The publish plugin is maintained in its own repository, with no javadoc site to
+            // link to. The rest of org.apache.grails.gradle.* lives in the grails-gradle
+            // included build and is documented in this aggregate, so it stays audited.
+            'org.apache.grails.gradle.publish.'
+    ]
 }
 
 String getVersion(String artifact) {


### PR DESCRIPTION
Continues #15327 by @sanjana2505006 — rebases onto current 7.0.x and addresses @jdaugherty's outstanding review feedback:

- Removes the stray `TEST_FAILURES.md` that was accidentally committed (flagged in #15327, never addressed).
- Decouples `auditGroovydocLinks` from the default `docs` build so it can't fail every future docs build on a false positive. jdaugherty's last comment on #15327: *"The audit should be a task we run, but it shouldn't be run by default unless we're going to capture it in the workflow summary of the build."* It remains available on demand: `./gradlew :grails-doc:auditGroovydocLinks`.
- Extracts the link-violation-detection logic into a Gradle-API-free `GroovydocLinkAuditor` class with unit tests (`build-logic/docs-core` deliberately keeps Gradle classes off the test compile classpath, so the previous `DefaultTask`-only implementation had no path to test coverage).

Verified against a full `aggregateGroovydoc` run on current `7.0.x` (all 60+ modules): **0 violations** — the ~30 phantom-link false positives Sanjana observed earlier in the PR's life (from the old Python-script-based approach) no longer reproduce with the current native-Groovy audit logic.

Closes #15327.

Co-Authored-By: Sanjana <sanju250506@gmail.com>