### PR TITLE
Import log4j-bom before Spring Boot in published BOMs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -230,7 +230,12 @@ ext {
 
     // Because pom exclusions aren't properly supported by gradle, we can't inherit the grails-gradle-bom
     // this requires copying the platforms selectively to the grails-bom. Create a combined version for convenience.
-    combinedPlatforms = ['spring-boot-bom': gradleBomPlatformDependencies['spring-boot-bom']] + bomPlatformDependencies
+    // log4j2-bom is listed ahead of spring-boot-bom so published POM import order keeps CVE-2026-49844's
+    // Log4j 2.25.5 management ahead of Spring Boot's older Log4j pin (see each BOM's dependencies block).
+    combinedPlatforms = [
+            'log4j2-bom'     : bomPlatformDependencies['log4j2-bom'],
+            'spring-boot-bom': gradleBomPlatformDependencies['spring-boot-bom'],
+    ] + bomPlatformDependencies.findAll { it.key != 'log4j2-bom' }
     combinedDependencies = gradleBomDependencies + bomDependencies
     combinedVersions = gradleBomDependencyVersions + bomDependencyVersions
 

--- a/grails-bom/base/build.gradle
+++ b/grails-bom/base/build.gradle
@@ -51,6 +51,9 @@ ext {
 }
 
 dependencies {
+    // Import Log4j ahead of Spring Boot so Maven consumers resolve the full Log4j family to the
+    // BOM-managed 2.25.5 (CVE-2026-49844) instead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'
@@ -60,6 +63,9 @@ dependencies {
     }
 
     for (def entry : bomPlatformDependencies.entrySet()) {
+        if (entry.key == 'log4j2-bom') {
+            continue
+        }
         api platform(entry.value)
     }
 

--- a/grails-bom/hibernate5-micronaut/build.gradle
+++ b/grails-bom/hibernate5-micronaut/build.gradle
@@ -66,6 +66,9 @@ def overriddenModules = customBomDependencies.values().collect { String coord ->
 Set<String> overriddenCoords = overriddenModules.collect { "${it.group}:${it.module}".toString() } as Set
 
 dependencies {
+    // Import Log4j ahead of inherited platforms so Maven consumers keep Log4j 2.25.5
+    // (CVE-2026-49844) ahead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api(platform(project(':grails-base-bom'))) {
         overriddenModules.each { ovr ->
             exclude group: ovr.group, module: ovr.module

--- a/grails-bom/hibernate5/build.gradle
+++ b/grails-bom/hibernate5/build.gradle
@@ -51,6 +51,9 @@ ext {
 }
 
 dependencies {
+    // Import Log4j ahead of inherited platforms so Maven consumers keep Log4j 2.25.5
+    // (CVE-2026-49844) ahead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api platform(project(':grails-bom'))
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.apache.groovy'

--- a/grails-bom/hibernate7-micronaut/build.gradle
+++ b/grails-bom/hibernate7-micronaut/build.gradle
@@ -66,6 +66,9 @@ def overriddenModules = customBomDependencies.values().collect { String coord ->
 Set<String> overriddenCoords = overriddenModules.collect { "${it.group}:${it.module}".toString() } as Set
 
 dependencies {
+    // Import Log4j ahead of inherited platforms so Maven consumers keep Log4j 2.25.5
+    // (CVE-2026-49844) ahead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api(platform(project(':grails-base-bom'))) {
         overriddenModules.each { ovr ->
             exclude group: ovr.group, module: ovr.module

--- a/grails-bom/hibernate7/build.gradle
+++ b/grails-bom/hibernate7/build.gradle
@@ -51,6 +51,9 @@ ext {
 }
 
 dependencies {
+    // Import Log4j ahead of inherited platforms so Maven consumers keep Log4j 2.25.5
+    // (CVE-2026-49844) ahead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api platform(project(':grails-base-bom'))
 
     constraints {

--- a/grails-bom/micronaut/build.gradle
+++ b/grails-bom/micronaut/build.gradle
@@ -66,6 +66,9 @@ def overriddenModules = customBomDependencies.values().collect { String coord ->
 Set<String> overriddenCoords = overriddenModules.collect { "${it.group}:${it.module}".toString() } as Set
 
 dependencies {
+    // Import Log4j ahead of inherited platforms so Maven consumers keep Log4j 2.25.5
+    // (CVE-2026-49844) ahead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api(platform(project(':grails-base-bom'))) {
         overriddenModules.each { ovr ->
             exclude group: ovr.group, module: ovr.module

--- a/grails-gradle/bom/build.gradle
+++ b/grails-gradle/bom/build.gradle
@@ -38,6 +38,9 @@ ext {
 }
 
 dependencies {
+    // Import Log4j ahead of Spring Boot so Maven consumers resolve the full Log4j family to the
+    // BOM-managed 2.25.5 (CVE-2026-49844) instead of Spring Boot's older managed Log4j version.
+    api platform(bomPlatformDependencies['log4j2-bom'])
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'


### PR DESCRIPTION
## Description

Slim residual for **CVE-2026-49844** after Log4j `2.25.5` management already landed on `8.0.x`.

This PR only ensures every published Grails BOM **imports `log4j-bom` before Spring Boot** (and before inherited Grails / Micronaut platforms) so Maven consumers resolve the full Log4j family to `2.25.5`, including modules Grails does not constrain directly (for example `log4j-layout-template-json`).

Touched BOMs:

- `grails-gradle-bom`
- `grails-base-bom` / `grails-bom` (via base)
- `grails-hibernate5-bom`
- `grails-hibernate7-bom`
- `grails-micronaut-bom`
- `grails-hibernate5-micronaut-bom`
- `grails-hibernate7-micronaut-bom`

`dependencies.gradle` only adjusts `combinedPlatforms` ordering so docs / property extraction match the same Log4j-first platform order. Version pins and module constraints are unchanged.

### Out of scope (handled elsewhere)

**Jansi / Grails console / CLI classpath work is not in this PR.**

That work lives in **#16078** ([Remove Jansi and separate CLI from production classpath](https://github.com/apache/grails-core/pull/16078)), which:

- removes FuseSource Jansi entirely (does not swap to `org.jline:jansi`)
- moves console / CLI types onto the CLI tier
- enforces production classpath hygiene

Once #16078 merges, the Jansi half of the original #16044 scope is obsolete. This branch no longer documents or exempts Jansi CVEs.

### Stacking

Does **not** need to stack on #16078. The two changes are independent and can merge in either order.

## Verification

- Staged change is import-order only across the published BOM projects listed above.
- Base BOM skips `log4j2-bom` in the remaining platform loop to avoid a duplicate Maven import.
- No Jansi / vulnerability-exemption edits remain on this branch.

No user-facing API changes. No application docs required beyond what #16078 covers for CLI/Jansi.

> Generative AI tooling was used to assist with residual-scope analysis and PR preparation. The resulting changes were reviewed and verified by the submitter.
