### PR TITLE
test(grails-data-hibernate7): re-enable Oracle in the RLikeHibernate7Spec dialect matrix

### DIFF
--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/RLikeHibernate7Spec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/RLikeHibernate7Spec.groovy
@@ -28,6 +28,8 @@ import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
 
+import java.time.Duration
+
 @Testcontainers
 @Requires({ isDockerAvailable() })
 class RLikeHibernate7Spec extends HibernateGormDatastoreSpec {
@@ -35,7 +37,12 @@ class RLikeHibernate7Spec extends HibernateGormDatastoreSpec {
     @Shared postgres = new PostgreSQLContainer("postgres:16")
     @Shared mysql = new MySQLContainer("mysql:8.0")
     @Shared mariadb = new MariaDBContainer("mariadb:10.11")
+    // slim-faststart ships native ARM64 + x86_64 images and typically reports ready in ~15s,
+    // but the default 60s Testcontainers timeout has been too tight on loaded/emulated CI
+    // runners (testcontainers/testcontainers-java#9057) - a generous explicit timeout avoids
+    // that without slowing down the common case.
     @Shared oracle = new OracleContainer("gvenzl/oracle-free:slim-faststart")
+            .withStartupTimeout(Duration.ofMinutes(3))
 
     void setupSpec() {
         manager.registerDomainClasses(RlikeFoo)
@@ -84,7 +91,7 @@ class RLikeHibernate7Spec extends HibernateGormDatastoreSpec {
         "Postgres"   | postgres
         "MySQL"      | mysql
         "MariaDB"    | mariadb
-        // "Oracle"     | oracle
+        "Oracle"     | oracle
     }
 }
 


### PR DESCRIPTION
Re-enables Oracle in RLikeHibernate7Spec dialect matrix (test-config only)

Changes:

Adds 3-minute startup timeout for Oracle Testcontainers (mitigates the tight 60s default that caused prior flakiness)
Uncomments Oracle row to run RLIKE assertion against Oracle

Risk: Only tested locally (Apple Silicon). Real validation is ubuntu-latest CI runners where original flakiness occurred.

Mitigation: Easy one-line revert if flakiness resurfaces. Local testing shows all 5 dialects pass with consistent ~13-15s Oracle startup.