### PR TITLE
Replace Gradle APIs deprecated for removal in Gradle 10

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -329,7 +329,7 @@ ${importStatements}
         // Adding an exclusion to every dependency in a pom is very verbose and
         // greatly increases the size of the pom.
         // It would be nice to have documented in a comment why this global exclude is in here
-        String slf4jPreventExclusion = project.properties['slf4jPreventExclusion']
+        String slf4jPreventExclusion = project.findProperty('slf4jPreventExclusion')
         if (!slf4jPreventExclusion || slf4jPreventExclusion != 'true') {
             project.configurations.configureEach { Configuration configuration ->
                 configuration.exclude(group: 'org.slf4j', module: 'slf4j-simple')
@@ -346,7 +346,7 @@ ${importStatements}
                 profileConfiguration.transitive = true
 
                 profileConfiguration.defaultDependencies { DependencySet deps ->
-                    String defaultProfileCoordinates = "org.apache.grails.profiles:${System.getProperty('grails.profile') ?: getDefaultProfile()}:${project.properties['grailsVersion'] ?: BuildSettings.grailsVersion}" as String
+                    String defaultProfileCoordinates = "org.apache.grails.profiles:${System.getProperty('grails.profile') ?: getDefaultProfile()}:${project.findProperty('grailsVersion') ?: BuildSettings.grailsVersion}" as String
                     project.logger.info('No Grails profile is defined for project {}, defaulting to: {}', project.name, defaultProfileCoordinates)
                     deps.add(
                             project.dependencies.create(defaultProfileCoordinates)
@@ -625,7 +625,7 @@ ${importStatements}
                     'grails.env': Environment.isSystemSet() ? Environment.getCurrent().getName() : Environment.PRODUCTION.getName(),
                     'info.app.name': project.name,
                     'info.app.version': project.version instanceof Serializable ? project.version : project.version.toString(),
-                    'info.app.grailsVersion': project.properties.get('grailsVersion')
+                    'info.app.grailsVersion': project.findProperty('grailsVersion')
             ]
 
             // Capture build directory at configuration time to avoid Task.project access at execution time
@@ -657,7 +657,7 @@ ${importStatements}
     @CompileStatic
     protected void configureMicronaut(Project project) {
         project.afterEvaluate {
-            boolean micronautEnabled = project.getConfigurations().getByName('runtimeClasspath').getAllDependencies().findAll { Dependency dep -> dep.group == 'org.apache.grails' && dep.name == 'grails-micronaut' } as boolean
+            boolean micronautEnabled = project.getConfigurations().getByName('runtimeClasspath').getAllDependencies().any { Dependency dep -> dep.group == 'org.apache.grails' && dep.name == 'grails-micronaut' }
             if (!micronautEnabled) {
                 return
             }
@@ -730,7 +730,7 @@ ${importStatements}
 
     @CompileStatic
     protected void configureGroovy(Project project) {
-        final String groovyVersion = project.properties['groovy.version']
+        final String groovyVersion = project.findProperty('groovy.version')
         if (groovyVersion) {
             project.logger.lifecycle('Warning: groovy.version is defined, Grails Gradle Plugin will force all groovy dependencies to version {}.', groovyVersion)
             project.configurations.configureEach { Configuration configuration ->

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/TestPhasesGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/TestPhasesGradlePlugin.groovy
@@ -63,7 +63,7 @@ class TestPhasesGradlePlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
-        testPhases = project.container(TestPhase) { String name ->
+        testPhases = project.objects.domainObjectContainer(TestPhase) { String name ->
             project.objects.newInstance(TestPhase, name)
         }
         project.extensions.add(EXTENSION_NAME, testPhases)


### PR DESCRIPTION
### Problem

Applying the Grails Gradle plugins under Gradle 9.x emits deprecation warnings for three APIs scheduled for removal in Gradle 10, so every consuming build prints *"Deprecated Gradle features were used in this build, making it incompatible with Gradle 10."* even when the app's own build scripts are fully migrated.

Observed from a Grails 8.0.0-M4 app on Gradle 9.6.1 with `--warning-mode all -Dorg.gradle.deprecation.trace=true`; the traces point at:

- `The Project.getProperties method has been deprecated.` — `project.properties['…']` lookups in `GrailsGradlePlugin` (`excludeDependencies`, `configureProfile`, `createBuildPropertiesTask`, `configureGroovy`)
- `The Project.container(Class, Closure) method has been deprecated.` — `TestPhasesGradlePlugin.apply`
- `The DomainObjectCollection.findAll(Closure) method has been deprecated.` — `GrailsGradlePlugin.configureMicronaut`

### Fix

Like-for-like replacements with the documented substitutes:

- `project.properties['name']` → `project.findProperty('name')` — same resolution chain (project object property → extra properties → gradle properties), no behavior change.
- `project.container(TestPhase) { … }` → `project.objects.domainObjectContainer(TestPhase) { … }` — the replacement named by the deprecation message. The class is `@CompileStatic`, so the closure statically coerces to `NamedDomainObjectFactory<TestPhase>`.
- `getAllDependencies().findAll { … } as boolean` → `getAllDependencies().any { … }` — the call was only an existence check, and `any` is a plain Groovy `Iterable` method rather than the deprecated live-collection API.

Verified with `:grails-gradle-plugins:compileGroovy` and the module test suite.