### PR TITLE
[Build] Replace deprecated Gradle test listener creation

### DIFF
--- a/etc/bin/test-bisect.groovy
+++ b/etc/bin/test-bisect.groovy
@@ -24,35 +24,36 @@ import groovy.cli.commons.CliBuilder
 
 /**
  * This script finds the test class that's causing test pollution in other tests.
- * To use it, gradle must be configured to run sequentially, without retries, and output a specific line
- * so the script knows the test order. The script will pass the property `testBisect` for gradle to detect when being called
- * by this script. For example:
+ * To use it, Gradle must be configured to run sequentially, without retries, and output a specific line
+ * so the script knows the test order. The script will pass the property `testBisect` for Gradle to detect when
+ * being called by this script. For example:
  *
- *     if(hasProperty('testBisect')) {
- *          tasks.withType(Test).configureEach {
- *              maxParallelForks = 1
- *              forkEvery = 0
- *               develocity {
- *                   testDistribution {
- *                       enabled.set(false)
- *                       retryInSameJvm.set(true)
- *                  }
- *                   testRetry {
- *                       maxRetries = 1
- *                       maxFailures = 1
- *                       failOnPassedAfterRetry = true
- *                   }
- *               }
- *              beforeTest { testDescriptor ->
- *                  logger.info "STARTED TEST: ${testDescriptor.className} > ${testDescriptor.name}"
- *              }
- *               afterSuite { desc, result ->
- *                   if (!desc.parent) {
- *                       logger.info("FINISHED - ${result.failedTestCount == 0 && result.testCount > 1} ? 'PASSED' : 'FAILED'} - ${result.testCount} tests executed, ${result.failedTestCount} failed")
- *                   }
- *               }
- *          }
- *      }
+ *     if (hasProperty('testBisect')) {
+ *         tasks.withType(Test).configureEach {
+ *             maxParallelForks = 1
+ *             forkEvery = 0
+ *             develocity {
+ *                 testDistribution {
+ *                     enabled.set(false)
+ *                     retryInSameJvm.set(true)
+ *                 }
+ *                 testRetry {
+ *                     maxRetries = 1
+ *                     maxFailures = 1
+ *                     failOnPassedAfterRetry = true
+ *                 }
+ *             }
+ *             addTestListener([
+ *                 beforeTest: { testDescriptor ->
+ *                     logger.info("STARTED TEST: ${testDescriptor.className} > ${testDescriptor.name}")
+ *                 }
+ *                 afterSuite: { desc, result ->
+ *                     if (!desc.parent) {
+ *                        logger.info("FINISHED - ${result.failedTestCount == 0 && result.testCount > 1} ? 'PASSED' : 'FAILED'} - ${result.testCount} tests executed, ${result.failedTestCount} failed")
+ *                     }
+ *             ] as TestListener)
+ *         }
+ *     }
  */
 class TestPollution {
 

--- a/gradle/hibernate5-test-config.gradle
+++ b/gradle/hibernate5-test-config.gradle
@@ -67,16 +67,18 @@ tasks.withType(Test).configureEach {
         info.events = debug.events
         info.exceptionFormat = debug.exceptionFormat
     }
-    afterTest { desc, result ->
-        logger.quiet(' -- Executed test {} [{}] with result: {}', desc.name, desc.className, result.resultType)
-    }
-    afterSuite { desc, result ->
-        if (!desc.parent) { // will match the outermost suite
-            def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
-            def startItem = '|  ', endItem = '  |'
-            def repeatLength = startItem.length() + output.length() + endItem.length()
-            def dashes = '-' * repeatLength
-            logger.quiet('\n{}\n{}{}{}\n{}', dashes, startItem, output, endItem, dashes)
+    addTestListener([
+        afterTest: { desc, result ->
+            logger.quiet(' -- Executed test {} [{}] with result: {}', desc.name, desc.className, result.resultType)
+        },
+        afterSuite: { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                def dashes = '-' * repeatLength
+                logger.quiet('\n{}\n{}{}{}\n{}', dashes, startItem, output, endItem, dashes)
+            }
         }
-    }
+    ] as TestListener)
 }

--- a/gradle/hibernate7-test-config.gradle
+++ b/gradle/hibernate7-test-config.gradle
@@ -65,16 +65,18 @@ tasks.withType(Test).configureEach {
         info.events = debug.events
         info.exceptionFormat = debug.exceptionFormat
     }
-    afterTest { desc, result ->
-        logger.quiet(' -- Executed test {} [{}] with result: {}', desc.name, desc.className, result.resultType)
-    }
-    afterSuite { desc, result ->
-        if (!desc.parent) { // will match the outermost suite
-            def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
-            def startItem = '|  ', endItem = '  |'
-            def repeatLength = startItem.length() + output.length() + endItem.length()
-            def dashes = '-' * repeatLength
-            logger.quiet('\n{}\n{}{}{}\n{}', dashes, startItem, output, endItem, dashes)
+    addTestListener([
+        afterTest: { desc, result ->
+            logger.quiet(' -- Executed test {} [{}] with result: {}', desc.name, desc.className, result.resultType)
+        },
+        afterSuite: { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                def dashes = '-' * repeatLength
+                logger.quiet('\n{}\n{}{}{}\n{}', dashes, startItem, output, endItem, dashes)
+            }
         }
-    }
+    ] as TestListener)
 }

--- a/gradle/mongodb-forked-test-config.gradle
+++ b/gradle/mongodb-forked-test-config.gradle
@@ -52,10 +52,12 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
     maxParallelForks = configuredTestParallel
     jvmArgs = ['-Xmx768M']
-    afterSuite {
-        System.out.print('.')
-        System.out.flush()
-    }
+    addTestListener([
+        afterSuite: { desc, result ->
+            System.out.print('.')
+            System.out.flush()
+        }
+    ] as TestListener)
     testLogging {
         events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'

--- a/gradle/mongodb-test-config.gradle
+++ b/gradle/mongodb-test-config.gradle
@@ -52,10 +52,12 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
     maxParallelForks = 1
     jvmArgs = ['-Xmx1028M']
-    afterSuite {
-        System.out.print('.')
-        System.out.flush()
-    }
+    addTestListener([
+        afterSuite: { desc, result ->
+            System.out.print('.')
+            System.out.flush()
+        }
+    ] as TestListener)
     testLogging {
         events('passed', 'skipped', 'failed')
         exceptionFormat = 'full'

--- a/gradle/redis-test-config.gradle
+++ b/gradle/redis-test-config.gradle
@@ -43,7 +43,9 @@ tasks.withType(Test).configureEach {
         exceptionFormat = 'full'
         events 'passed', 'skipped', 'failed'
     }
-    beforeTest { descriptor -> logger.quiet(" -- $descriptor") }
+    addTestListener([
+        beforeTest: { descriptor -> logger.quiet(" -- $descriptor") }
+    ] as TestListener)
 
     // Forwarded to org.apache.grails.testing.redis extensions to control the Testcontainers Redis image version
     if (project.hasProperty('redisContainerVersion')) {

--- a/gradle/spring-security-test-config.gradle
+++ b/gradle/spring-security-test-config.gradle
@@ -43,7 +43,9 @@ tasks.withType(Test).configureEach {
         exceptionFormat = 'full'
         events 'passed', 'skipped', 'failed'//, 'standardOut', 'standardError'
     }
-    beforeTest { descriptor -> logger.quiet(" -- $descriptor") }
+    addTestListener([
+            beforeTest: { descriptor -> logger.quiet(" -- $descriptor") }
+    ] as TestListener)
 }
 
 tasks.named('integrationTest', Test) {

--- a/gradle/test-config.gradle
+++ b/gradle/test-config.gradle
@@ -89,10 +89,12 @@ tasks.withType(Test).configureEach {
     if (System.getProperty('debug.tests')) {
         jvmArgs += debugArguments
     }
-    afterSuite {
-        System.out.print('.')
-        System.out.flush()
-    }
+    addTestListener([
+        afterSuite: { desc, result ->
+            System.out.print('.')
+            System.out.flush()
+        }
+    ] as TestListener)
     // Bridge Geb-specific properties (e.g. from local.properties) to the Test JVM
     // to allow local overrides of Docker images and other settings.
     project.properties.each { key, value ->
@@ -119,15 +121,19 @@ if (hasProperty('testBisect')) {
             }
         }
 
-        beforeTest { testDescriptor ->
-            logger.info('STARTED TEST: {} > {}', testDescriptor.className, testDescriptor.name)
-        }
-
-        afterSuite { desc, result ->
-            if (!desc.parent) {
-                def testStatus = result.failedTestCount == 0 && result.testCount > 1 ? 'PASSED' : 'FAILED'
-                logger.info('FINISHED - {} - {} tests executed, {} failed', testStatus, result.testCount, result.failedTestCount)
-            }
-        }
+        addTestListener([
+                beforeTest: { testDescriptor ->
+                    logger.info('STARTED TEST: {} > {}', testDescriptor.className, testDescriptor.name)
+                },
+                afterSuite: { suite, result ->
+                    if (!suite.parent) {
+                        def testStatus = result.failedTestCount == 0 && result.testCount > 1 ? 'PASSED' : 'FAILED'
+                        logger.info(
+                                'FINISHED - {} - {} tests executed, {} failed',
+                                testStatus, result.testCount, result.failedTestCount
+                        )
+                    }
+                }
+        ] as TestListener)
     }
 }

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/build.gradle
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/build.gradle
@@ -51,10 +51,12 @@ test {
     forkEvery = 10
 
     jvmArgs = ['-Xmx1028M']
-    afterSuite {
-        System.out.print('.')
-        System.out.flush()
-    }
+    addTestListener([
+        afterSuite: { desc, result ->
+            System.out.print('.')
+            System.out.flush()
+        }
+    ] as TestListener)
 }
 
 test.doFirst {


### PR DESCRIPTION
This pull request updates test configuration across multiple Gradle build files to use the `TestListener` interface instead of the deprecated test lifecycle hooks. These changes modernize test logging, improve compatibility with newer Gradle versions, and ensure consistency in test event handling.

**Test configuration modernization:**

* Replaced all usages of `beforeTest`, `afterTest`, and `afterSuite` closures with the `addTestListener` API and corresponding closures in the following files:  
  * `gradle/hibernate5-test-config.gradle` [[1]](diffhunk://#diff-d038087ed6543f58711609cda77c7e4bad72c9409f016123599cf30ed41661eaL70-R74) [[2]](diffhunk://#diff-d038087ed6543f58711609cda77c7e4bad72c9409f016123599cf30ed41661eaR83)  
  * `gradle/hibernate7-test-config.gradle` [[1]](diffhunk://#diff-d66378e8e6c7ec4aa5f7b2819c529cc6cc71cc788764c98f9d1575d80321e272L68-R72) [[2]](diffhunk://#diff-d66378e8e6c7ec4aa5f7b2819c529cc6cc71cc788764c98f9d1575d80321e272R81)  
  * `gradle/mongodb-forked-test-config.gradle`  
  * `gradle/mongodb-test-config.gradle`  
  * `gradle/redis-test-config.gradle`  
  * `gradle/spring-security-test-config.gradle`  
  * `gradle/test-config.gradle` [[1]](diffhunk://#diff-ae427bd33d1d638570fa945ebcd564182a2102280dfb09aa4499c27a12ad0002L92-R97) [[2]](diffhunk://#diff-ae427bd33d1d638570fa945ebcd564182a2102280dfb09aa4499c27a12ad0002L122-R137)  
  * `grails-data-neo4j/grails-datastore-gorm-neo4j/build.gradle`
