### PR TITLE
Fix spring-security-ui jQuery 4 / Bootstrap 5 compatibility

### DIFF
--- a/grails-doc/src/en/guide/security/securityPlugins/springSecurity/ui/customization.adoc
+++ b/grails-doc/src/en/guide/security/securityPlugins/springSecurity/ui/customization.adoc
@@ -177,7 +177,7 @@ The layouts use `grails-app/assets/javascripts/jquery.js`, which contains this:
 //=require jquery/jquery-${grails.plugin.springsecurity.ui.Constants.JQUERY_VERSION}.js
 ----
 
-This resolves to `grails-app/assets/javascripts/jquery/jquery-2.1.4.js`, and to use your own version, either use the same approach in a file called `jquery.js` or rename your file to `jquery.js`.
+This resolves to `grails-app/assets/javascripts/jquery/jquery-4.0.0.js`, and to use your own version, either use the same approach in a file called `jquery.js` or rename your file to `jquery.js`.
 
 Likewise for jQuery UI, the JavaScript file is `grails-app/assets/javascripts/jquery-ui.js`, which contains this
 
@@ -195,9 +195,9 @@ and the CSS file `grails-app/assets/stylesheets/jquery-ui.css`, which contains
  */
 ----
 
-The JavaScript file resolves to `grails-app/assets/javascripts/jquery-ui/jquery-ui-1.10.3.custom.js`, and to use your own version, either use the same approach in a file called `jquery-ui.js` or rename your file to `jquery-ui.js`.
+The JavaScript file resolves to `grails-app/assets/javascripts/jquery-ui/jquery-ui-1.14.1.js`, and to use your own version, either use the same approach in a file called `jquery-ui.js` or rename your file to `jquery-ui.js`.
 
-The CSS file resolves to `grails-app/assets/stylesheets/smoothness/jquery-ui-1.10.3.custom.css`, and to use your own version, either use the same approach in a file called `jquery-ui.js` or rename your file to `jquery-ui.js`.
+The CSS file resolves to `grails-app/assets/stylesheets/smoothness/jquery-ui-1.14.1.css`, and to use your own version, either use the same approach in a file called `jquery-ui.js` or rename your file to `jquery-ui.js`.
 
 Use your own `jquery-ui.js` and/or `jquery-ui.css` to override the plugin's.
 

--- a/grails-spring-security/ui/plugin/build.gradle
+++ b/grails-spring-security/ui/plugin/build.gradle
@@ -52,11 +52,11 @@ dependencies {
     implementation 'org.springframework.security:spring-security-web'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:datatables:1.10.25'
-    implementation 'org.webjars:jquery:2.1.4'
-    implementation 'org.webjars:jquery-form:3.51'
-    implementation 'org.webjars:jquery-ui:1.10.3'
-    implementation 'org.webjars:jquery-ui-themes:1.10.3'
+    implementation 'org.webjars:datatables:2.3.0'
+    implementation 'org.webjars:jquery:4.0.0'
+    implementation 'org.webjars:jquery-form:4.2.2'
+    implementation 'org.webjars:jquery-ui:1.14.1'
+    implementation 'org.webjars:jquery-ui-themes:1.13.2'
     implementation 'org.webjars.bower:bgiframe:3.0.1'
     implementation 'org.webjars.bower:jgrowl:1.4.6'
 

--- a/grails-spring-security/ui/plugin/grails-app/assets/javascripts/jquery/jquery.jdMenu.js
+++ b/grails-spring-security/ui/plugin/grails-app/assets/javascripts/jquery/jquery.jdMenu.js
@@ -18,9 +18,9 @@ $(function() {
 
 (function($){
 	function addEvents(ul) {
-		var settings = $.data( $(ul).parents().andSelf().filter('ul.jd_menu')[0], 'jdMenuSettings' );
+		var settings = $.data( $(ul).parents().addBack().filter('ul.jd_menu')[0], 'jdMenuSettings' );
 		$('> li', ul)
-			.bind('mouseenter.jdmenu mouseleave.jdmenu', function(evt) {
+			.on('mouseenter.jdmenu mouseleave.jdmenu', function(evt) {
 				$(this).toggleClass('jdm_hover');
 				var ul = $('> ul', this);
 				if ( ul.length == 1 ) {
@@ -32,7 +32,7 @@ $(function() {
 					}, enter ? settings.showDelay : settings.hideDelay );
 				}
 			})
-			.bind('click.jdmenu', function(evt) {
+			.on('click.jdmenu', function(evt) {
 				var ul = $('> ul', this);
 				if ( ul.length == 1 && 
 					( settings.disableLinks == true || $(this).hasClass('accessible') ) ) {
@@ -59,16 +59,16 @@ $(function() {
 				}
 			})
 			.find('> a')
-				.bind('focus.jdmenu blur.jdmenu', function(evt) {
+				.on('focus.jdmenu blur.jdmenu', function(evt) {
 					var p = $(this).parents('li:eq(0)');
 					if ( evt.type == 'focus' ) {
 						p.addClass('jdm_hover');
-					} else { 
+					} else {
 						p.removeClass('jdm_hover');
 					}
 				})
 				.filter('.accessible')
-					.bind('click.jdmenu', function(evt) {
+					.on('click.jdmenu', function(evt) {
 						evt.preventDefault();
 					});
 	}
@@ -139,7 +139,7 @@ $(function() {
 									// This callback allows for you to animate menus
 									//onAnimate:	null
 									}, settings);
-		if ( !$.isFunction( settings.onAnimate ) ) {
+		if ( typeof settings.onAnimate !== 'function' ) {
 			settings.onAnimate = undefined;
 		}
 		return this.filter('ul.jd_menu').each(function() {
@@ -153,8 +153,8 @@ $(function() {
 	
 	$.fn.jdMenuUnbind = function() {
 		$('ul.jdm_events', this)
-			.unbind('.jdmenu')
-			.find('> a').unbind('.jdmenu');
+			.off('.jdmenu')
+			.find('> a').off('.jdmenu');
 	};
 	$.fn.jdMenuHide = function() {
 		return this.filter('ul').each(function(){ 
@@ -165,7 +165,7 @@ $(function() {
 	// Private methods and logic
 	$(window)
 		// Bind a click event to hide all visible menus when the document is clicked
-		.bind('click.jdmenu', function(){
+		.on('click.jdmenu', function(){
 			$('ul.jd_menu ul:visible').jdMenuHide();
 		});
 })(jQuery);

--- a/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui-ajaxLogin.js
+++ b/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui-ajaxLogin.js
@@ -34,7 +34,7 @@ $(function() {
 		buttons: buttons
 	});
 
-	$('#loginForm').bind('submit', function() {
+	$('#loginForm').on('submit', function() {
 		$(this).ajaxSubmit({
 			target: '#loginMessage',
 			beforeSubmit: function() {

--- a/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui-register.js
+++ b/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui-register.js
@@ -17,6 +17,6 @@
  *  under the License.
  */
 
-//= require webjars/jquery/2.1.4/jquery.min.js
-//= require webjars/jquery-ui/1.10.3/ui/minified/jquery-ui.min.js
+//= require webjars/jquery/4.0.0/jquery.min.js
+//= require webjars/jquery-ui/1.14.1/jquery-ui.min.js
 //= require webjars/jgrowl/1.4.6/jquery.jgrowl.min.js

--- a/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui.js
+++ b/grails-spring-security/ui/plugin/grails-app/assets/javascripts/spring-security-ui.js
@@ -17,11 +17,11 @@
  *  under the License.
  */
 
-//= require webjars/jquery/2.1.4/jquery.min.js
-//= require webjars/jquery-ui/1.10.3/ui/minified/jquery-ui.min.js
+//= require webjars/jquery/4.0.0/jquery.min.js
+//= require webjars/jquery-ui/1.14.1/jquery-ui.min.js
 //= require webjars/jgrowl/1.4.6/jquery.jgrowl.min.js
 //= require jquery/jquery.positionBy.js
 //= require webjars/bgiframe/3.0.1/jquery.bgiframe.js
-//= require webjars/jquery-form/3.51/jquery.form.js
+//= require webjars/jquery-form/4.2.2/jquery.form.min.js
 //= require jquery/jquery.jdMenu.js
 //= require spring-security-ui-ajaxLogin.js

--- a/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/jquery-ui.css
+++ b/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/jquery-ui.css
@@ -18,5 +18,5 @@
  */
 
 /*
- *= require webjars/jquery-ui-themes/1.10.3/smoothness/jquery-ui
+ *= require webjars/jquery-ui-themes/1.13.2/smoothness/jquery-ui
  */

--- a/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/jquery.dataTables.css
+++ b/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/jquery.dataTables.css
@@ -18,5 +18,5 @@
  */
 
 /*
- *= require webjars/datatables/1.10.25/css/jquery.dataTables
+ *= require webjars/datatables/2.3.0/css/dataTables.dataTables
  */

--- a/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/spring-security-ui.css
+++ b/grails-spring-security/ui/plugin/grails-app/assets/stylesheets/spring-security-ui.css
@@ -19,7 +19,7 @@
 
 /*
  *= require reset
- *= require webjars/jquery-ui-themes/1.10.3/smoothness/jquery-ui
+ *= require webjars/jquery-ui-themes/1.13.2/smoothness/jquery-ui
  *= require jquery.jdMenu
  *= require jquery.jdMenu.slate
  *= require webjars/jgrowl/1.4.6/jquery.jgrowl

--- a/grails-spring-security/ui/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
+++ b/grails-spring-security/ui/plugin/grails-app/taglib/grails/plugin/springsecurity/ui/SecurityUiTagLib.groovy
@@ -155,7 +155,7 @@ class SecurityUiTagLib {
             <div id="deleteConfirmDialog" title="${message(code: 'default.button.delete.confirm.message')}"></div>"""
 
         writeDocumentReady out, """
-    \$("#deleteButton").button().bind('click', function() {
+    \$("#deleteButton").button().on('click', function() {
         \$('#deleteConfirmDialog').dialog('open');
     });
 
@@ -711,7 +711,7 @@ class SecurityUiTagLib {
 
         writeDocumentReady out, """\
     \$("#$elementId").button();
-    \$('#$elementId').bind('click', function() {
+    \$('#$elementId').on('click', function() {
         document.forms.${formName}.submit();
     });"""
     }

--- a/grails-spring-security/ui/plugin/grails-app/views/securityInfo/config.gsp
+++ b/grails-spring-security/ui/plugin/grails-app/views/securityInfo/config.gsp
@@ -54,7 +54,7 @@
         </tbody>
     </table>
 </div>
-<s2ui:deferredScript src='webjars/datatables/1.10.25/js/jquery.dataTables.js'/>
+<s2ui:deferredScript src='webjars/datatables/2.3.0/js/dataTables.js'/>
 <s2ui:documentReady>
     $('#config').DataTable();
 </s2ui:documentReady>

--- a/grails-spring-security/ui/plugin/grails-app/views/user/edit.gsp
+++ b/grails-spring-security/ui/plugin/grails-app/views/user/edit.gsp
@@ -68,7 +68,7 @@
 </g:if>
 <s2ui:documentReady>
 	$("#runAsButton").button();
-	$('#runAsButton').bind('click', function() {
+	$('#runAsButton').on('click', function() {
 		document.forms.runAsForm.submit();
 	});
 </s2ui:documentReady>

--- a/grails-spring-security/ui/plugin/src/main/groovy/grails/plugin/springsecurity/ui/Constants.groovy
+++ b/grails-spring-security/ui/plugin/src/main/groovy/grails/plugin/springsecurity/ui/Constants.groovy
@@ -28,6 +28,6 @@ import groovy.transform.CompileStatic
 @CompileStatic
 final class Constants {
 
-    public static final String JQUERY_VERSION = '2.1.4'
-    public static final String JQUERY_UI_VERSION = '1.10.3.custom'
+    public static final String JQUERY_VERSION = '4.0.0'
+    public static final String JQUERY_UI_VERSION = '1.14.1'
 }

--- a/grails-test-examples/spring-security/cas/test1/build.gradle
+++ b/grails-test-examples/spring-security/cas/test1/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:bootstrap:3.3.6'
-    implementation 'org.webjars:jquery:2.2.0'
+    implementation 'org.webjars:bootstrap:5.3.8'
+    implementation 'org.webjars:jquery:4.0.0'
 
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'

--- a/grails-test-examples/spring-security/cas/test1/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/spring-security/cas/test1/grails-app/assets/javascripts/application.js
@@ -24,8 +24,8 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/jquery/2.2.0/jquery
-//= require webjars/bootstrap/3.3.6/js/bootstrap.js
+//= require webjars/jquery/4.0.0/jquery
+//= require webjars/bootstrap/5.3.8/js/bootstrap.js
 //= require_self
 
 if (typeof jQuery !== 'undefined') {

--- a/grails-test-examples/spring-security/cas/test1/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/spring-security/cas/test1/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/bootstrap/3.3.6/css/bootstrap
+*= require webjars/bootstrap/5.3.8/css/bootstrap
 *= require grails
 *= require_self
 */

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/build.gradle
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:bootstrap:4.1.3'
-    implementation 'org.webjars:jquery:3.3.1'
+    implementation 'org.webjars:bootstrap:5.3.8'
+    implementation 'org.webjars:jquery:4.0.0'
 
     // to not depend on an external ldap server
     implementation 'com.unboundid:unboundid-ldapsdk'

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/jquery/3.3.1/jquery
-//= require webjars/bootstrap/4.1.3/js/bootstrap.bundle
+//= require webjars/jquery/4.0.0/jquery
+//= require webjars/bootstrap/5.3.8/js/bootstrap.bundle
 //= require_self

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/bootstrap/4.1.3/css/bootstrap
+*= require webjars/bootstrap/5.3.8/css/bootstrap
 *= require grails
 *= require main
 *= require mobile

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/views/index.gsp
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/views/index.gsp
@@ -25,7 +25,7 @@
 <body>
 <content tag="nav">
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
             <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
@@ -43,7 +43,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Controllers: ${grailsApplication.controllerClasses.size()}</a></li>
             <li class="dropdown-item"><a href="#">Domains: ${grailsApplication.domainClasses.size()}</a></li>
@@ -52,7 +52,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
                 <li class="dropdown-item"><a href="#">${plugin.name} - ${plugin.version}</a></li>

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/grails-app/views/layouts/main.gsp
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark navbar-static-top" role="navigation">
     <a class="navbar-brand" href="/#"><asset:image src="grails.svg" alt="Grails Logo"/></a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/grails-test-examples/spring-security/ldap/functional-test-app/build.gradle
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/build.gradle
@@ -40,8 +40,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:bootstrap:4.1.3'
-    implementation 'org.webjars:jquery:3.3.1'
+    implementation 'org.webjars:bootstrap:5.3.8'
+    implementation 'org.webjars:jquery:4.0.0'
 
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'

--- a/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/jquery/3.3.1/jquery
-//= require webjars/bootstrap/4.1.3/js/bootstrap.bundle
+//= require webjars/jquery/4.0.0/jquery
+//= require webjars/bootstrap/5.3.8/js/bootstrap.bundle
 //= require_self

--- a/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/bootstrap/4.1.3/css/bootstrap
+*= require webjars/bootstrap/5.3.8/css/bootstrap
 *= require grails
 *= require main
 *= require mobile

--- a/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/views/index.gsp
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/views/index.gsp
@@ -25,7 +25,7 @@
 <body>
 <content tag="nav">
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
             <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
@@ -43,7 +43,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Controllers: ${grailsApplication.controllerClasses.size()}</a></li>
             <li class="dropdown-item"><a href="#">Domains: ${grailsApplication.domainClasses.size()}</a></li>
@@ -52,7 +52,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
                 <li class="dropdown-item"><a href="#">${plugin.name} - ${plugin.version}</a></li>

--- a/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/grails-app/views/layouts/main.gsp
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark navbar-static-top" role="navigation">
     <a class="navbar-brand" href="/#"><asset:image src="grails.svg" alt="Grails Logo"/></a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/build.gradle
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:bootstrap:4.1.3'
-    implementation 'org.webjars:jquery:3.3.1'
+    implementation 'org.webjars:bootstrap:5.3.8'
+    implementation 'org.webjars:jquery:4.0.0'
 
     // in-memory ldap server for testing
     implementation 'com.unboundid:unboundid-ldapsdk'

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/jquery/3.3.1/jquery
-//= require webjars/bootstrap/4.1.3/js/bootstrap.bundle
+//= require webjars/jquery/4.0.0/jquery
+//= require webjars/bootstrap/5.3.8/js/bootstrap.bundle
 //= require_self

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/bootstrap/4.1.3/css/bootstrap
+*= require webjars/bootstrap/5.3.8/css/bootstrap
 *= require grails
 *= require main
 *= require mobile

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/views/index.gsp
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/views/index.gsp
@@ -25,7 +25,7 @@
 <body>
 <content tag="nav">
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
             <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
@@ -43,7 +43,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Controllers: ${grailsApplication.controllerClasses.size()}</a></li>
             <li class="dropdown-item"><a href="#">Domains: ${grailsApplication.domainClasses.size()}</a></li>
@@ -52,7 +52,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
                 <li class="dropdown-item"><a href="#">${plugin.name} - ${plugin.version}</a></li>

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/grails-app/views/layouts/main.gsp
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark navbar-static-top" role="navigation">
     <a class="navbar-brand" href="/#"><asset:image src="grails.svg" alt="Grails Logo"/></a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/build.gradle
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
 
     // 3rd party client-side assets bundled in webjars
-    implementation 'org.webjars:bootstrap:4.1.3'
-    implementation 'org.webjars:jquery:3.3.1'
+    implementation 'org.webjars:bootstrap:5.3.8'
+    implementation 'org.webjars:jquery:4.0.0'
 
     // to not depend on an external ldap server
     implementation 'com.unboundid:unboundid-ldapsdk'

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/assets/javascripts/application.js
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/assets/javascripts/application.js
@@ -24,6 +24,6 @@
 // You're free to add application-wide JavaScript to this file, but it's generally better
 // to create separate JavaScript files as needed.
 //
-//= require webjars/jquery/3.3.1/jquery
-//= require webjars/bootstrap/4.1.3/js/bootstrap.bundle
+//= require webjars/jquery/4.0.0/jquery
+//= require webjars/bootstrap/5.3.8/js/bootstrap.bundle
 //= require_self

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/assets/stylesheets/application.css
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/assets/stylesheets/application.css
@@ -26,7 +26,7 @@
 * You're free to add application-wide styles to this file and they'll appear at the top of the
 * compiled file, but it's generally better to create a new file per style scope.
 *
-*= require webjars/bootstrap/4.1.3/css/bootstrap
+*= require webjars/bootstrap/5.3.8/css/bootstrap
 *= require grails
 *= require main
 *= require mobile

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/views/index.gsp
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/views/index.gsp
@@ -25,7 +25,7 @@
 <body>
 <content tag="nav">
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Application Status <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Environment: ${grails.util.Environment.current.name}</a></li>
             <li class="dropdown-item"><a href="#">App profile: ${grailsApplication.config.grails?.profile}</a></li>
@@ -43,7 +43,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Artefacts <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <li class="dropdown-item"><a href="#">Controllers: ${grailsApplication.controllerClasses.size()}</a></li>
             <li class="dropdown-item"><a href="#">Domains: ${grailsApplication.domainClasses.size()}</a></li>
@@ -52,7 +52,7 @@
         </ul>
     </li>
     <li class="dropdown">
-        <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
+        <a href="#" class="dropdown-toggle" data-bs-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Installed Plugins <span class="caret"></span></a>
         <ul class="dropdown-menu">
             <g:each var="plugin" in="${applicationContext.getBean('pluginManager').allPlugins}">
                 <li class="dropdown-item"><a href="#">${plugin.name} - ${plugin.version}</a></li>

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/views/layouts/main.gsp
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/grails-app/views/layouts/main.gsp
@@ -36,7 +36,7 @@
 
 <nav class="navbar navbar-expand-lg navbar-dark navbar-static-top" role="navigation">
     <a class="navbar-brand" href="/#"><asset:image src="grails.svg" alt="Grails Logo"/></a>
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 

--- a/grails-test-examples/spring-security/ui/extended/grails-app/views/user/edit.gsp
+++ b/grails-test-examples/spring-security/ui/extended/grails-app/views/user/edit.gsp
@@ -68,7 +68,7 @@
 </g:if>
 <s2ui:documentReady>
 	$("#runAsButton").button();
-	$('#runAsButton').bind('click', function() {
+	$('#runAsButton').on('click', function() {
 		document.forms.runAsForm.submit();
 	});
 </s2ui:documentReady>

--- a/grails-test-examples/spring-security/ui/simple/grails-app/views/securityInfo/config.gsp
+++ b/grails-test-examples/spring-security/ui/simple/grails-app/views/securityInfo/config.gsp
@@ -53,7 +53,7 @@ if (value instanceof Class) {
 		</tbody>
 	</table>
 </div>
-<s2ui:deferredScript src='webjars/datatables/1.10.25/js/jquery.dataTables.js'/>
+<s2ui:deferredScript src='webjars/datatables/2.3.0/js/dataTables.js'/>
 <s2ui:documentReady>
 $('#config').DataTable();
 </s2ui:documentReady>

--- a/grails-test-examples/spring-security/ui/simple/grails-app/views/user/edit.gsp
+++ b/grails-test-examples/spring-security/ui/simple/grails-app/views/user/edit.gsp
@@ -68,7 +68,7 @@
 </g:if>
 <s2ui:documentReady>
 	$("#runAsButton").button();
-	$('#runAsButton').bind('click', function() {
+	$('#runAsButton').on('click', function() {
 		document.forms.runAsForm.submit();
 	});
 </s2ui:documentReady>


### PR DESCRIPTION
## Summary

`grails-spring-security-ui` and its example apps (cas/ldap/ui) relied on jQuery/Bootstrap 3-era APIs that were removed in jQuery 4 and renamed in Bootstrap 5. This currently blocks the pending Dependabot dependency bumps:

- #15838 (jQuery bump) and #15839 (Bootstrap bump) both cause reproducible functional test regressions when merged as-is, since the plugin and example apps still call deprecated jQuery APIs and use Bootstrap 3 markup attributes.

This PR fixes the underlying compatibility issues so those bumps (or their next iterations) can be merged cleanly:

- Migrate `grails-spring-security-ui`'s JavaScript off jQuery-4-removed APIs: `.bind()`/`.unbind()` → `.on()`/`.off()`, `.andSelf()` → `.addBack()`, `$.isFunction` → `typeof` check.
- Bump DataTables (1.10.25 → 2.3.0), jQuery (2.1.4 → 4.0.0), jQuery UI (1.10.3 → 1.14.1), and jQuery UI Themes (1.10.3 → 1.13.2) webjar versions in the plugin, with asset manifest `require` paths updated to match the actual resource layout of each new jar version.
- Bump jQuery (→ 4.0.0) and Bootstrap (→ 5.3.8) webjar versions in the `cas/test1` and all four `ldap/*` example apps.
- Update Bootstrap 3 `data-toggle`/`data-target` attributes to `data-bs-toggle`/`data-bs-target` in the ldap example apps' navbar/dropdown markup — Bootstrap 5's JS does not recognize the old attribute names, so the navbar toggle and dropdown menus were non-functional under Bootstrap 5.
- Update doc-cited version numbers in `customization.adoc`.

## Test plan

- [x] `assetCompile` runs clean (no "Unable to Locate Asset" warnings) on the plugin and all 5 touched example apps (cas/test1, ldap × 4) against the new webjar versions.
- [x] `DefaultSecurityInfoSpec` / `RegisterSpec` integration tests pass in both `spring-security-ui-simple` and `spring-security-ui-extended` — these exercise the DataTables-rendered security info page and the jQuery-validated registration/forgot-password forms.
- [x] `ldap/functional-test-app`'s full Geb functional suite (login, auth, secured URL visibility) passes with the bumped jQuery/Bootstrap and updated navbar markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)