### PR TITLE
Allow concurrent documentation publishing

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -758,12 +758,6 @@ jobs:
     if: github.repository_owner == 'apache' && github.event_name == 'push'
     needs: [ publish ]
     runs-on: ubuntu-24.04
-    # Documentation publishing targets a shared resource (the apache/grails-website repo).
-    # Share the static group used by the release documentation publish (release.yml) so only
-    # one documentation publish can run at a time across every branch; the rest queue.
-    concurrency:
-      group: grails-docs-publish
-      cancel-in-progress: false
     steps:
       - name: "⚙️ Maximize build space"
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -571,12 +571,6 @@ jobs:
     name: "VOTE SUCCEEDED - Publish Documentation"
     needs: [ publish, source, upload, release ]
     runs-on: ubuntu-24.04
-    # Documentation publishing targets a shared resource (the apache/grails-website repo).
-    # Use a static, branch-independent group so only one documentation publish can run at a
-    # time across every branch and across the snapshot publish in gradle.yml; the rest queue.
-    concurrency:
-      group: grails-docs-publish
-      cancel-in-progress: false
     steps:
       - name: "📝 Establish release version"
         run: echo "VERSION=${TAG#v}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Depends On

This PR must not merge until apache/grails-github-actions#110 is merged to `asf` and the updated `deploy-github-pages@asf` ref is verified.

## Summary

Remove the job-level `grails-docs-publish` queue from snapshot and release documentation publishing. Once the action-level optimistic retry is available, independent documentation jobs can run in parallel and let Git's normal fast-forward rules coordinate updates to the destination branch.

The diff removes only the two queue declarations added by #15988. It does not change documentation generation, credentials, destination paths, action references, or workflow-level release coordination.

## Why Remove the Queue

GitHub Actions concurrency groups coordinate runs only within one repository. Grails Core, `grails-static-website`, and future publishers such as Grails Forge can all target the same website repository, but a `grails-docs-publish` group in Grails Core cannot coordinate those other repositories. The manual `release-publish-docs.yml` workflow is also a publisher and has never used this group.

Within Grails Core, the static group makes unrelated release documentation jobs serial:

- the [8.0.0-M5 release run](https://github.com/apache/grails-core/actions/runs/30769584508) waited 18 minutes 7 seconds for its documentation job to start;
- the [7.2.2 release run](https://github.com/apache/grails-core/actions/runs/30769598969) waited 11 minutes 15 seconds; and
- the [7.1.5 release run](https://github.com/apache/grails-core/actions/runs/30769609958) was still queued after more than 6 minutes when observed.

This turned a parallel release sequence into a serial one and required manual retriggering.

## Replacement Safety

apache/grails-github-actions#110 retries only genuine non-fast-forward races. It fetches the new destination tip into the existing shallow checkout, verifies descendant history, rebases the unpublished local deployment commit, and retries a normal push. It never force-pushes or auto-resolves true conflicts.

Merge order is therefore mandatory:

1. Merge apache/grails-github-actions#110 to `asf`.
2. Verify `deploy-github-pages@asf` contains the retry implementation.
3. Merge this PR into `7.0.x`.
4. Merge forward through the maintained branches normally.

## Preserved Concurrency

The workflow-level `release-pipeline-${{ github.event.release.target_commitish }}` group remains unchanged. This PR removes only the documentation publishing mutex.

## Verification

- Both edited workflow files parse successfully as YAML.
- `git diff --check` passes.
- The diff is exactly 12 deletions across two workflow files.
- `grails-docs-publish` no longer appears in `.github/workflows`.
- `release-publish-docs.yml` is byte-identical.
- No Gradle task was run because this is a YAML-only deletion.
