### PR TITLE
fix(deps): Bump Groovy to 5.0.8

### DIFF
--- a/.agents/skills/grails-developer/SKILL.md
+++ b/.agents/skills/grails-developer/SKILL.md
@@ -865,6 +865,6 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
 - **Grails User Guide**: https://grails.apache.org/docs/latest/guide/single.html
 - **GORM Documentation**: https://grails.apache.org/docs/latest/grails-data/
 - **Grails Plugins**: https://grails.apache.org/plugins.html
-- **Groovy 5 Documentation**: https://docs.groovy-lang.org/docs/groovy-5.0.7/html/documentation/
+- **Groovy 5 Documentation**: https://groovy-lang.org/documentation.html#all-versions (select latest 5.0.x)
 - **Spock Framework**: https://spockframework.org/spock/docs/2.4/all_in_one.html
 - **Geb Manual**: https://groovy.apache.org/geb/manual/current/

--- a/.agents/skills/groovy-developer/SKILL.md
+++ b/.agents/skills/groovy-developer/SKILL.md
@@ -509,7 +509,7 @@ sql.execute("INSERT INTO books (title) VALUES ($title)")
 
 ## Resources
 
-- **Groovy 5 Documentation**: https://docs.groovy-lang.org/docs/groovy-5.0.7/html/documentation/
+- **Groovy 5 Documentation**: https://groovy-lang.org/documentation.html#all-versions (select latest 5.0.x)
 - **Groovy Style Guide**: https://groovy-lang.org/style-guide.html
 - **GORM Documentation**: https://grails.apache.org/docs/latest/grails-data/
 - **Spock Framework**: https://spockframework.org/spock/docs/2.4/all_in_one.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,7 +291,7 @@ and known non-findings — before reporting issues.
 ## Resources
 
 - **Grails Guide**: https://grails.apache.org/docs/latest/guide/single.html
-- **Groovy 5 Docs**: https://docs.groovy-lang.org/docs/groovy-5.0.7/html/documentation/
+- **Groovy 5 Docs**: https://groovy-lang.org/documentation.html#all-versions (select latest 5.0.x)
 - **Spock 2.4 Docs**: https://spockframework.org/spock/docs/2.4/all_in_one.html
 - **GORM Docs**: https://grails.apache.org/docs/latest/grails-data/
 - **Issues**: https://github.com/apache/grails-core/issues

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -28,7 +28,7 @@ ext {
             'asset-pipeline-gradle.version' : '5.2.0-M1',
             'commons-text.version'          : '1.15.0',
             'directory-watcher.version'     : '0.19.1',
-            'gradle-groovy.version'         : '4.0.32',
+            'gradle-groovy.version'         : '4.0.33',
             'gradle-spock.version'          : '2.4-groovy-4.0',
             'grails-publish-plugin.version' : '1.0.0-M2',
             'jansi.version'                 : '2.4.2',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ ext {
             // extended-scalars compatibility. See https://github.com/apache/grails-core/issues/15674
             'graphql-java.version'          : '25.0',
             'graphql-java-extended-scalars.version': '24.0',
-            'groovy.version'                : '5.0.7',
+            'groovy.version'                : '5.0.8',
             'guava.version'                 : '33.6.0-jre',
             // Security: overrides spring-boot-dependencies (5.4.2). 5.4.3 fixes CVE-2026-54399 (httpcore5) and CVE-2026-54428 (httpcore5-h2).
             'httpcore5.version'             : '5.4.3',
@@ -444,7 +444,7 @@ ext {
                 'liquibase-hibernate.version': '4.27.0',
                 'liquibase.version'          : '4.27.0',
                 'hibernate.version'          : '5.6.15.Final',
-                'groovy.version'  : '5.0.7',
+                'groovy.version'  : '5.0.8',
                 'spock.version'   : '2.4-groovy-5.0',
                 'protobuf.version': '4.30.2',
                 'asm.version'     : '9.10.1',
@@ -505,7 +505,7 @@ ext {
                 'liquibase-hibernate.version': '4.27.0',
                 'liquibase.version'          : '4.27.0',
                 'hibernate.version'          : '5.6.15.Final',
-                'groovy.version'  : '5.0.7',
+                'groovy.version'  : '5.0.8',
                 'spock.version'   : '2.4-groovy-5.0',
                 'protobuf.version': '4.30.2',
                 'asm.version'     : '9.10.1',

--- a/grails-forge/gradle.properties
+++ b/grails-forge/gradle.properties
@@ -31,7 +31,7 @@ asciidoctorGradleJvmVersion=4.0.5
 commonsCompressVersion=1.28.0
 gradleSdkvendorPluginVersion=3.0.0
 # minimum 4.0.32 - groovydoc output is non-deterministic before GROOVY-11954, breaking reproducible javadoc jars
-groovyVersion=4.0.32
+groovyVersion=4.0.33
 jacksonDatabindVersion=2.18.3
 # match the jansi version in grails-bom
 jansiVersion=2.4.2


### PR DESCRIPTION
## Summary

- Bump managed app/runtime `groovy.version` from **5.0.7** to **5.0.8** in:
  - main BOM
  - Micronaut/Hibernate custom BOM blocks
- Bump Gradle plugin toolchain `gradle-groovy.version` from **4.0.32** to **4.0.33**
  - On 8.0.x, runtime stays on Groovy 5 while `grails-gradle` deliberately uses a separate Groovy 4 pin
- Bump `grails-forge/gradle.properties` `groovyVersion` from **4.0.32** to **4.0.33**
  - Forge remains on Groovy 4 for its own stack (minimum 4.0.32 for GROOVY-11954 / reproducible groovydoc)
- Point agent/doc resource links (`AGENTS.md`, Groovy/Grails developer skills) at the official Groovy all-versions selector for latest **5.0.x**
  - Hardcoded patch URLs go stale every release
  - Apache Groovy has no floating `latest-5.x` docs alias, and `docs/latest` is not major-line safe
  - `grails-doc` already binds guide links via `getVersion('groovy')` and needs no change

Apache Groovy releases (2026-07-29):
- 5.0.8: https://groovy-lang.org/changelogs/changelog-5.0.8.html
- 4.0.33: https://groovy-lang.org/changelogs/changelog-4.0.33.html

## Files

- `dependencies.gradle` - `groovy.version` 5.0.8 + `gradle-groovy.version` 4.0.33
- `grails-forge/gradle.properties` - Forge Groovy 4.0.33
- `AGENTS.md`, `.agents/skills/groovy-developer/SKILL.md`, `.agents/skills/grails-developer/SKILL.md` - durable Groovy 5 docs links

## Verification

```text
./gradlew :grails-core:compileGroovy :grails-bootstrap:compileGroovy \
          validateDependencyVersions --refresh-dependencies
-> BUILD SUCCESSFUL

# from grails-gradle/
./gradlew :grails-gradle-plugins:validateDependencyVersions \
          :grails-gradle-tasks:validateDependencyVersions \
          :grails-gradle-common:validateDependencyVersions \
          :grails-gradle-model:validateDependencyVersions \
          --refresh-dependencies
-> BUILD SUCCESSFUL
```

## Notes

- Companion PR for 7.0.x (Groovy 4.0.33): https://github.com/apache/grails-core/pull/16081
- Keeps the intentional 8.0.x split: app/runtime Groovy 5 vs Gradle/Forge toolchain Groovy 4