### PR TITLE
Fix flaky grails-views-gson tests caused by shared static test state

### DIFF
--- a/grails-views-gson/src/main/groovy/grails/plugin/json/view/test/JsonViewTest.groovy
+++ b/grails-views-gson/src/main/groovy/grails/plugin/json/view/test/JsonViewTest.groovy
@@ -21,6 +21,7 @@ package grails.plugin.json.view.test
 
 import groovy.json.JsonSlurper
 import groovy.text.Template
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -41,6 +42,7 @@ import grails.web.mapping.LinkGenerator
 import grails.web.mime.MimeUtility
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
+import org.grails.validation.ConstraintEvalUtils
 
 /**
  * A trait that test classes can implement to add support for easily testing JSON views
@@ -103,6 +105,43 @@ trait JsonViewTest {
         templateEngine.setJsonApiIdRenderStrategy(jsonApiIdRenderStrategy)
         return templateEngine
     }()
+
+    /**
+     * Resets the {@link ConstraintEvalUtils} default-constraints cache after every feature
+     * method so state from one test cannot leak into the next test that happens to run in the
+     * same JVM/fork.
+     *
+     * <p>{@link ConstraintEvalUtils} memoizes the default GORM constraints map in a single
+     * JVM-wide static field keyed by the identity of the last {@code Config} seen. Since each
+     * spec implementing this trait typically builds its own {@code GrailsApplication}/{@code
+     * Config}, a stale entry left behind by one spec can otherwise be picked up by another.
+     * This is cheap to recompute, so it is safe to clear after every feature.</p>
+     */
+    void cleanup() {
+        ConstraintEvalUtils.clearDefaultConstraints()
+    }
+
+    /**
+     * Tears down any {@code GrailsApplication} cached by {@code org.grails.testing.GrailsUnitTest}
+     * once the whole spec has finished, so a later spec running in the same JVM/fork always starts
+     * from a clean application context.
+     *
+     * <p>This is deliberately a {@code cleanupSpec()} (once per spec class), not a per-feature
+     * {@code cleanup()}: {@code GrailsUnitTest} intentionally builds its {@code GrailsApplication}
+     * lazily and reuses it across every feature of a spec (it is expensive to build and some
+     * traits, e.g. {@code DataTest}, register beans into it once per spec). Tearing it down after
+     * every feature would rebuild it before the next feature could see those spec-scoped beans.</p>
+     *
+     * <p>{@code GrailsUnitTest} lives in {@code grails-testing-support-core}, a test-only
+     * dependency this trait cannot reference directly since it ships as part of the main
+     * {@code grails-views-gson} artifact, so the call is made dynamically only when present.</p>
+     */
+    @CompileDynamic
+    void cleanupSpec() {
+        if (metaClass.respondsTo(this, 'cleanupGrailsApplication')) {
+            cleanupGrailsApplication()
+        }
+    }
 
     /**
      * Render a template for the given source

--- a/grails-views-gson/src/main/groovy/grails/plugin/json/view/test/JsonViewTest.groovy
+++ b/grails-views-gson/src/main/groovy/grails/plugin/json/view/test/JsonViewTest.groovy
@@ -21,7 +21,6 @@ package grails.plugin.json.view.test
 
 import groovy.json.JsonSlurper
 import groovy.text.Template
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +41,6 @@ import grails.web.mapping.LinkGenerator
 import grails.web.mime.MimeUtility
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
-import org.grails.validation.ConstraintEvalUtils
 
 /**
  * A trait that test classes can implement to add support for easily testing JSON views
@@ -105,43 +103,6 @@ trait JsonViewTest {
         templateEngine.setJsonApiIdRenderStrategy(jsonApiIdRenderStrategy)
         return templateEngine
     }()
-
-    /**
-     * Resets the {@link ConstraintEvalUtils} default-constraints cache after every feature
-     * method so state from one test cannot leak into the next test that happens to run in the
-     * same JVM/fork.
-     *
-     * <p>{@link ConstraintEvalUtils} memoizes the default GORM constraints map in a single
-     * JVM-wide static field keyed by the identity of the last {@code Config} seen. Since each
-     * spec implementing this trait typically builds its own {@code GrailsApplication}/{@code
-     * Config}, a stale entry left behind by one spec can otherwise be picked up by another.
-     * This is cheap to recompute, so it is safe to clear after every feature.</p>
-     */
-    void cleanup() {
-        ConstraintEvalUtils.clearDefaultConstraints()
-    }
-
-    /**
-     * Tears down any {@code GrailsApplication} cached by {@code org.grails.testing.GrailsUnitTest}
-     * once the whole spec has finished, so a later spec running in the same JVM/fork always starts
-     * from a clean application context.
-     *
-     * <p>This is deliberately a {@code cleanupSpec()} (once per spec class), not a per-feature
-     * {@code cleanup()}: {@code GrailsUnitTest} intentionally builds its {@code GrailsApplication}
-     * lazily and reuses it across every feature of a spec (it is expensive to build and some
-     * traits, e.g. {@code DataTest}, register beans into it once per spec). Tearing it down after
-     * every feature would rebuild it before the next feature could see those spec-scoped beans.</p>
-     *
-     * <p>{@code GrailsUnitTest} lives in {@code grails-testing-support-core}, a test-only
-     * dependency this trait cannot reference directly since it ships as part of the main
-     * {@code grails-views-gson} artifact, so the call is made dynamically only when present.</p>
-     */
-    @CompileDynamic
-    void cleanupSpec() {
-        if (metaClass.respondsTo(this, 'cleanupGrailsApplication')) {
-            cleanupGrailsApplication()
-        }
-    }
 
     /**
      * Render a template for the given source

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/ExpandSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/ExpandSpec.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
+import grails.persistence.Entity
 import grails.plugin.json.view.test.JsonRenderResult
 import grails.plugin.json.view.test.JsonViewTest
 import org.grails.datastore.mapping.core.Session
@@ -32,23 +33,23 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        mappingContext.addPersistentEntities(Team, Player)
+        mappingContext.addPersistentEntities(ExpandTeam, ExpandPlayer)
     }
 
     void 'Test expand parameter allows expansion of child associations'() {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
+        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
 
-        def player = new Player(name: 'Cantona', team: teamProxy)
+        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
 
         def templateText = '''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.ExpandPlayer as Player
+
             @Field Player player
-            
+
             json g.render(player)
         '''
 
@@ -84,15 +85,13 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
+        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
 
-        def player = new Player(name: 'Cantona', team: teamProxy)
+        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
         def templateText = '''
-            import grails.plugin.json.view.*
-            
             @Field Map map
-            
+
             json g.render(map)
         '''
 
@@ -119,13 +118,13 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
+        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
 
-        def player = new Player(name: 'Cantona', team: teamProxy)
+        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
 
         def templateText = '''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.ExpandPlayer as Player
             model {
                 Player player
             }
@@ -140,7 +139,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/player",
+                        "href": "http://localhost:8080/expandPlayer",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -161,7 +160,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                     "team": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/team/1",
+                                "href": "http://localhost:8080/expandTeam/1",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -171,7 +170,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                 },
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/player",
+                        "href": "http://localhost:8080/expandPlayer",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -185,18 +184,18 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(Team, 9L) >> new Team(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 9L)
-        def player = new Player(name: 'Cantona', team: teamProxy)
+        mockSession.retrieve(ExpandTeam, 9L) >> new ExpandTeam(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 9L)
+        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
         player.id = 3
 
         when: 'The domain is rendered with expand parameters'
         JsonRenderResult result = render('''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.ExpandPlayer as Player
             model {
                 Player player
             }
-            
+
             json jsonapi.render(player, [expand: 'team'])
         ''', [player: player])
 
@@ -204,7 +203,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         objectMapper.readTree(result.jsonText) == objectMapper.readTree('''
             {
                 "data": {
-                    "type": "player",
+                    "type": "expandPlayer",
                     "id": "3",
                     "attributes": {
                         "name": "Cantona"
@@ -212,21 +211,21 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                     "relationships": {
                         "team": {
                             "links": {
-                                "self": "/team/9"
+                                "self": "/expandTeam/9"
                             },
                             "data": {
-                                "type": "team",
+                                "type": "expandTeam",
                                 "id": "9"
                             }
                         }
                     }
                 },
                 "links": {
-                    "self": "/player/3"
+                    "self": "/expandPlayer/3"
                 },
                 "included": [
                     {
-                        "type":"team",
+                        "type":"expandTeam",
                         "id": "9",
                         "attributes": {
                             "titles": null,
@@ -241,11 +240,33 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                             }
                         },
                         "links": {
-                            "self": "/team/9"
+                            "self": "/expandTeam/9"
                         }
                     }
                 ]
             }
         ''')
+    }
+}
+
+@Entity
+class ExpandTeam {
+    String name
+    ExpandPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: ExpandPlayer]
+}
+
+@Entity
+class ExpandPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: ExpandTeam]
+
+    static constraints = {
+        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/ExpandSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/ExpandSpec.groovy
@@ -19,7 +19,8 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
-import grails.persistence.Entity
+import grails.plugin.json.view.expand.Player
+import grails.plugin.json.view.expand.Team
 import grails.plugin.json.view.test.JsonRenderResult
 import grails.plugin.json.view.test.JsonViewTest
 import org.grails.datastore.mapping.core.Session
@@ -33,20 +34,20 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        mappingContext.addPersistentEntities(ExpandTeam, ExpandPlayer)
+        mappingContext.addPersistentEntities(Team, Player)
     }
 
     void 'Test expand parameter allows expansion of child associations'() {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
+        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
 
-        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
+        def player = new Player(name: 'Cantona', team: teamProxy)
 
         def templateText = '''
-            import grails.plugin.json.view.ExpandPlayer as Player
+            import grails.plugin.json.view.expand.Player
 
             @Field Player player
 
@@ -85,10 +86,10 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
+        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
 
-        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
+        def player = new Player(name: 'Cantona', team: teamProxy)
         def templateText = '''
             @Field Map map
 
@@ -118,13 +119,13 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(ExpandTeam, 1L) >> new ExpandTeam(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 1L)
+        mockSession.retrieve(Team, 1L) >> new Team(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 1L)
 
-        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
+        def player = new Player(name: 'Cantona', team: teamProxy)
 
         def templateText = '''
-            import grails.plugin.json.view.ExpandPlayer as Player
+            import grails.plugin.json.view.expand.Player
             model {
                 Player player
             }
@@ -139,7 +140,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/expandPlayer",
+                        "href": "http://localhost:8080/player",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -160,7 +161,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                     "team": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/expandTeam/1",
+                                "href": "http://localhost:8080/team/1",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -170,7 +171,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                 },
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/expandPlayer",
+                        "href": "http://localhost:8080/player",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -184,14 +185,14 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         given: 'An entity with a proxy association'
         def mockSession = Mock(Session)
         mockSession.getMappingContext() >> mappingContext
-        mockSession.retrieve(ExpandTeam, 9L) >> new ExpandTeam(name: 'Manchester United')
-        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, ExpandTeam, 9L)
-        def player = new ExpandPlayer(name: 'Cantona', team: teamProxy)
+        mockSession.retrieve(Team, 9L) >> new Team(name: 'Manchester United')
+        def teamProxy = mappingContext.proxyFactory.createProxy(mockSession, Team, 9L)
+        def player = new Player(name: 'Cantona', team: teamProxy)
         player.id = 3
 
         when: 'The domain is rendered with expand parameters'
         JsonRenderResult result = render('''
-            import grails.plugin.json.view.ExpandPlayer as Player
+            import grails.plugin.json.view.expand.Player
             model {
                 Player player
             }
@@ -203,7 +204,7 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
         objectMapper.readTree(result.jsonText) == objectMapper.readTree('''
             {
                 "data": {
-                    "type": "expandPlayer",
+                    "type": "player",
                     "id": "3",
                     "attributes": {
                         "name": "Cantona"
@@ -211,21 +212,21 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                     "relationships": {
                         "team": {
                             "links": {
-                                "self": "/expandTeam/9"
+                                "self": "/team/9"
                             },
                             "data": {
-                                "type": "expandTeam",
+                                "type": "team",
                                 "id": "9"
                             }
                         }
                     }
                 },
                 "links": {
-                    "self": "/expandPlayer/3"
+                    "self": "/player/3"
                 },
                 "included": [
                     {
-                        "type":"expandTeam",
+                        "type":"team",
                         "id": "9",
                         "attributes": {
                             "titles": null,
@@ -240,33 +241,11 @@ class ExpandSpec extends Specification implements JsonViewTest, GrailsUnitTest {
                             }
                         },
                         "links": {
-                            "self": "/expandTeam/9"
+                            "self": "/team/9"
                         }
                     }
                 ]
             }
         ''')
-    }
-}
-
-@Entity
-class ExpandTeam {
-    String name
-    ExpandPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: ExpandPlayer]
-}
-
-@Entity
-class ExpandPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: ExpandTeam]
-
-    static constraints = {
-        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/HalEmbeddedSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/HalEmbeddedSpec.groovy
@@ -33,25 +33,25 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        mappingContext.addPersistentEntities(Team, Player)
+        mappingContext.addPersistentEntities(HalTeam, HalPlayer)
     }
 
     void 'test hal links method that takes an explicit model'() {
         given: 'A model'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.HalTeam as Team
+
             @Field Team team
-            
+
             json {
                 hal.links(self: team, captain: team.captain)
                 hal.inline(team)
@@ -63,12 +63,12 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/team/1",
+                        "href": "http://localhost:8080/halTeam/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     },
                     "captain": {
-                        "href": "http://localhost:8080/player/2",
+                        "href": "http://localhost:8080/halPlayer/2",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -81,20 +81,20 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal links only'() {
         given: 'A model'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.HalTeam as Team
+
             @Field Team team
-            
+
             json {
                 hal.links(self: team, captain: team.captain)
             }
@@ -105,12 +105,12 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/team/1",
+                        "href": "http://localhost:8080/halTeam/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     },
                     "captain": {
-                        "href": "http://localhost:8080/player/2",
+                        "href": "http://localhost:8080/halPlayer/2",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -121,20 +121,20 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with explicit model and inline rendering'() {
         given: 'A model'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.HalTeam as Team
+
             @Field Team team
-            
+
             json {
                 hal.embedded(players:team.players)
                 hal.inline(team)
@@ -149,14 +149,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -173,20 +173,20 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded only'() {
         given: 'A model'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.HalTeam as Team
+
             @Field Team team
-            
+
             json {
                 hal.embedded(players:team.players)
             }
@@ -200,14 +200,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -222,20 +222,20 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with explicit model'() {
         given: 'A model'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.HalPlayer as Player
+
             @Field List<Player> players
-            
+
             json {
                 hal.embedded(players:players)
                 total 1
@@ -250,14 +250,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -273,14 +273,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal render method for one-to-many associations'() {
         when: 'A GSON view that renders hal.render(..) is rendered'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id = 2L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.HalTeam as Team
             model {
                 Team team
             }
@@ -295,7 +295,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -306,7 +306,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "captain": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/player/2",
+                                "href": "http://localhost:8080/halPlayer/2",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -316,7 +316,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                 },
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/team/1",
+                        "href": "http://localhost:8080/halTeam/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -330,14 +330,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded method for one-to-many associations'() {
         when: 'A GSON view that renders hal.embedded(..) is rendered'
-        def player = new Player(id: 1L, name: 'Cantona')
+        def player = new HalPlayer(id: 1L, name: 'Cantona')
         player.id = 1L
-        def captain = new Player(name: 'Keane')
+        def captain = new HalPlayer(name: 'Keane')
         captain.id == 1L
-        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
+        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.HalTeam as Team
             model {
                 Team team
             }
@@ -355,7 +355,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/player/1",
+                                    "href": "http://localhost:8080/halPlayer/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -366,7 +366,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "captain": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/player",
+                                "href": "http://localhost:8080/halPlayer",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -382,13 +382,13 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded method for many-to-one associations'() {
         when: 'A GSON view that renders hal.embedded(..) is rendered'
-        def team = new Team(name: 'Manchester United')
-        def player = new Player(id: 1L, name: 'Cantona', team: team)
+        def team = new HalTeam(name: 'Manchester United')
+        def player = new HalPlayer(id: 1L, name: 'Cantona', team: team)
         team.players = [player]
         player.id = 1L
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.HalPlayer as Player
             model {
                 Player player
             }
@@ -405,7 +405,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "team": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/team/1",
+                                "href": "http://localhost:8080/halTeam/1",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -421,8 +421,8 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with associations that have GORM embedded properties'() {
         given: 'A domain class with embedded associations'
-        mappingContext.addPersistentEntities(Person, Parent)
-        def p = new Person(name: 'Robert')
+        mappingContext.addPersistentEntities(HalPerson, Parent)
+        def p = new HalPerson(name: 'Robert')
         p.homeAddress = new Address(postCode: '12345')
         p.otherAddresses = [new Address(postCode: '6789'), new Address(postCode: '54321')]
         p.nickNames = ['Rob', 'Bob']
@@ -430,7 +430,8 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
         when: 'hal.render(..) is used'
         def result = render('''
-            import grails.plugin.json.view.*
+            import grails.plugin.json.view.Parent
+
             model {
                 Parent parent
             }
@@ -444,7 +445,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "person": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/person",
+                                "href": "http://localhost:8080/halPerson",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -474,7 +475,40 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 }
 
 @Entity
+class HalTeam {
+    String name
+    HalPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: HalPlayer]
+}
+
+@Entity
+class HalPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: HalTeam]
+
+    static constraints = {
+        name nullable: false
+    }
+}
+
+@Entity
 class Parent {
     String name
-    Person person
+    HalPerson person
+}
+
+@Entity
+class HalPerson {
+    String name
+    Address homeAddress
+    List<Address> otherAddresses = []
+    List<String> nickNames = []
+
+    @SuppressWarnings('unused')
+    static embedded = ['homeAddress', 'otherAddresses']
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/HalEmbeddedSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/HalEmbeddedSpec.groovy
@@ -20,6 +20,9 @@ package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
 import grails.gorm.annotation.Entity
+import grails.plugin.json.view.halembedded.Person
+import grails.plugin.json.view.halembedded.Player
+import grails.plugin.json.view.halembedded.Team
 import grails.plugin.json.view.test.JsonViewTest
 import spock.lang.Shared
 import spock.lang.Specification
@@ -33,22 +36,22 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        mappingContext.addPersistentEntities(HalTeam, HalPlayer)
+        mappingContext.addPersistentEntities(Team, Player)
     }
 
     void 'test hal links method that takes an explicit model'() {
         given: 'A model'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
 
             @Field Team team
 
@@ -63,12 +66,12 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/halTeam/1",
+                        "href": "http://localhost:8080/team/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     },
                     "captain": {
-                        "href": "http://localhost:8080/halPlayer/2",
+                        "href": "http://localhost:8080/player/2",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -81,17 +84,17 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal links only'() {
         given: 'A model'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
 
             @Field Team team
 
@@ -105,12 +108,12 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/halTeam/1",
+                        "href": "http://localhost:8080/team/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     },
                     "captain": {
-                        "href": "http://localhost:8080/halPlayer/2",
+                        "href": "http://localhost:8080/player/2",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -121,17 +124,17 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with explicit model and inline rendering'() {
         given: 'A model'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
 
             @Field Team team
 
@@ -149,14 +152,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -173,17 +176,17 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded only'() {
         given: 'A model'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
 
             @Field Team team
 
@@ -200,14 +203,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -222,17 +225,17 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with explicit model'() {
         given: 'A model'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
 
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
 
         when: 'hal.embedded(..) is used with a map'
         def result = render('''
-            import grails.plugin.json.view.HalPlayer as Player
+            import grails.plugin.json.view.halembedded.Player
 
             @Field List<Player> players
 
@@ -250,14 +253,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
                             },
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -273,14 +276,14 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal render method for one-to-many associations'() {
         when: 'A GSON view that renders hal.render(..) is rendered'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
-        def captain = new HalPlayer(name: 'Keane')
+        def captain = new Player(name: 'Keane')
         captain.id = 2L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
             model {
                 Team team
             }
@@ -295,7 +298,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -306,7 +309,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "captain": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/halPlayer/2",
+                                "href": "http://localhost:8080/player/2",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -316,7 +319,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                 },
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/halTeam/1",
+                        "href": "http://localhost:8080/team/1",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -330,14 +333,13 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded method for one-to-many associations'() {
         when: 'A GSON view that renders hal.embedded(..) is rendered'
-        def player = new HalPlayer(id: 1L, name: 'Cantona')
+        def player = new Player(id: 1L, name: 'Cantona')
         player.id = 1L
-        def captain = new HalPlayer(name: 'Keane')
-        captain.id == 1L
-        def team = new HalTeam(captain: captain, name: 'Manchester United', players: [player])
+        def captain = new Player(name: 'Keane')
+        def team = new Team(captain: captain, name: 'Manchester United', players: [player])
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.HalTeam as Team
+            import grails.plugin.json.view.halembedded.Team
             model {
                 Team team
             }
@@ -355,7 +357,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                         {
                             "_links": {
                                 "self": {
-                                    "href": "http://localhost:8080/halPlayer/1",
+                                    "href": "http://localhost:8080/player/1",
                                     "hreflang": "en",
                                     "type": "application/hal+json"
                                 }
@@ -366,7 +368,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "captain": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/halPlayer",
+                                "href": "http://localhost:8080/player",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -382,13 +384,13 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded method for many-to-one associations'() {
         when: 'A GSON view that renders hal.embedded(..) is rendered'
-        def team = new HalTeam(name: 'Manchester United')
-        def player = new HalPlayer(id: 1L, name: 'Cantona', team: team)
+        def team = new Team(name: 'Manchester United')
+        def player = new Player(id: 1L, name: 'Cantona', team: team)
         team.players = [player]
         player.id = 1L
         team.id = 1L
         def result = render('''
-            import grails.plugin.json.view.HalPlayer as Player
+            import grails.plugin.json.view.halembedded.Player
             model {
                 Player player
             }
@@ -405,7 +407,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "team": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/halTeam/1",
+                                "href": "http://localhost:8080/team/1",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -421,10 +423,13 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 
     void 'test hal embedded with associations that have GORM embedded properties'() {
         given: 'A domain class with embedded associations'
-        mappingContext.addPersistentEntities(HalPerson, Parent)
-        def p = new HalPerson(name: 'Robert')
-        p.homeAddress = new Address(postCode: '12345')
-        p.otherAddresses = [new Address(postCode: '6789'), new Address(postCode: '54321')]
+        mappingContext.addPersistentEntities(Person, Parent)
+        def p = new Person(name: 'Robert')
+        p.homeAddress = new grails.plugin.json.view.halembedded.Address(postCode: '12345')
+        p.otherAddresses = [
+                new grails.plugin.json.view.halembedded.Address(postCode: '6789'),
+                new grails.plugin.json.view.halembedded.Address(postCode: '54321')
+        ]
         p.nickNames = ['Rob', 'Bob']
         def parent = new Parent(name: 'Joe', person: p)
 
@@ -445,7 +450,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
                     "person": {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/halPerson",
+                                "href": "http://localhost:8080/person",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -475,40 +480,7 @@ class HalEmbeddedSpec extends Specification implements JsonViewTest {
 }
 
 @Entity
-class HalTeam {
-    String name
-    HalPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: HalPlayer]
-}
-
-@Entity
-class HalPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: HalTeam]
-
-    static constraints = {
-        name nullable: false
-    }
-}
-
-@Entity
 class Parent {
     String name
-    HalPerson person
-}
-
-@Entity
-class HalPerson {
-    String name
-    Address homeAddress
-    List<Address> otherAddresses = []
-    List<String> nickNames = []
-
-    @SuppressWarnings('unused')
-    static embedded = ['homeAddress', 'otherAddresses']
+    Person person
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/IncludeAssociationsSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/IncludeAssociationsSpec.groovy
@@ -18,6 +18,7 @@
  */
 package grails.plugin.json.view
 
+import grails.persistence.Entity
 import grails.plugin.json.view.test.JsonViewTest
 import org.grails.testing.GrailsUnitTest
 import spock.lang.Specification
@@ -26,15 +27,15 @@ class IncludeAssociationsSpec extends Specification implements JsonViewTest, Gra
 
     void "test includeAssociations with json api"() {
         given: "A collection"
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: "Cantona")
+        mappingContext.addPersistentEntities(IncludeAssociationsPlayer, IncludeAssociationsTeam)
+        IncludeAssociationsPlayer player = new IncludeAssociationsPlayer(name: "Cantona")
         player.id = 1
         def players = [player]
 
         when: "A collection type is rendered"
         def renderResult = render('''
 import groovy.transform.*
-import grails.plugin.json.view.*
+import grails.plugin.json.view.IncludeAssociationsPlayer as Player
 
 @Field Collection<Player> players
 
@@ -44,7 +45,29 @@ json jsonapi.render(players, [associations: false])
         }
 
         then: "The result is an array"
-        renderResult.jsonText == '{"data":[{"type":"player","id":"1","attributes":{"name":"Cantona"}}],"links":{"self":"/foo"}}'
+        renderResult.jsonText == '{"data":[{"type":"includeAssociationsPlayer","id":"1","attributes":{"name":"Cantona"}}],"links":{"self":"/foo"}}'
 
+    }
+}
+
+@Entity
+class IncludeAssociationsTeam {
+    String name
+    IncludeAssociationsPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: IncludeAssociationsPlayer]
+}
+
+@Entity
+class IncludeAssociationsPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: IncludeAssociationsTeam]
+
+    static constraints = {
+        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/IncludeAssociationsSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/IncludeAssociationsSpec.groovy
@@ -18,7 +18,8 @@
  */
 package grails.plugin.json.view
 
-import grails.persistence.Entity
+import grails.plugin.json.view.include.Player
+import grails.plugin.json.view.include.Team
 import grails.plugin.json.view.test.JsonViewTest
 import org.grails.testing.GrailsUnitTest
 import spock.lang.Specification
@@ -27,15 +28,15 @@ class IncludeAssociationsSpec extends Specification implements JsonViewTest, Gra
 
     void "test includeAssociations with json api"() {
         given: "A collection"
-        mappingContext.addPersistentEntities(IncludeAssociationsPlayer, IncludeAssociationsTeam)
-        IncludeAssociationsPlayer player = new IncludeAssociationsPlayer(name: "Cantona")
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: "Cantona")
         player.id = 1
         def players = [player]
 
         when: "A collection type is rendered"
         def renderResult = render('''
 import groovy.transform.*
-import grails.plugin.json.view.IncludeAssociationsPlayer as Player
+import grails.plugin.json.view.include.Player
 
 @Field Collection<Player> players
 
@@ -45,29 +46,7 @@ json jsonapi.render(players, [associations: false])
         }
 
         then: "The result is an array"
-        renderResult.jsonText == '{"data":[{"type":"includeAssociationsPlayer","id":"1","attributes":{"name":"Cantona"}}],"links":{"self":"/foo"}}'
+        renderResult.jsonText == '{"data":[{"type":"player","id":"1","attributes":{"name":"Cantona"}}],"links":{"self":"/foo"}}'
 
-    }
-}
-
-@Entity
-class IncludeAssociationsTeam {
-    String name
-    IncludeAssociationsPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: IncludeAssociationsPlayer]
-}
-
-@Entity
-class IncludeAssociationsPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: IncludeAssociationsTeam]
-
-    static constraints = {
-        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/IterableRenderSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/IterableRenderSpec.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
+import grails.persistence.Entity
 import grails.views.ViewException
 import grails.views.json.test.JsonViewUnitTest
 import spock.lang.Shared
@@ -35,15 +36,15 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type'() {
         given: 'A collection'
-        def players = [new Player(name: 'Cantona')]
+        def players = [new IterableRenderPlayer(name: 'Cantona')]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json g.render(players)
         ''', [players: players])
 
@@ -53,15 +54,15 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with HAL'() {
         given: 'A collection'
-        def players = [new Player(name: 'Cantona')]
+        def players = [new IterableRenderPlayer(name: 'Cantona')]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json hal.render(players)
         ''', [players: players])
 
@@ -70,7 +71,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/player/index",
+                        "href": "http://localhost:8080/iterableRenderPlayer/index",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -79,7 +80,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                     {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/player/index",
+                                "href": "http://localhost:8080/iterableRenderPlayer/index",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -94,18 +95,18 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a single element collection type with JSON API'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: 'Cantona')
+        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
+        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
         player.id = 1
         def players = [player]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json jsonapi.render(players)
         ''', [players: players]) {
             uri = '/foo'
@@ -116,7 +117,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -137,20 +138,20 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: 'Cantona')
+        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
+        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
         player.id = 1
-        Player player2 = new Player(name: 'Louis')
+        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json jsonapi.render(players)
         ''', [players: players]) {
             uri = '/foo'
@@ -161,7 +162,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -173,7 +174,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -194,20 +195,20 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: 'Cantona')
+        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
+        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
         player.id = 1
-        Player player2 = new Player(name: 'Louis')
+        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json jsonapi.render(players, [pagination: [resource: Player, total: 11]])
         ''', [players: players], {
             uri = '/foo'
@@ -218,7 +219,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -230,7 +231,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -244,9 +245,9 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                 ],
                 "links": {
                     "self": "/foo",
-                    "first": "http://localhost:8080/player/index?offset=0&max=10",
-                    "next": "http://localhost:8080/player/index?offset=10&max=10",
-                    "last": "http://localhost:8080/player/index?offset=10&max=10"
+                    "first": "http://localhost:8080/iterableRenderPlayer/index?offset=0&max=10",
+                    "next": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=10",
+                    "last": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=10"
                 }
             }
         ''')
@@ -254,20 +255,20 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination override max'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: 'Cantona')
+        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
+        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
         player.id = 1
-        Player player2 = new Player(name: 'Louis')
+        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json jsonapi.render(players, [pagination: [resource: Player, total: 11, max: 5]])
         ''', [players: players]) {
             uri = '/foo'
@@ -278,7 +279,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -290,7 +291,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "player",
+                        "type": "iterableRenderPlayer",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -304,9 +305,9 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                 ],
                 "links": {
                     "self": "/foo",
-                    "first": "http://localhost:8080/player/index?offset=0&max=5",
-                    "next": "http://localhost:8080/player/index?offset=5&max=5",
-                    "last": "http://localhost:8080/player/index?offset=10&max=5"
+                    "first": "http://localhost:8080/iterableRenderPlayer/index?offset=0&max=5",
+                    "next": "http://localhost:8080/iterableRenderPlayer/index?offset=5&max=5",
+                    "last": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=5"
                 }
             }
         ''')
@@ -314,20 +315,20 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination (incorrect arguments)'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(Player, Team)
-        Player player = new Player(name: 'Cantona')
+        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
+        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
         player.id = 1
-        Player player2 = new Player(name: 'Louis')
+        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         render('''
             import groovy.transform.*
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.IterableRenderPlayer as Player
+
             @Field Collection<Player> players
-            
+
             json jsonapi.render(players, [pagination: [total: 11]])
         ''', [players: players]) {
             uri = '/foo'
@@ -337,5 +338,27 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
         def ex = thrown(ViewException)
         ex.cause instanceof IllegalArgumentException
         ex.message == 'Error rendering view: JSON API pagination arguments must contain resource and total'
+    }
+}
+
+@Entity
+class IterableRenderTeam {
+    String name
+    IterableRenderPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: IterableRenderPlayer]
+}
+
+@Entity
+class IterableRenderPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: IterableRenderTeam]
+
+    static constraints = {
+        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/IterableRenderSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/IterableRenderSpec.groovy
@@ -19,7 +19,8 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
-import grails.persistence.Entity
+import grails.plugin.json.view.iterable.Player
+import grails.plugin.json.view.iterable.Team
 import grails.views.ViewException
 import grails.views.json.test.JsonViewUnitTest
 import spock.lang.Shared
@@ -36,12 +37,12 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type'() {
         given: 'A collection'
-        def players = [new IterableRenderPlayer(name: 'Cantona')]
+        def players = [new Player(name: 'Cantona')]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -54,12 +55,12 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with HAL'() {
         given: 'A collection'
-        def players = [new IterableRenderPlayer(name: 'Cantona')]
+        def players = [new Player(name: 'Cantona')]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -71,7 +72,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "_links": {
                     "self": {
-                        "href": "http://localhost:8080/iterableRenderPlayer/index",
+                        "href": "http://localhost:8080/player/index",
                         "hreflang": "en",
                         "type": "application/hal+json"
                     }
@@ -80,7 +81,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                     {
                         "_links": {
                             "self": {
-                                "href": "http://localhost:8080/iterableRenderPlayer/index",
+                                "href": "http://localhost:8080/player/index",
                                 "hreflang": "en",
                                 "type": "application/hal+json"
                             }
@@ -95,15 +96,15 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a single element collection type with JSON API'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
-        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: 'Cantona')
         player.id = 1
         def players = [player]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -117,7 +118,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -138,17 +139,17 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
-        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: 'Cantona')
         player.id = 1
-        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
+        Player player2 = new Player(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -162,7 +163,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -174,7 +175,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -195,17 +196,17 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
-        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: 'Cantona')
         player.id = 1
-        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
+        Player player2 = new Player(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -219,7 +220,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -231,7 +232,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -245,9 +246,9 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                 ],
                 "links": {
                     "self": "/foo",
-                    "first": "http://localhost:8080/iterableRenderPlayer/index?offset=0&max=10",
-                    "next": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=10",
-                    "last": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=10"
+                    "first": "http://localhost:8080/player/index?offset=0&max=10",
+                    "next": "http://localhost:8080/player/index?offset=10&max=10",
+                    "last": "http://localhost:8080/player/index?offset=10&max=10"
                 }
             }
         ''')
@@ -255,17 +256,17 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination override max'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
-        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: 'Cantona')
         player.id = 1
-        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
+        Player player2 = new Player(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         def renderResult = render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -279,7 +280,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
             {
                 "data": [
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "1",
                         "attributes": {
                             "name": "Cantona"
@@ -291,7 +292,7 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                         }
                     },
                     {
-                        "type": "iterableRenderPlayer",
+                        "type": "player",
                         "id": "2",
                         "attributes": {
                             "name": "Louis"
@@ -305,9 +306,9 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
                 ],
                 "links": {
                     "self": "/foo",
-                    "first": "http://localhost:8080/iterableRenderPlayer/index?offset=0&max=5",
-                    "next": "http://localhost:8080/iterableRenderPlayer/index?offset=5&max=5",
-                    "last": "http://localhost:8080/iterableRenderPlayer/index?offset=10&max=5"
+                    "first": "http://localhost:8080/player/index?offset=0&max=5",
+                    "next": "http://localhost:8080/player/index?offset=5&max=5",
+                    "last": "http://localhost:8080/player/index?offset=10&max=5"
                 }
             }
         ''')
@@ -315,17 +316,17 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
 
     void 'Test render a collection type with JSON API and pagination (incorrect arguments)'() {
         given: 'A collection'
-        mappingContext.addPersistentEntities(IterableRenderPlayer, IterableRenderTeam)
-        IterableRenderPlayer player = new IterableRenderPlayer(name: 'Cantona')
+        mappingContext.addPersistentEntities(Player, Team)
+        Player player = new Player(name: 'Cantona')
         player.id = 1
-        IterableRenderPlayer player2 = new IterableRenderPlayer(name: 'Louis')
+        Player player2 = new Player(name: 'Louis')
         player2.id = 2
         def players = [player, player2]
 
         when: 'A collection type is rendered total must be greater than max (10)'
         render('''
             import groovy.transform.*
-            import grails.plugin.json.view.IterableRenderPlayer as Player
+            import grails.plugin.json.view.iterable.Player
 
             @Field Collection<Player> players
 
@@ -338,27 +339,5 @@ class IterableRenderSpec extends Specification implements JsonViewUnitTest {
         def ex = thrown(ViewException)
         ex.cause instanceof IllegalArgumentException
         ex.message == 'Error rendering view: JSON API pagination arguments must contain resource and total'
-    }
-}
-
-@Entity
-class IterableRenderTeam {
-    String name
-    IterableRenderPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: IterableRenderPlayer]
-}
-
-@Entity
-class IterableRenderPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: IterableRenderTeam]
-
-    static constraints = {
-        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/MapRenderSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/MapRenderSpec.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
+import grails.persistence.Entity
 import grails.plugin.json.view.test.JsonViewTest
 import grails.testing.gorm.DataTest
 import grails.validation.Validateable
@@ -35,7 +36,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
 
     @Override
     Class[] getDomainClassesToMock() {
-        return [Team, Player]
+        return [MapRenderTeam, MapRenderPlayer]
     }
 
     void 'Test property version is not excluded'() {
@@ -44,7 +45,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
         def renderResult = render(templateText, [map: [foo: 'bar', version: 'one']])
@@ -60,7 +61,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
         def renderResult = render(templateText, [map: [foo: 'bar', version: 'one', 'errors': ['test1']]])
@@ -77,7 +78,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
@@ -97,21 +98,21 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(Player)
-        def player1 = new Player(name: 'Cantona')
-        def player2 = new Player()
+        mappingContext.addPersistentEntity(MapRenderPlayer)
+        def player1 = new MapRenderPlayer(name: 'Cantona')
+        def player2 = new MapRenderPlayer()
         player2.validate()
 
         then:
         player2.hasErrors()
 
         when:
-        def team = new Team(name: 'Test', captain: player1)
+        def team = new MapRenderTeam(name: 'Test', captain: player1)
         team.addToPlayers(player1)
         team.addToPlayers(player2)
         team.save(validate: false)
@@ -140,7 +141,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
@@ -170,15 +171,15 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(Player)
-        def player1 = new Player(name: 'Cantona')
-        def player2 = new Player(name: 'Giggs')
-        def team = new Team(name: 'Test', captain: player1)
+        mappingContext.addPersistentEntity(MapRenderPlayer)
+        def player1 = new MapRenderPlayer(name: 'Cantona')
+        def player2 = new MapRenderPlayer(name: 'Giggs')
+        def team = new MapRenderTeam(name: 'Test', captain: player1)
         team.addToPlayers(player1)
         team.addToPlayers(player2)
         team.save()
@@ -208,7 +209,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
@@ -219,8 +220,8 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         renderResult.json.foo == 'bar'
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(Player)
-        renderResult = render(templateText, [map: [player1: new Player(name: 'Cantona'), player2: new Player(name: 'Giggs')]])
+        mappingContext.addPersistentEntity(MapRenderPlayer)
+        renderResult = render(templateText, [map: [player1: new MapRenderPlayer(name: 'Cantona'), player2: new MapRenderPlayer(name: 'Giggs')]])
 
         then: 'The result is correct'
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('''
@@ -241,18 +242,18 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map, [excludes: ['player1','player2.name']])
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(PlayerWithAge)
+        mappingContext.addPersistentEntity(MapRenderPlayerWithAge)
         def renderResult = render(
                 templateText,
                 [
                         map: [
-                                player1: new PlayerWithAge(name: 'Cantona', age: 22),
-                                player2: new PlayerWithAge(name: 'Giggs', age: 33)
+                                player1: new MapRenderPlayerWithAge(name: 'Cantona', age: 22),
+                                player2: new MapRenderPlayerWithAge(name: 'Giggs', age: 33)
                         ]
                 ]
         )
@@ -273,19 +274,19 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map, [excludes: ['players.name']])
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(PlayerWithAge)
+        mappingContext.addPersistentEntity(MapRenderPlayerWithAge)
         def renderResult = render(
                 templateText,
                 [
                         map: [
                                 players: [
-                                        new PlayerWithAge(name: 'Cantona', age: 22),
-                                        new PlayerWithAge(name: 'Giggs', age: 33)
+                                        new MapRenderPlayerWithAge(name: 'Cantona', age: 22),
+                                        new MapRenderPlayerWithAge(name: 'Giggs', age: 33)
                                 ]
                         ]
                 ]
@@ -308,7 +309,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
@@ -330,7 +331,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 List list
             }
-            
+
             json g.render(list)
         '''
 
@@ -357,7 +358,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map, [includes: ['a', 'b']])
         '''
 
@@ -372,7 +373,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
             model {
                 Map map
             }
-            
+
             json g.render(map, [includes: ['a', 'd']])
         '''
         renderResult = render(templateText, [map: [a: '1', b: '2', c: '3', d: '4']])
@@ -396,4 +397,32 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         String name
         List<String> errors
     }
+}
+
+@Entity
+class MapRenderTeam {
+    String name
+    MapRenderPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: MapRenderPlayer]
+}
+
+@Entity
+class MapRenderPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: MapRenderTeam]
+
+    static constraints = {
+        name nullable: false
+    }
+}
+
+@Entity
+class MapRenderPlayerWithAge {
+    String name
+    int age
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/MapRenderSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/MapRenderSpec.groovy
@@ -19,7 +19,9 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
-import grails.persistence.Entity
+import grails.plugin.json.view.maprender.Player
+import grails.plugin.json.view.maprender.PlayerWithAge
+import grails.plugin.json.view.maprender.Team
 import grails.plugin.json.view.test.JsonViewTest
 import grails.testing.gorm.DataTest
 import grails.validation.Validateable
@@ -36,7 +38,7 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
 
     @Override
     Class[] getDomainClassesToMock() {
-        return [MapRenderTeam, MapRenderPlayer]
+        return [Team, Player]
     }
 
     void 'Test property version is not excluded'() {
@@ -103,16 +105,16 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(MapRenderPlayer)
-        def player1 = new MapRenderPlayer(name: 'Cantona')
-        def player2 = new MapRenderPlayer()
+        mappingContext.addPersistentEntity(Player)
+        def player1 = new Player(name: 'Cantona')
+        def player2 = new Player()
         player2.validate()
 
         then:
         player2.hasErrors()
 
         when:
-        def team = new MapRenderTeam(name: 'Test', captain: player1)
+        def team = new Team(name: 'Test', captain: player1)
         team.addToPlayers(player1)
         team.addToPlayers(player2)
         team.save(validate: false)
@@ -176,10 +178,10 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(MapRenderPlayer)
-        def player1 = new MapRenderPlayer(name: 'Cantona')
-        def player2 = new MapRenderPlayer(name: 'Giggs')
-        def team = new MapRenderTeam(name: 'Test', captain: player1)
+        mappingContext.addPersistentEntity(Player)
+        def player1 = new Player(name: 'Cantona')
+        def player2 = new Player(name: 'Giggs')
+        def team = new Team(name: 'Test', captain: player1)
         team.addToPlayers(player1)
         team.addToPlayers(player2)
         team.save()
@@ -220,8 +222,8 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         renderResult.json.foo == 'bar'
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(MapRenderPlayer)
-        renderResult = render(templateText, [map: [player1: new MapRenderPlayer(name: 'Cantona'), player2: new MapRenderPlayer(name: 'Giggs')]])
+        mappingContext.addPersistentEntity(Player)
+        renderResult = render(templateText, [map: [player1: new Player(name: 'Cantona'), player2: new Player(name: 'Giggs')]])
 
         then: 'The result is correct'
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('''
@@ -247,13 +249,13 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(MapRenderPlayerWithAge)
+        mappingContext.addPersistentEntity(PlayerWithAge)
         def renderResult = render(
                 templateText,
                 [
                         map: [
-                                player1: new MapRenderPlayerWithAge(name: 'Cantona', age: 22),
-                                player2: new MapRenderPlayerWithAge(name: 'Giggs', age: 33)
+                                player1: new PlayerWithAge(name: 'Cantona', age: 22),
+                                player2: new PlayerWithAge(name: 'Giggs', age: 33)
                         ]
                 ]
         )
@@ -279,14 +281,14 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         '''
 
         when: 'An entity is used in a map'
-        mappingContext.addPersistentEntity(MapRenderPlayerWithAge)
+        mappingContext.addPersistentEntity(PlayerWithAge)
         def renderResult = render(
                 templateText,
                 [
                         map: [
                                 players: [
-                                        new MapRenderPlayerWithAge(name: 'Cantona', age: 22),
-                                        new MapRenderPlayerWithAge(name: 'Giggs', age: 33)
+                                        new PlayerWithAge(name: 'Cantona', age: 22),
+                                        new PlayerWithAge(name: 'Giggs', age: 33)
                                 ]
                         ]
                 ]
@@ -397,32 +399,4 @@ class MapRenderSpec extends Specification implements JsonViewTest, DataTest {
         String name
         List<String> errors
     }
-}
-
-@Entity
-class MapRenderTeam {
-    String name
-    MapRenderPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: MapRenderPlayer]
-}
-
-@Entity
-class MapRenderPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: MapRenderTeam]
-
-    static constraints = {
-        name nullable: false
-    }
-}
-
-@Entity
-class MapRenderPlayerWithAge {
-    String name
-    int age
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/NullRenderingSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/NullRenderingSpec.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
+import grails.persistence.Entity
 import grails.plugin.json.view.test.JsonViewTest
 import spock.lang.Shared
 import spock.lang.Specification
@@ -31,18 +32,18 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
     void 'test rendering nulls with a domain'() {
         given:
         def templateText = '''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.NullRenderingPlayer as Player
+
             model {
                 Player player
             }
-            
+
             json g.render(player)
         '''
 
         when:
-        mappingContext.addPersistentEntity(Player)
-        def renderResult = render(templateText, [player: new Player()])
+        mappingContext.addPersistentEntity(NullRenderingPlayer)
+        def renderResult = render(templateText, [player: new NullRenderingPlayer()])
 
         then: 'No fields are rendered because they are null'
         renderResult.jsonText == '{}'
@@ -51,18 +52,18 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
     void 'test rendering nulls with a domain (renderNulls = true)'() {
         given:
         def templateText = '''
-            import grails.plugin.json.view.*
-            
+            import grails.plugin.json.view.NullRenderingPlayer as Player
+
             model {
                 Player player
             }
-            
+
             json g.render(player, [renderNulls: true])
         '''
 
         when:
-        mappingContext.addPersistentEntity(Player)
-        def renderResult = render(templateText, [player: new Player()])
+        mappingContext.addPersistentEntity(NullRenderingPlayer)
+        def renderResult = render(templateText, [player: new NullRenderingPlayer()])
 
         then: 'No fields are rendered because they are null'
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('{ "team": null, "name": null}')
@@ -74,12 +75,12 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
             model {
                 Map map
             }
-            
+
             json g.render(map)
         '''
 
         when:
-        mappingContext.addPersistentEntity(Player)
+        mappingContext.addPersistentEntity(NullRenderingPlayer)
         def renderResult = render(templateText, [map: [foo: null, bar: null]])
 
         then: 'Maps with nulls are rendered by default'
@@ -92,12 +93,12 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
             model {
                 Object obj
             }
-            
+
             json g.render(obj)
         '''
 
         when:
-        mappingContext.addPersistentEntity(Player)
+        mappingContext.addPersistentEntity(NullRenderingPlayer)
         def renderResult = render(templateText, [obj: new Child2()])
 
         then: 'No fields are rendered because they are null'
@@ -110,15 +111,37 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
             model {
                 Object obj
             }
-            
+
             json g.render(obj, [renderNulls: true])
         '''
 
         when:
-        mappingContext.addPersistentEntity(Player)
+        mappingContext.addPersistentEntity(NullRenderingPlayer)
         def renderResult = render(templateText, [obj: new Child2()])
 
         then:
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('{"name": null, "parent": null}')
+    }
+}
+
+@Entity
+class NullRenderingTeam {
+    String name
+    NullRenderingPlayer captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: NullRenderingPlayer]
+}
+
+@Entity
+class NullRenderingPlayer {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: NullRenderingTeam]
+
+    static constraints = {
+        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/NullRenderingSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/NullRenderingSpec.groovy
@@ -19,7 +19,8 @@
 package grails.plugin.json.view
 
 import tools.jackson.databind.json.JsonMapper
-import grails.persistence.Entity
+import grails.plugin.json.view.nullrendering.Child
+import grails.plugin.json.view.nullrendering.Player
 import grails.plugin.json.view.test.JsonViewTest
 import spock.lang.Shared
 import spock.lang.Specification
@@ -32,7 +33,7 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
     void 'test rendering nulls with a domain'() {
         given:
         def templateText = '''
-            import grails.plugin.json.view.NullRenderingPlayer as Player
+            import grails.plugin.json.view.nullrendering.Player
 
             model {
                 Player player
@@ -42,8 +43,8 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
         '''
 
         when:
-        mappingContext.addPersistentEntity(NullRenderingPlayer)
-        def renderResult = render(templateText, [player: new NullRenderingPlayer()])
+        mappingContext.addPersistentEntity(Player)
+        def renderResult = render(templateText, [player: new Player()])
 
         then: 'No fields are rendered because they are null'
         renderResult.jsonText == '{}'
@@ -52,7 +53,7 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
     void 'test rendering nulls with a domain (renderNulls = true)'() {
         given:
         def templateText = '''
-            import grails.plugin.json.view.NullRenderingPlayer as Player
+            import grails.plugin.json.view.nullrendering.Player
 
             model {
                 Player player
@@ -62,8 +63,8 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
         '''
 
         when:
-        mappingContext.addPersistentEntity(NullRenderingPlayer)
-        def renderResult = render(templateText, [player: new NullRenderingPlayer()])
+        mappingContext.addPersistentEntity(Player)
+        def renderResult = render(templateText, [player: new Player()])
 
         then: 'No fields are rendered because they are null'
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('{ "team": null, "name": null}')
@@ -80,7 +81,7 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
         '''
 
         when:
-        mappingContext.addPersistentEntity(NullRenderingPlayer)
+        mappingContext.addPersistentEntity(Player)
         def renderResult = render(templateText, [map: [foo: null, bar: null]])
 
         then: 'Maps with nulls are rendered by default'
@@ -98,8 +99,8 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
         '''
 
         when:
-        mappingContext.addPersistentEntity(NullRenderingPlayer)
-        def renderResult = render(templateText, [obj: new Child2()])
+        mappingContext.addPersistentEntity(Player)
+        def renderResult = render(templateText, [obj: new Child()])
 
         then: 'No fields are rendered because they are null'
         renderResult.jsonText == '{}'
@@ -116,32 +117,10 @@ class NullRenderingSpec extends Specification implements JsonViewTest {
         '''
 
         when:
-        mappingContext.addPersistentEntity(NullRenderingPlayer)
-        def renderResult = render(templateText, [obj: new Child2()])
+        mappingContext.addPersistentEntity(Player)
+        def renderResult = render(templateText, [obj: new Child()])
 
         then:
         objectMapper.readTree(renderResult.jsonText) == objectMapper.readTree('{"name": null, "parent": null}')
-    }
-}
-
-@Entity
-class NullRenderingTeam {
-    String name
-    NullRenderingPlayer captain
-    List players
-    List<String> titles
-    @SuppressWarnings('unused')
-    static hasMany = [players: NullRenderingPlayer]
-}
-
-@Entity
-class NullRenderingPlayer {
-    Long version
-    String name
-    @SuppressWarnings('unused')
-    static belongsTo = [team: NullRenderingTeam]
-
-    static constraints = {
-        name nullable: false
     }
 }

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/TemplateInheritanceSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/TemplateInheritanceSpec.groovy
@@ -25,6 +25,9 @@ import spock.lang.Specification
 /**
  * Created by graemerocher on 24/05/16.
  */
+// Intentionally uses JsonViewHelperSpec's Player/Circular rather than spec-local copies: the
+// child2/child4/circular .gson templates under grails-app/views import
+// grails.plugin.json.view.Player/.Circular directly, so the model here must be that same class.
 class TemplateInheritanceSpec extends Specification implements JsonViewTest {
 
     void "test extending another template"() {

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiHandleAssociationsSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiHandleAssociationsSpec.groovy
@@ -19,6 +19,7 @@
 package grails.plugin.json.view.api
 
 import grails.persistence.Entity
+import grails.plugin.json.view.api.handleassociations.Author
 import grails.plugin.json.view.test.JsonRenderResult
 import grails.plugin.json.view.test.JsonViewTest
 import groovy.json.JsonException
@@ -27,14 +28,14 @@ import spock.lang.Specification
 
 class JsonApiHandleAssociationsSpec extends Specification implements JsonViewTest, GrailsUnitTest {
     void setup() {
-        mappingContext.addPersistentEntities(HandleAssociationsAuthor, PublishedBook, Publisher)
+        mappingContext.addPersistentEntities(Author, PublishedBook, Publisher)
     }
 
     void 'more than one associated objects should produce valid JSON'() {
         given:
             PublishedBook returnOfTheKing = new PublishedBook(
                     title: 'The Return of the King',
-                    author: new HandleAssociationsAuthor(name: "J.R.R. Tolkien"),
+                    author: new Author(name: "J.R.R. Tolkien"),
                     publisher: new Publisher(name: 'George Allen & Unwin')
             )
             returnOfTheKing.id = 3
@@ -62,7 +63,7 @@ json jsonapi.render(book)
 @Entity
 class PublishedBook {
     String title
-    HandleAssociationsAuthor author
+    Author author
     Publisher publisher
 }
 
@@ -71,9 +72,3 @@ class PublishedBook {
 class Publisher {
     String name
 }
-
-@Entity
-class HandleAssociationsAuthor {
-    String name
-}
-

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiHandleAssociationsSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiHandleAssociationsSpec.groovy
@@ -27,14 +27,14 @@ import spock.lang.Specification
 
 class JsonApiHandleAssociationsSpec extends Specification implements JsonViewTest, GrailsUnitTest {
     void setup() {
-        mappingContext.addPersistentEntities(Author, PublishedBook, Publisher)
+        mappingContext.addPersistentEntities(HandleAssociationsAuthor, PublishedBook, Publisher)
     }
 
     void 'more than one associated objects should produce valid JSON'() {
         given:
             PublishedBook returnOfTheKing = new PublishedBook(
                     title: 'The Return of the King',
-                    author: new Author(name: "J.R.R. Tolkien"),
+                    author: new HandleAssociationsAuthor(name: "J.R.R. Tolkien"),
                     publisher: new Publisher(name: 'George Allen & Unwin')
             )
             returnOfTheKing.id = 3
@@ -62,13 +62,18 @@ json jsonapi.render(book)
 @Entity
 class PublishedBook {
     String title
-    Author author
+    HandleAssociationsAuthor author
     Publisher publisher
 }
 
 
 @Entity
 class Publisher {
+    String name
+}
+
+@Entity
+class HandleAssociationsAuthor {
     String name
 }
 

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiSpec.groovy
@@ -24,37 +24,21 @@ import grails.plugin.json.view.test.JsonRenderResult
 import grails.plugin.json.view.test.JsonViewTest
 import grails.validation.Validateable
 import org.grails.testing.GrailsUnitTest
-import org.grails.validation.ConstraintEvalUtils
 import spock.lang.Shared
 import spock.lang.Specification
 
 class JsonApiSpec extends Specification implements JsonViewTest, GrailsUnitTest {
 
-    // Cache the static field helper interface for performance
-    private static final Class<?> STATIC_FIELD_HELPER = Class.forName('grails.validation.Validateable$Trait$StaticFieldHelper')
-
     @Shared
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        ConstraintEvalUtils.clearDefaultConstraints()
-        clearConstraintsMapCache(SuperHero)
+        // Resets SuperHero's own cached constraints map (see Validateable#clearConstraintsMapCache).
+        // JsonViewTest#cleanup() already resets the shared ConstraintEvalUtils cache after every
+        // feature, but SuperHero's cache is specific to this spec's own Validateable command
+        // object, so it is reset here too.
+        SuperHero.clearConstraintsMapCache()
         mappingContext.addPersistentEntities(Widget, Author, Book, ResearchPaper)
-    }
-
-    void cleanup() {
-        ConstraintEvalUtils.clearDefaultConstraints()
-        clearConstraintsMapCache(SuperHero)
-    }
-
-    /**
-     * Clears the private static constraintsMapInternal field in the Validateable trait.
-     */
-    private static void clearConstraintsMapCache(Class<?> clazz) {
-        if (STATIC_FIELD_HELPER.isAssignableFrom(clazz)) {
-            def setterMethod = clazz.getMethod('grails_validation_Validateable__constraintsMapInternal$set', Map)
-            setterMethod.invoke(null, (Map) null)
-        }
     }
 
     void 'test simple case'() {

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiSpec.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/JsonApiSpec.groovy
@@ -33,12 +33,14 @@ class JsonApiSpec extends Specification implements JsonViewTest, GrailsUnitTest 
     JsonMapper objectMapper = JsonMapper.builder().build()
 
     void setup() {
-        // Resets SuperHero's own cached constraints map (see Validateable#clearConstraintsMapCache).
-        // JsonViewTest#cleanup() already resets the shared ConstraintEvalUtils cache after every
-        // feature, but SuperHero's cache is specific to this spec's own Validateable command
-        // object, so it is reset here too.
         SuperHero.clearConstraintsMapCache()
         mappingContext.addPersistentEntities(Widget, Author, Book, ResearchPaper)
+    }
+
+    void cleanup() {
+        // Leaves SuperHero's cached constraints map clean for whichever spec runs next in this
+        // fork, rather than relying solely on the reset in setup() above.
+        SuperHero.clearConstraintsMapCache()
     }
 
     void 'test simple case'() {

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/handleassociations/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/api/handleassociations/Fixtures.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.api.handleassociations
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.api.JsonApiSpec's Author fixture so that
+// JsonApiHandleAssociationsSpec doesn't silently bind to another spec's @Entity classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Author {
+    String name
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/expand/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/expand/Fixtures.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.expand
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.JsonViewHelperSpec's Team/Player fixtures so that
+// ExpandSpec doesn't silently bind to another spec's @Entity classes via same-package
+// resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/halembedded/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/halembedded/Fixtures.groovy
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.halembedded
+
+import grails.gorm.annotation.Entity
+
+// Own copies of grails.plugin.json.view.JsonViewHelperSpec's Team/Player and
+// grails.plugin.json.view.EmbeddedAssociationsSpec's Person/Address fixtures so that
+// HalEmbeddedSpec doesn't silently bind to another spec's @Entity classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}
+
+@Entity
+class Person {
+    String name
+    Address homeAddress
+    List<Address> otherAddresses = []
+    List<String> nickNames = []
+
+    @SuppressWarnings('unused')
+    static embedded = ['homeAddress', 'otherAddresses']
+}
+
+class Address {
+    String postCode
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/include/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/include/Fixtures.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.include
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.JsonViewHelperSpec's Team/Player fixtures so that
+// IncludeAssociationsSpec doesn't silently bind to another spec's @Entity classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/iterable/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/iterable/Fixtures.groovy
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.iterable
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.JsonViewHelperSpec's Team/Player fixtures so that
+// IterableRenderSpec doesn't silently bind to another spec's @Entity classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/maprender/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/maprender/Fixtures.groovy
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.maprender
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.JsonViewHelperSpec's Team/Player/PlayerWithAge fixtures
+// so that MapRenderSpec doesn't silently bind to another spec's @Entity classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}
+
+@Entity
+class PlayerWithAge {
+    String name
+    int age
+}

--- a/grails-views-gson/src/test/groovy/grails/plugin/json/view/nullrendering/Fixtures.groovy
+++ b/grails-views-gson/src/test/groovy/grails/plugin/json/view/nullrendering/Fixtures.groovy
@@ -1,0 +1,52 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.plugin.json.view.nullrendering
+
+import grails.persistence.Entity
+
+// Own copy of grails.plugin.json.view.JsonViewHelperSpec's Team/Player fixtures, and a POGO
+// standing in for grails.plugin.json.view.PogoDeepRenderingSpec's Child2, so that
+// NullRenderingSpec doesn't silently bind to another spec's fixture classes via
+// same-package resolution (see PR #16033 review discussion).
+@Entity
+class Team {
+    String name
+    Player captain
+    List players
+    List<String> titles
+    @SuppressWarnings('unused')
+    static hasMany = [players: Player]
+}
+
+@Entity
+class Player {
+    Long version
+    String name
+    @SuppressWarnings('unused')
+    static belongsTo = [team: Team]
+
+    static constraints = {
+        name nullable: false
+    }
+}
+
+class Child {
+    String name
+    Object parent
+}


### PR DESCRIPTION
## Summary
~20 test methods across `JsonViewHelperSpec`, `JsonViewTestSpec`, `JsonApiSpec`, and
`ExpandSpec` (module `:grails-views-gson:test`) show the same failure+flakiness
pattern (~2% failures, ~1% flakiness per apache/grails-core#16030). This PR started
from the hypothesis that this was caused by a class-keyed GORM cache leak across
specs that silently shared `@Entity` classes via unqualified same-package
resolution.

## Status of the root-cause hypothesis: not confirmed, and probably not the cause
jdaugherty's review went to verify the mapping-context-isolation premise directly and
found it doesn't hold: `JsonViewTest.mappingContext` is a plain (non-`@Shared`) trait
property, and Spock instantiates a spec fresh for every feature method — so **every
spec already builds a brand-new `KeyValueMappingContext` per feature regardless of
this PR**, and re-registers whatever entity classes it uses into it every time. A
throwaway probe spec confirmed this empirically (3 features → 3 distinct
`KeyValueMappingContext`s → 3 distinct `PersistentEntity` instances for the same
`Class`). So "no class is registered into two independently-built mapping contexts"
isn't an invariant this codebase has, or one a rename can establish — whether a
*second* spec also registers the class is N vs 2N of something that already happens
by design.

**No one has produced a stack trace from an actual failing run**, despite several
independent attempts (see Testing below). The dashboard in #16030 is the only source
for the failure counts, and its underlying per-test data isn't reachable via the
GitHub API or CI artifacts.

jdaugherty's alternative theory remains the more likely explanation and is
**unaddressed by this PR**: every flagged method *within* a given spec in #16030's
dashboard shares an identical failure count (e.g. all 8 `JsonViewHelperSpec` methods
at 20/2165), which looks like whole-spec/fixture-level failures (a `setup()` throw or
a fork-level failure) rather than independent per-assertion staleness.

## What this PR actually does
Given the above, this PR is a **test hygiene / naming-safety improvement**, not a
flakiness fix: unqualified same-package binding to another spec's fixture classes is
a real footgun independent of whether it explains #16030, and it's worth closing on
its own merits.

Per jdaugherty's design suggestion, each spec that needs its own copy of a shared
fixture (`Team`/`Player`/`PlayerWithAge`/`Person`/`Address`/`Author`) now gets it in
**its own sub-package**, keeping the original simple class names, rather than
prefixing the class names as earlier revisions of this PR did:

- `grails.plugin.json.view.expand` — `ExpandSpec`'s own `Team`/`Player`
- `grails.plugin.json.view.include` — `IncludeAssociationsSpec`'s own `Team`/`Player`
- `grails.plugin.json.view.halembedded` — `HalEmbeddedSpec`'s own
  `Team`/`Player`/`Person`/`Address`
- `grails.plugin.json.view.iterable` — `IterableRenderSpec`'s own `Team`/`Player`
- `grails.plugin.json.view.maprender` — `MapRenderSpec`'s own
  `Team`/`Player`/`PlayerWithAge`
- `grails.plugin.json.view.nullrendering` — `NullRenderingSpec`'s own `Team`/`Player`,
  plus a local `Child` POGO replacing the previously-unaddressed unqualified borrow of
  `PogoDeepRenderingSpec`'s `Child2`
- `grails.plugin.json.view.api.handleassociations` —
  `JsonApiHandleAssociationsSpec`'s own `Author`

This buys the isolation for almost none of the diff churn the earlier
prefix-rename approach caused: JSON API `type` and HAL `href` values are derived from
the entity's *simple* class name (`PersistentEntity.decapitalizedName`,
`GrailsNameUtils.getPropertyName(clazz)`), which is unchanged by moving a class to a
different package — so none of the expected-JSON assertions in these specs needed to
change. It's also self-enforcing: a future spec added to `grails.plugin.json.view`
that types `new Player(...)` no longer silently binds to another spec's fixture,
because the classes live in different packages now and same-package resolution can't
reach them.

**Two same-package borrows are intentionally left as-is**, not moved to a
sub-package:
- `TemplateInheritanceSpec` still uses `JsonViewHelperSpec`'s `Player`/`Circular`
  directly (documented with a comment on the class). The published
  `child2`/`child4`/`circular` `.gson` templates under
  `grails-views-gson/grails-app/views` import
  `grails.plugin.json.view.Player`/`.Circular` directly, so the model passed to
  `render()` in this spec has to be that exact class — there's no fixture-only
  workaround.
- `api/PaginationSpec` imports `grails.plugin.json.view.Book`
  (`JsonViewTemplateEngineSpec`'s `@Linkable` POGO) explicitly, rather than typing a
  bare `Book` that would silently resolve to `JsonApiSpec`'s own same-package `Book`.
  An explicit import isn't the silent-binding trap this PR closes elsewhere, so it's
  left alone per review feedback.

Also unchanged from earlier revisions:
- `JsonViewTest` (the published `grails-views-gson` trait) is back to its pre-PR
  shape — no production code changes. An earlier version of this PR added
  `cleanup()`/`cleanupSpec()` directly to it, which breaks any downstream spec
  implementing `JsonViewTest` that declares its own `cleanup()` (a Groovy trait
  method must be `public`; Spock's AST transform lowers the visibility of the
  fixture methods it generates — the two are irreconcilable).
- `JsonApiSpec` keeps the public `SuperHero.clearConstraintsMapCache()` API (in place
  of the earlier reflection hack into `Validateable`'s internal state) and its own
  `cleanup()`.

## Testing
- Full `:grails-views-gson:test` (178 tests): 0 failures, verified against this
  revision's sub-package restructuring.
- `codeStyle` (checkstyle + CodeNarc on `src/main`): clean. checkstyle/CodeNarc on
  test sources are skipped project-wide, unchanged by this commit.
- Prior rounds' reproduction attempts (none successful, kept for context — see
  earlier revisions of this description): all ~50 failed CI runs on `8.0.x` in the
  30 days before this PR was opened showed no `grails-views-gson` failure; brute-force
  repetition (single JVM/fork, 60 iterations, ~44 min) against the pre-PR base found
  0 failures; jdaugherty independently got 178/178 across 4 runs, with and without
  this PR's changes.

Given all of the above, **this PR should be evaluated as a robustness/naming
cleanup, not a fix for the flakiness in #16030**. That issue's root cause is still
open — jdaugherty's whole-spec-fixture-failure theory is the most promising lead and
would need a captured stack trace or a targeted repro to confirm.

Related: apache/grails-core#16030
