### PR TITLE
Declare processResources ReplaceTokens values as task inputs

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -1183,6 +1183,12 @@ ${importStatements}
                     'info.app.grailsVersion': grailsVersion
             ]
 
+            // Filter parameters are not part of Gradle's up-to-date checks (gradle/gradle#1191),
+            // so the token values must be declared as inputs — otherwise bumping grailsVersion or
+            // the app version leaves processResources UP-TO-DATE and stale substituted values
+            // (e.g. info.app.grailsVersion in application.yml) are repackaged into every build.
+            task.inputs.properties(replaceTokens)
+
             task.from(project.relativePath('src/main/templates')) { spec ->
                 spec.into('META-INF/templates')
             }


### PR DESCRIPTION
### Problem

`GrailsGradlePlugin` wires the `@info.app.name@` / `@info.app.version@` / `@info.app.grailsVersion@` substitution into `processResources` via an Ant `ReplaceTokens` content filter. Gradle does not consider filter parameters in Copy-task up-to-date checks (gradle/gradle#1191), and the token values are not declared as task inputs — so after a version change `processResources` still reports `UP-TO-DATE` and the previously substituted values are repackaged into every subsequent build until a `clean`.

Observed in practice: after upgrading an app from `8.0.0-M2` to `8.0.0-M3`, `<g:meta name="info.app.grailsVersion"/>` kept reporting `8.0.0-M2` in production. The classpath was fully M3, but `BOOT-INF/classes/application.yml` still carried the value substituted weeks earlier.

### Reproduce

1. Build any generated app (`./gradlew processResources`) — `build/resources/main/application.yml` contains the substituted `info.app.grailsVersion`.
2. Change `grailsVersion` in `gradle.properties`.
3. Run `./gradlew processResources` (or `bootJar`) again — the task is `UP-TO-DATE` and the file still contains the old version.

### Fix

Declare the token map as input properties on the task:

```groovy
task.inputs.properties(replaceTokens)
```

This is the same approach the plugin already uses for `grails.build.info` (`task.inputs.properties(buildPropertiesContents)`), which is why that file does pick up version bumps while the `application.yml` substitutions do not.
