### PR TITLE
fix: defer compile-classpath probes out of GroovyCompile task configuration

### DIFF
--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -256,37 +256,44 @@ class GrailsGradlePlugin implements Plugin<Project> {
     protected Closure<String> getGroovyCompilerScript(GroovyCompile compile, Project project) {
         GrailsExtension grails = project.extensions.findByType(GrailsExtension)
 
-        // Start with user-configured imports
-        Set<String> starImports = new LinkedHashSet<>(grails.starImports)
-
-        // Add java.time if enabled
-        if (grails.importJavaTime) {
-            starImports.add('java.time')
-        }
-
-        // Add Grails annotation packages and common validation annotations if enabled
-        if (grails.importGrailsCommonAnnotations) {
-            // Always add jakarta.validation.constraints
-            starImports.add('jakarta.validation.constraints')
-
-            // Check for grails.gorm.annotation.* classes on classpath
-            if (isClassOnClasspath(compile.classpath, 'grails.gorm.annotation.CreatedDate')) {
-                starImports.add('grails.gorm.annotation')
-            }
-
-            // Check for grails.plugin.scaffolding.annotation.* classes on classpath
-            if (isClassOnClasspath(compile.classpath, 'grails.plugin.scaffolding.annotation.Scaffold')) {
-                starImports.add('grails.plugin.scaffolding.annotation')
-            }
-        }
-
-        // Return null if no imports are needed
-        if (starImports.isEmpty()) {
-            return null
-        }
-
-        // Build the import statements
+        // Everything below runs inside the returned closure, invoked from the task's doFirst:
+        // the isClassOnClasspath probes resolve the compile classpath, which must not happen while
+        // the task is being configured. A GroovyCompile task can be realized from inside an
+        // in-flight resolution of compileClasspath (scheduling any task whose inputs include that
+        // configuration realizes the compile task through the target-JVM attribute's provider
+        // chain), and re-entering that resolution fails on Gradle 9.5+ with
+        // 'Cannot observe dependencies before markAsObserved(String) has been called'.
         return { ->
+            // Start with user-configured imports
+            Set<String> starImports = new LinkedHashSet<>(grails.starImports)
+
+            // Add java.time if enabled
+            if (grails.importJavaTime) {
+                starImports.add('java.time')
+            }
+
+            // Add Grails annotation packages and common validation annotations if enabled
+            if (grails.importGrailsCommonAnnotations) {
+                // Always add jakarta.validation.constraints
+                starImports.add('jakarta.validation.constraints')
+
+                // Check for grails.gorm.annotation.* classes on classpath
+                if (isClassOnClasspath(compile.classpath, 'grails.gorm.annotation.CreatedDate')) {
+                    starImports.add('grails.gorm.annotation')
+                }
+
+                // Check for grails.plugin.scaffolding.annotation.* classes on classpath
+                if (isClassOnClasspath(compile.classpath, 'grails.plugin.scaffolding.annotation.Scaffold')) {
+                    starImports.add('grails.plugin.scaffolding.annotation')
+                }
+            }
+
+            // Return null if no imports are needed
+            if (starImports.isEmpty()) {
+                return null
+            }
+
+            // Build the import statements
             def importStatements = starImports.collect { pkg -> "                        star '$pkg'" }.join('\n')
             """withConfig(configuration) {
                     imports {


### PR DESCRIPTION
### Problem

On Gradle 9.5+, running a task that depends on `compileClasspath` **without** also depending on the compile task — e.g. asset-pipeline's `assetCompile` — fails during task-graph construction:

```
Could not determine the dependencies of task ':assetCompile'.
> Could not resolve all dependencies for configuration ':compileClasspath'.
   > Could not create task ':compileGroovy'.
      > Could not resolve all dependencies for configuration ':compileClasspath'.
         > Cannot observe dependencies before markAsObserved(String) has been called.
```

The chain (observed from a Grails 8.0.0-M4 app on Gradle 9.6.1):

1. Scheduling `assetCompile` resolves `compileClasspath` for build dependencies.
2. Mid-resolve, Gradle freezes the configuration's attributes; the target-JVM attribute's provider chain realizes the `compileGroovy` task.
3. Task realization fires `GrailsGradlePlugin.configureGroovyCompiler`'s `configureEach` callback, which calls `getGroovyCompilerScript` → `isClassOnClasspath(compile.classpath, …)` → `classpath.files` — re-entering the resolution already in flight.
4. Gradle 9.5+'s stricter resolution state machine rejects the re-entrancy with the `markAsObserved` `IllegalStateException`. Older Gradle (9.4.x and below) tolerated it silently.

Invocations that realize the compile tasks during task selection (`build`, `compileGroovy`, or even `assetCompile compileGroovy`) are unaffected, which makes the failure look sporadic.

### Fix

Move the star-import computation — including the two `isClassOnClasspath` classpath probes — inside the closure that `getGroovyCompilerScript` returns. That closure is only invoked from the task's `doFirst`, at execution time, where resolving the classpath is legal. Nothing at task-configuration time touches the classpath anymore.

The `GrailsPluginGradlePlugin` override already invokes the parent closure lazily inside its own closure (`parent?.call() ?: ''`), so it composes unchanged, and the call site's existing null handling covers the no-imports case.

### Verification

- `:grails-gradle-plugins:compileGroovy` passes.
- Published the patched plugin locally and pointed the affected Grails 8.0.0-M4 app at it: `./gradlew assetCompile` now constructs its task graph and runs (previously failed as above), and the generated `grailsGroovyCompilerConfig-compileGroovy.groovy` still contains all three star-import packages (`jakarta.validation.constraints`, `grails.gorm.annotation`, `grails.plugin.scaffolding.annotation`), confirming the deferred probes see the same classpath. Full app compile succeeds with the auto-imports in effect.