### PR TITLE
Update the grails-gradle-publish plugin to the staged 1.0.0-M2 version

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
             'directory-watcher.version'     : '0.19.1',
             'gradle-groovy.version'         : '4.0.32',
             'gradle-spock.version'          : '2.4-groovy-4.0',
-            'grails-publish-plugin.version' : '1.0.0-SNAPSHOT',
+            'grails-publish-plugin.version' : '1.0.0-M2',
             'jansi.version'                 : '2.4.2',
             'javaparser-core.version'       : '3.28.2',
             'jline.version'                 : '3.30.6',


### PR DESCRIPTION
Now that 1.0.0-M2 is staged, this PR updates to a non-snapshot version so we can release the M4