### PR TITLE
Naming strategy table name fix

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -758,6 +758,12 @@ jobs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publish ]
     runs-on: ubuntu-24.04
+    # Documentation publishing targets a shared resource (the apache/grails-website repo).
+    # Share the static group used by the release documentation publish (release.yml) so only
+    # one documentation publish can run at a time across every branch; the rest queue.
+    concurrency:
+      group: grails-docs-publish
+      cancel-in-progress: false
     steps:
       - name: "⚙️ Maximize build space"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,6 +571,12 @@ jobs:
     name: "VOTE SUCCEEDED - Publish Documentation"
     needs: [ publish, source, upload, release ]
     runs-on: ubuntu-24.04
+    # Documentation publishing targets a shared resource (the apache/grails-website repo).
+    # Use a static, branch-independent group so only one documentation publish can run at a
+    # time across every branch and across the snapshot publish in gradle.yml; the rest queue.
+    concurrency:
+      group: grails-docs-publish
+      cancel-in-progress: false
     steps:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-projectVersion=7.0.14
+projectVersion=7.0.15-SNAPSHOT
 
 javaVersion=17
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-projectVersion=7.0.14-SNAPSHOT
+projectVersion=7.0.14
 
 javaVersion=17
 

--- a/grails-core/src/test/groovy/grails/util/GrailsUtilTests.java
+++ b/grails-core/src/test/groovy/grails/util/GrailsUtilTests.java
@@ -33,7 +33,7 @@ public class GrailsUtilTests {
 
     @Test
     public void testGrailsVersion() {
-        assertEquals("7.0.14", GrailsUtil.getGrailsVersion());
+        assertEquals("7.0.15-SNAPSHOT", GrailsUtil.getGrailsVersion());
     }
 
     @AfterEach

--- a/grails-core/src/test/groovy/grails/util/GrailsUtilTests.java
+++ b/grails-core/src/test/groovy/grails/util/GrailsUtilTests.java
@@ -33,7 +33,7 @@ public class GrailsUtilTests {
 
     @Test
     public void testGrailsVersion() {
-        assertEquals("7.0.14-SNAPSHOT", GrailsUtil.getGrailsVersion());
+        assertEquals("7.0.14", GrailsUtil.getGrailsVersion());
     }
 
     @AfterEach

--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinder.java
@@ -117,7 +117,6 @@ import org.grails.datastore.mapping.model.types.TenantId;
 import org.grails.datastore.mapping.model.types.ToMany;
 import org.grails.datastore.mapping.model.types.ToOne;
 import org.grails.datastore.mapping.reflect.EntityReflector;
-import org.grails.datastore.mapping.reflect.NameUtils;
 import org.grails.orm.hibernate.access.TraitPropertyAccessStrategy;
 
 /**
@@ -767,7 +766,7 @@ public class GrailsDomainBinder implements MetadataContributor {
                     columnName = config.getJoinTable().getColumn().getName();
                 }
                 else {
-                    columnName = namingStrategy.propertyToColumnName(NameUtils.decapitalize(domainClass.getName())) + FOREIGN_KEY_SUFFIX;
+                    columnName = getForeignKeyForDomainClass(domainClass, sessionFactoryBeanName);
                 }
 
                 bindSimpleValue("long", element, true, columnName, mappings);
@@ -3205,7 +3204,7 @@ public class GrailsDomainBinder implements MetadataContributor {
             }
 
             if (!association.isBidirectional() && association instanceof org.grails.datastore.mapping.model.types.OneToMany) {
-                String prefix = namingStrategy.classToTableName(property.getOwner().getName());
+                String prefix = trimBackTigs(getTableName(property.getOwner(), sessionFactoryBeanName));
                 return addUnderscore(prefix, columnName) + FOREIGN_KEY_SUFFIX;
             }
 
@@ -3221,9 +3220,12 @@ public class GrailsDomainBinder implements MetadataContributor {
 
     protected String getForeignKeyForPropertyDomainClass(PersistentProperty property,
                                                          String sessionFactoryBeanName) {
-        final String propertyName = NameUtils.decapitalize(property.getOwner().getName());
-        NamingStrategy namingStrategy = getNamingStrategy(sessionFactoryBeanName);
-        return namingStrategy.propertyToColumnName(propertyName) + FOREIGN_KEY_SUFFIX;
+        return getForeignKeyForDomainClass(property.getOwner(), sessionFactoryBeanName);
+    }
+
+    protected String getForeignKeyForDomainClass(PersistentEntity domainClass,
+                                                 String sessionFactoryBeanName) {
+        return trimBackTigs(getTableName(domainClass, sessionFactoryBeanName)) + FOREIGN_KEY_SUFFIX;
     }
 
     protected String getIndexColumnName(PersistentProperty property, String sessionFactoryBeanName) {

--- a/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/hasmany/JoinTableNamingStrategySpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/grails/gorm/tests/hasmany/JoinTableNamingStrategySpec.groovy
@@ -1,0 +1,131 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.tests.hasmany.jointablenaming
+
+import grails.gorm.annotation.Entity
+import org.grails.orm.hibernate.HibernateDatastore
+import org.grails.orm.hibernate.cfg.GrailsDomainBinder
+import org.grails.orm.hibernate.cfg.Settings
+import org.hibernate.cfg.ImprovedNamingStrategy
+import spock.lang.Issue
+import spock.lang.Specification
+
+class JoinTableNamingStrategySpec extends Specification {
+
+    HibernateDatastore datastore
+
+    void cleanup() {
+        datastore?.close()
+        GrailsDomainBinder.configureNamingStrategy(ImprovedNamingStrategy.INSTANCE)
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/15736')
+    void 'class name prefix is removed from entity and join table names'() {
+        given:
+        datastore = new HibernateDatastore([
+                (Settings.SETTING_DB_CREATE): 'create-drop',
+                'hibernate.naming_strategy': MyappClassPrefixNamingStrategy
+        ], MyappAuthor, MyappBook)
+
+        when:
+        def columnsByTable = readColumnsByTable()
+
+        then:
+        columnsByTable['book'].containsAll('id', 'version', 'title')
+        columnsByTable['author'].containsAll('id', 'version', 'name')
+        columnsByTable['author_books'].containsAll('author_id', 'book_id')
+        !columnsByTable.containsKey('myapp_book')
+        !columnsByTable.containsKey('myapp_author')
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/15736')
+    void 'entity and join table names use a prefix from the naming strategy'() {
+        given:
+        datastore = new HibernateDatastore([
+                (Settings.SETTING_DB_CREATE): 'create-drop',
+                'hibernate.naming_strategy': MyappTablePrefixNamingStrategy
+        ], Author, Book)
+
+        when:
+        def columnsByTable = readColumnsByTable()
+
+        then:
+        columnsByTable['myapp_book'].containsAll('id', 'version', 'title')
+        columnsByTable['myapp_author'].containsAll('id', 'version', 'name')
+        columnsByTable['myapp_author_books'].containsAll('myapp_author_id', 'myapp_book_id')
+        !columnsByTable.containsKey('book')
+        !columnsByTable.containsKey('author')
+    }
+
+    private Map<String, Set<String>> readColumnsByTable() {
+        datastore.connectionSources.defaultConnectionSource.dataSource.connection.withCloseable { connection ->
+            Map<String, Set<String>> columns = [:].withDefault { [] as Set<String> }
+            connection.metaData.getColumns(null, null, null, null).withCloseable { resultSet ->
+                while (resultSet.next()) {
+                    columns[resultSet.getString('TABLE_NAME').toLowerCase()] << resultSet.getString('COLUMN_NAME').toLowerCase()
+                }
+            }
+            columns
+        }
+    }
+}
+
+class MyappClassPrefixNamingStrategy extends ImprovedNamingStrategy {
+
+    @Override
+    String classToTableName(String className) {
+        super.classToTableName(className.replaceFirst('^Myapp', ''))
+    }
+}
+
+class MyappTablePrefixNamingStrategy extends ImprovedNamingStrategy {
+
+    @Override
+    String classToTableName(String className) {
+        "myapp_${super.classToTableName(className)}"
+    }
+}
+
+@Entity
+class MyappAuthor {
+    String name
+
+    static hasMany = [books: MyappBook]
+}
+
+@Entity
+class MyappBook {
+    String title
+
+    static hasMany = [authors: MyappAuthor]
+}
+
+@Entity
+class Author {
+    String name
+
+    static hasMany = [books: Book]
+}
+
+@Entity
+class Book {
+    String title
+
+    static hasMany = [authors: Author]
+}

--- a/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/ormdsl/customNamingStrategy.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/advancedGORMFeatures/ormdsl/customNamingStrategy.adoc
@@ -79,3 +79,4 @@ class CustomNamingStrategy extends ImprovedNamingStrategy {
 }
 ----
 
+The result of `classToTableName` is also used as the prefix for foreign-key columns in join tables. For example, if the strategy maps `TBook` to `book`, a `hasMany` join-table foreign key is named `book_id`. Changing this mapping can therefore require a database migration for existing join-table columns.

--- a/grails-testing-support-dbcleanup-postgresql/build.gradle
+++ b/grails-testing-support-dbcleanup-postgresql/build.gradle
@@ -50,8 +50,8 @@ dependencies {
 
     testImplementation 'org.apache.groovy:groovy'
     testImplementation 'org.postgresql:postgresql'
-    testImplementation 'org.testcontainers:postgresql:1.20.1'
-    testImplementation 'org.testcontainers:testcontainers:1.20.1'
+    testImplementation 'org.testcontainers:postgresql:1.21.4'
+    testImplementation 'org.testcontainers:testcontainers:1.21.4'
     testImplementation 'org.slf4j:slf4j-simple'
     testRuntimeOnly 'net.bytebuddy:byte-buddy'
 }


### PR DESCRIPTION
## Description

Fixes [#15736](https://github.com/apache/grails-core/issues/15736).

GORM previously generated `hasMany` join-table foreign-key columns from raw domain class names using `propertyToColumnName()`. This bypassed `classToTableName()`, causing inconsistent names when a custom Hibernate `NamingStrategy` transformed entity table names.

This change derives join-table foreign-key prefixes from the resolved entity table name. For example:

- `MyappBook` mapped to `book` now produces `book_id`.
- `Book` mapped to `myapp_book` now produces `myapp_book_id`.

The same behavior is applied consistently to many-to-many and unidirectional one-to-many associations.

Regression tests cover both directions:

- Removing `Myapp` from domain class names.
- Adding `myapp_` to database table names.

The custom naming strategy documentation now explains its effect on join-table foreign keys and notes that existing applications may require a schema migration.

## Contributor Checklist

### Issue and Scope

- [ ] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. If no approved issue exists, please give background on why this change is necessary. Tickets are preferred for release change log history.
- [x] This PR addresses the **complete scope** of the linked issue.
- [x] This PR contains a **single, focused change**.
- [ ] This PR targets the **correct branch** for the type of change.

### Code Quality

- [x] I have **added or updated tests** that cover the changes introduced in this PR.
- [ ] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`.
- [x] My code follows the project's **code style** guidelines. I ran `./gradlew :grails-data-hibernate5-core:codeStyle` and resolved all violations.
- [x] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring.
- [x] Generative AI tooling was used with a quality model, and the resulting changes were reviewed and tested for consistency with the project’s standards.

Targeted verification:

```text
./gradlew :grails-data-hibernate5-core:test \
  --tests "grails.gorm.tests.hasmany.jointablenaming.JoinTableNamingStrategySpec"
```

Result: 2 tests passed.

### Licensing and Attribution

- [x] All contributed code is provided under the Apache License 2.0, and the new test source includes the appropriate Apache license header.
- [ ] I have the necessary rights to submit this contribution and confirm it is my own original work.
- [ ] I have followed the Apache Software Foundation's policy on generative tooling and properly attributed its use.

### Documentation

- [x] Relevant documentation was updated to describe how `classToTableName()` affects join-table foreign-key columns.
- [x] This PR does not add a new feature, so no **What's New** update is required.
- [ ] The change can affect generated schema names; the documentation includes a migration warning, but the corresponding **Upgrade Notes** have not been updated.
- [x] The PR description clearly explains **what** was changed and **why**.