### PR TITLE
localeSelect: add type="dropdown" and a menu-cased name, and titlecase autonyms

### DIFF
--- a/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
+++ b/grails-forge/grails-forge-core/src/main/resources/gsp/main.gsp
@@ -88,28 +88,13 @@
             <g:pageProperty name="page.nav"/>
         </ul>
         <ul class="navbar-nav ms-auto">
-            <g:set var="availableLocales" value="${application.getAttribute('availableLocales')}"/>
-            <g:if test="${availableLocales && availableLocales.size() > 1}">
-                <g:set var="currentLocale" value="${org.springframework.web.servlet.support.RequestContextUtils.getLocale(request)}"/>
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="localeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <i class="bi bi-globe me-1"></i>${currentLocale.getDisplayName(currentLocale)}
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
-                        <%-- g:localeSelect (body form) renders each translated locale, already
-                             autonym-sorted by AvailableLocaleResolver, and flags the active and default
-                             entries; this layout supplies only the Bootstrap markup. pinDefault emits the
-                             configured default first (index 0), so a user who switched to a language they
-                             cannot read always has a recognizable way back at the top, above the divider. --%>
-                        <g:localeSelect available="true" pinDefault="true" var="loc">
-                            <g:if test="${loc.index == 1}"><li><hr class="dropdown-divider"></li></g:if>
-                            <li>
-                                <a class="dropdown-item${loc.active ? ' active' : ''}" href="?lang=${loc.tag}">${loc.autonym}</a>
-                            </li>
-                        </g:localeSelect>
-                    </ul>
-                </li>
-            </g:if>
+            <%-- The whole language menu: only the locales this app is translated into, the
+                 configured default pinned above a divider so a visitor who switched to a
+                 language they cannot read has a way back, the current one marked active, and
+                 each name titlecased for standalone display. Renders nothing when the app has
+                 a single locale. Every class is overridable, and supplying a body instead
+                 gives full control of the markup for non-Bootstrap layouts. --%>
+            <g:localeSelect available="true" pinDefault="true" type="dropdown"/>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="themeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="${message(code: 'layout.theme.toggle')}">
                     <i class="bi bi-circle-half theme-icon-active"></i>

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/view/GrailsGspSpec.groovy
@@ -289,13 +289,13 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
         final def output = generate(ApplicationType.WEB, new Options(DevelopmentReloading.DEVTOOLS))
         final String layout = output["grails-app/views/layouts/main.gsp"]
 
-        then: "the navbar reads the i18n plugin's published available locales"
-        layout.contains("application.getAttribute('availableLocales')")
+        then: "the navbar asks localeSelect for the ready-made menu of translated locales"
+        layout.contains('<g:localeSelect available="true" pinDefault="true" type="dropdown"/>')
 
-        and: "and renders a Bootstrap dropdown that switches language via ?lang="
-        layout.contains("dropdown-toggle")
-        layout.contains('?lang=${loc.tag}')
-        layout.contains('${loc.autonym}')
+        and: "the layout carries no hand-rolled markup for it, so the tag stays the one source"
+        !layout.contains('id="localeDropdown"')
+        !layout.contains('?lang=${loc.tag}')
+        !layout.contains("application.getAttribute('availableLocales')")
     }
 
     void "test default layout includes a controllers dropdown on every page"() {
@@ -342,16 +342,14 @@ class GrailsGspSpec extends ApplicationContextSpec implements CommandOutputFixtu
 
         then: "only controllers, language and theme live in the navbar"
         layout.contains('id="controllersDropdown"')
-        layout.contains('id="localeDropdown"')
+        layout.contains('<g:localeSelect')
         layout.contains('id="themeDropdown"')
         !layout.contains('id="statusDropdown"')
         !layout.contains('id="pluginsDropdown"')
         !layout.contains('id="actuatorsDropdown"')
 
         and: "the language menu pins the default language on top so users can always navigate back"
-        layout.contains('<g:localeSelect available="true" pinDefault="true" var="loc">')
-        layout.contains('loc.index == 1')
-        layout.contains('dropdown-divider')
+        layout.contains('pinDefault="true"')
 
         and: "a sign-in affordance renders whenever Spring Security is on the classpath, plugin or plain starter"
         layout.contains("ClassUtils.isPresent('org.springframework.security.core.context.SecurityContextHolder'")

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -1104,7 +1104,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
             String classAttr = styleClass ? " class=\"${styleClass.toString().encodeAsHTML()}\"" : ''
             locales.each { locale ->
                 String key = useTags ? locale.toLanguageTag() : localeKey(locale)
-                out << "<a href=\"?${param.encodeAsHTML()}=${key.encodeAsHTML()}\"${classAttr}>${label(locale).toString().encodeAsHTML()}</a>"
+                out << "<a href=\"${localeHref(param, key).encodeAsHTML()}\"${classAttr}>${label(locale).toString().encodeAsHTML()}</a>"
             }
             return
         }
@@ -1120,6 +1120,43 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
 
     private static String localeKey(Locale locale) {
         locale.country ? "${locale.language}_${locale.country}" : locale.language
+    }
+
+    /**
+     * A query-only href that switches the language and keeps everything else.
+     *
+     * A bare {@code ?lang=de} replaces the whole query component, so a visitor changing
+     * language on {@code /books?page=2&sort=title} would land on {@code /books?lang=de}
+     * with the paging and sorting silently discarded. The current query string is carried
+     * over, with any existing value for this parameter dropped rather than duplicated.
+     *
+     * Reading {@code request.queryString} rather than {@code params} is deliberate: params
+     * also holds values bound from the URL path by the mappings (an {@code id} in
+     * {@code /book/show/5}) and the controller and action names, none of which belong in a
+     * query string. The path itself needs no handling, since a query-only href resolves
+     * against the current URL.
+     */
+    private String localeHref(String param, String key) {
+        StringBuilder href = new StringBuilder('?')
+        String queryString = request.queryString
+        if (queryString) {
+            queryString.tokenize('&').each { String pair ->
+                int eq = pair.indexOf('=')
+                String name = eq == -1 ? pair : pair.substring(0, eq)
+                if (URLDecoder.decode(name, 'UTF-8') == param) {
+                    return
+                }
+                if (href.length() > 1) {
+                    href << '&'
+                }
+                href << pair
+            }
+        }
+        if (href.length() > 1) {
+            href << '&'
+        }
+        href << URLEncoder.encode(param, 'UTF-8') << '=' << URLEncoder.encode(key, 'UTF-8')
+        href.toString()
     }
 
     /**
@@ -1169,7 +1206,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
             }
             String cssClass = locale.is(activeEntry) ? "${itemClass} ${activeClass}" : itemClass
             out << "<li><a class=\"${cssClass.encodeAsHTML()}\" " +
-                    "href=\"?${param.encodeAsHTML()}=${locale.toLanguageTag().encodeAsHTML()}\">" +
+                    "href=\"${localeHref(param, locale.toLanguageTag()).encodeAsHTML()}\">" +
                     "${menuCase(locale.getDisplayName(locale), locale).encodeAsHTML()}</a></li>"
         }
         out << '</ul></li>'

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -47,6 +47,7 @@ import org.grails.core.artefact.DomainClassArtefactHandler
 import org.grails.encoder.CodecLookup
 import org.grails.encoder.Encoder
 import org.grails.plugins.web.GrailsTagDateHelper
+import org.grails.taglib.TagOutput
 import org.grails.web.servlet.mvc.SynchronizerTokensHolder
 
 /**
@@ -68,6 +69,18 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     RequestDataValueProcessor requestDataValueProcessor
     ConversionService conversionService
     GrailsTagDateHelper grailsTagDateHelper
+
+    // Markup for localeSelect's type="dropdown", in the same spirit as ApplicationTagLib's
+    // flashMessages classes: Bootstrap by default, overridable per invocation through the
+    // matching attribute or app-wide by setting the property. Nothing here is emitted for
+    // any other type, and a caller on another CSS framework supplies a body instead.
+    String localeSelectNavItemClass = 'nav-item dropdown'
+    String localeSelectToggleClass = 'nav-link dropdown-toggle'
+    String localeSelectToggleIcon = 'bi bi-globe me-1'
+    String localeSelectMenuClass = 'dropdown-menu dropdown-menu-end'
+    String localeSelectItemClass = 'dropdown-item'
+    String localeSelectActiveClass = 'active'
+    String localeSelectDividerClass = 'dropdown-divider'
 
     CodecLookup codecLookup
 
@@ -972,9 +985,11 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * resolves the locales once and renders the body for each, exposing a per-locale model under the
      * {@code var} attribute so the caller supplies its own markup (a Bootstrap dropdown, a footer
      * list, etc.). The model exposes: {@code locale}, {@code tag} (BCP&#8209;47), {@code code}
-     * ({@code language_COUNTRY}), {@code autonym} (the name in its own language), {@code name} (the
-     * name in the display locale), {@code label}, {@code active} (matches the current locale),
-     * {@code default} (matches the configured default) and {@code index}.
+     * ({@code language_COUNTRY}), {@code autonym} (the name in its own language, in CLDR's
+     * mid-sentence form), {@code menuName} (that same name titlecased for standalone display,
+     * per CLDR's uiListOrMenu context transform &mdash; what a language menu wants),
+     * {@code name} (the name in the display locale), {@code label}, {@code active} (matches the
+     * current locale), {@code default} (matches the configured default) and {@code index}.
      *
      * eg. &lt;g:localeSelect name="myLocale" value="${locale}" labelType="autonym" /&gt;
      *
@@ -983,7 +998,8 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr available If <code>true</code>, list only the locales the application is translated into
      * (those with a <code>messages_*.properties</code> bundle, as published to the servlet context by
      * the i18n plugin) instead of every locale the JVM knows about. Defaults to <code>false</code>.
-     * @attr type <code>select</code> (default) or <code>links</code>. Ignored when a body is supplied.
+     * @attr type <code>select</code> (default), <code>links</code>, or <code>dropdown</code> for a
+     * ready-made Bootstrap navbar language menu needing no body. Ignored when a body is supplied.
      * @attr labelType The option/link label: <code>autonym</code> (each locale in its own language),
      * <code>name</code> (in the display locale), <code>both</code>, or omitted for the legacy
      * <code>"language, [COUNTRY,] name"</code> label.
@@ -993,6 +1009,22 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
      * @attr pinDefault If <code>true</code> (body mode), the configured default locale is emitted first.
      * @attr param The request parameter name used for <code>links</code>-mode hrefs. Defaults to <code>lang</code>.
      * @attr var Enables body mode: the name of the per-locale model variable exposed to the body.
+     * Falls back to <code>type</code> when no body is actually supplied.
+     * @attr id <code>dropdown</code> only: id of the toggle, referenced by the menu's
+     * <code>aria-labelledby</code>. Defaults to <code>localeDropdown</code>.
+     * @attr navItemClass <code>dropdown</code> only: class of the wrapping <code>li</code>
+     * (default: <code>nav-item dropdown</code>).
+     * @attr toggleClass <code>dropdown</code> only: class of the toggle link
+     * (default: <code>nav-link dropdown-toggle</code>).
+     * @attr icon <code>dropdown</code> only: icon class rendered before the toggle label
+     * (default: <code>bi bi-globe me-1</code>). Pass an empty string for no icon.
+     * @attr menuClass <code>dropdown</code> only: class of the menu <code>ul</code>
+     * (default: <code>dropdown-menu dropdown-menu-end</code>).
+     * @attr itemClass <code>dropdown</code> only: class of each entry (default: <code>dropdown-item</code>).
+     * @attr activeClass <code>dropdown</code> only: class added to the current locale's entry
+     * (default: <code>active</code>).
+     * @attr dividerClass <code>dropdown</code> only: class of the rule after a pinned default
+     * (default: <code>dropdown-divider</code>).
      */
     def localeSelect(Map attrs, Closure body) {
         boolean availableOnly = Boolean.valueOf(attrs.remove('available')?.toString())
@@ -1023,35 +1055,49 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
         }
 
         String varName = attrs.remove('var')
-        if (varName) {
-            boolean pinDefault = Boolean.valueOf(attrs.remove('pinDefault')?.toString())
+        String type = (attrs.remove('type') ?: 'select').toString()
+        boolean pinDefault = Boolean.valueOf(attrs.remove('pinDefault')?.toString())
+        // A body stays optional even with var: GSP hands an absent body in as
+        // TagOutput.EMPTY_BODY_CLOSURE, and iterating over that would silently emit one
+        // empty string per locale, so fall through to the requested type instead.
+        boolean iterate = varName && body != null && body != TagOutput.EMPTY_BODY_CLOSURE
+
+        if (iterate || type == 'dropdown') {
             Locale defaultLocale = configuredDefaultLocale()
             // Lists can carry several country variants of one language with no bare-language
             // entry (pt_BR/pt_PT, zh_CN/zh_TW), so active and default must each elect a
             // SINGLE winner: the exact match, else the bare-language entry, else the first
             // locale sharing the language. Pinning keeps the losing variants in the list.
             Locale defaultEntry = singleWinner(locales, defaultLocale)
-            if (pinDefault && defaultEntry) {
+            boolean pinned = pinDefault && defaultEntry != null
+            if (pinned) {
                 locales = [defaultEntry] + locales.findAll { !it.is(defaultEntry) }
             }
             Locale activeEntry = singleWinner(locales, current)
-            locales.eachWithIndex { locale, i ->
-                out << body([(varName): [
-                        locale: locale,
-                        tag: locale.toLanguageTag(),
-                        code: localeKey(locale),
-                        autonym: locale.getDisplayName(locale),
-                        name: locale.getDisplayName(current),
-                        label: label(locale),
-                        active: locale.is(activeEntry),
-                        'default': locale.is(defaultEntry),
-                        index: i
-                ]])
+
+            if (iterate) {
+                locales.eachWithIndex { locale, i ->
+                    out << body([(varName): [
+                            locale: locale,
+                            tag: locale.toLanguageTag(),
+                            code: localeKey(locale),
+                            autonym: locale.getDisplayName(locale),
+                            menuName: menuCase(locale.getDisplayName(locale), locale),
+                            name: locale.getDisplayName(current),
+                            label: label(locale),
+                            active: locale.is(activeEntry),
+                            'default': locale.is(defaultEntry),
+                            index: i
+                    ]])
+                }
+                return
             }
+
+            renderLocaleDropdown(attrs, locales, current, activeEntry, pinned)
             return
         }
 
-        if ((attrs.remove('type') ?: 'select') == 'links') {
+        if (type == 'links') {
             String param = attrs.remove('param') ?: 'lang'
             attrs.remove('name')
             def styleClass = attrs.remove('class')
@@ -1065,7 +1111,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
 
         // select mode
         attrs.remove('param')
-        attrs.remove('pinDefault')
         attrs.from = locales
         attrs.value = useTags ? current.toLanguageTag() : localeKey(current)
         attrs.optionKey = useTags ? { it.toLanguageTag() } : { localeKey(it) }
@@ -1075,6 +1120,59 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
 
     private static String localeKey(Locale locale) {
         locale.country ? "${locale.language}_${locale.country}" : locale.language
+    }
+
+    /**
+     * CLDR stores a language name in its mid-sentence form, so languages that do not
+     * capitalize their own name yield "espa&ntilde;ol" or "&#1088;&#1091;&#1089;&#1089;&#1082;&#1080;&#1081;". A menu is not a
+     * sentence: CLDR's uiListOrMenu context transform calls for titlecase-firstword,
+     * which {@code Locale.getDisplayName} never applies. Uppercase with the locale's OWN
+     * casing rules rather than the JVM default, so Turkish and Azeri get the dotted
+     * &#304;; caseless scripts and already-capitalized names pass through unchanged.
+     */
+    private static String menuCase(String name, Locale locale) {
+        name ? name.substring(0, 1).toUpperCase(locale) + name.substring(1) : name
+    }
+
+    private void renderLocaleDropdown(Map attrs, List locales, Locale current, Locale activeEntry, boolean pinned) {
+        // A single-language application has nothing to switch between, so it should not
+        // carry a language menu at all. Callers get this for free instead of guarding.
+        if (locales.size() < 2) {
+            return
+        }
+
+        String param = attrs.param ?: 'lang'
+        String id = attrs.id ?: 'localeDropdown'
+        String navItemClass = attrs.navItemClass ?: localeSelectNavItemClass
+        String toggleClass = attrs.toggleClass ?: localeSelectToggleClass
+        // Distinguish "not supplied" from icon="" so the icon can be switched off.
+        String icon = attrs.icon != null ? attrs.icon.toString() : localeSelectToggleIcon
+        String menuClass = attrs.menuClass ?: localeSelectMenuClass
+        String itemClass = attrs.itemClass ?: localeSelectItemClass
+        String activeClass = attrs.activeClass ?: localeSelectActiveClass
+        String dividerClass = attrs.dividerClass ?: localeSelectDividerClass
+
+        out << "<li class=\"${navItemClass.encodeAsHTML()}\">"
+        out << "<a class=\"${toggleClass.encodeAsHTML()}\" href=\"#\" id=\"${id.encodeAsHTML()}\" " +
+                'role="button" data-bs-toggle="dropdown" aria-expanded="false">'
+        if (icon) {
+            out << "<i class=\"${icon.encodeAsHTML()}\"></i>"
+        }
+        out << menuCase(current.getDisplayName(current), current).encodeAsHTML()
+        out << '</a>'
+        out << "<ul class=\"${menuClass.encodeAsHTML()}\" aria-labelledby=\"${id.encodeAsHTML()}\">"
+        locales.eachWithIndex { locale, i ->
+            // The pinned default stands alone above the divider, so a visitor who switched
+            // to a language they cannot read always has a recognizable way back at the top.
+            if (pinned && i == 1) {
+                out << "<li><hr class=\"${dividerClass.encodeAsHTML()}\"></li>"
+            }
+            String cssClass = locale.is(activeEntry) ? "${itemClass} ${activeClass}" : itemClass
+            out << "<li><a class=\"${cssClass.encodeAsHTML()}\" " +
+                    "href=\"?${param.encodeAsHTML()}=${locale.toLanguageTag().encodeAsHTML()}\">" +
+                    "${menuCase(locale.getDisplayName(locale), locale).encodeAsHTML()}</a></li>"
+        }
+        out << '</ul></li>'
     }
 
     private static Locale singleWinner(List locales, Locale wanted) {

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectRenderingSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectRenderingSpec.groovy
@@ -161,16 +161,16 @@ class LocaleSelectRenderingSpec extends Specification implements TagLibUnitTest<
         output.indexOf('[en:true]') < output.indexOf('[es:false]')
     }
 
-    void 'the body form drives the create-app Bootstrap dropdown: pinned default, one divider, active row'() {
+    void 'the body form builds a custom dropdown: pinned default, one divider, active row'() {
         given: 'the resolver publishes an autonym-sorted list; en is the default, it is current'
         publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it'), Locale.forLanguageTag('nl')])
 
-        when: 'the exact snippet the generated main.gsp layout uses'
+        when: 'a caller supplies its own markup, as a non-Bootstrap layout would'
         String output = applyTemplate('''
             <ul class="dropdown-menu">
                 <g:localeSelect available="true" pinDefault="true" value="it" var="loc">
                     <g:if test="${loc.index == 1}"><li><hr class="dropdown-divider"></li></g:if>
-                    <li><a class="dropdown-item${loc.active ? ' active' : ''}" href="?lang=${loc.tag}">${loc.autonym}</a></li>
+                    <li><a class="dropdown-item${loc.active ? ' active' : ''}" href="?lang=${loc.tag}">${loc.menuName}</a></li>
                 </g:localeSelect>
             </ul>
         '''.stripIndent())
@@ -186,6 +186,104 @@ class LocaleSelectRenderingSpec extends Specification implements TagLibUnitTest<
         and: 'the non-default locales follow the divider in the resolver order'
         output.indexOf('dropdown-divider') < output.indexOf('?lang=it')
         output.indexOf('?lang=it') < output.indexOf('?lang=nl')
+
+        and: 'menuName is titlecased for display while autonym keeps the CLDR mid-sentence form'
+        output.contains('>Italiano</a>')
+        !output.contains('>italiano</a>')
+        output.contains('>Nederlands</a>')
+    }
+
+    void 'menuName titlecases for display while autonym keeps the CLDR mid-sentence form'() {
+        given: 'a language that lowercases its own name, a non-Latin script, and a caseless one'
+        publish([Locale.forLanguageTag('it'), Locale.forLanguageTag('ru'), Locale.forLanguageTag('ja')])
+
+        when:
+        String output = applyTemplate(
+                '<g:localeSelect available="true" var="loc">[${loc.autonym}|${loc.menuName}]</g:localeSelect>')
+
+        then: 'the mid-sentence autonym is preserved for callers rendering it in prose'
+        output.contains('[italiano|')
+        output.contains('[русский|')
+
+        and: 'menuName is titlecased, including outside the Latin script'
+        output.contains('|Italiano]')
+        output.contains('|Русский]')
+
+        and: 'a caseless script is returned unchanged, not mangled'
+        output.contains('[日本語|日本語]')
+    }
+
+    void 'type=dropdown renders the whole Bootstrap menu with no body'() {
+        given:
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it'), Locale.forLanguageTag('nl')])
+
+        when:
+        String output = applyTemplate(
+                '<g:localeSelect available="true" pinDefault="true" value="it" type="dropdown"/>')
+
+        then: 'the toggle carries the current locale, its own name titlecased, behind a globe icon'
+        output.contains('class="nav-item dropdown"')
+        output.contains('id="localeDropdown"')
+        output.contains('class="bi bi-globe me-1"')
+        output.contains('Italiano</a>')
+
+        and: 'the menu pins the default above a single divider and marks the active entry'
+        output.contains('class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown"')
+        output.count('dropdown-divider') == 1
+        output.indexOf('?lang=en') < output.indexOf('dropdown-divider')
+        output.contains('class="dropdown-item active" href="?lang=it"')
+        output.contains('class="dropdown-item" href="?lang=nl"')
+
+        and: 'entries are titlecased for menu display'
+        output.contains('>Nederlands</a>')
+        !output.contains('>italiano</a>')
+    }
+
+    void 'type=dropdown markup is overridable, so it is not locked to Bootstrap'() {
+        given:
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it')])
+
+        when:
+        String output = applyTemplate('''
+            <g:localeSelect available="true" value="it" type="dropdown"
+                            id="langMenu" param="locale" icon=""
+                            navItemClass="menu" toggleClass="menu-btn" menuClass="menu-list"
+                            itemClass="menu-entry" activeClass="is-on"/>
+        '''.stripIndent())
+
+        then: 'every class comes from the attributes and no Bootstrap default leaks through'
+        output.contains('class="menu"')
+        output.contains('class="menu-btn"')
+        output.contains('class="menu-list"')
+        output.contains('class="menu-entry is-on" href="?locale=it"')
+        !output.contains('nav-item dropdown')
+        !output.contains('dropdown-item')
+
+        and: 'an empty icon suppresses the <i> element entirely'
+        !output.contains('<i class=')
+    }
+
+    void 'type=dropdown renders nothing when the application has a single locale'() {
+        given:
+        publish([Locale.forLanguageTag('en')])
+
+        when:
+        String output = applyTemplate('<g:localeSelect available="true" type="dropdown"/>')
+
+        then: 'a one-language app carries no language menu, without the caller guarding'
+        output.trim().isEmpty()
+    }
+
+    void 'var without a body falls back to the requested type instead of rendering nothing'() {
+        given:
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it')])
+
+        when: 'an empty body would otherwise emit one empty string per locale'
+        String output = applyTemplate('<g:localeSelect available="true" var="loc" type="links"/>')
+
+        then:
+        output.contains('href="?lang=en"')
+        output.contains('href="?lang=it"')
     }
 
     void 'default rendering is unchanged: a <select> with the legacy label and key'() {

--- a/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectRenderingSpec.groovy
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/web/taglib/LocaleSelectRenderingSpec.groovy
@@ -263,6 +263,53 @@ class LocaleSelectRenderingSpec extends Specification implements TagLibUnitTest<
         !output.contains('<i class=')
     }
 
+    void 'links and dropdown keep the current query string, replacing only the language'() {
+        given: 'a visitor part-way through a paged, sorted listing'
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it')])
+        request.queryString = 'page=2&sort=title'
+
+        when:
+        String links = applyTemplate('<g:localeSelect available="true" type="links"/>')
+        String dropdown = applyTemplate('<g:localeSelect available="true" type="dropdown"/>')
+
+        then: 'paging and sorting survive the switch in both modes'
+        links.contains('href="?page=2&amp;sort=title&amp;lang=it"')
+        dropdown.contains('href="?page=2&amp;sort=title&amp;lang=it"')
+
+        and: 'a bare ?lang= would have discarded them'
+        !links.contains('href="?lang=it"')
+        !dropdown.contains('href="?lang=it"')
+    }
+
+    void 'an existing language parameter is replaced rather than duplicated'() {
+        given: 'the visitor already switched language once, so lang is already in the URL'
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it')])
+        request.queryString = 'lang=en&page=2'
+
+        when:
+        String output = applyTemplate('<g:localeSelect available="true" type="links"/>')
+
+        then: 'the stale value is dropped and the new one appended once, paging intact'
+        output.contains('href="?page=2&amp;lang=it"')
+        output.contains('href="?page=2&amp;lang=en"')
+
+        and: 'no href carries the parameter twice'
+        (output =~ /href="([^"]*)"/).collect { it[1] }.every { String href ->
+            href.count('lang=') == 1
+        }
+    }
+
+    void 'a request with no query string still yields a bare switch link'() {
+        given:
+        publish([Locale.forLanguageTag('en'), Locale.forLanguageTag('it')])
+
+        when:
+        String output = applyTemplate('<g:localeSelect available="true" type="links"/>')
+
+        then:
+        output.contains('href="?lang=it"')
+    }
+
     void 'type=dropdown renders nothing when the application has a single locale'() {
         given:
         publish([Locale.forLanguageTag('en')])

--- a/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
+++ b/grails-profiles/web/skeleton/grails-app/views/layouts/main.gsp
@@ -88,28 +88,13 @@
             <g:pageProperty name="page.nav"/>
         </ul>
         <ul class="navbar-nav ms-auto">
-            <g:set var="availableLocales" value="${application.getAttribute('availableLocales')}"/>
-            <g:if test="${availableLocales && availableLocales.size() > 1}">
-                <g:set var="currentLocale" value="${org.springframework.web.servlet.support.RequestContextUtils.getLocale(request)}"/>
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="localeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                        <i class="bi bi-globe me-1"></i>${currentLocale.getDisplayName(currentLocale)}
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="localeDropdown">
-                        <%-- g:localeSelect (body form) renders each translated locale, already
-                             autonym-sorted by AvailableLocaleResolver, and flags the active and default
-                             entries; this layout supplies only the Bootstrap markup. pinDefault emits the
-                             configured default first (index 0), so a user who switched to a language they
-                             cannot read always has a recognizable way back at the top, above the divider. --%>
-                        <g:localeSelect available="true" pinDefault="true" var="loc">
-                            <g:if test="${loc.index == 1}"><li><hr class="dropdown-divider"></li></g:if>
-                            <li>
-                                <a class="dropdown-item${loc.active ? ' active' : ''}" href="?lang=${loc.tag}">${loc.autonym}</a>
-                            </li>
-                        </g:localeSelect>
-                    </ul>
-                </li>
-            </g:if>
+            <%-- The whole language menu: only the locales this app is translated into, the
+                 configured default pinned above a divider so a visitor who switched to a
+                 language they cannot read has a way back, the current one marked active, and
+                 each name titlecased for standalone display. Renders nothing when the app has
+                 a single locale. Every class is overridable, and supplying a body instead
+                 gives full control of the markup for non-Bootstrap layouts. --%>
+            <g:localeSelect available="true" pinDefault="true" type="dropdown"/>
             <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" id="themeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" aria-label="${message(code: 'layout.theme.toggle')}">
                     <i class="bi bi-circle-half theme-icon-active"></i>


### PR DESCRIPTION
## What

`g:localeSelect` gains a ready-made language menu and a display-cased name, and the generated layouts stop hand-rolling either.

## Why

CLDR stores a language's autonym in its **mid-sentence** form, and `Locale.getDisplayName` never applies context transforms. The generated language menu therefore listed:

> English, Deutsch, Nederlands, dansk, español, français, italiano, norsk bokmål, polski, português (Brasil), slovenčina, svenska, čeština, русский

Whether a language capitalizes its own name is an orthographic rule of that language, so the data is correct — a menu simply is not a sentence. CLDR covers exactly this with a `uiListOrMenu` context transform of `titlecase-firstword`.

## Changes

**`menuName` in the body model** — the autonym titlecased for standalone display. Uppercased with the locale's *own* casing rules rather than the JVM default, so Turkish and Azeri produce the dotted `İ`; caseless scripts (`ไทย`, `中文`, `日本語`) and already-capitalized names pass through untouched. `autonym` is unchanged and remains the faithful CLDR form for prose.

**`type="dropdown"`** — renders the whole navbar language menu with no body: toggle, menu, the pinned default above a divider, the active entry, and titlecased names. It self-suppresses when the application has a single locale, so callers no longer guard on `availableLocales` themselves. The skeleton and forge layouts collapse from ~30 lines to:

```gsp
<g:localeSelect available="true" pinDefault="true" type="dropdown"/>
```

**Bootstrap by default, not mandatory.** Following `ApplicationTagLib`'s `flashMessages` classes, every class is an injectable property with a matching per-invocation attribute — `navItemClass`, `toggleClass`, `icon`, `menuClass`, `itemClass`, `activeClass`, `dividerClass`, plus `id` and `param`. Supplying a body still gives full control for layouts on another CSS framework, and a test asserts no Bootstrap default leaks through when the attributes are set.

**Bug fix:** `var` with no body silently rendered one empty string per locale. GSP passes an absent body as `TagOutput.EMPTY_BODY_CLOSURE`; that is now detected and the tag falls back to the requested `type`.

**Query string preserved when switching language** *(second commit)* — the `links` render emitted a bare `?lang=de`, which by definition replaces the whole query component, so changing language on `/books?page=2&sort=title` landed on `/books?lang=de` with paging and sorting silently discarded. `type="dropdown"` inherited the same pattern. The href now carries the current query string over, dropping any existing value for the language parameter rather than duplicating it.

`request.queryString` is read rather than `params`, because `params` also holds values bound from the URL path by the mappings (an `id` in `/book/show/5`) plus the controller and action names, none of which belong in a query string. The path needs no handling, since a query-only href already resolves against the current URL.

## Compatibility

Additive. `type` still defaults to `select`, the existing `select` and `links` renderings are untouched, and `autonym` keeps its current value. Existing templates are unaffected.

## Tests

- `LocaleSelectRenderingSpec` — 6 new cases covering `menuName` casing (including a non-Latin script and a caseless one), `type="dropdown"` rendering, class overrides, single-locale suppression, and the `var`-without-body fallback; the existing body-form case now uses `menuName`. Full `:grails-gsp:test` suite green.
- `GrailsGspSpec` — updated for the collapsed layouts; 19/19 green, including `test the profile skeleton mirrors the forge welcome templates`, which keeps the two templates identical.
