### PR TITLE
fix: keep plugin templates out of the processResources filters

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1881,10 +1881,25 @@ of already-published Grails 7 command plugins must opt in with
   the complete workflow. Applying `org.apache.grails.gradle.grails-plugin-cli` also routes
   `src/main/scripts` into that companion automatically - leave scripts under `src/main/scripts`
   or place them under `src/cli/resources/META-INF/commands`.
-* After first applying `grails-plugin-cli` on a project that was already built without it, run
-  `./gradlew clean` once. Older plugin packaging wrote command scripts into
-  `build/resources/main/META-INF/commands`; a clean build directory is the supported way to drop
-  that leftover output. Fresh builds never place companion scripts on the runtime classpath.
+* The `copyCommands` and `copyTemplates` tasks stage into a directory of their own instead of
+  writing into the `processResources` output, and are registered when the plugin is applied rather
+  than in `afterEvaluate`. They are still `Copy` tasks, and paths are still relative to
+  `META-INF/templates` (or `META-INF/commands`), so a build script that configures them only needs
+  to drop the `afterEvaluate { }` wrapper that used to be required:
++
+[source,groovy]
+----
+tasks.named('copyTemplates', Copy) {
+    from(layout.projectDirectory.dir('grails-app/views')) {
+        into('views')
+    }
+}
+----
+* After first applying `grails-plugin-cli` on a project that was already built without it, consider
+  running `./gradlew clean` once. Older plugin packaging wrote command scripts directly into
+  `build/resources/main/META-INF/commands`; the first build on 8.0 drops those files, but the empty
+  directories they lived in remain until the build directory is cleaned. Fresh builds never place
+  companion scripts on the runtime classpath.
 
 NOTE: The compatibility layer applies only to the legacy application-command contract. Independently
 of it, a Grails 7 plugin that relies on APIs removed in Grails 8, Spring Boot 4, or other Grails 8

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -41,6 +41,7 @@ import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.attributes.AttributeMatchingStrategy
 import org.gradle.api.attributes.Category
+import org.gradle.api.file.CopySpec
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
@@ -130,6 +131,8 @@ class GrailsGradlePlugin implements Plugin<Project> {
         String grailsVersion = resolveGrailsVersion(project)
 
         enableNative2Ascii(project, grailsVersion)
+
+        configureTemplateResources(project)
 
         configureAssetCompilation(project)
 
@@ -1097,6 +1100,22 @@ ${importStatements}
     }
 
     /**
+     * Packages {@code src/main/templates} into the main resources as {@code META-INF/templates}.
+     *
+     * <p>Grails plugins override this: they stage templates through the {@code copyTemplates} task
+     * into a directory of their own so that a plugin's templates are not subject to the resource
+     * filters {@code processResources} applies to {@code grails-app} resource directories.</p>
+     */
+    protected void configureTemplateResources(Project project) {
+        SourceSet sourceSet = SourceSets.findMainSourceSet(project)
+        project.tasks.named(sourceSet.processResourcesTaskName, ProcessResources).configure { ProcessResources task ->
+            task.from(project.layout.projectDirectory.dir('src/main/templates')) { CopySpec spec ->
+                spec.into('META-INF/templates')
+            }
+        }
+    }
+
+    /**
      * Enables native2ascii processing of resource bundles
      **/
     @CompileDynamic
@@ -1127,10 +1146,6 @@ ${importStatements}
             // the app version leaves processResources UP-TO-DATE and stale substituted values
             // (e.g. info.app.grailsVersion in application.yml) are repackaged into every build.
             task.inputs.properties(replaceTokens)
-
-            task.from(project.relativePath('src/main/templates')) { spec ->
-                spec.into('META-INF/templates')
-            }
 
             if (!native2ascii) {
                 task.from(sourceSet.resources) { spec ->

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -25,6 +25,7 @@ import groovy.transform.CompileStatic
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.SourceSet
@@ -52,6 +53,12 @@ import org.grails.gradle.plugin.util.SourceSets
 class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
 
     public static final String PLUGIN_ID = 'org.apache.grails.gradle.grails-plugin'
+
+    /** Build-dir root staged by {@code copyCommands}; laid out as the archive sees it. */
+    protected static final String COMMANDS_STAGING_DIR = 'grails/plugin-commands'
+
+    /** Build-dir root staged by {@code copyTemplates}; laid out as the archive sees it. */
+    protected static final String TEMPLATES_STAGING_DIR = 'grails/plugin-templates'
 
     @Inject
     GrailsPluginGradlePlugin(ToolingModelBuilderRegistry registry) {
@@ -246,61 +253,96 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
     }
 
     /**
+     * A plugin's {@code src/main/templates} are always packaged by {@code copyTemplates}, so the
+     * base wiring that folds them into {@code processResources} must not also apply. Routing them
+     * through {@code processResources} would subject them to the {@code **}{@code /*.gsp} exclusion
+     * that keeps compiled views out of {@code build/resources/main}, silently dropping GSP
+     * templates such as the ones {@code generate-views} and {@code s2ui-override} render from.
+     */
+    @Override
+    protected void configureTemplateResources(Project project) {
+    }
+
+    /**
      * Packages plugin templates into the runtime jar and routes command scripts into either the
      * runtime jar or the companion {@code -cli} jar.
      *
-     * <p>When {@link GrailsCliArtifactGradlePlugin} is applied, {@code src/main/scripts} is copied
-     * into the cli source set as {@code META-INF/commands} so Groovy/YAML/JSON command resources
+     * <p>When {@link GrailsCliArtifactGradlePlugin} is applied, {@code src/main/scripts} is staged
+     * as {@code META-INF/commands} on the cli source set, so Groovy/YAML/JSON command resources
      * ship only on {@code grailsCliClasspath} and stay out of {@code runtimeClasspath},
      * {@code bootJar}, and {@code bootWar}. Without a companion, the historical behavior is
      * preserved: scripts remain in the runtime plugin jar so unmigrated Grails 7 plugins and
      * {@code legacyCommandSupport} consumers keep discovering them on the application classpath.
      * Templates always stay on the runtime jar.</p>
      *
-     * <p>{@code copyCommands} and {@code copyTemplates} are {@link Copy} tasks, each with a unique
-     * output directory under the build dir. They never side-write into
-     * {@code processResources.destinationDir}. The appropriate {@code process*Resources} task is
-     * only a composition of those unique outputs (via {@code from(...)}), so Gradle tracks
-     * ownership without a forced clean task. Prefer {@code Copy} over {@code Sync} here so end-app
-     * and asset-pipeline consumers that type {@code tasks.named('copyTemplates', Copy)} keep working.</p>
+     * <p>{@code copyCommands} and {@code copyTemplates} stay {@link Copy} tasks - build scripts
+     * configure them through {@code tasks.named('copyTemplates', Copy)} - and each owns one
+     * directory that nothing else writes, laid out exactly as the archive sees it. The staging
+     * tree is wiped before it is regenerated, so a script or template whose source was deleted
+     * stops being packaged; a plain {@code Copy} only ever adds. The wipe runs as a task action,
+     * so it happens only when the task actually executes and up-to-date checks are untouched.</p>
+     *
+     * <p>Those directories are attached to a source set output instead of being copied again by
+     * {@code process*Resources}. That is what keeps GSP templates intact: {@code grails-app/views}
+     * is a resource directory whose {@code *.gsp} files are excluded from {@code processResources},
+     * and copy patterns set on a task apply to every spec composed into it - so anything routed
+     * through {@code processResources} would lose the GSP templates that {@code generate-views} and
+     * {@code s2ui-override} render from.</p>
      */
-    @CompileDynamic
     protected void configurePluginResources(Project project) {
-        project.afterEvaluate() {
-            ProcessResources processResources = (ProcessResources) project.tasks.getByName('processResources')
-            boolean hasCliCompanion = project.pluginManager.hasPlugin(GrailsCliArtifactGradlePlugin.PLUGIN_ID)
+        ProjectLayout layout = project.layout
 
-            // Unique Copy outputs - never side-write into processResources.destinationDir.
-            TaskProvider<Copy> copyCommands = project.tasks.register('copyCommands', Copy) { Copy copy ->
-                copy.from("${project.projectDir}/src/main/scripts")
-                copy.into(project.layout.buildDirectory.dir('tmp/grails-plugin-commands'))
-            }
+        TaskProvider<Copy> copyCommands = project.tasks.register('copyCommands', Copy) { Copy copy ->
+            copy.from(layout.projectDirectory.dir('src/main/scripts'))
+            copy.into(layout.buildDirectory.dir("${COMMANDS_STAGING_DIR}/META-INF/commands"))
+            regenerateStagingTree(copy)
+        }
 
-            TaskProvider<Copy> copyTemplates = project.tasks.register('copyTemplates', Copy) { Copy copy ->
-                copy.from("${project.projectDir}/src/main/templates")
-                copy.into(project.layout.buildDirectory.dir('tmp/grails-plugin-templates'))
-            }
+        TaskProvider<Copy> copyTemplates = project.tasks.register('copyTemplates', Copy) { Copy copy ->
+            copy.from(layout.projectDirectory.dir('src/main/templates'))
+            copy.into(layout.buildDirectory.dir("${TEMPLATES_STAGING_DIR}/META-INF/templates"))
+            regenerateStagingTree(copy)
+        }
 
-            // processResources is only a combination of unique task outputs + main resources.
-            // Do not set DuplicatesStrategy.INCLUDE - overlapping paths are a configuration error.
-            processResources.from(copyTemplates) { into 'META-INF/templates' }
+        SourceSetContainer sourceSets = project.extensions.getByType(SourceSetContainer)
+        SourceSet mainSourceSet = sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+        mainSourceSet.output.dir([builtBy: copyTemplates], layout.buildDirectory.dir(TEMPLATES_STAGING_DIR))
 
-            if (hasCliCompanion) {
-                SourceSet cliSourceSet = project.extensions.getByType(SourceSetContainer)
-                        .getByName(GrailsCliArtifactGradlePlugin.CLI_SOURCE_SET_NAME)
-                ProcessResources commandResources = (ProcessResources) project.tasks
-                        .getByName(cliSourceSet.processResourcesTaskName)
-                commandResources.from(copyCommands) { into 'META-INF/commands' }
-            }
-            else {
-                processResources.from(copyCommands) { into 'META-INF/commands' }
-            }
+        project.tasks.named('processResources', ProcessResources).configure { ProcessResources task ->
+            // grails-app/views is a resource directory, but a plugin's views are compiled rather
+            // than packaged. Templates carrying the same GSPs are staged above, out of reach of
+            // this pattern.
+            task.exclude('**/*.gsp')
+        }
 
-            project.processResources {
-                // spring/resources.groovy is excluded from the published jar (see configureJarTask)
-                // but is allowed into build/resources/main/ so plugin integration tests can load it.
-                exclude('**/*.gsp')
-            }
+        routeCommandResources(project, copyCommands)
+    }
+
+    /**
+     * Clears a copy task's own destination before it runs, so the tree it produces is exactly the
+     * tree its sources describe. Registered as a task action rather than a separate clean task:
+     * Gradle settles up-to-dateness before any action runs, so an unchanged build still skips the
+     * task instead of being forced to re-copy.
+     */
+    private static void regenerateStagingTree(Copy copy) {
+        copy.doFirst { Task task ->
+            ((Copy) task).destinationDir.deleteDir()
+        }
+    }
+
+    /**
+     * Sends {@code src/main/scripts} to the cli source set when a companion is published and to the
+     * main source set otherwise. The choice can only be made once the build script has been
+     * evaluated, because {@code grails-plugin-cli} is applied after this plugin.
+     */
+    private void routeCommandResources(Project project, TaskProvider<Copy> copyCommands) {
+        project.afterEvaluate {
+            SourceSetContainer sourceSets = project.extensions.getByType(SourceSetContainer)
+            SourceSet target = project.pluginManager.hasPlugin(GrailsCliArtifactGradlePlugin.PLUGIN_ID)
+                    ? sourceSets.getByName(GrailsCliArtifactGradlePlugin.CLI_SOURCE_SET_NAME)
+                    : sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME)
+            target.output.dir([builtBy: copyCommands],
+                    project.layout.buildDirectory.dir(COMMANDS_STAGING_DIR))
         }
     }
 

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/commands/PluginScriptCommandPackagingSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/commands/PluginScriptCommandPackagingSpec.groovy
@@ -18,17 +18,23 @@
  */
 package org.grails.gradle.plugin.commands
 
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+
 import org.grails.gradle.plugin.core.GradleSpecification
 
 /**
- * Verifies that {@code src/main/scripts} command resources are packaged according to whether the
- * plugin publishes a companion {@code -cli} artifact (issue #16035).
+ * Verifies that {@code src/main/scripts} command resources and {@code src/main/templates} are
+ * packaged according to whether the plugin publishes a companion {@code -cli} artifact (issue
+ * #16035).
  *
  * <p>With {@code grails-plugin-cli}, Groovy/YAML command scripts must leave the runtime plugin jar
  * and land only in the companion. Without a companion, the historical runtime-jar packaging is
  * preserved so unmigrated Grails 7 plugins keep working under {@code legacyCommandSupport}.
- * {@code copyCommands} is a {@code Copy} task with a unique output directory consumed via
- * {@code from(...)} so Gradle tracks ownership without forced cleans or packaging-time filters.</p>
+ * {@code copyCommands} and {@code copyTemplates} stay {@code Copy} tasks, but the owning
+ * {@code process*Resources} task composes their {@code CopySpec} instead of copying a staged
+ * directory. One task writes each directory, so a deleted source stops being packaged without a
+ * forced clean task, and the GSP exclusion applied to plugin views does not reach templates.</p>
  */
 class PluginScriptCommandPackagingSpec extends GradleSpecification {
 
@@ -37,7 +43,7 @@ class PluginScriptCommandPackagingSpec extends GradleSpecification {
         setupTestResourceProject('plugin-script-commands')
 
         when:
-        def result = executeTask(':plugin-with-cli:inspectCommandPackaging')
+        BuildResult result = executeTask(':plugin-with-cli:inspectCommandPackaging')
 
         then:
         result.output.contains('RUNTIME_HAS_SCRIPT=false')
@@ -46,11 +52,11 @@ class PluginScriptCommandPackagingSpec extends GradleSpecification {
         result.output.contains('CLI_HAS_SCRIPT=true')
         result.output.contains('CLI_HAS_YAML=true')
 
+        and: 'the runtime resources output holds only the hand-authored resource, nothing staged'
+        result.output.contains('RUNTIME_RESOURCES_COMMANDS=hand-authored.yml')
+
         and: 'templates remain a runtime concern'
         result.output.contains('RUNTIME_HAS_TEMPLATE=true')
-
-        and: 'copyCommands owns a unique output directory under the build dir'
-        result.output.find(/COPY_COMMANDS_DIR=.*\/tmp\/grails-plugin-commands/)
     }
 
     def "plugins without a companion keep src/main/scripts in the runtime jar"() {
@@ -58,10 +64,66 @@ class PluginScriptCommandPackagingSpec extends GradleSpecification {
         setupTestResourceProject('plugin-script-commands')
 
         when:
-        def result = executeTask(':plugin-without-cli:inspectCommandPackaging')
+        BuildResult result = executeTask(':plugin-without-cli:inspectCommandPackaging')
 
         then:
         result.output.contains('RUNTIME_HAS_SCRIPT=true')
         result.output.contains('RUNTIME_HAS_TEMPLATE=true')
+
+        and: 'the script is packaged once, not once per contributing task'
+        result.output.contains('RUNTIME_SCRIPT_COUNT=1')
+    }
+
+    def "GSP templates are packaged even though plugin views are excluded from resources"() {
+        given: 'a .gsp under src/main/templates, a view contributed to copyTemplates, and a plugin view'
+        setupTestResourceProject('plugin-script-commands')
+
+        when:
+        BuildResult result = executeTask(':plugin-with-cli:inspectCommandPackaging')
+
+        then: 'templates keep their GSPs - they are staged outside processResources'
+        result.output.contains('RUNTIME_HAS_GSP_TEMPLATE=true')
+        result.output.contains('RUNTIME_HAS_VIEW_TEMPLATE=true')
+
+        and: 'the plugin views themselves are still kept out of the runtime resources'
+        result.output.contains('RUNTIME_HAS_RAW_VIEW=false')
+
+        and: 'a plugin without a companion packages its GSP templates too'
+        executeTask(':plugin-without-cli:inspectCommandPackaging')
+                .output.contains('RUNTIME_HAS_GSP_TEMPLATE=true')
+    }
+
+    def "neither copy task writes into a process*Resources output directory"() {
+        given:
+        setupTestResourceProject('plugin-script-commands')
+
+        when:
+        BuildResult result = executeTask(':plugin-with-cli:inspectCommandPackaging')
+
+        then:
+        result.output.contains('STAGING_DIRS_DISTINCT=true')
+        result.output.contains('COMMANDS_OUTSIDE_RESOURCES=true')
+        result.output.contains('TEMPLATES_OUTSIDE_RESOURCES=true')
+    }
+
+    def "deleting a script or template drops it from the next build without a clean"() {
+        given:
+        GradleRunner runner = setupTestResourceProject('plugin-script-commands')
+        File projectDir = runner.projectDir
+        executeTask(':plugin-with-cli:inspectCommandPackaging')
+
+        when: 'the sources are removed and the project is rebuilt in place'
+        assert new File(projectDir, 'plugin-with-cli/src/main/scripts/example-script.groovy').delete()
+        assert new File(projectDir, 'plugin-with-cli/src/main/templates/example.txt').delete()
+        BuildResult result = executeTask(':plugin-with-cli:inspectCommandPackaging')
+
+        then: 'the stale entries are gone from both jars'
+        result.output.contains('CLI_HAS_SCRIPT=false')
+        result.output.contains('RUNTIME_HAS_TEMPLATE=false')
+
+        and: 'the untouched resources still ship'
+        result.output.contains('CLI_HAS_YAML=true')
+        result.output.contains('RUNTIME_HAS_GSP_TEMPLATE=true')
+        result.output.contains('RUNTIME_HAS_HAND_AUTHORED=true')
     }
 }

--- a/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/build.gradle
@@ -17,8 +17,17 @@ cliArtifact {
     automaticModuleName = 'org.example.test.plugin.with.cli'
 }
 
+// A consumer contributing extra sources to copyTemplates: paths stay relative to
+// META-INF/templates, exactly as before.
+tasks.named('copyTemplates', Copy) {
+    from(layout.projectDirectory.dir('grails-app/views')) {
+        into('views')
+    }
+}
+
 tasks.register('inspectCommandPackaging') {
     dependsOn 'jar', 'cliJar'
+    def projectLayout = layout
     doLast {
         def runtimeJar = tasks.named('jar', Jar).get().archiveFile.get().asFile
         def cliJarFile = tasks.named('cliJar', Jar).get().archiveFile.get().asFile
@@ -32,8 +41,38 @@ tasks.register('inspectCommandPackaging') {
         println "CLI_HAS_SCRIPT=${cliEntries.contains('META-INF/commands/example-script.groovy')}"
         println "CLI_HAS_YAML=${cliEntries.contains('META-INF/commands/example-multi-step.yml')}"
         println "RUNTIME_HAS_TEMPLATE=${runtimeEntries.contains('META-INF/templates/example.txt')}"
-        println "COPY_COMMANDS_DIR=${tasks.named('copyCommands', Copy).get().destinationDir.absolutePath.replace('\\', '/')}"
+
+        // GSP templates must survive: grails-app/views is a resource directory whose GSPs are
+        // excluded from processResources, but templates are staged outside that task.
+        println "RUNTIME_HAS_GSP_TEMPLATE=${runtimeEntries.contains('META-INF/templates/example.gsp')}"
+        println "RUNTIME_HAS_VIEW_TEMPLATE=${runtimeEntries.contains('META-INF/templates/views/sample/show.gsp')}"
+
+        // ...while the plugin's own views are still kept out of the runtime resources.
+        println "RUNTIME_HAS_RAW_VIEW=${runtimeEntries.contains('sample/show.gsp')}"
+
+        // Neither copy task writes into a process*Resources output directory.
+        def commandsDir = tasks.named('copyCommands', Copy).get().destinationDir
+        def templatesDir = tasks.named('copyTemplates', Copy).get().destinationDir
+        def mainResourcesDir = tasks.named('processResources', ProcessResources).get().destinationDir
+        def cliResourcesDir = tasks.named('processCliResources', ProcessResources).get().destinationDir
+        println "COPY_COMMANDS_DIR=${normalize(commandsDir)}"
+        println "COPY_TEMPLATES_DIR=${normalize(templatesDir)}"
+        println "STAGING_DIRS_DISTINCT=${commandsDir != templatesDir}"
+        println "COMMANDS_OUTSIDE_RESOURCES=${!isInside(commandsDir, mainResourcesDir) && !isInside(commandsDir, cliResourcesDir)}"
+        println "TEMPLATES_OUTSIDE_RESOURCES=${!isInside(templatesDir, mainResourcesDir) && !isInside(templatesDir, cliResourcesDir)}"
+
+        // Nothing is written into the runtime resources output for command/template staging.
+        def runtimeCommands = new File(mainResourcesDir, 'META-INF/commands')
+        println "RUNTIME_RESOURCES_COMMANDS=${runtimeCommands.exists() ? runtimeCommands.list().sort().join(',') : ''}"
     }
+}
+
+static String normalize(File file) {
+    file.absolutePath.replace('\\', '/')
+}
+
+static boolean isInside(File candidate, File parent) {
+    candidate.canonicalPath.startsWith(parent.canonicalPath + File.separator)
 }
 
 static Set<String> jarEntries(File jarFile) {

--- a/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/grails-app/views/sample/show.gsp
+++ b/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/grails-app/views/sample/show.gsp
@@ -1,0 +1,1 @@
+<html><body>plugin view</body></html>

--- a/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/src/main/templates/example.gsp
+++ b/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-with-cli/src/main/templates/example.gsp
@@ -1,0 +1,1 @@
+<html><body>gsp template</body></html>

--- a/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-without-cli/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-without-cli/build.gradle
@@ -19,6 +19,8 @@ tasks.register('inspectCommandPackaging') {
         println "RUNTIME_JAR=${runtimeJar.name}"
         println "RUNTIME_HAS_SCRIPT=${runtimeEntries.contains('META-INF/commands/legacy-only-script.groovy')}"
         println "RUNTIME_HAS_TEMPLATE=${runtimeEntries.contains('META-INF/templates/legacy-only.txt')}"
+        println "RUNTIME_HAS_GSP_TEMPLATE=${runtimeEntries.contains('META-INF/templates/legacy-only.gsp')}"
+        println "RUNTIME_SCRIPT_COUNT=${runtimeEntries.count { it.startsWith('META-INF/commands/') && !it.endsWith('/') }}"
     }
 }
 

--- a/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-without-cli/src/main/templates/legacy-only.gsp
+++ b/grails-gradle/plugins/src/test/resources/test-projects/plugin-script-commands/plugin-without-cli/src/main/templates/legacy-only.gsp
@@ -1,0 +1,1 @@
+<html><body>legacy gsp template</body></html>

--- a/grails-spring-security/ui/plugin/build.gradle
+++ b/grails-spring-security/ui/plugin/build.gradle
@@ -66,13 +66,11 @@ dependencies {
 }
 
 // Ship the plugin views as templates (used by the s2ui-override command).
-// 'copyTemplates' is registered by the grails-plugin gradle plugin in afterEvaluate as a Copy
-// task with a unique output directory, so it can only be configured from a later afterEvaluate.
-afterEvaluate {
-    tasks.named('copyTemplates', Copy) {
-        from(layout.projectDirectory.dir('grails-app/views')) {
-            into('views')
-        }
+// 'copyTemplates' is registered by the grails-plugin gradle plugin when the plugin is applied;
+// it stages META-INF/templates into a directory of its own that is packaged into the plugin jar.
+tasks.named('copyTemplates', Copy) {
+    from(layout.projectDirectory.dir('grails-app/views')) {
+        into('views')
     }
 }
 


### PR DESCRIPTION
See https://github.com/apache/grails-core/pull/16082