### PR TITLE
fix(deps): Bump Groovy to 4.0.33

### DIFF
--- a/.agents/skills/grails-developer/SKILL.md
+++ b/.agents/skills/grails-developer/SKILL.md
@@ -880,6 +880,6 @@ grails.plugin.springsecurity.controllerAnnotations.staticRules = [
 - **Grails 7 User Guide**: https://grails.apache.org/docs/latest/guide/single.html
 - **GORM Documentation**: https://grails.apache.org/docs/latest/grails-data/
 - **Grails Plugins**: https://grails.apache.org/plugins.html
-- **Groovy 4 Documentation**: https://docs.groovy-lang.org/docs/groovy-4.0.30/html/documentation/
+- **Groovy 4 Documentation**: https://groovy-lang.org/documentation.html#all-versions (select latest 4.0.x)
 - **Spock Framework**: https://spockframework.org/spock/docs/2.3/all_in_one.html
 - **Geb Manual**: https://groovy.apache.org/geb/manual/current/

--- a/.agents/skills/groovy-developer/SKILL.md
+++ b/.agents/skills/groovy-developer/SKILL.md
@@ -515,7 +515,7 @@ sql.execute("INSERT INTO books (title) VALUES ($title)")
 
 ## Resources
 
-- **Groovy 4 Documentation**: https://docs.groovy-lang.org/docs/groovy-4.0.30/html/documentation/
+- **Groovy 4 Documentation**: https://groovy-lang.org/documentation.html#all-versions (select latest 4.0.x)
 - **Groovy Style Guide**: https://groovy-lang.org/style-guide.html
 - **GORM Documentation**: https://grails.apache.org/docs/latest/grails-data/
 - **Spock Framework**: https://spockframework.org/spock/docs/2.3/all_in_one.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,7 @@ Please see the page of the [ASF Security Team](https://www.apache.org/security/)
 ## Resources
 
 - **Grails 7 Guide**: https://grails.apache.org/docs/latest/guide/single.html
-- **Groovy 4 Docs**: https://docs.groovy-lang.org/docs/groovy-4.0.30/html/documentation/
+- **Groovy 4 Docs**: https://groovy-lang.org/documentation.html#all-versions (select latest 4.0.x)
 - **Spock 2.3 Docs**: https://spockframework.org/spock/docs/2.3/all_in_one.html
 - **GORM Docs**: https://grails.apache.org/docs/latest/grails-data/
 - **Issues**: https://github.com/apache/grails-core/issues

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -23,7 +23,7 @@
 ext {
     gradleBomDependencyVersions = [
             'ant.version'                   : '1.10.15',
-            'asm.version'                   : '9.10',
+            'asm.version'                   : '9.10.1',
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
             'asset-pipeline-gradle.version' : '5.0.34',
@@ -89,7 +89,7 @@ ext {
             'commons-compress.version'      : '1.28.0',
             'commons-lang3.version'         : '3.20.0',
             'geb-spock.version'             : '8.0.1',
-            'groovy.version'                : '4.0.32',
+            'groovy.version'                : '4.0.33',
             'guava.version'                 : '33.6.0-jre',
             'h2.version'                    : '2.4.240',
             // Security: overrides spring-boot-dependencies (5.3.6). 5.4.3 fixes CVE-2026-54399 (httpcore5) and CVE-2026-54428 (httpcore5-h2).
@@ -272,7 +272,7 @@ ext {
     else if (project.name == 'grails-micronaut-bom') {
         customBomVersions = [
                 'javaparser-core.version': '3.27.0', // micronaut requires 3.27, groovy 4 ships with 3.28 but is compatible with 3.27
-                'asm.version'            : '9.10',
+                'asm.version'            : '9.10.1',
         ]
         combinedVersions += customBomVersions
         customBomDependencies = [


### PR DESCRIPTION
## Summary

- Bump managed `groovy.version` from **4.0.32** to **4.0.33**
  - On 7.0.x this single pin covers both the framework runtime and the `grails-gradle` plugin project (no separate `gradle-groovy.version` split)
- Align `asm.version` from **9.10** to **9.10.1** (Gradle BOM + Micronaut BOM) so the BOM stays ahead of Groovy 4.0.33's transitive ASM and `validateDependencyVersions` remains green
- Point agent/doc resource links (`AGENTS.md`, Groovy/Grails developer skills) at the official Groovy all-versions selector for latest **4.0.x**
  - Hardcoded patch URLs go stale every release
  - Apache Groovy has no floating `latest-4.x` docs alias, and `docs/latest` is not major-line safe
  - `grails-doc` already binds guide links via `getVersion('groovy')` and needs no change

Apache Groovy 4.0.33 released 2026-07-29:
- https://groovy-lang.org/changelogs/changelog-4.0.33.html
- https://repo1.maven.org/maven2/org/apache/groovy/groovy/4.0.33/

## Files

- `dependencies.gradle` - Groovy + ASM pins
- `AGENTS.md`, `.agents/skills/groovy-developer/SKILL.md`, `.agents/skills/grails-developer/SKILL.md` - durable Groovy 4 docs links

## Verification

```text
./gradlew :grails-core:compileGroovy :grails-bootstrap:compileGroovy \
          validateDependencyVersions --refresh-dependencies
-> BUILD SUCCESSFUL
```

## Notes

- Companion PR for 8.0.x (Groovy 5.0.8 + Gradle toolchain 4.0.33): https://github.com/apache/grails-core/pull/16080
- 7.0.x can merge upward through the 7.x line; 8.0.x is already on Groovy 5 and is handled separately