### PR TITLE
Update Log4j to 2.25.5 and document unfixed Jansi CVE

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/VulnerabilityScanPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/VulnerabilityScanPlugin.groovy
@@ -64,6 +64,11 @@ class VulnerabilityScanPlugin implements Plugin<Project> {
             'org.hibernate:hibernate-core:5.6.11.Final',
             // CVE-2018-14335: Sonatype flags this against all H2 versions; no upstream fix exists.
             'com.h2database:h2:2.4.240',
+            // CVE-2026-8484: org.fusesource.jansi is unmaintained; all versions through 2.4.3 are flagged and no
+            // fixed release exists upstream. Grails still uses the fusesource coordinate for ANSI console output
+            // (package org.fusesource.jansi). Remove once consumers migrate off fusesource jansi or a patched
+            // release ships.
+            'org.fusesource.jansi:jansi:1.18',
             // CVE-2026-14683/14684/14685/14686: pulled transitively via micrometer/actuator (LatencyUtils).
             // The fix is HdrHistogram 2.2.3, which is not yet published to Maven Central (2.2.2 is the latest
             // release). Remove this exclusion once 2.2.3+ is available and resolves on the classpath.

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -87,6 +87,8 @@ ext {
             'jackson.version'               : '2.21.5',
             // Security: overrides spring-boot-dependencies (1.5.34). 1.5.37 fixes CVE-2026-13006 flagged against logback-core.
             'logback.version'               : '1.5.37',
+            // Security: overrides spring-boot-dependencies (2.24.3). 2.25.5 fixes CVE-2026-49844 flagged against log4j-api.
+            'log4j2.version'                : '2.25.5',
             'jquery.version'                : '3.7.1',
             'hibernate-groovy-proxy.version': '1.1',
             'jakarta-servlet-api.version'   : '6.1.0',
@@ -118,6 +120,7 @@ ext {
             'asset-pipeline-bom': "cloud.wondrify:asset-pipeline-bom:${bomDependencyVersions['asset-pipeline-bom.version']}",
             'spock-bom'         : "org.spockframework:spock-bom:${bomDependencyVersions['spock.version']}",
             'jackson-bom'       : "com.fasterxml.jackson:jackson-bom:${bomDependencyVersions['jackson.version']}",
+            'log4j2-bom'        : "org.apache.logging.log4j:log4j-bom:${bomDependencyVersions['log4j2.version']}",
             'groovy-bom'        : "org.apache.groovy:groovy-bom:${bomDependencyVersions['groovy.version']}",
             'junit-bom'         : "org.junit:junit-bom:${bomDependencyVersions['junit.version']}",
             'selenium-bom'      : "org.seleniumhq.selenium:selenium-bom:${bomDependencyVersions['selenium.version']}",
@@ -173,6 +176,12 @@ ext {
             // Security override of spring-boot-dependencies - see logback.version
             'logback-classic'            : "ch.qos.logback:logback-classic:${bomDependencyVersions['logback.version']}",
             'logback-core'               : "ch.qos.logback:logback-core:${bomDependencyVersions['logback.version']}",
+            // Security override of spring-boot-dependencies - see log4j2.version
+            'log4j2-api'                 : "org.apache.logging.log4j:log4j-api:${bomDependencyVersions['log4j2.version']}",
+            'log4j2-core'                : "org.apache.logging.log4j:log4j-core:${bomDependencyVersions['log4j2.version']}",
+            'log4j2-jul'                 : "org.apache.logging.log4j:log4j-jul:${bomDependencyVersions['log4j2.version']}",
+            'log4j2-slf4j2-impl'         : "org.apache.logging.log4j:log4j-slf4j2-impl:${bomDependencyVersions['log4j2.version']}",
+            'log4j2-to-slf4j'            : "org.apache.logging.log4j:log4j-to-slf4j:${bomDependencyVersions['log4j2.version']}",
             // start - boot & selenium conflict, so pin the version we want (newest)
             'jakarta-servlet-api'         : "jakarta.servlet:jakarta.servlet-api:${bomDependencyVersions['jakarta-servlet-api.version']}",
             'jakarta-validation-api'      : "jakarta.validation:jakarta.validation-api:${bomDependencyVersions['jakarta-validation-api.version']}",


### PR DESCRIPTION
## Description

Remediates the vulnerability findings reported by the scheduled OSS Index scan on `7.0.x`:

- **CVE-2026-49844**: overrides Spring Boot 3.5.16's Log4j `2.24.3` management with fixed Log4j `2.25.5`. `grails-gradle-bom` and `grails-base-bom` import the Log4j BOM, and all three published Grails BOMs directly manage the API, Core, JUL, SLF4J 2 implementation, and SLF4J bridge modules through the shared `log4j2.version` property.
- **CVE-2026-8484**: documents and excludes the exact managed `org.fusesource.jansi:jansi:1.18` coordinate from OSS Index. FuseSource Jansi is unmaintained, every available release through `2.4.3` is affected, and no fixed upstream release exists. The exemption includes a removal condition for a future migration or patched release.

The Log4j upgrade also brings `biz.aQute.bnd.annotation:7.1.0`; the shared BOM maps now manage that winning version instead of Spring Boot's older `7.0.0`, fixing the dependency-version validation failure from the initial PR run.

The Jansi coordinate is not replaced with `org.jline:jansi`: that artifact uses different Java packages, and its native implementation is not confirmed as a security fix for CVE-2026-8484.

## Verification

- Root `validateDependencyVersions`: **214 tasks successful**.
- Grails Gradle `validateDependencyVersions`: **11 tasks successful**.
- `grails-gradle-bom`, `grails-base-bom`, and `grails-bom` generated POMs manage Bnd `7.1.0` and the five Log4j modules through shared properties.
- `grails-gradle-bom` and `grails-base-bom` import `log4j-bom` through `${log4j2.version}` with value `2.25.5`.
- `git diff --check` passes.

No user-facing API changes or documentation updates are needed for this dependency/security-scan configuration change.

> Generative AI tooling was used to assist with scan-log analysis, CVE research, dependency resolution verification, and PR preparation. The resulting changes were reviewed and verified by the submitter.
