### PR TITLE
Speed up Gradle builds by reusing cacheable outputs in CI

### DIFF
--- a/.github/workflows/gradle-build-validation.yml
+++ b/.github/workflows/gradle-build-validation.yml
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Gradle Build Validation"
+on:
+  schedule:
+    - cron: '0 4 * * 1'
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  validate:
+    name: "Forced Rerun Build Validation"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "📥 Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          distribution: liberica
+          java-version: 21
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-disabled: true
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: "🔍 Setup TestLens"
+        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
+      - name: "🔨 Build project"
+        run: >
+          ./gradlew build :grails-shell-cli:installDist groovydoc
+          --continue
+          --rerun-tasks
+          --stacktrace
+          -PonlyCoreTests
+          -PskipCodeStyle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -114,12 +114,13 @@ jobs:
           -PskipTests
       - name: "🔨 Build project with tests"
         if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         working-directory: 'grails-gradle'
         run: >
           ./gradlew build
           --continue
           --stacktrace
-          --rerun-tasks
           -PskipCodeStyle
   build:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
@@ -172,56 +173,18 @@ jobs:
         # and included automatically on JDK 25+. So the Java 21 entries build everything
         # except the island and the Java 25 entries build the full graph - no flag needed.
         run: >
-          ./gradlew build :grails-shell-cli:installDist groovydoc
+          ./gradlew build :grails-shell-cli:installDist
           --continue
           --stacktrace
           -PonlyCoreTests
           -PskipCodeStyle
-  buildRerunTasks:
-    if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: 'Build Grails-Core Rerunning all Tasks'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            java: 21
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
-        run: curl -s https://api.ipify.org
-      - name: "📥 Checkout repository"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: "☕️ Setup JDK"
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          distribution: liberica
-          java-version: ${{ matrix.java }}
-      - name: "🗄️ Restore dependency jar cache"
-        uses: actions/cache@v4
-        with:
-          # Cache only downloaded dependency jars and wrapper distributions, never Grails build outputs.
-          # Keyed by branch version so each release branch maintains its own warm cache.
-          path: |
-            ~/.gradle/caches/modules-2
-            ~/.gradle/wrapper
-          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
-      - name: "🐘 Setup Gradle"
-        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-        with:
-          cache-disabled: true # dependency jars are cached by the explicit branch-keyed step above
-          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
-      - name: "🔍 Setup TestLens"
-        uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
-      - name: "🔨 Build project"
-        # This job only runs on Java 21, where settings.gradle auto-prunes the Micronaut
-        # island (Micronaut 5 GA targets JVM 25 bytecode). See comment on `build`.
+      - name: "📚 Generate Groovydoc"
+        # Runs on the JDK 25 entry so the Micronaut island is documented too; a sub-25
+        # JDK prunes that island from the build graph (see the comment above).
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.java == 25 }}
         run: >
-          ./gradlew build :grails-shell-cli:installDist groovydoc
+          ./gradlew groovydoc
           --continue
-          --rerun-tasks
           --stacktrace
           -PonlyCoreTests
           -PskipCodeStyle
@@ -280,12 +243,13 @@ jobs:
           -PskipTests
       - name: "🔨 Build project with tests"
         if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         working-directory: 'grails-forge'
         # See comment above on the auto-managed Micronaut island.
         run: >
           ./gradlew build
           --continue
-          --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PskipCodeStyle
@@ -346,12 +310,13 @@ jobs:
       - name: "🔍 Setup TestLens"
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
       - name: "🏃 Run Functional Tests"
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         # The Micronaut island is auto-pruned on a sub-25 JDK (settings.gradle), so the
         # Java 21 entries skip it and the Java 25 entries include it (see comment on `build`).
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PonlyFunctionalTests
@@ -394,10 +359,11 @@ jobs:
       - name: "🔍 Setup TestLens"
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
       - name: "🏃 Run Functional Tests"
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PonlySpringSecurityTests
           -PskipCodeStyle
@@ -432,11 +398,12 @@ jobs:
       - name: "🔍 Setup TestLens"
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
       - name: "🏃 Run Spring Security Functional Tests (TESTCONFIG=${{ matrix.test-config }})"
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         run: >
           ./gradlew
           :grails-test-examples-spring-security-core-functional-test-app:check
           --continue
-          --rerun-tasks
           --stacktrace
           -DTESTCONFIG=${{ matrix.test-config }}
           -PskipCodeStyle
@@ -467,10 +434,11 @@ jobs:
       - name: "🔍 Setup TestLens"
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
       - name: "🏃 Run Redis Tests"
+        env:
+          DO_NOT_CACHE_TESTS: '1'
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PonlyRedisTests
           -PredisContainerVersion=${{ matrix.redis-version }}
@@ -518,12 +486,12 @@ jobs:
       - name: "🏃 Run Functional Tests"
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DO_NOT_CACHE_TESTS: '1'
         # The Micronaut island is auto-pruned on a sub-25 JDK (settings.gradle), so the
         # Java 21 entries skip it and the Java 25 entries include it (see comment on `build`).
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PonlyMongodbTests
@@ -570,12 +538,12 @@ jobs:
       - name: "🏃 Run Functional Tests"
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DO_NOT_CACHE_TESTS: '1'
         # The Micronaut island is auto-pruned on a sub-25 JDK (settings.gradle), so the
         # Java 21 entries skip it and the Java 25 entries include it (see comment on `build`).
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PonlyHibernate5Tests
@@ -610,10 +578,10 @@ jobs:
       - name: "🏃 Run Functional Tests"
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DO_NOT_CACHE_TESTS: '1'
         run: >
           ./gradlew bootJar check
           --continue
-          --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PonlyHibernate7Tests

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -72,17 +72,22 @@ Example with multiple tags:
 ./gradlew iT -PincludeTestTags=geb,api
 ```
 
-## Environment variables
+## Build performance
 
-* `DO_NOT_CACHE_TESTS` - set to `1` (or any truthy value) to force every `Test` task to run
-  every invocation, without needing `--rerun-tasks`. This skips both Gradle's build cache
-  and the `up-to-date` check for tests, while leaving the rest of the build (compilation,
-  resource processing, etc.) cacheable. Useful when chasing flaky tests that depend on
-  test execution order across runs.
+Root and `grails-gradle` `Test` tasks use four local forks by default. Use
+`-PmaxTestParallel=N` to override that default, such as when bisecting a flaky test.
 
-  ```
-  DO_NOT_CACHE_TESTS=1 ./gradlew :grails-gsp:test
-  ```
+Set `DO_NOT_CACHE_TESTS=1` to force every `Test` task to execute without disabling
+caching or up-to-date checks for compilation and other build work:
+
+```bash
+DO_NOT_CACHE_TESTS=1 ./gradlew :grails-gsp:test
+```
+
+`--rerun-tasks` forces every selected task, not just tests, to run again. CI test jobs that
+need forced test execution use `DO_NOT_CACHE_TESTS=1`; the weekly and manually dispatched
+build-validation workflow keeps the full forced-rerun sentinel so every task is still
+executed from scratch on a schedule.
 
 ## Start a mongo docker container (containers will start by default)
 `docker run -d  --name mongo-on-docker  -p 27017:27017 mongo`

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ ext {
     // needing --rerun-tasks. Useful for repeatedly running the same test command while
     // chasing flaky tests across runs.
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
-    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: (isCiBuild ? 4 : Runtime.runtime.availableProcessors() * 3 / 4 as int ?: 1)
+    // Four forks are a conservative local default; -PmaxTestParallel=N takes precedence.
+    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: 4
     excludeUnusedTransDeps = findProperty('excludeUnusedTransDeps')
 
     testProjectsStartWith = [

--- a/gradle/spring-security-test-config.gradle
+++ b/gradle/spring-security-test-config.gradle
@@ -23,6 +23,10 @@ dependencies {
 }
 
 tasks.withType(Test).configureEach {
+    // Honor DO_NOT_CACHE_TESTS=1 without rerunning non-test tasks.
+    outputs.cacheIf { !doNotCacheTests }
+    outputs.upToDateWhen { !doNotCacheTests }
+
     onlyIf {
         ![
                 'skipSpringSecurityTests',

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -47,7 +47,8 @@ ext {
     // needing --rerun-tasks. Useful for repeatedly running the same test command while
     // chasing flaky tests across runs.
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
-    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: (isCiBuild ? 3 : Runtime.runtime.availableProcessors() * 3/4 as int ?: 1)
+    // Four forks are a conservative local default; -PmaxTestParallel=N takes precedence.
+    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: (isCiBuild ? 3 : 4)
 }
 
 apply {


### PR DESCRIPTION
## Summary

Reduces Gradle build time on CI and locally without dropping any test family, matrix leg, or validation.

Opened as a draft so the timing can be measured against the historical baseline before asking for review. If the CI wall-clock does not actually improve, this PR will be closed.

## Why

Two sources of avoidable work were measured on `8.0.x`:

1. **CI discarded the remote cache.** Most jobs passed `--rerun-tasks`, which forces *every* selected task, not just tests. A sampled normal job logged 500+ `FROM-CACHE` outcomes; the forced job logged none. The flag was throwing away the Develocity benefit purely to guarantee tests actually ran.
2. **A dedicated forced-rerun job sat on the critical path.** `buildRerunTasks` cost a **78.4 minute median**. Across **253 completed `8.0.x` runs** it produced no confirmed unique correctness catch (the one apparent catch was a runner shutdown).

Baseline for comparison: **148.6 min median** for the last 20 successful push runs, **106.7 min median** across the recent PR cohort.

## Changes

**1. Limit the default local test fork count**

The local default was `availableProcessors * 3/4`, i.e. 15 concurrent JVMs on a 20-thread machine, which oversubscribed CPU and RAM. Now defaults to 4. Measured on a 14-core / 20-thread workstation with identical warm inputs and tests forced:

| Suite | 15 forks | 4 forks |
|---|---|---|
| `:grails-test-suite-web:test` | 114.5s | **79.4s** |
| `:grails-gradle-plugins:test` | 232.0s | **217.7s** |

(2 forks was slower than 4 at 89.1s.) CI defaults are unchanged, and `-PmaxTestParallel=N` still overrides.

**2. Reuse cacheable build outputs in normal CI runs**

- CI test jobs use `DO_NOT_CACHE_TESTS=1` instead of `--rerun-tasks`: tests are still forced to execute, but compilation and resource processing stay cacheable.
- `gradle/spring-security-test-config.gradle` now honours that variable, so its suites are forced like every other test family. Verified: two consecutive runs both executed the `Test` task while 209 other tasks stayed up-to-date.
- The whole-build forced rerun moves to a new weekly + `workflow_dispatch` `gradle-build-validation.yml` running the identical command, so nothing stops being validated - it just leaves every PR and push.
- Aggregate Groovydoc runs once on the Ubuntu / JDK 25 leg instead of all four core legs. JDK 25 builds the full graph including the Micronaut island that a sub-25 JDK prunes, so the documented surface is a superset of what JDK 21 covered. A Groovydoc failure still fails that leg and still blocks publishing.

**3. Document the controls** in `DEVELOPMENT.md`.

## Verification

- `./gradlew validateActions` - all 24 workflows compliant.
- `./gradlew clean aggregateViolations :grails-test-report:check --continue` - Checkstyle, CodeNarc, PMD and SpotBugs all report **no violations**.
- Post-change scoped runs green: web suite 78.7s, `grails-gradle` 204.7s, `:grails-redis:test`, and `:grails-spring-security:test -PonlySpringSecurityTests`.
- Two full-suite failures were triaged and reproduced in isolation, and **neither is caused by this branch**:
  - `grails-test-examples-mail` - pre-existing Windows-only CRLF assertion (`Hello\r\nWorld!` vs `Hello\nWorld!`), reproduces identically in isolation.
  - `grails-test-examples-spring-security-ui-extended` - Selenium deleted the shared session after 32s of inactivity under full-repo load; passes all 63 tests in isolation.

## Note for a follow-up

Unrelated to this PR: the existing `-PonlyRedisTests` selector composes conflicting `onlyIf` predicates, so the `grails-redis` plugin module's unit tests are skipped in the Redis CI lane even under `--rerun-tasks`. Left alone here because fixing it would *add* coverage and confound this timing experiment.
