### PR TITLE
fix: preserve full transaction attribute state in CustomizableRollbackTransactionAttribute copy constructors

### DIFF
--- a/grails-datamapping-core/src/test/groovy/grails/gorm/transactions/TransactionRollbackRulePropagationSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/grails/gorm/transactions/TransactionRollbackRulePropagationSpec.groovy
@@ -1,0 +1,159 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.transactions
+
+import javax.sql.DataSource
+
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.jdbc.datasource.DriverManagerDataSource
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.TransactionStatus
+import org.springframework.transaction.interceptor.NoRollbackRuleAttribute
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+import org.springframework.transaction.support.DefaultTransactionStatus
+import spock.lang.Specification
+
+import org.grails.datastore.gorm.services.DefaultTransactionService
+import org.grails.datastore.mapping.transactions.TransactionCapableDatastore
+
+/**
+ * Verifies that rollback rules configured on a transaction definition survive the conversion
+ * to {@link org.grails.datastore.mapping.transactions.CustomizableRollbackTransactionAttribute}
+ * performed by the public transaction APIs.
+ */
+class TransactionRollbackRulePropagationSpec extends Specification {
+
+    RecordingTransactionManager transactionManager
+
+    void setup() {
+        def dataSource = new DriverManagerDataSource(
+                "jdbc:h2:mem:${TransactionRollbackRulePropagationSpec.name};LOCK_TIMEOUT=10000", 'sa', '')
+        dataSource.driverClassName = 'org.h2.Driver'
+        transactionManager = new RecordingTransactionManager(dataSource)
+    }
+
+    void "GrailsTransactionTemplate honors a NoRollbackRuleAttribute on the supplied transaction attribute"() {
+        given: "a rule based attribute that must not roll back on the business exception"
+        def attribute = new RuleBasedTransactionAttribute()
+        attribute.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+        def template = new GrailsTransactionTemplate(transactionManager, attribute)
+
+        when: "the transactional closure throws the matching exception"
+        template.execute { TransactionStatus status ->
+            throw new TestBusinessException()
+        }
+
+        then: "the exception propagates but the transaction is committed, not rolled back"
+        thrown(TestBusinessException)
+        transactionManager.committed
+        !transactionManager.rolledBack
+    }
+
+    void "GrailsTransactionTemplate still rolls back when no rule matches the thrown exception"() {
+        given:
+        def attribute = new RuleBasedTransactionAttribute()
+        attribute.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+        def template = new GrailsTransactionTemplate(transactionManager, attribute)
+
+        when:
+        template.execute { TransactionStatus status ->
+            throw new IllegalStateException('no rule matches this')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        transactionManager.rolledBack
+        !transactionManager.committed
+    }
+
+    void "withNewTransaction honors rollback rules from a RuleBasedTransactionAttribute definition"() {
+        given:
+        def service = new DefaultTransactionService()
+        service.datastore = Stub(TransactionCapableDatastore) {
+            getTransactionManager() >> transactionManager
+        }
+        def definition = new RuleBasedTransactionAttribute()
+        definition.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+
+        when: "the transactional closure throws the matching exception"
+        service.withNewTransaction((TransactionDefinition) definition) { TransactionStatus status ->
+            throw new TestBusinessException()
+        }
+
+        then: "the exception propagates but the transaction is committed, not rolled back"
+        thrown(TestBusinessException)
+        transactionManager.committed
+        !transactionManager.rolledBack
+
+        and: "the new transaction was started with REQUIRES_NEW propagation"
+        transactionManager.definition.propagationBehavior == TransactionDefinition.PROPAGATION_REQUIRES_NEW
+    }
+
+    void "withNewTransaction still rolls back when no rule matches the thrown exception"() {
+        given:
+        def service = new DefaultTransactionService()
+        service.datastore = Stub(TransactionCapableDatastore) {
+            getTransactionManager() >> transactionManager
+        }
+        def definition = new RuleBasedTransactionAttribute()
+        definition.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+
+        when:
+        service.withNewTransaction((TransactionDefinition) definition) { TransactionStatus status ->
+            throw new IllegalStateException('no rule matches this')
+        }
+
+        then:
+        thrown(IllegalStateException)
+        transactionManager.rolledBack
+        !transactionManager.committed
+    }
+
+    static class TestBusinessException extends RuntimeException {
+    }
+
+    static class RecordingTransactionManager extends DataSourceTransactionManager {
+
+        boolean committed = false
+        boolean rolledBack = false
+        TransactionDefinition definition
+
+        RecordingTransactionManager(DataSource dataSource) {
+            super(dataSource)
+        }
+
+        @Override
+        protected void doBegin(Object transaction, TransactionDefinition definition) {
+            this.definition = definition
+            super.doBegin(transaction, definition)
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus status) {
+            committed = true
+            super.doCommit(status)
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus status) {
+            rolledBack = true
+            super.doRollback(status)
+        }
+    }
+}

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/CustomizableRollbackTransactionAttribute.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/transactions/CustomizableRollbackTransactionAttribute.java
@@ -19,15 +19,19 @@
 
 package org.grails.datastore.mapping.transactions;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute;
 import org.springframework.transaction.interceptor.NoRollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RollbackRuleAttribute;
 import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute;
+import org.springframework.transaction.interceptor.TransactionAttribute;
 
 /**
  * Extended version of {@link RuleBasedTransactionAttribute} that ensures all exception types are rolled back and allows inheritance of setRollbackOnly
@@ -51,13 +55,8 @@ public class CustomizableRollbackTransactionAttribute extends RuleBasedTransacti
         super(propagationBehavior, rollbackRules);
     }
 
-    public CustomizableRollbackTransactionAttribute(org.springframework.transaction.interceptor.TransactionAttribute other) {
-        super();
-        setPropagationBehavior(other.getPropagationBehavior());
-        setIsolationLevel(other.getIsolationLevel());
-        setTimeout(other.getTimeout());
-        setReadOnly(other.isReadOnly());
-        setName(other.getName());
+    public CustomizableRollbackTransactionAttribute(TransactionAttribute other) {
+        this((TransactionDefinition) other);
     }
 
     public CustomizableRollbackTransactionAttribute(TransactionDefinition other) {
@@ -67,6 +66,15 @@ public class CustomizableRollbackTransactionAttribute extends RuleBasedTransacti
         setTimeout(other.getTimeout());
         setReadOnly(other.isReadOnly());
         setName(other.getName());
+        if (other instanceof TransactionAttribute attribute) {
+            copyAttributeState(attribute);
+        }
+        if (other instanceof RuleBasedTransactionAttribute ruleBased) {
+            // Spring's copy constructor snapshots the source's rule list from the field, unlike
+            // getRollbackRules() which would lazily assign a new list into the source object
+            setRollbackRules(new RuleBasedTransactionAttribute(ruleBased).getRollbackRules());
+        }
+        copyCustomizableState(other);
     }
 
     public CustomizableRollbackTransactionAttribute(CustomizableRollbackTransactionAttribute other) {
@@ -74,15 +82,40 @@ public class CustomizableRollbackTransactionAttribute extends RuleBasedTransacti
     }
 
     public CustomizableRollbackTransactionAttribute(RuleBasedTransactionAttribute other) {
-        if (other instanceof CustomizableRollbackTransactionAttribute) {
-            this.inheritRollbackOnly = ((CustomizableRollbackTransactionAttribute) other).inheritRollbackOnly;
+        super(other);
+        copyAttributeState(other);
+        copyCustomizableState(other);
+    }
+
+    /**
+     * Copies the attribute-level state that Spring's copy constructors do not carry over.
+     * As of Spring Framework 7.0, {@code DefaultTransactionAttribute(TransactionAttribute)}
+     * only copies the {@link TransactionDefinition} fields.
+     */
+    private void copyAttributeState(TransactionAttribute other) {
+        if (other instanceof DefaultTransactionAttribute defaultAttribute) {
+            setDescriptor(defaultAttribute.getDescriptor());
+            setTimeoutString(defaultAttribute.getTimeoutString());
+        }
+        setQualifier(other.getQualifier());
+        Collection<String> labels = other.getLabels();
+        if (labels != null) {
+            // defensive copy: setLabels stores the given reference
+            setLabels(new ArrayList<>(labels));
+        }
+    }
+
+    private void copyCustomizableState(TransactionDefinition other) {
+        if (other instanceof CustomizableRollbackTransactionAttribute custom) {
+            this.inheritRollbackOnly = custom.inheritRollbackOnly;
+            this.connection = custom.connection;
         }
     }
 
     @Override
     public boolean rollbackOn(Throwable ex) {
         if (log.isTraceEnabled()) {
-            log.trace("Applying rules to determine whether transaction should rollback on $ex");
+            log.trace("Applying rules to determine whether transaction should rollback on " + ex);
         }
 
         RollbackRuleAttribute winner = null;
@@ -100,12 +133,14 @@ public class CustomizableRollbackTransactionAttribute extends RuleBasedTransacti
         }
 
         if (log.isTraceEnabled()) {
-            log.trace("Winning rollback rule is: $winner");
+            log.trace("Winning rollback rule is: " + winner);
         }
 
         // User superclass behavior (rollback on unchecked) if no rule matches.
         if (winner == null) {
-            log.trace("No relevant rollback rule found: applying default rules");
+            if (log.isTraceEnabled()) {
+                log.trace("No relevant rollback rule found: applying default rules");
+            }
 
             // always rollback regardless if it is a checked or unchecked exception since Groovy doesn't differentiate those
             return true;

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/transactions/CustomizableRollbackTransactionAttributeSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/transactions/CustomizableRollbackTransactionAttributeSpec.groovy
@@ -1,0 +1,294 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.mapping.transactions
+
+import groovy.transform.CompileStatic
+
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute
+import org.springframework.transaction.interceptor.NoRollbackRuleAttribute
+import org.springframework.transaction.interceptor.RollbackRuleAttribute
+import org.springframework.transaction.interceptor.RuleBasedTransactionAttribute
+import org.springframework.transaction.interceptor.TransactionAttribute
+import org.springframework.transaction.support.DefaultTransactionDefinition
+import spock.lang.Specification
+
+class CustomizableRollbackTransactionAttributeSpec extends Specification {
+
+    void "copy constructor deep-copies the rollback rule list instead of aliasing it"() {
+        given:
+        def sourceRules = [new RollbackRuleAttribute(IllegalStateException)]
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setRollbackRules(sourceRules)
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+        copy.getRollbackRules().add(new NoRollbackRuleAttribute(IllegalArgumentException))
+
+        then: "mutating the copy's rule list does not affect the source's list"
+        source.getRollbackRules().size() == 1
+        copy.getRollbackRules().size() == 2
+
+        when: "the source's rule list is mutated"
+        source.getRollbackRules().add(new RollbackRuleAttribute(UnsupportedOperationException))
+
+        then: "the copy's rule list is unaffected"
+        source.getRollbackRules().size() == 2
+        copy.getRollbackRules().size() == 2
+
+        and: "copying did not replace the source's internal rule list"
+        source.getRollbackRules().is(sourceRules)
+    }
+
+    void "copy constructor deep-copies the labels collection instead of aliasing it"() {
+        given:
+        def sourceLabels = ['audited']
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setLabels(sourceLabels)
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+        copy.getLabels().add('copy-only')
+
+        then: "mutating the copy's labels does not affect the source's labels"
+        source.getLabels() as List == ['audited']
+        copy.getLabels() as List == ['audited', 'copy-only']
+
+        when: "the source's labels are mutated"
+        sourceLabels.add('source-only')
+
+        then: "the copy's labels are unaffected"
+        source.getLabels() as List == ['audited', 'source-only']
+        copy.getLabels() as List == ['audited', 'copy-only']
+
+        and: "copying did not replace the source's internal labels collection"
+        source.getLabels().is(sourceLabels)
+    }
+
+    void "copy constructor preserves qualifier, labels, connection and inheritRollbackOnly metadata"() {
+        given:
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setQualifier('secondary')
+        source.setLabels(['audited'])
+        source.setConnection('secondary')
+        source.setInheritRollbackOnly(false)
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then:
+        copy.getQualifier() == 'secondary'
+        copy.getLabels() as Set == ['audited'] as Set
+        copy.getConnection() == 'secondary'
+        !copy.isInheritRollbackOnly()
+    }
+
+    void "copy constructor preserves all definition-level properties"() {
+        given:
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW)
+        source.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE)
+        source.setTimeout(42)
+        source.setReadOnly(true)
+        source.setName('sourceTx')
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then:
+        copy.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        copy.getIsolationLevel() == TransactionDefinition.ISOLATION_SERIALIZABLE
+        copy.getTimeout() == 42
+        copy.isReadOnly()
+        copy.getName() == 'sourceTx'
+    }
+
+    void "copy constructor preserves descriptor and timeoutString"() {
+        given:
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setDescriptor('BookService.save')
+        source.setTimeoutString('${tx.timeout}')
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then:
+        copy.getDescriptor() == 'BookService.save'
+        copy.getTimeoutString() == '${tx.timeout}'
+    }
+
+    void "copy constructor from a plain RuleBasedTransactionAttribute copies its rollback rules defensively"() {
+        given:
+        def source = new RuleBasedTransactionAttribute()
+        source.setRollbackRules([new RollbackRuleAttribute(RuntimeException)])
+        source.setQualifier('books')
+        source.setLabels(['audited'])
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then:
+        copy.getRollbackRules().size() == 1
+        !copy.getRollbackRules().is(source.getRollbackRules())
+        copy.getQualifier() == 'books'
+        copy.getLabels() as List == ['audited']
+        !copy.getLabels().is(source.getLabels())
+        copy.isInheritRollbackOnly()
+        copy.getConnection() == null
+    }
+
+    void "a NoRollbackRuleAttribute on the source is honored by the copy's rollbackOn"() {
+        given:
+        def source = new RuleBasedTransactionAttribute()
+        source.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then: "a matching exception does not trigger rollback"
+        !copy.rollbackOn(new TestBusinessException())
+
+        and: "a non-matching exception still triggers the default rollback-everything behavior"
+        copy.rollbackOn(new IllegalStateException())
+        copy.rollbackOn(new Exception())
+    }
+
+    void "rollbackOn applies the deepest matching rule"() {
+        given:
+        def attribute = new CustomizableRollbackTransactionAttribute()
+        attribute.setRollbackRules([
+                new NoRollbackRuleAttribute(RuntimeException),
+                new RollbackRuleAttribute(TestBusinessException)
+        ])
+
+        expect: "the rule closest to the thrown exception type wins"
+        attribute.rollbackOn(new TestBusinessException())
+        !attribute.rollbackOn(new IllegalStateException())
+    }
+
+    void "rollbackOn rolls back on any exception when no rules are configured"() {
+        given:
+        def attribute = new CustomizableRollbackTransactionAttribute()
+
+        expect: "unchecked and checked exceptions both roll back, unlike Spring's default"
+        attribute.rollbackOn(new RuntimeException())
+        attribute.rollbackOn(new Exception())
+        attribute.rollbackOn(new Error())
+    }
+
+    void "statically dispatched TransactionDefinition copy still propagates rules and custom state from the dynamic type"() {
+        given: "a CustomizableRollbackTransactionAttribute passed around as a plain TransactionDefinition"
+        def rules = [new NoRollbackRuleAttribute(TestBusinessException)]
+        def source = new CustomizableRollbackTransactionAttribute()
+        source.setRollbackRules(rules)
+        source.setConnection('secondary')
+        source.setInheritRollbackOnly(false)
+        source.setQualifier('books')
+        source.setLabels(['audited'])
+
+        when: "copied through the statically chosen TransactionDefinition constructor"
+        def copy = copyAsTransactionDefinition(source)
+
+        then:
+        !copy.rollbackOn(new TestBusinessException())
+        copy.getConnection() == 'secondary'
+        !copy.isInheritRollbackOnly()
+        copy.getQualifier() == 'books'
+        copy.getLabels() as List == ['audited']
+
+        and: "the copy's rule list is independent of the source's"
+        !copy.getRollbackRules().is(source.getRollbackRules())
+
+        and: "the source's internal rule list was not replaced"
+        source.getRollbackRules().is(rules)
+    }
+
+    void "statically dispatched TransactionAttribute copy still propagates rules from the dynamic type"() {
+        given: "a RuleBasedTransactionAttribute passed around as a plain TransactionAttribute"
+        def source = new RuleBasedTransactionAttribute()
+        source.setRollbackRules([new NoRollbackRuleAttribute(TestBusinessException)])
+
+        when: "copied through the statically chosen TransactionAttribute constructor"
+        def copy = copyAsTransactionAttribute(source)
+
+        then:
+        !copy.rollbackOn(new TestBusinessException())
+        !copy.getRollbackRules().is(source.getRollbackRules())
+    }
+
+    void "copy constructor from a non-rule-based DefaultTransactionAttribute copies qualifier and labels defensively"() {
+        given:
+        def sourceLabels = ['audited']
+        def source = new DefaultTransactionAttribute()
+        source.setQualifier('books')
+        source.setLabels(sourceLabels)
+        source.setTimeout(21)
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute((TransactionAttribute) source)
+        copy.getLabels().add('copy-only')
+
+        then:
+        copy.getQualifier() == 'books'
+        copy.getTimeout() == 21
+        source.getLabels() as List == ['audited']
+        source.getLabels().is(sourceLabels)
+    }
+
+    void "copy constructor from a plain TransactionDefinition copies only definition-level properties"() {
+        given: "a source that is neither a TransactionAttribute nor a RuleBasedTransactionAttribute"
+        TransactionDefinition source = new DefaultTransactionDefinition().tap {
+            propagationBehavior = TransactionDefinition.PROPAGATION_REQUIRES_NEW
+            isolationLevel = TransactionDefinition.ISOLATION_SERIALIZABLE
+            timeout = 42
+            readOnly = true
+            name = 'plainDefinition'
+        }
+
+        when:
+        def copy = new CustomizableRollbackTransactionAttribute(source)
+
+        then: "the base TransactionDefinition properties are copied"
+        copy.getPropagationBehavior() == TransactionDefinition.PROPAGATION_REQUIRES_NEW
+        copy.getIsolationLevel() == TransactionDefinition.ISOLATION_SERIALIZABLE
+        copy.getTimeout() == 42
+        copy.isReadOnly()
+        copy.getName() == 'plainDefinition'
+
+        and: "attribute-only metadata that TransactionDefinition doesn't expose is left at its default"
+        copy.getQualifier() == null
+        !copy.getLabels()
+        !copy.getRollbackRules()
+        copy.getConnection() == null
+        copy.isInheritRollbackOnly()
+    }
+
+    @CompileStatic
+    private static CustomizableRollbackTransactionAttribute copyAsTransactionDefinition(TransactionDefinition source) {
+        return new CustomizableRollbackTransactionAttribute(source)
+    }
+
+    @CompileStatic
+    private static CustomizableRollbackTransactionAttribute copyAsTransactionAttribute(TransactionAttribute source) {
+        return new CustomizableRollbackTransactionAttribute(source)
+    }
+
+    static class TestBusinessException extends RuntimeException {
+    }
+}


### PR DESCRIPTION
# fix: preserve full transaction attribute state in CustomizableRollbackTransactionAttribute copy constructors

Split out of the GormRegistry consolidation per review discussion on #15779 (this class's copy semantics are an independent bug fix and deserve their own review).

## Problem

The copy constructors of `CustomizableRollbackTransactionAttribute` were lossy:

- The `TransactionAttribute`/`TransactionDefinition` overloads copied only the five `TransactionDefinition` fields (propagation, isolation, timeout, readOnly, name) — **rollback rules, qualifier, labels, descriptor, and `timeoutString` were silently dropped**. In practice this meant a `NoRollbackRuleAttribute` configured on an attribute passed into `GrailsTransactionTemplate` or `TransactionService.withTransaction`/`withNewTransaction` was ignored: every exception rolled back regardless.
- The `RuleBasedTransactionAttribute` overload copied almost **nothing** — not even the definition fields — because it never called `super(other)`.
- The previous implementation's `copyFrom` helper also mutated the *source* object: calling `getRollbackRules()` on a `RuleBasedTransactionAttribute` lazily installs a new list into it, and `setLabels(other.getLabels())` aliased the label collection between source and copy.
- Two trace log statements in this `.java` file used GString-style placeholders (`"$ex"`, `"$winner"`) that never interpolate in Java.

## Fix

- The `RuleBasedTransactionAttribute`/`CustomizableRollbackTransactionAttribute` overloads now delegate to Spring's own copy constructor via `super(other)`, which snapshots the rule list from the field (never the lazily-materializing getter).
- The `TransactionDefinition`/`TransactionAttribute` overloads copy the definition fields and then recover the dynamic type: rules are snapshotted through a temporary `RuleBasedTransactionAttribute` copy (so the source is never mutated), and attribute-level state is copied explicitly.
- `descriptor`, `timeoutString`, and `qualifier` are carried over explicitly — as of Spring Framework 7, `DefaultTransactionAttribute(TransactionAttribute)` copies only the `TransactionDefinition` fields, so these would otherwise be lost.
- `labels` gets a defensive copy (`setLabels` stores the given reference).
- `connection` and `inheritRollbackOnly` survive every copy path when the source is a `CustomizableRollbackTransactionAttribute`.
- Log placeholders fixed; the remaining unguarded trace call is now behind `isTraceEnabled()`.

## Behavior change (release-note material)

`@Transactional` / `@ReadOnly` / `@Rollback` semantics are **unchanged** — the AST transform builds the attribute directly and never goes through these copy constructors.

For **programmatic** API users: an application that passes its own rule-bearing `TransactionAttribute` (e.g. a `RuleBasedTransactionAttribute` with `NoRollbackRuleAttribute`s) into `DomainClass.withTransaction(definition)`, `TransactionService.withTransaction(definition)`, or `withNewTransaction(definition)` will now have those rules **honored**: an exception matching a no-rollback rule commits the transaction (the exception still propagates). Previously the rules were silently dropped and every exception rolled back. The change is one-directional — no scenario turns a commit into a rollback; with no matching rule the class still rolls back on every exception, checked or unchecked, as documented.

Suggested upgrade note:

> Rollback rules configured on a `TransactionAttribute` passed to the programmatic transaction APIs (`withTransaction`, `withNewTransaction`, `GrailsTransactionTemplate`) are now honored. Previously `noRollbackFor`-style rules supplied this way were silently ignored and every exception caused a rollback.

## Tests

- `CustomizableRollbackTransactionAttributeSpec` (13 tests): deep-copy independence of rule lists and labels in both directions, non-mutation of the source's internal rule list, preservation of every definition- and attribute-level property across all four constructor dispatch paths (including statically-dispatched `TransactionDefinition`/`TransactionAttribute` entry points via `@CompileStatic` helpers), and the rollback-on-everything default.
- `TransactionRollbackRulePropagationSpec` (4 tests): behavior through the public APIs — `GrailsTransactionTemplate.execute` and `DefaultTransactionService.withNewTransaction` against a real H2 `DataSourceTransactionManager` — asserting commit-vs-rollback outcomes and `REQUIRES_NEW` propagation.

All fix-specific assertions fail against the previous implementation (verified — the tests are not vacuous).

## Known follow-up (out of scope)

`grails.gorm.transactions.GrailsTransactionAttribute` (grails-datamapping-core) and `org.grails.transaction.GrailsTransactionAttribute` (grails-core) contain the same lossy copy-constructor pattern on their `TransactionAttribute`/`TransactionDefinition` overloads. Fixing them belongs in a separate change with its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
