### PR TITLE
Improve project dependency substitution logic

### DIFF
--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -16,21 +16,25 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-def skippedProjects = testProjects + docProjects + cliProjects
-def substitutableProjects = rootProject.subprojects
-        .findAll { !(it.name in skippedProjects) }
-        .collect { subproject ->
-            // Ensure the target project is evaluated before we attempt to substitute it.
-            // This is necessary because it may not have been evaluated yet, and we need to
-            // ensure that the artifactId and cliArtifactId properties are available for substitution.
-            project.evaluationDependsOn(subproject.path)
-            return [
-                    project: subproject,
-                    artifactId: subproject.findProperty('pomArtifactId') ?: subproject.name,
-                    cliArtifactId: subproject.findProperty('cliArtifactId')
-            ]
-        }
 
+if (!rootProject.ext.has('substitutableFunctionalTestProjectsCache')) {
+    def skippedProjects = testProjects + docProjects + cliProjects
+    rootProject.ext.set('substitutableFunctionalTestProjectsCache', rootProject.subprojects
+            .findAll { !(it.name in skippedProjects) }
+            .collect { subproject ->
+                // Ensure the target project is evaluated before we attempt to substitute it.
+                // This is necessary because it may not have been evaluated yet, and we need to
+                // ensure that the artifactId and cliArtifactId properties are available for substitution.
+                project.evaluationDependsOn(subproject.path)
+                return [
+                        project: subproject,
+                        artifactId: subproject.findProperty('pomArtifactId') ?: subproject.name,
+                        cliArtifactId: subproject.findProperty('cliArtifactId')
+                ]
+            }
+    )
+}
+def substitutableProjects = rootProject.ext.get('substitutableFunctionalTestProjectsCache')
 configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         // Test projects will often include dependencies from local projects. This will ensure any dependencies

--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -16,15 +16,18 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
+def skippedProjects = testProjects + docProjects + cliProjects
 def substitutableProjects = rootProject.subprojects
-        .findAll { !(it.name in testProjects) && !(it.name in docProjects) && !(it.name in cliProjects) }
-        .collect {
-            project.evaluationDependsOn(it.path)
+        .findAll { !(it.name in skippedProjects) }
+        .collect { subproject ->
+            // Ensure the target project is evaluated before we attempt to substitute it.
+            // This is necessary because it may not have been evaluated yet, and we need to
+            // ensure that the artifactId and cliArtifactId properties are available for substitution.
+            project.evaluationDependsOn(subproject.path)
             return [
-                    project: it,
-                    artifactId: it.findProperty('pomArtifactId') ?: it.name,
-                    cliArtifactId: it.findProperty('cliArtifactId')
+                    project: subproject,
+                    artifactId: subproject.findProperty('pomArtifactId') ?: subproject.name,
+                    cliArtifactId: subproject.findProperty('cliArtifactId')
             ]
         }
 
@@ -32,35 +35,35 @@ configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         // Test projects will often include dependencies from local projects. This will ensure any dependencies
         // included will be substituted with the local projects in this repository instead of pulling upstream.
-        for (def substitution : substitutableProjects) {
-            def possibleProject = substitution.project
-            def substitutedArtifact = "$possibleProject.group:${substitution.artifactId}"
+        for (def substitutionInfo : substitutableProjects) {
+            def substitutableProject = substitutionInfo.project as Project
+            def substitutedArtifact = "$substitutableProject.group:${substitutionInfo.artifactId}"
             //TODO: This does not handle libraries that are both test fixtures & a libraries like grails-data-mongodb,
             // see grails-test-examples-mongodb-base, & grails-test-examples-mongodb-hibernate5 for project() workaround
-            if (possibleProject.name == 'grails-bom') {
+            if (substitutableProject.name == 'grails-bom') {
                 substitute module(substitutedArtifact) using platform(project(':grails-bom'))
             }
-            else if(possibleProject.name == 'grails-geb') {
+            else if(substitutableProject.name == 'grails-geb') {
                 def selector = it.variant(module(substitutedArtifact)) { VariantSelectionDetails details ->
                     details.capabilities { ModuleDependencyCapabilitiesHandler handler ->
                         handler.requireCapability("${substitutedArtifact}-test-fixtures" as String)
                     }
                 }
 
-                def replacement = it.variant(project(":$possibleProject.name")) { v ->
+                def replacement = it.variant(project(":$substitutableProject.name")) { v ->
                     v.capabilities { it.requireCapability("${substitutedArtifact}-test-fixtures") }
                 }
                 substitute selector using replacement
             }
             else {
-                substitute module(substitutedArtifact) using project(":$possibleProject.name")
+                substitute module(substitutedArtifact) using project(":$substitutableProject.name")
             }
 
             // companion cli artifacts are additional publications of the same project,
             // reachable locally through the project's cli capability
-            if (substitution.cliArtifactId) {
-                def cliCoordinate = "$possibleProject.group:${substitution.cliArtifactId}" as String
-                def cliReplacement = it.variant(project(":$possibleProject.name")) { v ->
+            if (substitutionInfo.cliArtifactId) {
+                def cliCoordinate = "$substitutableProject.group:$substitutionInfo.cliArtifactId" as String
+                def cliReplacement = it.variant(project(":$substitutableProject.name")) { v ->
                     v.capabilities { it.requireCapability(cliCoordinate) }
                 }
                 substitute module(cliCoordinate) using cliReplacement

--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -17,49 +17,53 @@
  *  under the License.
  */
 
-rootProject.subprojects
+def substitutableProjects = rootProject.subprojects
         .findAll { !(it.name in testProjects) && !(it.name in docProjects) && !(it.name in cliProjects) }
-        .each { project.evaluationDependsOn(it.path) }
+        .collect {
+            project.evaluationDependsOn(it.path)
+            return [
+                    project: it,
+                    artifactId: it.findProperty('pomArtifactId') ?: it.name,
+                    cliArtifactId: it.findProperty('cliArtifactId')
+            ]
+        }
 
 configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         // Test projects will often include dependencies from local projects. This will ensure any dependencies
         // included will be substituted with the local projects in this repository instead of pulling upstream.
-        for (def possibleProject : rootProject.subprojects) {
-            if (!(possibleProject.name in testProjects) && !(possibleProject.name in docProjects) && !(possibleProject.name in cliProjects)) {
-                def artifactId = possibleProject.findProperty('pomArtifactId') ?: possibleProject.name
-                def substitutedArtifact = "$possibleProject.group:$artifactId"
-                //TODO: This does not handle libraries that are both test fixtures & a libraries like grails-data-mongodb,
-                // see grails-test-examples-mongodb-base, & grails-test-examples-mongodb-hibernate5 for project() workaround
-                if (possibleProject.name == 'grails-bom') {
-                    substitute module(substitutedArtifact) using platform(project(':grails-bom'))
-                }
-                else if(possibleProject.name == 'grails-geb') {
-                    def selector = it.variant(module(substitutedArtifact)) { VariantSelectionDetails details ->
-                        details.capabilities { ModuleDependencyCapabilitiesHandler handler ->
-                            handler.requireCapability("${substitutedArtifact}-test-fixtures" as String)
-                        }
+        for (def substitution : substitutableProjects) {
+            def possibleProject = substitution.project
+            def substitutedArtifact = "$possibleProject.group:${substitution.artifactId}"
+            //TODO: This does not handle libraries that are both test fixtures & a libraries like grails-data-mongodb,
+            // see grails-test-examples-mongodb-base, & grails-test-examples-mongodb-hibernate5 for project() workaround
+            if (possibleProject.name == 'grails-bom') {
+                substitute module(substitutedArtifact) using platform(project(':grails-bom'))
+            }
+            else if(possibleProject.name == 'grails-geb') {
+                def selector = it.variant(module(substitutedArtifact)) { VariantSelectionDetails details ->
+                    details.capabilities { ModuleDependencyCapabilitiesHandler handler ->
+                        handler.requireCapability("${substitutedArtifact}-test-fixtures" as String)
                     }
-
-                    def replacement = it.variant(project(":$possibleProject.name")) { v ->
-                        v.capabilities { it.requireCapability("${substitutedArtifact}-test-fixtures") }
-                    }
-                    substitute selector using replacement
-                }
-                else {
-                    substitute module(substitutedArtifact) using project(":$possibleProject.name")
                 }
 
-                // companion cli artifacts are additional publications of the same project,
-                // reachable locally through the project's cli capability
-                def cliArtifactId = possibleProject.findProperty('cliArtifactId')
-                if (cliArtifactId) {
-                    def cliCoordinate = "$possibleProject.group:$cliArtifactId" as String
-                    def cliReplacement = it.variant(project(":$possibleProject.name")) { v ->
-                        v.capabilities { it.requireCapability(cliCoordinate) }
-                    }
-                    substitute module(cliCoordinate) using cliReplacement
+                def replacement = it.variant(project(":$possibleProject.name")) { v ->
+                    v.capabilities { it.requireCapability("${substitutedArtifact}-test-fixtures") }
                 }
+                substitute selector using replacement
+            }
+            else {
+                substitute module(substitutedArtifact) using project(":$possibleProject.name")
+            }
+
+            // companion cli artifacts are additional publications of the same project,
+            // reachable locally through the project's cli capability
+            if (substitution.cliArtifactId) {
+                def cliCoordinate = "$possibleProject.group:${substitution.cliArtifactId}" as String
+                def cliReplacement = it.variant(project(":$possibleProject.name")) { v ->
+                    v.capabilities { it.requireCapability(cliCoordinate) }
+                }
+                substitute module(cliCoordinate) using cliReplacement
             }
         }
     }


### PR DESCRIPTION
This cuts the Gradle configuration time roughly in half.