### PR TITLE
Align Log4j across published BOMs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,7 @@ ext {
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
             'asset-pipeline-gradle.version' : '5.0.34',
+            'bnd.version'                   : '7.1.0',
             'byte-buddy.version'            : '1.18.3',
             'commons-text.version'          : '1.15.0',
             'directory-watcher.version'     : '0.19.1',
@@ -37,6 +38,8 @@ ext {
             'jline.version'                 : '2.14.6',
             'jna.version'                   : '5.17.0',
             'jquery.version'                : '3.7.1',
+            // Security: overrides spring-boot-dependencies (2.24.3). 2.25.5 fixes CVE-2026-49844 flagged against log4j-api.
+            'log4j2.version'                : '2.25.5',
             'objenesis.version'             : '3.4',
             'spring-boot.version'           : '3.5.16',
     ]
@@ -44,6 +47,7 @@ ext {
     // Note: the name of the dependency must be the prefix of the property name so properties in the pom are resolved correctly
     gradleBomPlatformDependencies = [
             'spring-boot-bom' : "org.springframework.boot:spring-boot-dependencies:${gradleBomDependencyVersions['spring-boot.version']}",
+            'log4j2-bom'      : "org.apache.logging.log4j:log4j-bom:${gradleBomDependencyVersions['log4j2.version']}",
             'gradle-spock-bom': "org.spockframework:spock-bom:${gradleBomDependencyVersions['gradle-spock.version']}",
     ]
 
@@ -56,6 +60,7 @@ ext {
             'asciidoctor-gradle-jvm': "org.asciidoctor:asciidoctor-gradle-jvm:${gradleBomDependencyVersions['asciidoctor-gradle-jvm.version']}",
             'asciidoctorj'          : "org.asciidoctor:asciidoctorj:${gradleBomDependencyVersions['asciidoctorj.version']}",
             'asset-pipeline-gradle' : "cloud.wondrify:asset-pipeline-gradle:${gradleBomDependencyVersions['asset-pipeline-gradle.version']}",
+            'bnd-annotation'        : "biz.aQute.bnd:biz.aQute.bnd.annotation:${gradleBomDependencyVersions['bnd.version']}",
             'byte-buddy'            : "net.bytebuddy:byte-buddy:${gradleBomDependencyVersions['byte-buddy.version']}",
             'commons-text'          : "org.apache.commons:commons-text:${gradleBomDependencyVersions['commons-text.version']}",
             'directory-watcher'     : "io.methvin:directory-watcher:${gradleBomDependencyVersions['directory-watcher.version']}",
@@ -64,6 +69,12 @@ ext {
             'javaparser-core'       : "com.github.javaparser:javaparser-core:${gradleBomDependencyVersions['javaparser-core.version']}",
             'jline'                 : "jline:jline:${gradleBomDependencyVersions['jline.version']}",
             'jna'                   : "net.java.dev.jna:jna:${gradleBomDependencyVersions['jna.version']}",
+            // Security override of spring-boot-dependencies - see log4j2.version
+            'log4j2-api'            : "org.apache.logging.log4j:log4j-api:${gradleBomDependencyVersions['log4j2.version']}",
+            'log4j2-core'           : "org.apache.logging.log4j:log4j-core:${gradleBomDependencyVersions['log4j2.version']}",
+            'log4j2-jul'            : "org.apache.logging.log4j:log4j-jul:${gradleBomDependencyVersions['log4j2.version']}",
+            'log4j2-slf4j2-impl'    : "org.apache.logging.log4j:log4j-slf4j2-impl:${gradleBomDependencyVersions['log4j2.version']}",
+            'log4j2-to-slf4j'       : "org.apache.logging.log4j:log4j-to-slf4j:${gradleBomDependencyVersions['log4j2.version']}",
             'objenesis'             : "org.objenesis:objenesis:${gradleBomDependencyVersions['objenesis.version']}",
             'spring-boot-cli'       : "org.springframework.boot:spring-boot-cli:${gradleBomDependencyVersions['spring-boot.version']}",
             'spring-boot-gradle'    : "org.springframework.boot:spring-boot-gradle-plugin:${gradleBomDependencyVersions['spring-boot.version']}",
@@ -87,8 +98,6 @@ ext {
             'jackson.version'               : '2.21.5',
             // Security: overrides spring-boot-dependencies (1.5.34). 1.5.37 fixes CVE-2026-13006 flagged against logback-core.
             'logback.version'               : '1.5.37',
-            // Security: overrides spring-boot-dependencies (2.24.3). 2.25.5 fixes CVE-2026-49844 flagged against log4j-api.
-            'log4j2.version'                : '2.25.5',
             'jquery.version'                : '3.7.1',
             'hibernate-groovy-proxy.version': '1.1',
             'jakarta-servlet-api.version'   : '6.1.0',
@@ -120,7 +129,6 @@ ext {
             'asset-pipeline-bom': "cloud.wondrify:asset-pipeline-bom:${bomDependencyVersions['asset-pipeline-bom.version']}",
             'spock-bom'         : "org.spockframework:spock-bom:${bomDependencyVersions['spock.version']}",
             'jackson-bom'       : "com.fasterxml.jackson:jackson-bom:${bomDependencyVersions['jackson.version']}",
-            'log4j2-bom'        : "org.apache.logging.log4j:log4j-bom:${bomDependencyVersions['log4j2.version']}",
             'groovy-bom'        : "org.apache.groovy:groovy-bom:${bomDependencyVersions['groovy.version']}",
             'junit-bom'         : "org.junit:junit-bom:${bomDependencyVersions['junit.version']}",
             'selenium-bom'      : "org.seleniumhq.selenium:selenium-bom:${bomDependencyVersions['selenium.version']}",
@@ -176,12 +184,6 @@ ext {
             // Security override of spring-boot-dependencies - see logback.version
             'logback-classic'            : "ch.qos.logback:logback-classic:${bomDependencyVersions['logback.version']}",
             'logback-core'               : "ch.qos.logback:logback-core:${bomDependencyVersions['logback.version']}",
-            // Security override of spring-boot-dependencies - see log4j2.version
-            'log4j2-api'                 : "org.apache.logging.log4j:log4j-api:${bomDependencyVersions['log4j2.version']}",
-            'log4j2-core'                : "org.apache.logging.log4j:log4j-core:${bomDependencyVersions['log4j2.version']}",
-            'log4j2-jul'                 : "org.apache.logging.log4j:log4j-jul:${bomDependencyVersions['log4j2.version']}",
-            'log4j2-slf4j2-impl'         : "org.apache.logging.log4j:log4j-slf4j2-impl:${bomDependencyVersions['log4j2.version']}",
-            'log4j2-to-slf4j'            : "org.apache.logging.log4j:log4j-to-slf4j:${bomDependencyVersions['log4j2.version']}",
             // start - boot & selenium conflict, so pin the version we want (newest)
             'jakarta-servlet-api'         : "jakarta.servlet:jakarta.servlet-api:${bomDependencyVersions['jakarta-servlet-api.version']}",
             'jakarta-validation-api'      : "jakarta.validation:jakarta.validation-api:${bomDependencyVersions['jakarta-validation-api.version']}",
@@ -234,7 +236,10 @@ ext {
 
     // Because pom exclusions aren't properly supported by gradle, we can't inherit the grails-gradle-bom
     // this requires copying the platforms selectively to the grails-bom. Create a combined version for convenience.
-    combinedPlatforms = ['spring-boot-bom': gradleBomPlatformDependencies['spring-boot-bom']] + bomPlatformDependencies
+    combinedPlatforms = [
+            'spring-boot-bom': gradleBomPlatformDependencies['spring-boot-bom'],
+            'log4j2-bom'     : gradleBomPlatformDependencies['log4j2-bom'],
+    ] + bomPlatformDependencies
     combinedDependencies = gradleBomDependencies + bomDependencies
     combinedVersions = gradleBomDependencyVersions + bomDependencyVersions
 

--- a/grails-bom/base/build.gradle
+++ b/grails-bom/base/build.gradle
@@ -51,6 +51,7 @@ ext {
 }
 
 dependencies {
+    api platform(gradleBomPlatformDependencies['log4j2-bom'])
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'

--- a/grails-bom/hibernate5/build.gradle
+++ b/grails-bom/hibernate5/build.gradle
@@ -51,6 +51,7 @@ ext {
 }
 
 dependencies {
+    api platform(gradleBomPlatformDependencies['log4j2-bom'])
     api platform(project(':grails-bom'))
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.hibernate.orm'

--- a/grails-bom/micronaut/build.gradle
+++ b/grails-bom/micronaut/build.gradle
@@ -66,6 +66,7 @@ def overriddenModules = customBomDependencies.values().collect { String coord ->
 Set<String> overriddenCoords = overriddenModules.collect { "${it.group}:${it.module}".toString() } as Set
 
 dependencies {
+    api platform(gradleBomPlatformDependencies['log4j2-bom'])
     api(platform(project(':grails-bom'))) {
         overriddenModules.each { ovr ->
             exclude group: ovr.group, module: ovr.module

--- a/grails-gradle/bom/build.gradle
+++ b/grails-gradle/bom/build.gradle
@@ -38,6 +38,7 @@ ext {
 }
 
 dependencies {
+    api platform(gradleBomPlatformDependencies['log4j2-bom'])
     api platform(gradleBomPlatformDependencies['spring-boot-bom']), {
         exclude group: 'org.apache.groovy'
         exclude group: 'org.spockframework'


### PR DESCRIPTION
## Description

Follow-up to merged PR #16043. That PR correctly upgraded Log4j to `2.25.5`, but its CI run exposed two publication issues that this change resolves:

- Log4j `2.25.5` transitively selects `biz.aQute.bnd.annotation:7.1.0`, while Spring Boot 3.5.16 manages `7.0.0`. The shared Grails BOM maps now manage the winning `7.1.0` version, fixing `Validate Dependency Versions`.
- Log4j management now lives in the shared Gradle BOM maps and every published BOM imports `log4j-bom` before inherited platforms. This prevents Maven's first-import-wins behavior and Gradle `enforcedPlatform` variants from leaving non-explicit Log4j modules at Spring Boot's older `2.24.3` version.

The affected publications are:

- `grails-gradle-bom`
- `grails-base-bom`
- `grails-bom`
- `grails-hibernate5-bom`
- `grails-micronaut-bom`

## Verification

- Root POM generation plus all dependency validators: **216 tasks successful**.
- Grails Gradle POM generation plus all dependency validators: **11 tasks successful**.
- Generated Gradle, base, Hibernate 5, and Micronaut POMs import `log4j-bom` before Spring Boot/Grails/Micronaut inherited platforms.
- A temporary real Gradle consumer imported each of the five published BOM POMs and resolved the non-explicit `org.apache.logging.log4j:log4j-layout-template-json` module to **2.25.5** in every case.
- `git diff --check` passes.

> Generative AI tooling was used to assist with dependency analysis, generated-POM verification, consumer resolution testing, review, and PR preparation. The resulting changes were reviewed and verified by the submitter.
