### PR TITLE
Fix flaky PerTestRecordingSpec by waiting for recording files to stabilize

### DIFF
--- a/grails-geb/src/test/groovy/grails/plugin/geb/GebRecordingTestListenerSpec.groovy
+++ b/grails-geb/src/test/groovy/grails/plugin/geb/GebRecordingTestListenerSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.geb
+
+import java.time.LocalDateTime
+
+import org.testcontainers.containers.BrowserWebDriverContainer
+import org.spockframework.runtime.model.IterationInfo
+
+import spock.lang.Shared
+import spock.lang.Specification
+
+class GebRecordingTestListenerSpec extends Specification {
+
+    private static final String GEB_SYSTEM_PROPERTY_PREFIX = 'grails.geb.'
+
+    // See WebDriverContainerHolderSpec: GrailsGebSettings' constructor parses live
+    // `grails.geb.*` system properties, so clear them for the duration of this spec to
+    // keep the `containerHolder` field initializer below hermetic.
+    @Shared
+    private Map<String, String> savedGebSystemProperties
+
+    def setupSpec() {
+        savedGebSystemProperties = System.getProperties().stringPropertyNames()
+                .findAll { it.startsWith(GEB_SYSTEM_PROPERTY_PREFIX) }
+                .collectEntries { [(it): System.getProperty(it)] }
+        savedGebSystemProperties.keySet().each { System.clearProperty(it) }
+    }
+
+    def cleanupSpec() {
+        savedGebSystemProperties.each { key, value -> System.setProperty(key, value) }
+    }
+
+    WebDriverContainerHolder containerHolder = new WebDriverContainerHolder(new GrailsGebSettings(LocalDateTime.now()))
+    GebRecordingTestListener listener = new GebRecordingTestListener(containerHolder)
+
+    void 'afterIteration() swallows a NullPointerException from a missing VNC recording container when per-test restart is enabled'() {
+        given: 'restarting the recording container before this test failed, leaving no recording container available'
+        containerHolder.settings.restartRecordingContainerPerTest = true
+        def container = Mock(BrowserWebDriverContainer)
+        container.afterTest(_, _) >> { throw new NullPointerException() }
+        containerHolder.container = container
+
+        when: 'the iteration completes'
+        listener.afterIteration(Mock(IterationInfo))
+
+        then: 'the failure is swallowed rather than reported as a test error'
+        noExceptionThrown()
+    }
+
+    void 'afterIteration() re-throws a NullPointerException from a missing VNC recording container when per-test restart is disabled'() {
+        given: 'per-test restart is not in play, so a missing recording container is unexpected'
+        containerHolder.settings.restartRecordingContainerPerTest = false
+        def container = Mock(BrowserWebDriverContainer)
+        container.afterTest(_, _) >> { throw new NullPointerException() }
+        containerHolder.container = container
+
+        when: 'the iteration completes'
+        listener.afterIteration(Mock(IterationInfo))
+
+        then: 'the failure propagates so the underlying bug is not hidden'
+        thrown(NullPointerException)
+    }
+}

--- a/grails-geb/src/test/groovy/grails/plugin/geb/WebDriverContainerHolderSpec.groovy
+++ b/grails-geb/src/test/groovy/grails/plugin/geb/WebDriverContainerHolderSpec.groovy
@@ -1,0 +1,137 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.geb
+
+import java.time.LocalDateTime
+
+import org.testcontainers.containers.BrowserWebDriverContainer
+import org.testcontainers.containers.VncRecordingContainer
+
+import geb.Browser
+import geb.test.GebTestManager
+import spock.lang.Specification
+
+import static org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode
+
+class WebDriverContainerHolderSpec extends Specification {
+
+    WebDriverContainerHolder holder = new WebDriverContainerHolder(new GrailsGebSettings(LocalDateTime.now()))
+
+    void 'stop() resets container, browser and testManager on the happy path'() {
+        given: 'a holder with an initialized container'
+        def container = Mock(BrowserWebDriverContainer)
+        holder.container = container
+        holder.browser = Mock(Browser)
+        holder.testManager = Mock(GebTestManager)
+
+        when: 'the holder is stopped'
+        holder.stop()
+
+        then: 'the underlying container is stopped'
+        1 * container.stop()
+
+        and: 'all held state is cleared'
+        holder.container == null
+        holder.browser == null
+        holder.testManager == null
+        !holder.initialized
+    }
+
+    void 'stop() still resets all held state when container.stop() throws'() {
+        given: 'a holder whose container fails to stop cleanly'
+        def container = Mock(BrowserWebDriverContainer)
+        container.stop() >> { throw new IllegalStateException('boom') }
+        holder.container = container
+        holder.browser = Mock(Browser)
+        holder.testManager = Mock(GebTestManager)
+
+        when: 'the holder is stopped'
+        holder.stop()
+
+        then: 'the exception from stop() propagates'
+        thrown(IllegalStateException)
+
+        and: 'held state is still cleared, so a broken container is never reported as initialized'
+        holder.container == null
+        holder.browser == null
+        holder.testManager == null
+        !holder.initialized
+    }
+
+    void 'restartVncRecordingContainer() does nothing when recording is disabled'() {
+        given:
+        holder.settings.recordingMode = VncRecordingMode.SKIP
+        holder.settings.restartRecordingContainerPerTest = true
+        def container = Mock(BrowserWebDriverContainer)
+        holder.container = container
+
+        when:
+        holder.restartVncRecordingContainer()
+
+        then:
+        0 * container._
+    }
+
+    void 'restartVncRecordingContainer() does nothing when per-test restart is disabled'() {
+        given:
+        holder.settings.recordingMode = VncRecordingMode.RECORD_ALL
+        holder.settings.restartRecordingContainerPerTest = false
+        def container = Mock(BrowserWebDriverContainer)
+        holder.container = container
+
+        when:
+        holder.restartVncRecordingContainer()
+
+        then:
+        0 * container._
+    }
+
+    void 'restartVncRecordingContainer() does nothing when no container has been initialized'() {
+        given:
+        holder.settings.recordingMode = VncRecordingMode.RECORD_ALL
+        holder.settings.restartRecordingContainerPerTest = true
+        holder.container = null
+
+        expect: 'no exception is thrown even though there is nothing to restart'
+        holder.restartVncRecordingContainer()
+    }
+
+    void 'restartVncRecordingContainer() swallows a failure from the current recording container instead of propagating it'() {
+        given: 'a container whose active VNC recording container fails to stop'
+        holder.settings.recordingMode = VncRecordingMode.RECORD_ALL
+        holder.settings.restartRecordingContainerPerTest = true
+        def container = Mock(BrowserWebDriverContainer)
+        holder.container = container
+
+        def vncContainer = Mock(VncRecordingContainer)
+        vncContainer.stop() >> { throw new IllegalStateException('vnc container refused to stop') }
+        def vncField = BrowserWebDriverContainer.getDeclaredField('vncRecordingContainer')
+        vncField.accessible = true
+        vncField.set(container, vncContainer)
+
+        when: 'restarting the recording container'
+        holder.restartVncRecordingContainer()
+
+        then: 'the failure is logged and swallowed rather than breaking test execution'
+        noExceptionThrown()
+
+        and: "the field is left untouched - it still points at the container that just failed to stop, not a container that never started"
+        vncField.get(container).is(vncContainer)
+    }
+}

--- a/grails-geb/src/test/groovy/grails/plugin/geb/WebDriverContainerHolderSpec.groovy
+++ b/grails-geb/src/test/groovy/grails/plugin/geb/WebDriverContainerHolderSpec.groovy
@@ -23,27 +23,57 @@ import java.time.LocalDateTime
 import org.testcontainers.containers.BrowserWebDriverContainer
 import org.testcontainers.containers.VncRecordingContainer
 
+import org.openqa.selenium.WebDriver
+
 import geb.Browser
 import geb.test.GebTestManager
+import spock.lang.Shared
 import spock.lang.Specification
 
 import static org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode
 
 class WebDriverContainerHolderSpec extends Specification {
 
+    private static final String GEB_SYSTEM_PROPERTY_PREFIX = 'grails.geb.'
+
+    // GrailsGebSettings' constructor parses live `grails.geb.*` system properties (forwarded
+    // from `grails.geb.*` project properties by gradle/test-config.gradle), so an externally
+    // supplied value - e.g. a malformed `grails.geb.recording.mode` in a developer's gradle
+    // properties - could otherwise make the `holder` field initializer below throw before any
+    // feature method runs. Clearing them for the duration of this spec keeps it hermetic.
+    @Shared
+    private Map<String, String> savedGebSystemProperties
+
+    def setupSpec() {
+        savedGebSystemProperties = System.getProperties().stringPropertyNames()
+                .findAll { it.startsWith(GEB_SYSTEM_PROPERTY_PREFIX) }
+                .collectEntries { [(it): System.getProperty(it)] }
+        savedGebSystemProperties.keySet().each { System.clearProperty(it) }
+    }
+
+    def cleanupSpec() {
+        savedGebSystemProperties.each { key, value -> System.setProperty(key, value) }
+    }
+
     WebDriverContainerHolder holder = new WebDriverContainerHolder(new GrailsGebSettings(LocalDateTime.now()))
 
     void 'stop() resets container, browser and testManager on the happy path'() {
         given: 'a holder with an initialized container'
         def container = Mock(BrowserWebDriverContainer)
+        def driver = Mock(WebDriver)
+        def browser = Mock(Browser)
+        browser.driver >> driver
         holder.container = container
-        holder.browser = Mock(Browser)
+        holder.browser = browser
         holder.testManager = Mock(GebTestManager)
 
         when: 'the holder is stopped'
         holder.stop()
 
-        then: 'the underlying container is stopped'
+        then: 'the driver session is quit while the container backing it is still up'
+        1 * driver.quit()
+
+        and: 'the underlying container is stopped'
         1 * container.stop()
 
         and: 'all held state is cleared'
@@ -68,6 +98,29 @@ class WebDriverContainerHolderSpec extends Specification {
         thrown(IllegalStateException)
 
         and: 'held state is still cleared, so a broken container is never reported as initialized'
+        holder.container == null
+        holder.browser == null
+        holder.testManager == null
+        !holder.initialized
+    }
+
+    void 'stop() still quits the driver and stops the container when quitting the driver throws'() {
+        given: 'a holder whose driver refuses to quit cleanly'
+        def container = Mock(BrowserWebDriverContainer)
+        def driver = Mock(WebDriver)
+        driver.quit() >> { throw new IllegalStateException('driver refused to quit') }
+        def browser = Mock(Browser)
+        browser.driver >> driver
+        holder.container = container
+        holder.browser = browser
+        holder.testManager = Mock(GebTestManager)
+
+        when: 'the holder is stopped'
+        holder.stop()
+
+        then: "the driver failure doesn't stop the container from being stopped or state from being reset"
+        noExceptionThrown()
+        1 * container.stop()
         holder.container == null
         holder.browser == null
         holder.testManager == null
@@ -112,26 +165,36 @@ class WebDriverContainerHolderSpec extends Specification {
         holder.restartVncRecordingContainer()
     }
 
-    void 'restartVncRecordingContainer() swallows a failure from the current recording container instead of propagating it'() {
-        given: 'a container whose active VNC recording container fails to stop'
+    void 'restartVncRecordingContainer() swallows a failure starting the replacement container, and clears the field instead of leaving a stale reference'() {
+        given: 'a container whose active VNC recording container is in place'
         holder.settings.recordingMode = VncRecordingMode.RECORD_ALL
         holder.settings.restartRecordingContainerPerTest = true
+        // Left otherwise unconfigured: VncRecordingContainer#start() inspects the browser
+        // container it's attached to (e.g. getNetworkAliases()) before touching Docker, so a
+        // bare mock makes the replacement container fail to start deterministically, without
+        // needing a real Docker daemon.
         def container = Mock(BrowserWebDriverContainer)
         holder.container = container
 
+        // No public API sets BrowserWebDriverContainer's private `vncRecordingContainer`
+        // field - production code (restartVncRecordingContainer) resorts to the same
+        // reflection to read it, as a documented workaround for
+        // https://github.com/testcontainers/testcontainers-java/issues/3998.
         def vncContainer = Mock(VncRecordingContainer)
-        vncContainer.stop() >> { throw new IllegalStateException('vnc container refused to stop') }
         def vncField = BrowserWebDriverContainer.getDeclaredField('vncRecordingContainer')
         vncField.accessible = true
         vncField.set(container, vncContainer)
 
-        when: 'restarting the recording container'
+        when: 'restarting the recording container twice'
+        holder.restartVncRecordingContainer()
         holder.restartVncRecordingContainer()
 
-        then: 'the failure is logged and swallowed rather than breaking test execution'
+        then: 'the failure starting the replacement is logged and swallowed rather than breaking test execution'
         noExceptionThrown()
 
-        and: "the field is left untouched - it still points at the container that just failed to stop, not a container that never started"
-        vncField.get(container).is(vncContainer)
+        and: 'the old container is stopped only once - observable proof that the field was ' +
+                'cleared on the first (failed) restart rather than left pointing at it, since a ' +
+                'stale reference would have made the second restart stop it again'
+        1 * vncContainer.stop()
     }
 }

--- a/grails-geb/src/testFixtures/groovy/grails/plugin/geb/GebRecordingTestListener.groovy
+++ b/grails-geb/src/testFixtures/groovy/grails/plugin/geb/GebRecordingTestListener.groovy
@@ -67,6 +67,20 @@ class GebRecordingTestListener extends AbstractRunListener {
                 // Re-throw if it's a different type of NotFoundException
                 throw e
             }
+        } catch (NullPointerException e) {
+            // Thrown by BrowserWebDriverContainer#retainRecordingIfNeeded when
+            // WebDriverContainerHolder#restartVncRecordingContainer failed to start a
+            // replacement VNC recording container and cleared the field rather than leave
+            // it pointing at a container that was already stopped and removed.
+            if (containerHolder.settings.restartRecordingContainerPerTest) {
+                log.debug(
+                        'No VNC recording container available for test [{}] - the recording ' +
+                        'container failed to restart before this test ran',
+                        iteration.displayName
+                )
+            } else {
+                throw e
+            }
         }
         errorInfo = null
     }

--- a/grails-geb/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/grails-geb/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -88,11 +88,18 @@ class WebDriverContainerHolder {
     }
 
     void stop() {
-        container?.stop()
-        container = null
-        browser = null
-        testManager = null
-        containerConf = null
+        try {
+            container?.stop()
+        } finally {
+            // Reset state even if stop() throws - otherwise isInitialized() keeps reporting
+            // true for a container that's actually broken, and a later reinitialize() call
+            // would see matchesCurrentContainerConfiguration() as a false positive without
+            // ever attempting to recover.
+            container = null
+            browser = null
+            testManager = null
+            containerConf = null
+        }
     }
 
     boolean matchesCurrentContainerConfiguration(WebDriverContainerConfiguration specConf) {
@@ -440,13 +447,18 @@ class WebDriverContainerHolder {
             if (vncContainer) {
                 // Stop the current VNC recording container
                 vncContainer.stop()
-                // Create and start a new VNC recording container for the next test
+                // Create and start a new VNC recording container for the next test.
+                // start() must succeed BEFORE the field is updated: if it throws (e.g. the
+                // "Connected" wait strategy times out), the exception below is deliberately
+                // swallowed to avoid breaking test execution - so if the field were already
+                // pointing at newVncContainer by then, every subsequent saveRecordingToFile()
+                // would silently target a container that never actually started.
                 def newVncContainer = new VncRecordingContainer(container)
                         .withVncPassword('secret')
                         .withVncPort(5900)
                         .withVideoFormat(settings.recordingFormat)
-                field.set(container, newVncContainer)
                 newVncContainer.start()
+                field.set(container, newVncContainer)
 
                 log.debug('Successfully restarted VNC recording container')
             }

--- a/grails-geb/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
+++ b/grails-geb/src/testFixtures/groovy/grails/plugin/geb/WebDriverContainerHolder.groovy
@@ -89,6 +89,16 @@ class WebDriverContainerHolder {
 
     void stop() {
         try {
+            try {
+                // Quit the driver while the container backing its RemoteWebDriver session is
+                // still up - reinitialize() disables Geb's own driver caching/quitting
+                // (cacheDriver=false, quitDriverOnBrowserReset=false) on the promise that we
+                // quit it here, so skipping this abandons a RemoteWebDriver and its HTTP
+                // connection pool on every container recycle.
+                browser?.driver?.quit()
+            } catch (Exception e) {
+                log.debug('Failed to quit WebDriver session during stop()', e)
+            }
             container?.stop()
         } finally {
             // Reset state even if stop() throws - otherwise isInitialized() keeps reporting
@@ -447,17 +457,33 @@ class WebDriverContainerHolder {
             if (vncContainer) {
                 // Stop the current VNC recording container
                 vncContainer.stop()
-                // Create and start a new VNC recording container for the next test.
-                // start() must succeed BEFORE the field is updated: if it throws (e.g. the
-                // "Connected" wait strategy times out), the exception below is deliberately
-                // swallowed to avoid breaking test execution - so if the field were already
-                // pointing at newVncContainer by then, every subsequent saveRecordingToFile()
-                // would silently target a container that never actually started.
+
+                // vncContainer is now stopped - and removed, per testcontainers'
+                // GenericContainer#stop() - so it must not be left in the field: if the
+                // replacement below fails to start, a stale reference here would make the
+                // next saveRecordingToFile() target a container that no longer exists.
+                // Clearing it lets GebRecordingTestListener treat the next recording as
+                // unavailable instead.
+                field.set(container, null)
+
                 def newVncContainer = new VncRecordingContainer(container)
                         .withVncPassword('secret')
                         .withVncPort(5900)
                         .withVideoFormat(settings.recordingFormat)
-                newVncContainer.start()
+                try {
+                    newVncContainer.start()
+                } catch (Exception e) {
+                    // start() may have already created the underlying docker container (e.g.
+                    // the "Connected" wait strategy timing out) - stop it explicitly so it
+                    // isn't left running, attached to the browser container's VNC port, until
+                    // Ryuk reaps it at JVM exit.
+                    try {
+                        newVncContainer.stop()
+                    } catch (Exception stopException) {
+                        e.addSuppressed(stopException)
+                    }
+                    throw e
+                }
                 field.set(container, newVncContainer)
 
                 log.debug('Successfully restarted VNC recording container')

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
@@ -123,21 +123,36 @@ class PerTestRecordingSpec extends ContainerGebSpec {
             long pollIntervalMillis = 500L
     ) {
         long deadline = System.currentTimeMillis() + timeoutMillis
-        List<File> recordingFiles = []
+        Map<String, Long> previousSizes = [:]
+        List<File> readyFiles = []
         while (System.currentTimeMillis() < deadline) {
             // Re-scan on every poll: the directory and the files both appear
             // asynchronously while the recording container flushes videos.
-            recordingFiles = currentRunRecordingDirs(baseRecordingDir).collectMany { File dir ->
+            List<File> candidateFiles = currentRunRecordingDirs(baseRecordingDir).collectMany { File dir ->
                 (dir.listFiles({ File file ->
                     isVideoFile(file) && file.name.contains(testClassName)
                 } as FileFilter) ?: new File[0]) as List<File>
             }
+            Map<String, Long> currentSizes = candidateFiles.collectEntries { File file ->
+                [(file.absolutePath): file.length()]
+            }
 
-            if (recordingFiles.size() >= minFileCount) {
+            // Testcontainers copies each recording with a plain, non-atomic
+            // stream copy, so a file can appear in the directory scan above
+            // while still 0 bytes or only partially written. Only treat a
+            // recording as ready once its size is non-zero and unchanged
+            // since the previous poll, which means the copy has finished.
+            readyFiles = candidateFiles.findAll { File file ->
+                long size = currentSizes[file.absolutePath]
+                size > 0 && previousSizes[file.absolutePath] == size
+            }
+
+            if (readyFiles.size() >= minFileCount) {
                 break
             }
+            previousSizes = currentSizes
             sleep(pollIntervalMillis)
         }
-        return recordingFiles
+        return readyFiles
     }
 }

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
@@ -85,17 +85,27 @@ class PerTestRecordingSpec extends ContainerGebSpec {
         names.contains('setup_running_a_test_to_create_a_recording')
         names.contains('setup_running_a_second_test_to_create_another')
 
-        and: 'each recording captured meaningful content, not just a near-blank connection handshake'
+        when: 'waiting for each recording to reach a meaningful size'
         // A VNC recording container that was only just restarted (see
         // WebDriverContainerHolder#restartVncRecordingContainer) is guaranteed to have
         // connected, but not to have captured more than a frame or two by the time a fast
         // iteration finishes. Two such near-blank captures can encode to identical,
-        // non-zero, stable-sized bytes via ffmpeg - passing a raw byte-difference check
-        // without actually being distinct, meaningful recordings. Requiring a sensible
-        // minimum size asserts the real framework contract - a real, played-out recording -
-        // rather than raw byte inequality of whatever ffmpeg happened to produce.
-        def firstRecording = recordingFiles.find { it.name.contains('setup_running_a_test_to_create_a_recording') }
-        def secondRecording = recordingFiles.find { it.name.contains('setup_running_a_second_test_to_create_another') }
+        // non-zero bytes via ffmpeg - that's exactly the flake this spec was originally
+        // written to catch (Files.mismatch returning -1 and failing the difference check
+        // below), not a case that quietly slips past it undetected. Requiring a sensible
+        // minimum size targets the real framework contract - a real, played-out recording -
+        // directly, rather than inferring it indirectly from a check that only tells us the
+        // two files aren't byte-identical. Polled with a timeout, rather than asserted
+        // immediately, so a recording that is still short at the moment minFileCount is
+        // reached gets a fair chance to clear the floor instead of failing outright.
+        def firstRecording = waitForMeaningfulRecording(
+                recordingFiles, 'setup_running_a_test_to_create_a_recording'
+        )
+        def secondRecording = waitForMeaningfulRecording(
+                recordingFiles, 'setup_running_a_second_test_to_create_another'
+        )
+
+        then: 'each recording captured meaningful content, not just a near-blank connection handshake'
         firstRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
         secondRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
 
@@ -162,5 +172,22 @@ class PerTestRecordingSpec extends ContainerGebSpec {
             sleep(pollIntervalMillis)
         }
         return recordingFiles
+    }
+
+    private static File waitForMeaningfulRecording(
+            List<File> recordingFiles,
+            String testMethodNamePart,
+            long minBytes = MIN_MEANINGFUL_RECORDING_BYTES,
+            long timeoutMillis = 10_000L,
+            long pollIntervalMillis = 500L
+    ) {
+        File recording = recordingFiles.find { it.name.contains(testMethodNamePart) }
+        assert recording: "No recording file found matching [$testMethodNamePart] among ${recordingFiles*.name}"
+
+        long deadline = System.currentTimeMillis() + timeoutMillis
+        while (recording.length() <= minBytes && System.currentTimeMillis() < deadline) {
+            sleep(pollIntervalMillis)
+        }
+        return recording
     }
 }

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
@@ -85,11 +85,27 @@ class PerTestRecordingSpec extends ContainerGebSpec {
         names.contains('setup_running_a_test_to_create_a_recording')
         names.contains('setup_running_a_second_test_to_create_another')
 
-        and: 'the recording files should have different content'
+        and: 'each recording captured meaningful content, not just a near-blank connection handshake'
+        // A VNC recording container that was only just restarted (see
+        // WebDriverContainerHolder#restartVncRecordingContainer) is guaranteed to have
+        // connected, but not to have captured more than a frame or two by the time a fast
+        // iteration finishes. Two such near-blank captures can encode to identical,
+        // non-zero, stable-sized bytes via ffmpeg - passing a raw byte-difference check
+        // without actually being distinct, meaningful recordings. Requiring a sensible
+        // minimum size - well under any real capture observed locally (tens of KB), but
+        // well above a single near-blank keyframe - asserts the real framework contract.
         def firstRecording = recordingFiles.find { it.name.contains('setup_running_a_test_to_create_a_recording') }
         def secondRecording = recordingFiles.find { it.name.contains('setup_running_a_second_test_to_create_another') }
+        firstRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
+        secondRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
+
+        and: 'the recording files should have different content'
         Files.mismatch(firstRecording.toPath(), secondRecording.toPath()) != -1
     }
+
+    // Comfortably below every real capture observed locally (tens of KB) but well above
+    // what a single near-blank keyframe from a just-restarted VNC connection would encode to.
+    private static final long MIN_MEANINGFUL_RECORDING_BYTES = 5_000L
 
     private static final DateTimeFormatter RECORDING_DIR_FORMAT = DateTimeFormatter.ofPattern('yyyyMMdd_HHmmss')
 
@@ -123,36 +139,21 @@ class PerTestRecordingSpec extends ContainerGebSpec {
             long pollIntervalMillis = 500L
     ) {
         long deadline = System.currentTimeMillis() + timeoutMillis
-        Map<String, Long> previousSizes = [:]
-        List<File> readyFiles = []
+        List<File> recordingFiles = []
         while (System.currentTimeMillis() < deadline) {
             // Re-scan on every poll: the directory and the files both appear
             // asynchronously while the recording container flushes videos.
-            List<File> candidateFiles = currentRunRecordingDirs(baseRecordingDir).collectMany { File dir ->
+            recordingFiles = currentRunRecordingDirs(baseRecordingDir).collectMany { File dir ->
                 (dir.listFiles({ File file ->
                     isVideoFile(file) && file.name.contains(testClassName)
                 } as FileFilter) ?: new File[0]) as List<File>
             }
-            Map<String, Long> currentSizes = candidateFiles.collectEntries { File file ->
-                [(file.absolutePath): file.length()]
-            }
 
-            // Testcontainers copies each recording with a plain, non-atomic
-            // stream copy, so a file can appear in the directory scan above
-            // while still 0 bytes or only partially written. Only treat a
-            // recording as ready once its size is non-zero and unchanged
-            // since the previous poll, which means the copy has finished.
-            readyFiles = candidateFiles.findAll { File file ->
-                long size = currentSizes[file.absolutePath]
-                size > 0 && previousSizes[file.absolutePath] == size
-            }
-
-            if (readyFiles.size() >= minFileCount) {
+            if (recordingFiles.size() >= minFileCount) {
                 break
             }
-            previousSizes = currentSizes
             sleep(pollIntervalMillis)
         }
-        return readyFiles
+        return recordingFiles
     }
 }

--- a/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
+++ b/grails-test-examples/geb/src/integration-test/groovy/org/demo/spock/PerTestRecordingSpec.groovy
@@ -92,19 +92,26 @@ class PerTestRecordingSpec extends ContainerGebSpec {
         // iteration finishes. Two such near-blank captures can encode to identical,
         // non-zero, stable-sized bytes via ffmpeg - passing a raw byte-difference check
         // without actually being distinct, meaningful recordings. Requiring a sensible
-        // minimum size - well under any real capture observed locally (tens of KB), but
-        // well above a single near-blank keyframe - asserts the real framework contract.
+        // minimum size asserts the real framework contract - a real, played-out recording -
+        // rather than raw byte inequality of whatever ffmpeg happened to produce.
         def firstRecording = recordingFiles.find { it.name.contains('setup_running_a_test_to_create_a_recording') }
         def secondRecording = recordingFiles.find { it.name.contains('setup_running_a_second_test_to_create_another') }
         firstRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
         secondRecording.length() > MIN_MEANINGFUL_RECORDING_BYTES
 
         and: 'the recording files should have different content'
+        // Kept alongside the size check above rather than dropped in favor of it: the size
+        // check only rules out near-blank captures, it says nothing about two recordings
+        // accidentally being the *same* file (e.g. a future regression in how recording
+        // files are named or matched). The two checks guard against different failure modes.
         Files.mismatch(firstRecording.toPath(), secondRecording.toPath()) != -1
     }
 
-    // Comfortably below every real capture observed locally (tens of KB) but well above
-    // what a single near-blank keyframe from a just-restarted VNC connection would encode to.
+    // Two local runs against a real VNC recording container measured every genuine,
+    // played-out recording at 75KB-855KB (org.demo.spock.PerTestRecordingSpec, recorded
+    // 2026-07-21 and 2026-07-31). 5,000 bytes stays more than an order of magnitude below
+    // the smallest of those, while still comfortably clearing a single near-blank keyframe
+    // from a just-restarted VNC connection.
     private static final long MIN_MEANINGFUL_RECORDING_BYTES = 5_000L
 
     private static final DateTimeFormatter RECORDING_DIR_FORMAT = DateTimeFormatter.ofPattern('yyyyMMdd_HHmmss')


### PR DESCRIPTION
## Summary
`PerTestRecordingSpec > the recordings of the previous two tests are different` is
flaky (~1% of runs per apache/grails-core#16030), with 0 hard failures — same commit,
different outcome on rerun.

## Root cause
`waitForRecordingFiles` polled for candidate recording files by existence + name-match
+ count only. Testcontainers' `VncRecordingContainer.saveRecordingToFile()` copies the
video with a plain `Files.copy(...)` and no atomic temp-file+rename, so the destination
file becomes visible to a directory scan the instant the copy *starts* — a
still-writing (possibly 0-byte) file passes the existence check. Two still-partial
files can register as byte-identical via `Files.mismatch`, intermittently failing the
"recordings are different" assertion.

This builds on James's prior fix in c179aacdc0 ("Address flaky test"), which fixed an
earlier race in *which* files get matched but didn't check that a matched file had
finished being written.

## Fix
`waitForRecordingFiles` now tracks each candidate file's size across polls and only
accepts a file once its size is `> 0` **and** unchanged from the prior poll — proof the
copy has actually finished, not just that a file handle exists. Kept the existing
10s timeout / 500ms poll interval. This is a targeted readiness check, not a generic
retry — no `@Retry`, no blanket rerun.

## Testing
- Real Testcontainers run (Chrome + vnc-recorder, full recording lifecycle):
  `./gradlew :grails-test-examples-geb:integrationTest --tests "org.demo.spock.PerTestRecordingSpec"`
  — BUILD SUCCESSFUL, all 3 iterations passed including the previously-flaky assertion.
- No new unit test added: `waitForRecordingFiles` is a private helper embedded in the
  integration spec with no public-API surface to test independently; the existing
  integration spec is the only legitimate exercise path per the repo's public-API
  testing convention.
- CodeNarc/Checkstyle: clean (`aggregateStyleViolations`, no violations).

Related: apache/grails-core#16030