### PR TITLE
[Build] Cleanup redundant build console output

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/SbomPlugin.groovy
@@ -469,7 +469,7 @@ class SbomPlugin implements Plugin<Project> {
             // There are several reasons that cyclone will get the license wrong, usually due to upstream not publishing information or publishing it incorrectly
             // see the licenseMapping map above for details
             def licenseId = LICENSE_MAPPING[bomRef]
-            logger.lifecycle('Forcing license for {} to {}', bomRef, licenseId)
+            logger.info('Forcing license for {} to {}', bomRef, licenseId)
 
             def licenseBlock = LICENSES[licenseId]
             if (!licenseBlock) {

--- a/grails-async/plugin/build.gradle
+++ b/grails-async/plugin/build.gradle
@@ -52,12 +52,12 @@ dependencies {
     implementation 'org.springframework:spring-web'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api' // Provided
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.springframework:spring-test'
-
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during test task
 
 }
 

--- a/grails-beans-dsl/build.gradle
+++ b/grails-beans-dsl/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.spockframework:spock-core'
     testRuntimeOnly 'org.slf4j:slf4j-simple'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-cache/build.gradle
+++ b/grails-cache/build.gradle
@@ -40,6 +40,9 @@ ext {
 
 dependencies {
     implementation platform(project(':grails-bom'))
+    astCompileOnly platform(project(':grails-bom'))
+
+    astCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     api project(':grails-core')
     api project(':grails-web-boot')
@@ -50,12 +53,15 @@ dependencies {
     api "com.googlecode.concurrentlinkedhashmap:concurrentlinkedhashmap-lru:$concurrentlinkedhashmapLruVersion"
 
     compileOnly project(':grails-domain-class')
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     console project(':grails-console')
 
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'net.bytebuddy:byte-buddy' // Required by Spock's mocking support
 }

--- a/grails-codecs/build.gradle
+++ b/grails-codecs/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     runtimeOnly project(':grails-codecs-core')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-console/build.gradle
+++ b/grails-console/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
     api 'jakarta.servlet:jakarta.servlet-api'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-suite'

--- a/grails-controllers/build.gradle
+++ b/grails-controllers/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     testRuntimeOnly 'org.jline:jline'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test'
 
     testImplementation 'jakarta.servlet:jakarta.servlet-api'

--- a/grails-converters/build.gradle
+++ b/grails-converters/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation project(':grails-web-common')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-core-cli-legacy/build.gradle
+++ b/grails-core-cli-legacy/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     api 'org.apache.groovy:groovy'
     implementation 'org.apache.groovy:groovy-templates'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-suite'

--- a/grails-core/build.gradle
+++ b/grails-core/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     cliImplementation 'org.apache.groovy:groovy-json'
     cliImplementation 'org.apache.groovy:groovy-templates'
 
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.springframework:spring-jdbc'
     testImplementation 'org.springframework.boot:spring-boot-test'
     // ApplicationContextRunner's signatures reach AssertJ through ApplicationContextAssertProvider;

--- a/grails-data-graphql/plugin/build.gradle
+++ b/grails-data-graphql/plugin/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     // dependency stays `compileOnly` to avoid shipping anything new on the
     // production classpath.
     compileOnly 'org.springframework:spring-web'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation project(':grails-testing-support-web')
     testImplementation 'org.spockframework:spock-core'
@@ -86,6 +87,9 @@ dependencies {
     testImplementation 'org.springframework:spring-web'
     testImplementation "io.github.cjstehno.ersatz:ersatz:$ersatzVersion"
     testImplementation "io.github.cjstehno.ersatz:ersatz-groovy:$ersatzVersion"
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'tools.jackson.core:jackson-databind'
     testRuntimeOnly 'net.bytebuddy:byte-buddy' // Required by Spock's mocking support
     testRuntimeOnly 'org.objenesis:objenesis' // Required by Spock for mocking classes without default constructor

--- a/grails-data-hibernate5/core/build.gradle
+++ b/grails-data-hibernate5/core/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     testImplementation 'org.apache.groovy:groovy-json'
     testImplementation 'org.apache.tomcat:tomcat-jdbc'
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'org.hibernate:hibernate-ehcache', {
         // exclude javax variant of hibernate-core 5.6
         exclude group: 'org.hibernate', module: 'hibernate-core'

--- a/grails-data-hibernate5/dbmigration/build.gradle
+++ b/grails-data-hibernate5/dbmigration/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     cliImplementation project(':grails-data-hibernate5')
     cliCompileOnly 'org.apache.groovy:groovy-sql'
     cliCompileOnly 'org.apache.groovy:groovy-xml'
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     cliImplementation(project(':grails-shell-cli')) {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
 

--- a/grails-data-hibernate5/grails-plugin/build.gradle
+++ b/grails-data-hibernate5/grails-plugin/build.gradle
@@ -54,6 +54,7 @@ dependencies {
             requireCapability('org.apache.grails:grails-core-cli')
         }
     }
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     // TODO: Clarify and clean up dependencies
     implementation platform(project(':grails-hibernate5-bom'))
@@ -77,6 +78,7 @@ dependencies {
     compileOnly project(':grails-bootstrap')
     compileOnly project(':grails-core')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.spockframework:spock-core', {
         exclude group: 'junit', module: 'junit-dep'
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
@@ -86,6 +88,8 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.apache.tomcat:tomcat-jdbc'

--- a/grails-data-hibernate7/core/build.gradle
+++ b/grails-data-hibernate7/core/build.gradle
@@ -117,6 +117,8 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc'
     testImplementation 'org.spockframework:spock-core'
 
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'org.slf4j:slf4j-simple'
     testRuntimeOnly 'org.slf4j:jcl-over-slf4j'
     testRuntimeOnly 'org.springframework:spring-aop'

--- a/grails-data-hibernate7/dbmigration/build.gradle
+++ b/grails-data-hibernate7/dbmigration/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     cliImplementation project(':grails-data-hibernate7')
     cliCompileOnly 'org.apache.groovy:groovy-sql'
     cliCompileOnly 'org.apache.groovy:groovy-xml'
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     cliImplementation(project(':grails-shell-cli')) {
         exclude group: 'org.slf4j', module: 'slf4j-simple'
 

--- a/grails-data-hibernate7/grails-plugin/build.gradle
+++ b/grails-data-hibernate7/grails-plugin/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     // SchemaExport lives in hibernate-tools, which is implementation-scoped in the main tier
     cliImplementation 'org.hibernate.tool:hibernate-tools-orm'
 
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     implementation platform(project(':grails-hibernate7-bom'))
 
     api 'org.springframework.boot:spring-boot'
@@ -81,6 +83,7 @@ dependencies {
     compileOnly project(':grails-bootstrap')
     compileOnly project(':grails-core')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.spockframework:spock-core', {
         exclude group: 'junit', module: 'junit-dep'
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
@@ -90,6 +93,8 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.apache.tomcat:tomcat-jdbc'

--- a/grails-data-mongodb/boot-plugin/build.gradle
+++ b/grails-data-mongodb/boot-plugin/build.gradle
@@ -100,11 +100,14 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api', {
         // "optional" compile dependency in mongodb-driver-core
     }
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
+    testImplementation project(':grails-testing-support-mongodb')
     testImplementation 'org.spockframework:spock-core'
 
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'org.slf4j:slf4j-nop'
-    testImplementation project(':grails-testing-support-mongodb')
 }
 
 apply {

--- a/grails-data-mongodb/core/build.gradle
+++ b/grails-data-mongodb/core/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     }
 
     compileOnly 'org.apache.groovy:groovy'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'com.github.ben-manes.caffeine:caffeine', {
         // comp: RemovalCause, this should perhaps be api in data-mapping as it is needed for compilation downstream
     }
@@ -139,12 +140,12 @@ dependencies {
         // test: GenericWebApplicationContext requires ServletContext on the classpath
     }
 
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:testcontainers-mongodb'
     testImplementation 'org.testcontainers:testcontainers-spock'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
 }
 
 apply {

--- a/grails-data-mongodb/ext/build.gradle
+++ b/grails-data-mongodb/ext/build.gradle
@@ -86,6 +86,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api', {
         // "optional" compile dependency in mongodb-driver-core
     }
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-data-mongodb/grails-plugin/build.gradle
+++ b/grails-data-mongodb/grails-plugin/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     }
 
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly project(':grails-core'), { // Provided as this is a Grails plugin
         // api: GrailsPlugin
         // impl: DomainClassArtefactHandler, GrailsClass, GrailsPlugin, Metadata
@@ -114,6 +115,7 @@ dependencies {
     testFixturesImplementation 'org.spockframework:spock-core'
 
     testFixturesCompileOnly 'org.apache.groovy:groovy'
+    testFixturesCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 def disabledTasks = ['bootRun', 'bootTestRun']

--- a/grails-data-mongodb/spring-data/build.gradle
+++ b/grails-data-mongodb/spring-data/build.gradle
@@ -63,6 +63,8 @@ dependencies {
         // impl: @AutoConfiguration, @ConditionalOnClass/Bean, @AutoConfigureAfter
     }
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.spockframework:spock-core'
     testImplementation project(':grails-testing-support-mongodb')
     testImplementation 'org.springframework.boot:spring-boot-test', {
@@ -71,7 +73,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core', {
         // test: required by Spring Boot's AssertableApplicationContext
     }
-    testRuntimeOnly 'org.slf4j:slf4j-nop'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
 }
 
 apply {

--- a/grails-databinding/build.gradle
+++ b/grails-databinding/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     testImplementation project(':grails-testing-support-core')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-datamapping-core-test/build.gradle
+++ b/grails-datamapping-core-test/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     // Use the simple datastore to ensure the base implementation works correctly
     api project(':grails-data-simple')
 
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
 
     runtimeOnly 'org.apache.groovy:groovy-dateutil', {
         // Groovy Date Utils Extensions are used in the tests

--- a/grails-datamapping-core/build.gradle
+++ b/grails-datamapping-core/build.gradle
@@ -111,8 +111,8 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
 
     testImplementation 'com.zaxxer:HikariCP'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testRuntimeOnly 'com.h2database:h2'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
 }
 
 //compileGroovy.groovyOptions.forkOptions.jvmArgs = ['-Xdebug', '-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']

--- a/grails-datamapping-support/build.gradle
+++ b/grails-datamapping-support/build.gradle
@@ -106,10 +106,11 @@ dependencies {
     compileOnly 'org.apache.groovy:groovy', {
         // comp: CompileStatic
     }
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation 'org.spockframework:spock-core'
 
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
 }
 
 tasks.withType(Jar).configureEach {

--- a/grails-datamapping-tck/build.gradle
+++ b/grails-datamapping-tck/build.gradle
@@ -41,6 +41,7 @@ ext {
 dependencies {
     implementation platform(project(':grails-bom'))
     compileOnly 'org.apache.groovy:groovy'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.spockframework:spock-core'
     api project(':grails-datastore-core'), {
         // api: AbstractPersistenceEvent, AbstractPersistenceEventListener, AbstractQueryEvent, Datastore,

--- a/grails-datasource/build.gradle
+++ b/grails-datasource/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     api project(':grails-datastore-core')
 
     compileOnly 'org.apache.tomcat:tomcat-jdbc'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     api project(':grails-core')
 

--- a/grails-domain-class/build.gradle
+++ b/grails-domain-class/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     }
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-encoder/build.gradle
+++ b/grails-encoder/build.gradle
@@ -45,6 +45,8 @@ dependencies {
         // HtmlUtils is used from spring-web
     }
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-suite'

--- a/grails-events/plugin/build.gradle
+++ b/grails-events/plugin/build.gradle
@@ -46,14 +46,15 @@ dependencies {
 
     // As this is a plugin these dependencies will be provided by the Grails application
     // This removes circular dependencies
-    compileOnly 'org.apache.grails.gradle:grails-gradle-model'
     compileOnly project(':grails-core')
+    compileOnly 'org.apache.grails.gradle:grails-gradle-model'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
-    testImplementation 'org.spockframework:spock-core'
     testImplementation project(':grails-core')
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
+    testImplementation 'org.spockframework:spock-core'
 
     testRuntimeOnly 'org.apache.grails.gradle:grails-gradle-model'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during test task
 }
 
 apply {

--- a/grails-fields/build.gradle
+++ b/grails-fields/build.gradle
@@ -59,6 +59,8 @@ dependencies {
         exclude module: 'asm'
     }
 
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'org.objenesis:objenesis' // Required by Spock for mocking classes without default constructor
 }
 

--- a/grails-geb/build.gradle
+++ b/grails-geb/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testFixturesImplementation platform(project(':grails-bom'))
 
     compileOnly project(':grails-core') // Provided, as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testFixturesCompileOnly 'jakarta.servlet:jakarta.servlet-api'
     testFixturesCompileOnly 'org.slf4j:slf4j-simple' // Remove compilation warning about missing slf4j impl

--- a/grails-gsp/core/build.gradle
+++ b/grails-gsp/core/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     // GSP rendering/compilation Micrometer instrumentation (gsp.view/template/layout/compile + cache counters)
     implementation 'io.micrometer:micrometer-observation'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
 //    api project(':grails-bootstrap'), { // ConfigMap
 //        // API dependencies in grails-bootstrap
 //        exclude group: 'org.yaml', module: 'snakeyaml'
@@ -90,10 +92,8 @@ dependencies {
 //    implementation 'org.springframework:spring-context' // ApplicationContext
 //
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
-
-    testRuntimeOnly 'org.slf4j:slf4j-nop'
-    // Get rid of warning about missing slf4j implementation during test compilation
 }
 
 apply {

--- a/grails-gsp/grails-layout/build.gradle
+++ b/grails-gsp/grails-layout/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api project(':grails-web-taglib')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api' // Provided
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     implementation 'org.apache.groovy:groovy'
     implementation platform(project(':grails-bom'))
@@ -61,6 +62,9 @@ dependencies {
         // impl: MockHttpServletRequest
     }
     testImplementation project(':grails-testing-support-web')
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testRuntimeOnly 'net.bytebuddy:byte-buddy' // Required by Spock's mocking support
     testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during test task
 }

--- a/grails-gsp/grails-taglib/build.gradle
+++ b/grails-gsp/grails-taglib/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     api project(':grails-core')
     api project(':grails-encoder')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
 //    api 'org.apache.grails:grails-core', { // InjectableGrailsClass, ArtefactHandlerAdapter, ArtefactInfo, GrailsClass, AbstractInjectableGrailsClass, GrailsApplication, EncodingStateRegistry, EncodingStateRegistryLookup
 //        // API dependencies in grails-core
 //        exclude group: 'org.apache.groovy', module: 'groovy'
@@ -80,9 +82,8 @@ dependencies {
 //    compileOnly 'org.apache.groovy:groovy' // Needed as there are Java files that reference Groovy classes
 //
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
+    testImplementation 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
-
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
 }
 
 apply {

--- a/grails-gsp/grails-web-gsp-taglib/build.gradle
+++ b/grails-gsp/grails-web-gsp-taglib/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation platform(project(':grails-bom'))
     api project(':grails-web-jsp')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
 //    api project(':grails-taglib'), { // GrailsTagLibClass
 //        // API dependencies in grails-taglib
 //        exclude group: 'org.apache.grails', module: 'grails-core'

--- a/grails-gsp/grails-web-gsp/build.gradle
+++ b/grails-gsp/grails-web-gsp/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation platform(project(':grails-bom'))
     compileOnlyApi 'jakarta.servlet:jakarta.servlet-api' // api needed downstream to compile GSPs, and exposed by GroovyPageView/PageRenderer/GroovyPagesServlet
     compileOnly 'org.apache.ant:ant'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     api project(':grails-gsp-core')
     api project(':grails-web-common')
     api project(':grails-web-taglib')
@@ -128,10 +129,9 @@ dependencies {
         exclude group: 'org.springframework', module: 'spring-context-support'
     }
     testImplementation 'org.apache.groovy:groovy-xml'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.springframework:spring-test' // MockHttpServletRequest is transitively used by GrailsWebMockUtils in grails-web-common
-
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
 }
 
 apply {

--- a/grails-gsp/grails-web-jsp/build.gradle
+++ b/grails-gsp/grails-web-jsp/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     api project(':grails-web-common')
     api project(':grails-web-gsp')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     // Required for JSP support
     compileOnly "jakarta.servlet.jsp:jakarta.servlet.jsp-api:$jspApiVersion"
     compileOnly "jakarta.el:jakarta.el-api:$elApiVersion"

--- a/grails-gsp/grails-web-taglib/build.gradle
+++ b/grails-gsp/grails-web-taglib/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     api project(':grails-web-common')
     api project(':grails-taglib')
     compileOnly project(':grails-gsp-core')
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
 //    compileOnlyApi 'jakarta.annotation:jakarta.annotation-api'
 //    compileOnlyApi 'jakarta.servlet:jakarta.servlet-api' // Needed downstream to compile for TagLibrary trait
@@ -103,11 +104,11 @@ dependencies {
 //    }
 //
     testImplementation project(':grails-gsp-core')
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.springframework:spring-test'
 
     testRuntimeOnly 'jakarta.servlet:jakarta.servlet-api'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during tests
 }
 
 // The `grails.factories` resources file will be "copied" into the generated one, so do not also copy the original to prevent a copy conflict (see issue #10118)

--- a/grails-gsp/plugin/build.gradle
+++ b/grails-gsp/plugin/build.gradle
@@ -136,6 +136,8 @@ dependencies {
     }
     implementation 'org.springframework:spring-beans' // PropertyEditorRegistry
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     astImplementation project(':grails-web-core'), {
         // API dependencies in grails-web
         exclude group: 'org.apache.grails.web', module: 'grails-web-common'
@@ -154,14 +156,14 @@ dependencies {
         exclude group: 'org.springframework.boot', module: 'spring-boot-autoconfigure'
     }
 
+    astCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly project(':grails-web-jsp'), { // Provided by Application for JSP support
         // API dependencies in grails-web-jsp
         exclude group: 'org.apache.grails.views', module: 'grails-web-gsp'
     }
 
     api project(':grails-codecs') // Registers CodecLookup bean
-
-    testCompileOnly 'jakarta.annotation:jakarta.annotation-api'
 
     testImplementation project(':grails-web-jsp'), { // TagLibraryResolverImpl
         // API dependencies in grails-web-jsp
@@ -175,6 +177,9 @@ dependencies {
     testImplementation 'org.apache.grails:grails-testing-support-datamapping'
     testImplementation project(':grails-testing-support-core')
     testImplementation project(':grails-testing-support-web')
+
+    testCompileOnly 'jakarta.annotation:jakarta.annotation-api'
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'org.glassfish.web:jakarta.servlet.jsp.jstl'
     testRuntimeOnly project(':grails-url-mappings')

--- a/grails-i18n/build.gradle
+++ b/grails-i18n/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testCompileOnly 'org.apache.groovy:groovy-ant'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework.boot:spring-boot-webmvc'
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes

--- a/grails-interceptors/build.gradle
+++ b/grails-interceptors/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-logging/build.gradle
+++ b/grails-logging/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     api project(':grails-core')
     api 'org.apache.groovy:groovy'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-suite'

--- a/grails-mail/build.gradle
+++ b/grails-mail/build.gradle
@@ -76,14 +76,17 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-autoconfigure' // @AutoConfiguration, @ConditionalOnProperty, @ConfigurationProperties
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
     compileOnly 'org.slf4j:slf4j-api' // @Slf4j
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation project(':grails-testing-support-web')
     testImplementation 'jakarta.mail:jakarta.mail-api'
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.springframework.boot:spring-boot-autoconfigure'
     testImplementation 'org.springframework.boot:spring-boot-test'
-    testRuntimeOnly 'org.assertj:assertj-core'
 
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
+    testRuntimeOnly 'org.assertj:assertj-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/grails-mimetypes/build.gradle
+++ b/grails-mimetypes/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-redis/build.gradle
+++ b/grails-redis/build.gradle
@@ -66,9 +66,9 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-nop' // Remove warning about missing slf4j implementation during gsp compilation
 
     testImplementation project(':grails-core')
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.springframework:spring-beans'
-    testRuntimeOnly 'org.slf4j:slf4j-nop'
 
     integrationTestImplementation project(':grails-testing-support-redis')
     integrationTestImplementation project(':grails-testing-support-web')

--- a/grails-rest-transforms/build.gradle
+++ b/grails-rest-transforms/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     testImplementation 'tools.jackson.core:jackson-databind'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-scaffolding/build.gradle
+++ b/grails-scaffolding/build.gradle
@@ -60,10 +60,15 @@ dependencies {
     }
     // GrailsConsole (used by the scaffolding commands) needs jline at compile time
     cliImplementation 'org.jline:jline'
+
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     api project(':grails-fields')
     api project(':grails-rest-transforms')
 
     implementation project(':grails-gsp')
+
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation 'org.spockframework:spock-core'
     testImplementation project(':grails-layout')
@@ -72,6 +77,8 @@ dependencies {
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
     testImplementation 'org.springframework:spring-web'
     testImplementation 'net.bytebuddy:byte-buddy'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-services/build.gradle
+++ b/grails-services/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-spring-security/ldap/plugin/build.gradle
+++ b/grails-spring-security/ldap/plugin/build.gradle
@@ -51,9 +51,13 @@ dependencies {
 		 'spring-core', 'spring-data-commons', 'spring-test', 'spring-tx'].each { exclude module: it }
 	}
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
 	runtimeOnly project(':grails-web-boot')
 
 	testImplementation project(':grails-testing-support-web')
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-spring-security/oauth2/plugin/build.gradle
+++ b/grails-spring-security/oauth2/plugin/build.gradle
@@ -57,7 +57,9 @@ dependencies {
 	// GrailsConsole (used by init-o-auth2) needs jline at compile time
 	cliImplementation 'org.jline:jline'
 
-	api project(':grails-spring-security'), {
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
+    api project(':grails-spring-security'), {
 		// api: GrailsUserDetailsService, SpringSecurityService
 		// impl: GormUserDetailsService, GrailsUser, ReflectionUtils, @Secured(runtime), SecurityContextHolder,
 		//       SpringSecurityUtils

--- a/grails-spring-security/plugin/build.gradle
+++ b/grails-spring-security/plugin/build.gradle
@@ -58,6 +58,8 @@ dependencies {
 	// GrailsConsole (used by the s2-* commands) needs jline at compile time
 	cliImplementation 'org.jline:jline'
 
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
 	api project(':grails-spring-security-compat')
 	api project(':grails-async') // AsyncGrailsWebRequest is used in public API
 	api project(':grails-mimetypes')
@@ -100,6 +102,8 @@ dependencies {
 	testFixturesImplementation(platform(project(':grails-bom')))
 	testFixturesImplementation 'org.springframework.security:spring-security-core'
 	testFixturesImplementation 'org.springframework.security:spring-security-config'
+
+    testFixturesCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
 	testImplementation project(':grails-testing-support-datamapping')
 	testImplementation project(':grails-testing-support-web')

--- a/grails-spring-security/rest/core/build.gradle
+++ b/grails-spring-security/rest/core/build.gradle
@@ -115,6 +115,7 @@ dependencies {
     compileOnly 'jakarta.servlet:jakarta.servlet-api', { // Provided by Tomcat
         // api: FilterChain, HttpServletResponse, HttpServletRequest, ServletException, ServletRequest, ServletResponse
     }
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation "org.pac4j:pac4j-oauth", {
         // impl: CasOAuthWrapperClient
@@ -122,6 +123,8 @@ dependencies {
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-testing-support-web')
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'net.bytebuddy:byte-buddy'
 }

--- a/grails-spring-security/rest/gorm/build.gradle
+++ b/grails-spring-security/rest/gorm/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     }
 
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly project(':grails-core') // Provided as this is a Grails plugin
 }
 

--- a/grails-spring-security/rest/grailscache/build.gradle
+++ b/grails-spring-security/rest/grailscache/build.gradle
@@ -57,9 +57,12 @@ dependencies {
     }
 
     compileOnly project(':grails-core') // Provided as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
 
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-spring-security/rest/memcached/build.gradle
+++ b/grails-spring-security/rest/memcached/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     }
 
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly project(':grails-core') // Provided as this is a Grails plugin
 }
 

--- a/grails-spring-security/rest/redis/build.gradle
+++ b/grails-spring-security/rest/redis/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     }
 
     compileOnly 'org.apache.groovy:groovy' // Provided as this is a Grails plugin
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly project(':grails-core') // Provided as this is a Grails plugin
 }
 

--- a/grails-spring-security/ui/plugin/build.gradle
+++ b/grails-spring-security/ui/plugin/build.gradle
@@ -59,10 +59,14 @@ dependencies {
     compileOnly project(':grails-services')
     compileOnly project(':grails-domain-class')
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
 
     testImplementation project(':grails-testing-support-web')
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 // Ship the plugin views as templates (used by the s2ui-override command).

--- a/grails-test-core/build.gradle
+++ b/grails-test-core/build.gradle
@@ -62,6 +62,7 @@ dependencies {
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
     compileOnly 'org.jline:jline' // command line requirements
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-test-examples/beans-dsl-plugin/build.gradle
+++ b/grails-test-examples/beans-dsl-plugin/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     api 'org.springframework.boot:spring-boot-autoconfigure'
     api 'org.springframework:spring-context'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.springframework.boot:spring-boot-test'
     testImplementation 'org.springframework:spring-test'
     testImplementation 'org.assertj:assertj-core'
@@ -54,6 +56,8 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testImplementation 'org.spockframework:spock-core'
     testRuntimeOnly 'org.slf4j:slf4j-simple'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     // functional-test-config.gradle does not supply the launcher that test-config.gradle does,
     // and these modules hold plain unit tests

--- a/grails-test-examples/gsp-layout/build.gradle
+++ b/grails-test-examples/gsp-layout/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'org.apache.grails:grails-controllers'
     implementation 'org.apache.grails:grails-rest-transforms'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
@@ -68,6 +70,8 @@ dependencies {
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'org.apache.grails:grails-testing-support-datamapping'
     testImplementation 'org.apache.grails:grails-testing-support-web'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-test-examples/hibernate5/criteria-extension/build.gradle
+++ b/grails-test-examples/hibernate5/criteria-extension/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'
@@ -45,6 +47,8 @@ dependencies {
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
 
     testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     integrationTestImplementation 'org.apache.grails.testing:grails-testing-support-core'
 }

--- a/grails-test-examples/hibernate5/grails-data-service-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate5/grails-data-service-multi-datasource/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/build.gradle
+++ b/grails-test-examples/hibernate5/grails-hibernate-groovy-proxy/build.gradle
@@ -34,12 +34,16 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
 
     testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
+++ b/grails-test-examples/hibernate5/grails-multiple-datasources/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.apache.grails:grails-core'
     implementation 'org.apache.grails:grails-domain-class'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate5/grails-multitenant-multi-datasource/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate5'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/hibernate7/criteria-extension/build.gradle
+++ b/grails-test-examples/hibernate7/criteria-extension/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'jakarta.validation:jakarta.validation-api'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'
@@ -45,6 +47,8 @@ dependencies {
     runtimeOnly 'org.springframework.boot:spring-boot-starter-tomcat'
 
     testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     integrationTestImplementation 'org.apache.grails.testing:grails-testing-support-core'
 }

--- a/grails-test-examples/hibernate7/grails-data-service-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate7/grails-data-service-multi-datasource/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate7'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/hibernate7/grails-hibernate-groovy-proxy/build.gradle
+++ b/grails-test-examples/hibernate7/grails-hibernate-groovy-proxy/build.gradle
@@ -33,12 +33,16 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate7'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'
     runtimeOnly 'org.springframework.boot:spring-boot-starter-logging'
 
     testImplementation 'org.apache.grails.testing:grails-testing-support-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-test-examples/hibernate7/grails-multiple-datasources/build.gradle
+++ b/grails-test-examples/hibernate7/grails-multiple-datasources/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.apache.grails:grails-core'
     implementation 'org.apache.grails:grails-domain-class'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/hibernate7/grails-multitenant-multi-datasource/build.gradle
+++ b/grails-test-examples/hibernate7/grails-multitenant-multi-datasource/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     implementation 'org.apache.grails:grails-data-hibernate7'
     implementation 'org.apache.grails:grails-core'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/mail/build.gradle
+++ b/grails-test-examples/mail/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     testAndDevelopmentOnly 'org.webjars.npm:bootstrap-icons'
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'org.apache.grails:grails-services'
     runtimeOnly 'org.apache.grails:grails-url-mappings'

--- a/grails-test-examples/mongodb/test-data-service/build.gradle
+++ b/grails-test-examples/mongodb/test-data-service/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.apache.grails:grails-spring-security-rest'
     implementation 'org.apache.grails:grails-views-gson'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'org.apache.grails:grails-url-mappings'
     runtimeOnly 'org.apache.grails:grails-events'
     runtimeOnly 'org.springframework.boot:spring-boot-autoconfigure'

--- a/grails-test-examples/redis/build.gradle
+++ b/grails-test-examples/redis/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     testAndDevelopmentOnly platform(project(':grails-bom'))
     testAndDevelopmentOnly 'org.webjars.npm:jquery'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.apache.tomcat:tomcat-jdbc'
@@ -58,6 +60,8 @@ dependencies {
     testImplementation 'org.apache.grails:grails-testing-support-web'
     testImplementation 'org.apache.grails.testing:grails-testing-support-redis'
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     // This project also has unit tests in it, so we must define the launcher per
     // https://docs.gradle.org/8.3/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

--- a/grails-test-examples/spring-security/acl/functional-test-app/build.gradle
+++ b/grails-test-examples/spring-security/acl/functional-test-app/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
     implementation 'org.apache.grails:grails-data-hibernate5'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/spring-security/acl/integration-test-app/build.gradle
+++ b/grails-test-examples/spring-security/acl/integration-test-app/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'org.apache.grails:grails-gsp'
     implementation 'org.apache.grails:grails-layout'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-databinding'

--- a/grails-test-examples/spring-security/cas/test1/build.gradle
+++ b/grails-test-examples/spring-security/cas/test1/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     implementation 'org.webjars:bootstrap:3.3.6'
     implementation 'org.webjars:jquery:2.2.0'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/core/functional-test-app/build.gradle
+++ b/grails-test-examples/spring-security/core/functional-test-app/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     implementation 'org.apache.grails:grails-layout'
     implementation 'org.apache.grails:grails-rest-transforms'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/core/integration-test-app/build.gradle
+++ b/grails-test-examples/spring-security/core/integration-test-app/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     implementation 'org.apache.grails.data:grails-datamapping-core'
     implementation 'org.apache.grails:grails-domain-class'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-data-hibernate5'

--- a/grails-test-examples/spring-security/core/misc-functional-test-app/group/build.gradle
+++ b/grails-test-examples/spring-security/core/misc-functional-test-app/group/build.gradle
@@ -47,6 +47,8 @@ dependencies {
         // @Autowired
     }
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-url-mappings'

--- a/grails-test-examples/spring-security/core/misc-functional-test-app/roles/build.gradle
+++ b/grails-test-examples/spring-security/core/misc-functional-test-app/roles/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     }
     implementation 'org.apache.grails:grails-layout'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'
     runtimeOnly 'org.apache.grails:grails-data-hibernate5'

--- a/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/build.gradle
+++ b/grails-test-examples/spring-security/ldap/custom-user-details-context-mapper/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     // to not depend on an external ldap server
     implementation 'com.unboundid:unboundid-ldapsdk'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/ldap/functional-test-app/build.gradle
+++ b/grails-test-examples/spring-security/ldap/functional-test-app/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation 'org.webjars:bootstrap:4.1.3'
     implementation 'org.webjars:jquery:3.3.1'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/ldap/retrieve-db-roles/build.gradle
+++ b/grails-test-examples/spring-security/ldap/retrieve-db-roles/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     // in-memory ldap server for testing
     implementation 'com.unboundid:unboundid-ldapsdk'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/ldap/retrieve-group-roles/build.gradle
+++ b/grails-test-examples/spring-security/ldap/retrieve-group-roles/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     // to not depend on an external ldap server
     implementation 'com.unboundid:unboundid-ldapsdk'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.zaxxer:HikariCP'

--- a/grails-test-examples/spring-security/ui/common/build.gradle
+++ b/grails-test-examples/spring-security/ui/common/build.gradle
@@ -24,9 +24,12 @@ plugins {
 
 dependencies {
     implementation platform(project(':grails-bom'))
+
     testFixturesImplementation platform(project(':grails-bom'))
     testFixturesImplementation testFixtures('org.apache.grails:grails-spring-security')
     testFixturesImplementation testFixtures('org.apache.grails:grails-geb')
+
+    testFixturesCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-test-examples/spring-security/ui/extended/build.gradle
+++ b/grails-test-examples/spring-security/ui/extended/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     implementation 'org.apache.grails:grails-mail'
 
-    compileOnly 'org.slf4j:slf4j-nop' // Remove warning about missing slf4j implementation during gsp compilation
+    compileOnly 'org.slf4j:slf4j-nop' // Remove warning about missing slf4j implementation during compilation
 
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
     runtimeOnly 'com.h2database:h2'
@@ -55,6 +55,8 @@ dependencies {
 
     testImplementation 'org.apache.grails:grails-testing-support-datamapping'
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     integrationTestImplementation testFixtures(project(':grails-test-examples-spring-security-ui-common'))
     integrationTestImplementation testFixtures('org.apache.grails:grails-geb')

--- a/grails-test-examples/undertow/build.gradle
+++ b/grails-test-examples/undertow/build.gradle
@@ -57,6 +57,8 @@ dependencies {
 
     runtimeOnly 'cloud.wondrify:asset-pipeline-grails'
 
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     integrationTestImplementation testFixtures('org.apache.grails:grails-geb')
 }
 

--- a/grails-test-suite-base/build.gradle
+++ b/grails-test-suite-base/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -48,6 +48,8 @@ dependencies {
         exclude group: 'org.apache.grails', module: 'grails-rest-transforms'
     }
     testImplementation 'org.spockframework:spock-core'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 def defaultTestConfig = {

--- a/grails-testing-support-core/build.gradle
+++ b/grails-testing-support-core/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     api 'org.junit.platform:junit-platform-suite'
     runtimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'org.apache.groovy:groovy-test-junit5'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.junit.platform:junit-platform-suite'

--- a/grails-testing-support-datamapping/build.gradle
+++ b/grails-testing-support-datamapping/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     compileOnly 'org.apache.groovy:groovy', {
         // comp: CompileStatic, CompileDynamic, TypeCheckingMode
     }
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-testing-support-http-client/build.gradle
+++ b/grails-testing-support-http-client/build.gradle
@@ -50,11 +50,12 @@ dependencies {
     implementation "org.opentest4j:opentest4j:$openTest4jVersion" // AssertionFailedError
     implementation 'org.springframework:spring-beans' // @Value
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation "io.github.cjstehno.ersatz:ersatz:$ersatzVersion"
     testImplementation "io.github.cjstehno.ersatz:ersatz-groovy:$ersatzVersion"
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
-
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Remove annoying warning
 }
 
 apply {

--- a/grails-testing-support-views-gson/build.gradle
+++ b/grails-testing-support-views-gson/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation 'org.apache.groovy:groovy-json'
     implementation 'org.apache.groovy:groovy-templates'
     implementation 'org.springframework:spring-webmvc'
+
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-testing-support-web/build.gradle
+++ b/grails-testing-support-web/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     implementation project(':grails-web-jsp'), {
         // impl: TagLibraryResolverImpl
     }
+
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 }
 
 apply {

--- a/grails-undertow/plugin/build.gradle
+++ b/grails-undertow/plugin/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly project(':grails-core')
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     runtimeOnly 'io.undertow.ee:undertow-websockets'
 
@@ -52,6 +53,8 @@ dependencies {
     testImplementation 'org.springframework:spring-webmvc'
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
+
+    testCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testRuntimeOnly 'org.slf4j:slf4j-nop'
 }

--- a/grails-url-mappings/build.gradle
+++ b/grails-url-mappings/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     testCompileOnly 'org.junit.jupiter:junit-jupiter-api'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-validation/build.gradle
+++ b/grails-validation/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-views-core/build.gradle
+++ b/grails-views-core/build.gradle
@@ -56,8 +56,10 @@ dependencies {
     implementation 'org.slf4j:slf4j-api'
     implementation 'org.springframework:spring-beans'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warnings about missing slf4j implementation during test task
 }
 
 apply {

--- a/grails-views-gson/build.gradle
+++ b/grails-views-gson/build.gradle
@@ -50,16 +50,18 @@ dependencies {
     implementation 'org.apache.groovy:groovy-json'
     implementation 'jakarta.validation:jakarta.validation-api'
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation project(':grails-testing-support-views-gson')
     testImplementation project(':grails-testing-support-core')
     testImplementation project(':grails-testing-support-datamapping')
     testImplementation project(':grails-data-hibernate5-core')
+    testImplementation 'jakarta.servlet:jakarta.servlet-api'
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'tools.jackson.core:jackson-databind'
-    testImplementation 'jakarta.servlet:jakarta.servlet-api'
 
     testRuntimeOnly 'org.objenesis:objenesis' // Required by Spock for mocking classes without default constructor
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during test task
 }
 
 def testArtifacts = ['*.gson', 'circular/**']

--- a/grails-views-markup/build.gradle
+++ b/grails-views-markup/build.gradle
@@ -49,11 +49,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot' // For @ConfigurationProperties
 
     compileOnly 'jakarta.annotation:jakarta.annotation-api' // Provided
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     testImplementation project(':grails-web-url-mappings')
     testImplementation 'org.spockframework:spock-core'
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
-    testRuntimeOnly 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during test task
+    testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
 }
 
 apply {

--- a/grails-web-boot/build.gradle
+++ b/grails-web-boot/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testRuntimeOnly project(':grails-url-mappings')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-web-common/build.gradle
+++ b/grails-web-common/build.gradle
@@ -62,6 +62,8 @@ dependencies {
         // MockHttpServletRequest/Response/Context used in many classes
     }
 
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
+
     testImplementation 'jakarta.servlet:jakarta.servlet-api'
     testImplementation 'org.springframework:spring-test'
 

--- a/grails-web-core/build.gradle
+++ b/grails-web-core/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     }
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-web-databinding/build.gradle
+++ b/grails-web-databinding/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     }
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-web-mvc/build.gradle
+++ b/grails-web-mvc/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     api 'org.apache.groovy:groovy'
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }

--- a/grails-web-url-mappings/build.gradle
+++ b/grails-web-url-mappings/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     // jline comes with it: the renderer reads GrailsConsole, whose signature Groovy has to resolve.
     cliImplementation 'org.jline:jline'
     cliCompileOnly 'jakarta.servlet:jakarta.servlet-api'
+    cliCompileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
 
     api project(':grails-web-common')
     implementation 'io.micrometer:micrometer-observation'
@@ -75,6 +76,7 @@ dependencies {
     testImplementation project(':grails-test-suite-base')
 
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
+    compileOnly 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation
     compileOnly 'org.springframework:spring-test', {
         // MockHttpServletRequest/Response/Context used in many classes
     }


### PR DESCRIPTION
This pull request focuses on eliminating SLF4J implementation warnings during compilation and testing across multiple modules by consistently adding the `org.slf4j:slf4j-nop` dependency where appropriate. Additionally, it adjusts a logging statement in the SBOM plugin to reduce log verbosity. 

The most important changes are:

**Suppressing SLF4J Warnings (by module):**

*General build and plugin modules:*
- Added `compileOnly 'org.slf4j:slf4j-nop'` to the compile classpath in various modules (e.g., `grails-core`, `grails-console`, `grails-codecs`, `grails-controllers`, `grails-converters`, `grails-data-graphql`, `grails-data-hibernate5`, `grails-data-hibernate7`, `grails-data-mongodb`, `grails-async`, `grails-cache`, etc.) to prevent warnings about missing SLF4J implementations during compilation. [[1]](diffhunk://#diff-ae11b410043af7834380b5ebe9348e8f2ea9710cfde80268d56ffd3d0a7bd454R94-R95) [[2]](diffhunk://#diff-332a1aed7c8c49f5590c81f5971e59d0867f94434da33a3e6e6b2025f767e478R66-R67) [[3]](diffhunk://#diff-29c90f5b85762a427c4381b560c7cef637a89ec511e89644aca6911056c8016dR47) [[4]](diffhunk://#diff-9b0330f85c526716ae9da717f7d7f478f984f323da1da16409fa7862652e59caR60) [[5]](diffhunk://#diff-6b0570777539c57b3055a9c047d42e37e4c722f50c639082dfbfb54a71b58bb8R57) [[6]](diffhunk://#diff-2ed49fbbbe5bcf0178efc900ff0a9580a5d7dbf57b7320d453d37a92c0ce177fR82-R92) [[7]](diffhunk://#diff-920faa99050907540ecf8861f8e10c62998b78c849c37c8d03d3606de17fe97bR81) [[8]](diffhunk://#diff-18077521a4669d34c7ed6d6fe432461fabb6c8d498a7841427123e946724e911R86) [[9]](diffhunk://#diff-9a3e8115587462330492f188b8f55355f4133b8932765796731f4aee2524a34aR103-L107) [[10]](diffhunk://#diff-81c8d9d6e7b64c6309e2ebed3492264f0d191388d239ed36e48a3ab7d5e88724R126) [[11]](diffhunk://#diff-b91e009cadb16616500af3e2a31d464a9a9e0b286504ecef753bc3d2a02f64a8R55-L61) [[12]](diffhunk://#diff-e811591a138a1268ee9ff1a78c130053a93c4f2a5e8dad7470a95a9b2a97378cR56-R65) [[13]](diffhunk://#diff-d8299c0b3919a5b92f65bdcfceb4d79adce538a1d2c6420b32f886ed77e9f400R89)

*Test and CLI configurations:*
- Added `testCompileOnly` and/or `testImplementation 'org.slf4j:slf4j-nop'` to test configurations in several modules to suppress SLF4J warnings during test compilation and execution. [[1]](diffhunk://#diff-df03346c55a1946a395e10975ca95e799921f33eec738cb5a02c5539cf10d205R77-R79) [[2]](diffhunk://#diff-17c24c310017bcdadd8216a9f7f4e08860c058c18aa9af61c9f13cd3d4886c82R120-R121) [[3]](diffhunk://#diff-18077521a4669d34c7ed6d6fe432461fabb6c8d498a7841427123e946724e911R97-R98) [[4]](diffhunk://#diff-920faa99050907540ecf8861f8e10c62998b78c849c37c8d03d3606de17fe97bR92-R93) [[5]](diffhunk://#diff-9a3e8115587462330492f188b8f55355f4133b8932765796731f4aee2524a34aR103-L107) [[6]](diffhunk://#diff-81c8d9d6e7b64c6309e2ebed3492264f0d191388d239ed36e48a3ab7d5e88724R143-L147) [[7]](diffhunk://#diff-70ff2d2fa6be5d7475fae0f9b7bc07114411b808346dd53c0f6450660b6ae99dR66-R67) [[8]](diffhunk://#diff-2ed49fbbbe5bcf0178efc900ff0a9580a5d7dbf57b7320d453d37a92c0ce177fR82-R92) [[9]](diffhunk://#diff-b91e009cadb16616500af3e2a31d464a9a9e0b286504ecef753bc3d2a02f64a8R55-L61) [[10]](diffhunk://#diff-e811591a138a1268ee9ff1a78c130053a93c4f2a5e8dad7470a95a9b2a97378cR56-R65)

*AST and CLI-specific configurations:*
- Added `astCompileOnly` and `cliCompileOnly 'org.slf4j:slf4j-nop'` in appropriate modules to prevent warnings in annotation processing and CLI builds. [[1]](diffhunk://#diff-e811591a138a1268ee9ff1a78c130053a93c4f2a5e8dad7470a95a9b2a97378cR43-R45) [[2]](diffhunk://#diff-2565acf8b7d676c046c5823c98f182591ee76f82fa03d04fd2376ec5b0e24614R88) [[3]](diffhunk://#diff-0db02c0a03aa91d23c1a341b6ef0391e6f76666b119a2f5e6dee2eab43ff067eR85) [[4]](diffhunk://#diff-18077521a4669d34c7ed6d6fe432461fabb6c8d498a7841427123e946724e911R59-R60) [[5]](diffhunk://#diff-920faa99050907540ecf8861f8e10c62998b78c849c37c8d03d3606de17fe97bR57)

**Logging adjustment:**

*SBOM Plugin:*
- Changed the log level from `lifecycle` to `info` for the message about forcing a license in `SbomPlugin.groovy`, reducing log verbosity during builds.

These changes collectively improve the developer experience by ensuring cleaner build and test logs and more consistent dependency management.