### PR TITLE
Bump github/codeql-action init and analyze together to v4.37.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
         java-version: 21
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+      uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
       with:
         languages: ${{ matrix.language }}
         # The autobuild action runs `./gradlew testClasses`, which compiles Groovy sample apps that are covered by regular CI.
@@ -77,4 +77,4 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+      uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3


### PR DESCRIPTION
## Summary
- Bumps both `github/codeql-action/init` and `github/codeql-action/analyze` from v4.36.0 to v4.37.3 in `.github/workflows/codeql.yml`.
- The two steps must use matching versions; running them out of sync fails the `Analyze (java)` job with `Loaded a configuration file for version '4.37.3', but running version '4.36.0'`.
- Dependabot opened these as two separate single-line PRs, each of which breaks CI on its own since it leaves the other step behind: #16039 (init only) and #16036 (analyze only). This combines them into one consistent bump.

Closes #16039
Closes #16036

## Test plan
- [x] Confirmed both action references now point at the same pinned SHA (v4.37.3)
- [ ] CI green on this PR, including the `Analyze (java)` CodeQL job