### PR TITLE
Fix reproducible build artifact verification script

### DIFF
--- a/etc/bin/extract-build-artifact.sh
+++ b/etc/bin/extract-build-artifact.sh
@@ -30,17 +30,17 @@ EXTRACT_LOCATION="${2:-${SCRIPT_DIR}/results}"
 
 echo "Looking for build artifact ${ARTIFACT_NAME} in ${EXTRACT_LOCATION}"
 
-if [ -z "${EXTRACT_LOCATION}/first/${ARTIFACT_NAME}" ]; then
+if [ ! -f "${EXTRACT_LOCATION}/first/${ARTIFACT_NAME}" ]; then
     echo "❌ First Artifact Not found: ${ARTIFACT_NAME} could not be found under ${EXTRACT_LOCATION}/first/${ARTIFACT_NAME}"
     exit 1;
 else
   echo "     ✅ First Artifact Found @ ${EXTRACT_LOCATION}/first/${ARTIFACT_NAME}"
 fi
-if [ -z "${EXTRACT_LOCATION}/second/${ARTIFACT_NAME}" ]; then
+if [ ! -f "${EXTRACT_LOCATION}/second/${ARTIFACT_NAME}" ]; then
     echo "❌ Second Artifact Not found: ${ARTIFACT_NAME} could not be found under ${EXTRACT_LOCATION}/second/${ARTIFACT_NAME}"
     exit 1;
 else
-  echo "     ✅ Second Artifact Found @ ${EXTRACT_LOCATION}/first/${ARTIFACT_NAME}"
+  echo "     ✅ Second Artifact Found @ ${EXTRACT_LOCATION}/second/${ARTIFACT_NAME}"
 fi
 
 rm -rf "${EXTRACT_LOCATION}/firstArtifact" || true

--- a/etc/bin/verify-reproducible.sh
+++ b/etc/bin/verify-reproducible.sh
@@ -150,7 +150,9 @@ cd "${DOWNLOAD_LOCATION}/grails/etc/bin/results"
 echo "Checking for differences in checksums"
 # diff -u CHECKSUMS second.txt
 DIFF_RESULTS=$(comm -3 <(sort ../../../CHECKSUMS) <(sort second.txt) | cut -d' ' -f1 | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -v '^$' | uniq | sort)
-echo "$DIFF_RESULTS" > diff.txt
+if [[ -n $DIFF_RESULTS ]]; then
+    printf '%s\n' "$DIFF_RESULTS"
+fi > diff.txt
 
 if [ -s diff.txt ]; then
   echo "Differences were found, diffing jar files ..."
@@ -165,6 +167,7 @@ if [ -s diff.txt ]; then
 
   : > diff_purged.txt  # Ensure the file exists and is empty
   while IFS= read -r jar_file; do
+      [[ -z "${jar_file//[[:space:]]/}" ]] && continue
       echo "Checking jar ${jar_file}..."
 
       echo "Extracting ${jar_file}"


### PR DESCRIPTION
Avoid blank artifact names when no checksum differences are found,
and validate extracted artifacts with proper file checks.