### PR TITLE
Fix afterEvaluate race between applyGrailsBom and GrailsCliGradlePlugin

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -18,6 +18,7 @@
  */
 package org.grails.gradle.plugin.core
 
+import java.util.function.Function
 import java.util.zip.ZipFile
 
 import grails.util.BuildSettings
@@ -59,6 +60,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.process.JavaForkOptions
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
+import org.grails.gradle.plugin.bom.BomPropertyOverridesExtension
 import org.grails.gradle.plugin.bom.BomPropertyOverridesPlugin
 import org.grails.gradle.plugin.commands.GrailsCliGradlePlugin
 import org.grails.gradle.plugin.exploded.ExplodedCompatibilityRule
@@ -418,6 +420,25 @@ ${importStatements}
         // same configuration phase can rely on the configuration existing.
         project.configurations.maybeCreate('developmentOnly')
 
+        // Register the bom-property-overrides extension eagerly (not via
+        // project.plugins.apply(BomPropertyOverridesPlugin) inside the afterEvaluate below) so it's
+        // configurable from the user's build.gradle. Applying the plugin class itself there would
+        // register a SECOND, nested project.afterEvaluate{} for the override-application logic -
+        // and because Gradle appends a newly-registered afterEvaluate listener to the END of the
+        // notification queue that's currently being processed, that nested registration jumps
+        // behind every afterEvaluate callback other plugins registered synchronously during
+        // apply() - including GrailsCliGradlePlugin's CLI companion probe (configureApplicationCommands),
+        // which eagerly resolves the api/implementation/runtimeOnly buckets via grailsCliDetect and
+        // locks them against further mutation. That race is what made BomManagedVersions.applyTo()
+        // throw "Cannot mutate the dependencies of configuration ... after ... was resolved" in
+        // multi-project builds. Calling BomPropertyOverridesPlugin.applyOverrides() directly, in the
+        // SAME already-correctly-ordered afterEvaluate below, avoids the extra deferral hop entirely.
+        def bomPropertyOverrides = project.extensions.create(
+                BomPropertyOverridesExtension.EXTENSION_NAME,
+                BomPropertyOverridesExtension,
+                project.objects
+        )
+
         // The BOM selection `grails { bom = ... }` is set in the user's build.gradle,
         // which runs AFTER plugin apply. We therefore wait until afterEvaluate to read
         // it and apply the BOM accordingly. By that point all declarable configurations
@@ -485,12 +506,20 @@ ${importStatements}
                 }
             }
 
-            // Delegate property-based version overrides to the bundled plugin.
+            // Delegate property-based version overrides to the bundled plugin's core logic.
             // Auto-detect picks up the platform()/enforcedPlatform() declaration (whether we
             // injected it above or the build declared it by hand), plus any additional
             // platform()/enforcedPlatform() the user declares. Users can extend the override
             // surface by declaring their own platforms - no extra configuration is required here.
-            project.plugins.apply(BomPropertyOverridesPlugin)
+            // Called directly (not via project.plugins.apply()) so it runs synchronously in this
+            // callback, right after the platform is injected above - see the comment where
+            // bomPropertyOverrides is created for why a second afterEvaluate hop is unsafe here.
+            BomPropertyOverridesPlugin.applyOverrides(
+                    project.configurations,
+                    project.dependencies,
+                    { String name -> project.hasProperty(name) ? project.property(name)?.toString() : null } as Function<String, String>,
+                    bomPropertyOverrides
+            )
         }
     }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -18,7 +18,6 @@
  */
 package org.grails.gradle.plugin.core
 
-import java.util.function.Function
 import java.util.zip.ZipFile
 
 import grails.util.BuildSettings
@@ -60,7 +59,6 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.process.JavaForkOptions
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
-import org.grails.gradle.plugin.bom.BomPropertyOverridesExtension
 import org.grails.gradle.plugin.bom.BomPropertyOverridesPlugin
 import org.grails.gradle.plugin.commands.GrailsCliGradlePlugin
 import org.grails.gradle.plugin.exploded.ExplodedCompatibilityRule
@@ -420,25 +418,6 @@ ${importStatements}
         // same configuration phase can rely on the configuration existing.
         project.configurations.maybeCreate('developmentOnly')
 
-        // Register the bom-property-overrides extension eagerly (not via
-        // project.plugins.apply(BomPropertyOverridesPlugin) inside the afterEvaluate below) so it's
-        // configurable from the user's build.gradle. Applying the plugin class itself there would
-        // register a SECOND, nested project.afterEvaluate{} for the override-application logic -
-        // and because Gradle appends a newly-registered afterEvaluate listener to the END of the
-        // notification queue that's currently being processed, that nested registration jumps
-        // behind every afterEvaluate callback other plugins registered synchronously during
-        // apply() - including GrailsCliGradlePlugin's CLI companion probe (configureApplicationCommands),
-        // which eagerly resolves the api/implementation/runtimeOnly buckets via grailsCliDetect and
-        // locks them against further mutation. That race is what made BomManagedVersions.applyTo()
-        // throw "Cannot mutate the dependencies of configuration ... after ... was resolved" in
-        // multi-project builds. Calling BomPropertyOverridesPlugin.applyOverrides() directly, in the
-        // SAME already-correctly-ordered afterEvaluate below, avoids the extra deferral hop entirely.
-        def bomPropertyOverrides = project.extensions.create(
-                BomPropertyOverridesExtension.EXTENSION_NAME,
-                BomPropertyOverridesExtension,
-                project.objects
-        )
-
         // The BOM selection `grails { bom = ... }` is set in the user's build.gradle,
         // which runs AFTER plugin apply. We therefore wait until afterEvaluate to read
         // it and apply the BOM accordingly. By that point all declarable configurations
@@ -505,22 +484,42 @@ ${importStatements}
                     project.dependencies.add(it.name, platformDependency)
                 }
             }
-
-            // Delegate property-based version overrides to the bundled plugin's core logic.
-            // Auto-detect picks up the platform()/enforcedPlatform() declaration (whether we
-            // injected it above or the build declared it by hand), plus any additional
-            // platform()/enforcedPlatform() the user declares. Users can extend the override
-            // surface by declaring their own platforms - no extra configuration is required here.
-            // Called directly (not via project.plugins.apply()) so it runs synchronously in this
-            // callback, right after the platform is injected above - see the comment where
-            // bomPropertyOverrides is created for why a second afterEvaluate hop is unsafe here.
-            BomPropertyOverridesPlugin.applyOverrides(
-                    project.configurations,
-                    project.dependencies,
-                    { String name -> project.hasProperty(name) ? project.property(name)?.toString() : null } as Function<String, String>,
-                    bomPropertyOverrides
-            )
         }
+
+        // Delegate property-based version overrides to the bundled plugin. Auto-detect picks up
+        // the platform()/enforcedPlatform() declaration (whether injected above or declared by
+        // hand), plus any additional platform()/enforcedPlatform() the user declares. Users can
+        // extend the override surface by declaring their own platforms - no extra configuration
+        // is required here.
+        //
+        // Applied unconditionally, as its own top-level statement here - NOT nested inside the
+        // afterEvaluate{} above, and NOT gated on grails.bom being set. Two things depend on that:
+        //
+        // 1. Ordering: BomPropertyOverridesPlugin.apply() registers its own project.afterEvaluate{}
+        //    for the actual override-application logic. Gradle appends a newly-registered
+        //    afterEvaluate listener to the END of the notification queue it's currently
+        //    processing - so calling project.plugins.apply(BomPropertyOverridesPlugin) from INSIDE
+        //    the afterEvaluate{} above (as this method used to) pushes that registration behind
+        //    every afterEvaluate callback other plugins registered synchronously during apply() -
+        //    including GrailsCliGradlePlugin's CLI companion probe (configureApplicationCommands),
+        //    which eagerly resolves the api/implementation/runtimeOnly buckets via grailsCliDetect
+        //    and locks them against further mutation. In a multi-project build, resolving one
+        //    project's probe can force a dependency project to finish configuring mid-resolution,
+        //    landing squarely in that window - causing BomManagedVersions.applyTo() to throw
+        //    "Cannot mutate the dependencies of configuration ... after ... was resolved". Applying
+        //    the plugin here, synchronously and before GrailsCliGradlePlugin is applied further
+        //    down in this method, keeps both registrations in the same, race-free, apply()-time
+        //    queue position. project.plugins.apply() is also idempotent, so this stays safe even
+        //    if the build separately applies org.apache.grails.gradle.bom-property-overrides itself.
+        //
+        // 2. Unconditional application: whether grails.bom ends up null is only known once the
+        //    afterEvaluate{} above runs, which - per point 1 - is too late to gate this call
+        //    without reintroducing the same race. This is safe: when there's no BOM (grails.bom
+        //    null and no platform() declared by hand), BomPropertyOverridesPlugin's own
+        //    auto-detection finds no declared platform and applyOverrides() is a no-op - so
+        //    opting out of the BOM still results in zero constraints being added, only
+        //    project.plugins.findPlugin(...) now reports it as applied.
+        project.plugins.apply(BomPropertyOverridesPlugin)
     }
 
     /**

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/BomCliMultiprojectRaceFunctionalSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/BomCliMultiprojectRaceFunctionalSpec.groovy
@@ -1,0 +1,65 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.gradle.plugin.core
+
+/**
+ * Regression test for a multi-project {@code afterEvaluate} ordering race between
+ * {@link GrailsGradlePlugin#applyGrailsBom} and {@code GrailsCliGradlePlugin}'s CLI companion
+ * probe (introduced by the {@code grailsCliDetect} configuration).
+ *
+ * <p>The fixture is two Grails-plugin projects, {@code consumer} depending on {@code producer}
+ * via {@code project(':producer')}, with {@code producer} carrying an active property-based BOM
+ * version override. Resolving {@code consumer}'s own {@code grailsCliDetect} probe needs to
+ * select a variant of the {@code producer} project dependency, which forces {@code producer} to
+ * fully configure mid-resolution - landing inside the window where {@code producer}'s own
+ * BOM-override mutation could previously race its own CLI probe resolving (and locking)
+ * {@code api}/{@code implementation}/{@code runtimeOnly} first, causing:
+ *
+ * <pre>
+ * Cannot mutate the dependencies of configuration ':producer:implementation' after the
+ * configuration's child configuration ':producer:grailsCliDetect' was resolved. After a
+ * configuration has been observed, it should not be modified.
+ * </pre>
+ *
+ * <p>None of the other functional specs in this module exercise this: they're all single-project
+ * fixtures, so they never force one project's configuration to complete as a side effect of
+ * resolving another's.</p>
+ *
+ * @since 8.0
+ * @see GrailsGradlePlugin#applyGrailsBom
+ */
+class BomCliMultiprojectRaceFunctionalSpec extends GradleSpecification {
+
+    def "a property-based BOM override on a project depended on by another project does not race the CLI companion probe"() {
+        given:
+        setupTestResourceProject('bom-cli-multiproject-race')
+
+        when:
+        def result = executeTask('help', ['-PgrailsVersion=1.0-race'])
+
+        then: 'the whole build configures successfully, including cross-project resolution into :producer'
+        result.output.contains('BUILD SUCCESSFUL')
+
+        when: 'the override is inspected directly'
+        result = executeTask(':producer:printOverrideApplied', ['-PgrailsVersion=1.0-race'])
+
+        then: 'the property-based override was genuinely computed and applied, not silently skipped'
+        result.output.contains('OVERRIDE_APPLIED=true')
+    }
+}

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/BomOptOutFunctionalSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/BomOptOutFunctionalSpec.groovy
@@ -20,8 +20,15 @@ package org.grails.gradle.plugin.core
 
 /**
  * Functional test verifying that {@code grails.bom = null} suppresses the automatic
- * application of the Grails platform BOM and the
- * {@code org.apache.grails.gradle.bom-property-overrides} plugin.
+ * application of the Grails platform BOM and, in effect, all bom-property-overrides behavior.
+ *
+ * <p>{@code org.apache.grails.gradle.bom-property-overrides} is applied unconditionally by
+ * {@link GrailsGradlePlugin#applyGrailsBom} (see that method for why - applying it eagerly,
+ * before {@code GrailsCliGradlePlugin}, avoids an {@code afterEvaluate} ordering race in
+ * multi-project builds), so {@code project.plugins.findPlugin(...)} alone can no longer be used
+ * to verify the opt-out. What matters is the functional outcome: with no declared Grails BOM (and
+ * none declared by hand), bom-property-overrides' own auto-detection finds nothing to override,
+ * so it adds zero constraints - opting out is still fully effective.</p>
  *
  * @since 8.0
  * @see GrailsExtension#getBom
@@ -29,7 +36,7 @@ package org.grails.gradle.plugin.core
  */
 class BomOptOutFunctionalSpec extends GradleSpecification {
 
-    def "grails.bom = null suppresses the platform BOM and bom-property-overrides plugin"() {
+    def "grails.bom = null suppresses the platform BOM and any property-based version overrides"() {
         given:
         setupTestResourceProject('auto-apply-bom-disabled')
 
@@ -39,8 +46,8 @@ class BomOptOutFunctionalSpec extends GradleSpecification {
         then: 'no Grails platform BOM is added to implementation'
         result.output.contains('HAS_PLATFORM_BOM=false')
 
-        and: 'the bom-property-overrides plugin is NOT applied'
-        result.output.contains('HAS_BOM_PROPERTY_OVERRIDES=false')
+        and: 'bom-property-overrides finds no declared platform, so it adds no version-override constraints'
+        result.output.contains('HAS_BOM_OVERRIDE_CONSTRAINTS=false')
 
         and: 'Spring DM is also not applied (regardless of the bom setting)'
         result.output.contains('HAS_SPRING_DM=false')

--- a/grails-gradle/plugins/src/test/resources/test-projects/auto-apply-bom-disabled/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/auto-apply-bom-disabled/build.gradle
@@ -14,8 +14,12 @@ tasks.register('inspectBomSetup') {
         }
         println "HAS_PLATFORM_BOM=${hasPlatform}"
 
-        def hasBomPropertyOverrides = project.plugins.findPlugin('org.apache.grails.gradle.bom-property-overrides') != null
-        println "HAS_BOM_PROPERTY_OVERRIDES=${hasBomPropertyOverrides}"
+        // bom-property-overrides is now always applied (see GrailsGradlePlugin#applyGrailsBom for
+        // why), so plugin identity alone no longer signals whether the BOM opt-out took effect.
+        // What matters functionally is that it found nothing to override: no declared platform, so
+        // no constraints added.
+        def hasOverrideConstraints = !configurations.implementation.dependencyConstraints.isEmpty()
+        println "HAS_BOM_OVERRIDE_CONSTRAINTS=${hasOverrideConstraints}"
 
         def hasSpringDm = project.plugins.findPlugin('io.spring.dependency-management') != null
         println "HAS_SPRING_DM=${hasSpringDm}"

--- a/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/consumer/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/consumer/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'org.apache.grails.gradle.grails-plugin'
+}
+
+// This project needs no real BOM of its own - only its CLI tier (GrailsCliGradlePlugin,
+// applied regardless of grails.bom) matters here. Resolving consumer's own grailsCliDetect
+// probe requires selecting a variant of the project(':producer') dependency below, which
+// forces :producer to fully configure mid-resolution - landing squarely in the window where
+// :producer's own BOM-override mutation used to race its own CLI probe.
+grails {
+    bom = null
+}
+
+dependencies {
+    implementation project(':producer')
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/maven-repo/org/apache/grails/race-bom/1.0-race/race-bom-1.0-race.pom
+++ b/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/maven-repo/org/apache/grails/race-bom/1.0-race/race-bom-1.0-race.pom
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.grails</groupId>
+    <artifactId>race-bom</artifactId>
+    <version>1.0-race</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <race.managed.version>1.0.0</race.managed.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.example</groupId>
+                <artifactId>race-lib</artifactId>
+                <version>${race.managed.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/producer/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/producer/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'org.apache.grails.gradle.grails-plugin'
+}
+
+repositories {
+    maven {
+        url = uri("${rootDir}/maven-repo")
+    }
+}
+
+grails {
+    bom = 'race-bom'
+}
+
+// Overrides race-bom's default (1.0.0), so BomPropertyOverridesPlugin computes a real
+// version override and its afterEvaluate callback actually attempts to mutate this
+// project's declarable configurations - the step that used to race
+// GrailsCliGradlePlugin's grailsCliDetect probe (see the multiproject-race spec).
+ext['race.managed.version'] = '2.0.0'
+
+tasks.register('printOverrideApplied') {
+    def implConstraints = configurations.implementation.dependencyConstraints
+    doLast {
+        def applied = implConstraints.any { it.group == 'org.example' && it.name == 'race-lib' && it.versionConstraint.strictVersion == '2.0.0' }
+        println "OVERRIDE_APPLIED=${applied}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/settings.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/bom-cli-multiproject-race/settings.gradle
@@ -1,0 +1,4 @@
+rootProject.name = 'bom-cli-multiproject-race'
+
+include 'producer'
+include 'consumer'


### PR DESCRIPTION
## Problem

`GrailsGradlePlugin.applyGrailsBom()` applies `BomPropertyOverridesPlugin` from inside its own `project.afterEvaluate {}` callback. Since `BomPropertyOverridesPlugin.apply()` itself registers a *second*, nested `project.afterEvaluate {}` for the actual override-application logic, and Gradle appends newly-registered `afterEvaluate` listeners to the end of the notification queue that's currently being processed, that nested registration ends up running **after** every `afterEvaluate` callback other plugins registered synchronously during `apply()` — including `GrailsCliGradlePlugin`'s `configureApplicationCommands` (added in #15948), which eagerly resolves the `api`/`implementation`/`runtimeOnly` buckets via the `grailsCliDetect` probe configuration and locks them against further mutation.

In multi-project builds this surfaces as:

```
Cannot mutate the dependencies of configuration ':foo:api' after the configuration's child
configuration ':foo:grailsCliDetect' was resolved. After a configuration has been observed,
it should not be modified.
```

The trigger: resolving one project's `grailsCliDetect` (e.g. while a sibling project's own CLI probe reaches it through a `project(...)` dependency) forces that project to fully configure mid-resolution. If the forced configuration happens to land inside the window between the CLI probe locking its buckets and the re-queued BOM-override callback trying to mutate them, the build fails at configuration time — with any `grailsVersion`/BOM property override active (e.g. `-PgrailsVersion=...`) in a build with `project(...)` dependencies between Grails-plugin projects.

Reproduced against a real multi-project Grails 8 app; confirmed via `--stacktrace` that the failure is exactly this ordering race (`BomManagedVersions.applyTo()` → `DependencyConstraintSet.add()` on `api`, after `GrailsCliGradlePlugin.autoProvisionCliDependencies()` had already resolved `grailsCliDetect`, which extends `api`).

## Fix

Register the `bomPropertyOverrides` extension eagerly (not via `project.plugins.apply(BomPropertyOverridesPlugin)` inside the `afterEvaluate`), and call `BomPropertyOverridesPlugin.applyOverrides()` directly from the *existing*, correctly-ordered `afterEvaluate` callback in `applyGrailsBom`, immediately after the platform is injected — instead of re-deferring through `project.plugins.apply()`. This eliminates the extra deferral hop entirely while preserving the required "platform injected, then overrides computed" sequencing, and keeps `BomPropertyOverridesPlugin` unchanged for its documented standalone use case.

As a side benefit, the `bomPropertyOverrides {}` extension is now created eagerly at `apply()` time rather than inside `afterEvaluate`, so it's now actually usable from a consumer's own `build.gradle` (previously the extension didn't exist yet when the user's own script body ran).

## Testing

- `:grails-gradle-plugins:compileGroovy` — clean compile.
- Published the patched plugin to `mavenLocal`, pointed a real multi-project Grails 8 app's buildscript at it (scoped via `content { includeModule(...) }` so only this one artifact was affected), and reran the previously-failing `-PgrailsVersion=8.0.0-SNAPSHOT` build: every subproject now configures successfully (`BUILD SUCCESSFUL`), where it previously failed with the `InvalidUserCodeException` above.