### PR TITLE
Configure generated applications for component scanning

### DIFF
--- a/grails-doc/src/en/guide/conf/applicationClass/customizing.adoc
+++ b/grails-doc/src/en/guide/conf/applicationClass/customizing.adoc
@@ -23,7 +23,9 @@ There are several ways in which you can customize the `Application` class.
 === Customizing Scanning
 
 
-By default Grails will scan all known source directories for controllers, domain class etc., however if there are packages in other JAR files you wish to scan you can do so by overriding the `packageNames()` method of the `Application` class:
+Newly generated Grails applications include `@ComponentScan(value = 'your.application.package')` on the `Application` class. This scans standard Spring components in the application's base package and its subpackages.
+
+Grails scans its known source directories separately for Grails artefacts such as controllers and domain classes. To add packages to that Grails artefact scan, override the `packageNames()` method of the `Application` class:
 
 [source,groovy]
 ----

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/application.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/lang/groovy/application.rocker.raw
@@ -31,10 +31,12 @@ import groovy.transform.CompileStatic
 import io.micronaut.spring.boot.starter.EnableMicronaut
 
 }
+import org.springframework.context.annotation.ComponentScan
 @if(features.contains("spring-boot-starter-security")) {
 import org.springframework.context.annotation.Import
-
 }
+
+
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
 @if(applicationType.equals(ApplicationType.PLUGIN) || applicationType.equals(ApplicationType.WEB_PLUGIN)) {
@@ -46,6 +48,7 @@ import grails.plugins.metadata.PluginSource
 @@PluginSource
 }
 @@CompileStatic
+@@ComponentScan(value = '@project.getPackageName()')
 @if(features.contains("grails-micronaut")) {
 @@EnableMicronaut
 }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
@@ -42,6 +42,7 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
         output.containsKey("grails-app/init/example/grails/Application.${Language.GROOVY.extension}".toString())
         def applicationGroovyFile = output.get("grails-app/init/example/grails/Application.${Language.GROOVY.extension}".toString())
         applicationGroovyFile.contains("@CompileStatic")
+        applicationGroovyFile.contains("@ComponentScan(value = 'example.grails')")
         !applicationGroovyFile.contains("@PluginSource")
 
         where:
@@ -58,9 +59,24 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
         output.containsKey("grails-app/init/example/grails/Application.${Language.GROOVY.extension}".toString())
         def applicationGroovyFile = output.get("grails-app/init/example/grails/Application.${Language.GROOVY.extension}".toString())
         applicationGroovyFile.contains("@PluginSource")
+        applicationGroovyFile.contains("@ComponentScan(value = 'example.grails')")
 
         where:
         applicationType << [ApplicationType.PLUGIN, ApplicationType.WEB_PLUGIN]
+    }
+
+    void 'profile Application skeletons configure base-package component scanning'() {
+        given:
+        File profiles = new File('../../grails-profiles').canonicalFile
+
+        expect:
+        ['base', 'plugin'].every { String profile ->
+            File application = new File(profiles, "${profile}/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/Application.groovy")
+            assert application.file, "missing profile Application skeleton ${application}"
+            assert application.text.contains('import org.springframework.context.annotation.ComponentScan')
+            assert application.text.contains("@ComponentScan(value = '@grails.codegen.defaultPackage@')")
+            true
+        }
     }
 
     void "REST-API application should have ApplicationController"() {

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/lang/GrailsApplicationSpec.groovy
@@ -67,7 +67,7 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
 
     void 'profile Application skeletons configure base-package component scanning'() {
         given:
-        File profiles = new File('../../grails-profiles').canonicalFile
+        File profiles = findProfilesDirectory()
 
         expect:
         ['base', 'plugin'].every { String profile ->
@@ -142,5 +142,14 @@ class GrailsApplicationSpec extends BeanContextSpec implements CommandOutputFixt
         where:
         applicationType << ApplicationType.values().toList()
 
+    }
+
+    private static File findProfilesDirectory() {
+        File current = new File(GrailsApplicationSpec.getProtectionDomain().getCodeSource().getLocation().toURI())
+        while (current && !new File(current, 'grails-profiles').isDirectory()) {
+            current = current.parentFile
+        }
+        assert current != null: 'Unable to locate the grails-core repository root'
+        new File(current, 'grails-profiles')
     }
 }

--- a/grails-forge/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
+++ b/grails-forge/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
@@ -19,6 +19,7 @@
 
 package org.grails.forge.create
 
+import org.gradle.testkit.runner.TaskOutcome
 import org.grails.forge.application.ApplicationType
 import org.grails.forge.application.OperatingSystem
 import org.grails.forge.options.DevelopmentReloading
@@ -192,10 +193,10 @@ class CreateAppSpec extends CommandSpec {
         '''.stripIndent()
 
         when:
-        String output = executeGradle('test', '--tests', 'example.grails.ComponentScanningSpec').output
+        def result = executeGradle('test', '--tests', 'example.grails.ComponentScanningSpec')
 
         then:
-        output.contains('BUILD SUCCESSFUL')
+        result.task(':test').outcome == TaskOutcome.SUCCESS
     }
 
     void "test create-app with micronaut feature"() {

--- a/grails-forge/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
+++ b/grails-forge/test-core/src/test/groovy/org/grails/forge/create/CreateAppSpec.groovy
@@ -24,6 +24,7 @@ import org.grails.forge.application.OperatingSystem
 import org.grails.forge.options.DevelopmentReloading
 import org.grails.forge.options.JdkVersion
 import org.grails.forge.utils.CommandSpec
+import spock.lang.Unroll
 
 class CreateAppSpec extends CommandSpec {
 
@@ -60,28 +61,141 @@ class CreateAppSpec extends CommandSpec {
         new File(dir, "grails-app/i18n").exists()
     }
 
-    void "test create-app creates a correct Application.groovy"() {
+    @Unroll
+    void "test create-app #applicationType creates a correct Application.groovy"() {
         given:
-        generateProject(OperatingSystem.MACOS_ARCH64, [], ApplicationType.DEFAULT_OPTION)
+        generateProject(OperatingSystem.MACOS_ARCH64, [], applicationType)
         def applicationClassSourceFile = new File(dir, 'grails-app/init/example/grails/Application.groovy')
 
         expect:
         applicationClassSourceFile.exists()
-        applicationClassSourceFile.text == '''\
+        applicationClassSourceFile.text == applicationSource.stripIndent(8)
+
+        where:
+        applicationType            | applicationSource
+        ApplicationType.WEB        | '''\
         package example.grails
         
         import groovy.transform.CompileStatic
+
+        import org.springframework.context.annotation.ComponentScan
 
         import grails.boot.GrailsApp
         import grails.boot.config.GrailsAutoConfiguration
         
         @CompileStatic
+        @ComponentScan(value = 'example.grails')
         class Application extends GrailsAutoConfiguration {
             static void main(String[] args) {
                 GrailsApp.run(Application, args)
             }
         }
-        '''.stripIndent(8)
+        '''
+        ApplicationType.REST_API   | '''\
+        package example.grails
+
+        import groovy.transform.CompileStatic
+
+        import org.springframework.context.annotation.ComponentScan
+
+        import grails.boot.GrailsApp
+        import grails.boot.config.GrailsAutoConfiguration
+
+        @CompileStatic
+        @ComponentScan(value = 'example.grails')
+        class Application extends GrailsAutoConfiguration {
+            static void main(String[] args) {
+                GrailsApp.run(Application, args)
+            }
+        }
+        '''
+        ApplicationType.PLUGIN     | '''\
+        package example.grails
+
+        import groovy.transform.CompileStatic
+
+        import org.springframework.context.annotation.ComponentScan
+
+        import grails.boot.GrailsApp
+        import grails.boot.config.GrailsAutoConfiguration
+        import grails.plugins.metadata.PluginSource
+
+        @PluginSource
+        @CompileStatic
+        @ComponentScan(value = 'example.grails')
+        class Application extends GrailsAutoConfiguration {
+            static void main(String[] args) {
+                GrailsApp.run(Application, args)
+            }
+        }
+        '''
+        ApplicationType.WEB_PLUGIN | '''\
+        package example.grails
+        
+        import groovy.transform.CompileStatic
+
+        import org.springframework.context.annotation.ComponentScan
+
+        import grails.boot.GrailsApp
+        import grails.boot.config.GrailsAutoConfiguration
+        import grails.plugins.metadata.PluginSource
+        
+        @PluginSource
+        @CompileStatic
+        @ComponentScan(value = 'example.grails')
+        class Application extends GrailsAutoConfiguration {
+            static void main(String[] args) {
+                GrailsApp.run(Application, args)
+            }
+        }
+        '''
+    }
+
+    void "test generated application scans standard Spring components"() {
+        given:
+        generateProject(OperatingSystem.MACOS_ARCH64)
+        File componentSourceFile = new File(dir, 'src/main/groovy/example/grails/components/ScannedComponent.groovy')
+        componentSourceFile.parentFile.mkdirs()
+        componentSourceFile.text = '''\
+            package example.grails.components
+
+            import org.springframework.stereotype.Component
+
+            @Component
+            class ScannedComponent {
+                String value() {
+                    'scanned'
+                }
+            }
+        '''.stripIndent()
+        File componentSpecFile = new File(dir, 'src/test/groovy/example/grails/ComponentScanningSpec.groovy')
+        componentSpecFile.parentFile.mkdirs()
+        componentSpecFile.text = '''\
+            package example.grails
+
+            import example.grails.components.ScannedComponent
+            import grails.testing.mixin.integration.Integration
+            import org.springframework.beans.factory.annotation.Autowired
+            import spock.lang.Specification
+
+            @Integration
+            class ComponentScanningSpec extends Specification {
+
+                @Autowired
+                ScannedComponent scannedComponent
+
+                void "standard Spring component is injected"() {
+                    expect:
+                    scannedComponent.value() == 'scanned'
+                }
+            }
+        '''.stripIndent()
+
+        when:
+        String output = executeGradle('test', '--tests', 'example.grails.ComponentScanningSpec').output
+
+        then:
+        output.contains('BUILD SUCCESSFUL')
     }
 
     void "test create-app with micronaut feature"() {
@@ -99,33 +213,6 @@ class CreateAppSpec extends CommandSpec {
         gradleProperties.text.contains('micronautPlatformVersion=4.10.16')
         gradleBuildFile.exists()
         gradleBuildFile.text.contains('implementation "org.apache.grails:grails-micronaut"')
-    }
-
-    void "test create-app web-plugin creates a correct Application.groovy"() {
-        given:
-        generateProject(OperatingSystem.MACOS_ARCH64, [], ApplicationType.WEB_PLUGIN)
-
-        def applicationClassSourceFile = new File(dir, 'grails-app/init/example/grails/Application.groovy')
-
-        expect:
-        applicationClassSourceFile.exists()
-        applicationClassSourceFile.text == '''\
-        package example.grails
-        
-        import groovy.transform.CompileStatic
-
-        import grails.boot.GrailsApp
-        import grails.boot.config.GrailsAutoConfiguration
-        import grails.plugins.metadata.PluginSource
-        
-        @PluginSource
-        @CompileStatic
-        class Application extends GrailsAutoConfiguration {
-            static void main(String[] args) {
-                GrailsApp.run(Application, args)
-            }
-        }
-        '''.stripIndent(8)
     }
 
     @Override

--- a/grails-profiles/base/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/Application.groovy
+++ b/grails-profiles/base/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/Application.groovy
@@ -2,10 +2,12 @@ package @grails.codegen.defaultPackage@
 
 import grails.boot.GrailsApp
 import grails.boot.config.GrailsAutoConfiguration
+import org.springframework.context.annotation.ComponentScan
 
 import groovy.transform.CompileStatic
 
 @CompileStatic
+@ComponentScan(value = '@grails.codegen.defaultPackage@')
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
         GrailsApp.run(Application, args)

--- a/grails-profiles/plugin/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/Application.groovy
+++ b/grails-profiles/plugin/skeleton/grails-app/init/@grails.codegen.defaultPackage.path@/Application.groovy
@@ -3,8 +3,10 @@ package @grails.codegen.defaultPackage@
 import grails.boot.*
 import grails.boot.config.GrailsAutoConfiguration
 import grails.plugins.metadata.*
+import org.springframework.context.annotation.ComponentScan
 
 @PluginSource
+@ComponentScan(value = '@grails.codegen.defaultPackage@')
 class Application extends GrailsAutoConfiguration {
     static void main(String[] args) {
         GrailsApp.run(Application, args)


### PR DESCRIPTION
## Summary

- add explicit base-package Spring component scanning to Forge-generated applications
- keep base and plugin profile Application skeletons aligned with Forge output
- verify all application types and standard Spring component injection without `resources.groovy`
- document the generated scanning default separately from Grails artefact scanning

## Verification

- `:grails-forge-core:check :test-core:check`
- `:grails-profiles-base:check :grails-profiles-plugin:check`
- `:grails-doc:publishGuide -x aggregateGroovydoc`
- `GrailsApplicationSpec`: 18 tests, 0 failures
- `CreateAppSpec` generated-source matrix: 4 tests, 0 failures
- mandatory Oracle and Codex review gate: GREEN

Closes #14914
