### PR TITLE
change cooldown for dependabot to 7 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     target-branch: 6.2.x
     labels:
@@ -38,3 +40,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
this buys a little extra time for GitHub actions to be further battle tested by other projects and to be added to the ASF infra allow list
