### PR TITLE
fix(deps): Manage bnd.annotation 7.1.0 for Log4j 2.25.5 (7.2.x)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -27,6 +27,10 @@ ext {
             'asciidoctor-gradle-jvm.version': '4.0.5',
             'asciidoctorj.version'          : '3.0.0',
             'asset-pipeline-gradle.version' : '5.0.34',
+            // Log4j 2.25.5 requires biz.aQute.bnd.annotation 7.1.0; manage it so the
+            // dependency version validator matches the winning transitive version
+            // (Spring Boot still manages 7.0.0).
+            'bnd.version'                   : '7.1.0',
             'byte-buddy.version'            : '1.18.3',
             'commons-text.version'          : '1.15.0',
             'directory-watcher.version'     : '0.19.1',
@@ -60,6 +64,7 @@ ext {
             'asciidoctor-gradle-jvm': "org.asciidoctor:asciidoctor-gradle-jvm:${gradleBomDependencyVersions['asciidoctor-gradle-jvm.version']}",
             'asciidoctorj'          : "org.asciidoctor:asciidoctorj:${gradleBomDependencyVersions['asciidoctorj.version']}",
             'asset-pipeline-gradle' : "cloud.wondrify:asset-pipeline-gradle:${gradleBomDependencyVersions['asset-pipeline-gradle.version']}",
+            'bnd-annotation'        : "biz.aQute.bnd:biz.aQute.bnd.annotation:${gradleBomDependencyVersions['bnd.version']}",
             'byte-buddy'            : "net.bytebuddy:byte-buddy:${gradleBomDependencyVersions['byte-buddy.version']}",
             'commons-text'          : "org.apache.commons:commons-text:${gradleBomDependencyVersions['commons-text.version']}",
             'directory-watcher'     : "io.methvin:directory-watcher:${gradleBomDependencyVersions['directory-watcher.version']}",


### PR DESCRIPTION
## Summary

Fixes failing CI `Validate Dependency Versions` on `7.2.x`.

Log4j 2.25.5 transitively requires `biz.aQute.bnd:biz.aQute.bnd.annotation` **7.1.0**, while Spring Boot still manages **7.0.0**. The 7.0.x alignment already pinned 7.1.0 in the shared Gradle BOM maps, but the forward-merge into 7.1.x/7.2.x kept the Log4j bump and dropped the bnd pin.

## Change

- Restore `bnd.version` = `7.1.0` in `gradleBomDependencyVersions`
- Restore `bnd-annotation` coordinate in `gradleBomDependencies`

## Verification

```
./gradlew validateDependencyVersions --continue
# BUILD SUCCESSFUL
```

## Related

Same fix applied on 7.0.x in commit `811faed161`. Companion PR targeting 7.1.x.
