### PR TITLE
Parallelize critical CI test workloads

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -367,16 +367,46 @@ jobs:
           path: grails-forge/tmp1/cli/**/*
           if-no-files-found: 'error'
   functional:
-    name: "Functional Tests (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
+    name: "Functional Tests (${{ matrix.job_name }})"
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 25 ]
-        indy: [ false ]
         include:
           - java: 21
+            indy: false
+            job_name: Java 21, indy=false
+            gradle_task: 'bootJar check'
+            artifact_suffix: java21-indyfalse
+            cache_writer: true
+          - java: 21
             indy: true
+            job_name: Java 21, indy=true
+            gradle_task: 'bootJar check'
+            artifact_suffix: java21-indytrue-shard0
+            cache_writer: false
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 21
+            indy: true
+            job_name: Java 21, indy=true, shard 1
+            gradle_task: testShard
+            artifact_suffix: java21-indytrue-shard1
+            cache_writer: false
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+          - java: 25
+            indy: false
+            job_name: Java 25, indy=false
+            gradle_task: 'bootJar check'
+            artifact_suffix: java25-indyfalse-shard0
+            cache_writer: false
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 25
+            indy: false
+            job_name: Java 25, indy=false, shard 1
+            gradle_task: testShard
+            artifact_suffix: java25-indyfalse-shard1
+            cache_writer: false
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -389,7 +419,8 @@ jobs:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: "🗄️ Restore dependency jar cache"
-        uses: actions/cache@v4
+        id: dependency-cache
+        uses: actions/cache/restore@v4
         with:
           # Cache only downloaded dependency jars and wrapper distributions, never Grails build outputs.
           # Keyed by branch version so each release branch maintains its own warm cache.
@@ -410,7 +441,7 @@ jobs:
         # The Micronaut island is auto-pruned on a sub-25 JDK (settings.gradle), so the
         # Java 21 entries skip it and the Java 25 entries include it (see comment on `build`).
         run: >
-          ./gradlew bootJar check
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --rerun-tasks
           --stacktrace
@@ -422,11 +453,20 @@ jobs:
           -PskipMongodbTests
           -PskipSpringSecurityTests
           -PskipRedisTests
+          ${{ matrix.shard_arguments }}
+      - name: "🗄️ Save dependency jar cache"
+        if: ${{ success() && matrix.cache_writer && steps.dependency-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/wrapper
+          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
       - name: "📤 Upload Geb Reports"
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: geb-reports-functional-java${{ matrix.java }}-indy${{ matrix.indy }}
+          name: geb-reports-functional-${{ matrix.artifact_suffix }}
           path: '**/build/geb-reports/'
           if-no-files-found: ignore
   security:
@@ -643,16 +683,36 @@ jobs:
           -PskipCodeStyle
   hibernate7Functional:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: "Hibernate7 Functional Tests (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
+    name: "Hibernate7 Functional Tests (${{ matrix.job_name }})"
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 25 ]
-        indy: [ false ]
         include:
           - java: 21
+            indy: false
+            job_name: Java 21, indy=false
+            gradle_task: 'bootJar check'
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 21
+            indy: false
+            job_name: Java 21, indy=false, shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+          - java: 21
             indy: true
+            job_name: Java 21, indy=true
+            gradle_task: 'bootJar check'
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 21
+            indy: true
+            job_name: Java 21, indy=true, shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+          - java: 25
+            indy: false
+            job_name: Java 25, indy=false
+            gradle_task: 'bootJar check'
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org
@@ -672,13 +732,14 @@ jobs:
         env:
           GITHUB_MAVEN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
         run: >
-          ./gradlew bootJar check
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --rerun-tasks
           --stacktrace
           -PgrailsIndy=${{ matrix.indy }}
           -PonlyHibernate7Tests
           -PskipCodeStyle
+          ${{ matrix.shard_arguments }}
   publishGradle:
     if: github.repository_owner == 'apache' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     needs: [ buildGradle ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -123,19 +123,38 @@ jobs:
           -PskipCodeStyle
   build:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: 'Build Grails-Core'
+    name: 'Build Grails-Core (${{ matrix.job_name }})'
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             java: 21
+            job_name: Ubuntu JDK 21
+            gradle_task: 'build :grails-shell-cli:installDist groovydoc'
+            cache_writer: true
           - os: ubuntu-latest
             java: 25
+            job_name: Ubuntu JDK 25
+            gradle_task: 'build :grails-shell-cli:installDist groovydoc'
+            cache_writer: false
           - os: macos-latest
             java: 21
+            job_name: macOS JDK 21
+            gradle_task: 'build :grails-shell-cli:installDist groovydoc'
+            cache_writer: true
           - os: windows-latest
             java: 25
+            job_name: Windows JDK 25 shard 0
+            gradle_task: 'build :grails-shell-cli:installDist groovydoc'
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+            cache_writer: true
+          - os: windows-latest
+            java: 25
+            job_name: Windows JDK 25 shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+            cache_writer: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -148,7 +167,8 @@ jobs:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: "🗄️ Restore dependency jar cache"
-        uses: actions/cache@v4
+        id: dependency-cache
+        uses: actions/cache/restore@v4
         with:
           # Cache only downloaded dependency jars and wrapper distributions, never Grails build outputs.
           # Keyed by branch version so each release branch maintains its own warm cache.
@@ -172,11 +192,20 @@ jobs:
         # and included automatically on JDK 25+. So the Java 21 entries build everything
         # except the island and the Java 25 entries build the full graph - no flag needed.
         run: >
-          ./gradlew build :grails-shell-cli:installDist groovydoc
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --stacktrace
           -PonlyCoreTests
           -PskipCodeStyle
+          ${{ matrix.shard_arguments }}
+      - name: "🗄️ Save dependency jar cache"
+        if: ${{ success() && matrix.cache_writer && steps.dependency-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/wrapper
+          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
   buildRerunTasks:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     name: 'Build Grails-Core Rerunning all Tasks'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -147,13 +147,19 @@ jobs:
             java: 25
             job_name: Windows JDK 25 shard 0
             gradle_task: 'build :grails-shell-cli:installDist groovydoc'
-            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=0'
             cache_writer: true
           - os: windows-latest
             java: 25
             job_name: Windows JDK 25 shard 1
             gradle_task: testShard
-            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=1'
+            cache_writer: false
+          - os: windows-latest
+            java: 25
+            job_name: Windows JDK 25 shard 2
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=2'
             cache_writer: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -208,13 +214,29 @@ jobs:
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
   buildRerunTasks:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
-    name: 'Build Grails-Core Rerunning all Tasks'
+    name: 'Build Grails-Core Rerunning all Tasks (${{ matrix.job_name }})'
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             java: 21
+            job_name: Ubuntu JDK 21 shard 0
+            gradle_task: 'build :grails-shell-cli:installDist groovydoc'
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=0'
+            cache_writer: true
+          - os: ubuntu-latest
+            java: 21
+            job_name: Ubuntu JDK 21 shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=1'
+            cache_writer: false
+          - os: ubuntu-latest
+            java: 21
+            job_name: Ubuntu JDK 21 shard 2
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=2'
+            cache_writer: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -227,7 +249,8 @@ jobs:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: "🗄️ Restore dependency jar cache"
-        uses: actions/cache@v4
+        id: dependency-cache
+        uses: actions/cache/restore@v4
         with:
           # Cache only downloaded dependency jars and wrapper distributions, never Grails build outputs.
           # Keyed by branch version so each release branch maintains its own warm cache.
@@ -248,12 +271,21 @@ jobs:
         # This job only runs on Java 21, where settings.gradle auto-prunes the Micronaut
         # island (Micronaut 5 GA targets JVM 25 bytecode). See comment on `build`.
         run: >
-          ./gradlew build :grails-shell-cli:installDist groovydoc
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --rerun-tasks
           --stacktrace
           -PonlyCoreTests
           -PskipCodeStyle
+          ${{ matrix.shard_arguments }}
+      - name: "🗄️ Save dependency jar cache"
+        if: ${{ success() && matrix.cache_writer && steps.dependency-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/wrapper
+          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
   buildForge:
     name: "Build Grails Forge (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
     strategy:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -383,8 +383,16 @@ jobs:
             indy: false
             job_name: Java 21, indy=false
             gradle_task: 'bootJar check'
-            artifact_suffix: java21-indyfalse
+            artifact_suffix: java21-indyfalse-shard0
             cache_writer: true
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 21
+            indy: false
+            job_name: Java 21, indy=false, shard 1
+            gradle_task: testShard
+            artifact_suffix: java21-indyfalse-shard1
+            cache_writer: false
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
           - java: 21
             indy: true
             job_name: Java 21, indy=true
@@ -476,12 +484,23 @@ jobs:
           path: '**/build/geb-reports/'
           if-no-files-found: ignore
   security:
-    name: "Spring Security Tests"
+    name: "Spring Security Tests (${{ matrix.job_name }})"
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
     strategy:
       fail-fast: false
       matrix:
-        java: [ 21, 25 ]
+        include:
+          - java: 21
+            job_name: Java 21
+            gradle_task: 'bootJar check'
+          - java: 25
+            job_name: Java 25
+            gradle_task: 'bootJar check'
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 25
+            job_name: Java 25, shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
     runs-on: ubuntu-24.04
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
@@ -502,12 +521,13 @@ jobs:
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
       - name: "🏃 Run Functional Tests"
         run: >
-          ./gradlew bootJar check
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --rerun-tasks
           --stacktrace
           -PonlySpringSecurityTests
           -PskipCodeStyle
+          ${{ matrix.shard_arguments }}
   securityConfig:
     name: "Spring Security Config Functional Tests"
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
@@ -699,12 +719,17 @@ jobs:
             indy: false
             job_name: Java 21, indy=false
             gradle_task: 'bootJar check'
-            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=0'
           - java: 21
             indy: false
             job_name: Java 21, indy=false, shard 1
             gradle_task: testShard
-            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=1'
+          - java: 21
+            indy: false
+            job_name: Java 21, indy=false, shard 2
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=2'
           - java: 21
             indy: true
             job_name: Java 21, indy=true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -221,21 +221,27 @@ jobs:
         include:
           - os: ubuntu-latest
             java: 21
-            job_name: Ubuntu JDK 21 shard 0
+            job_name: Ubuntu JDK 21 build
             gradle_task: 'build :grails-shell-cli:installDist groovydoc'
-            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=0'
+            extra_arguments: '-PskipTests'
             cache_writer: true
+          - os: ubuntu-latest
+            java: 21
+            job_name: Ubuntu JDK 21 shard 0
+            gradle_task: testShard
+            extra_arguments: '-PtestShardCount=3 -PtestShardIndex=0'
+            cache_writer: false
           - os: ubuntu-latest
             java: 21
             job_name: Ubuntu JDK 21 shard 1
             gradle_task: testShard
-            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=1'
+            extra_arguments: '-PtestShardCount=3 -PtestShardIndex=1'
             cache_writer: false
           - os: ubuntu-latest
             java: 21
             job_name: Ubuntu JDK 21 shard 2
             gradle_task: testShard
-            shard_arguments: '-PtestShardCount=3 -PtestShardIndex=2'
+            extra_arguments: '-PtestShardCount=3 -PtestShardIndex=2'
             cache_writer: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -277,7 +283,7 @@ jobs:
           --stacktrace
           -PonlyCoreTests
           -PskipCodeStyle
-          ${{ matrix.shard_arguments }}
+          ${{ matrix.extra_arguments }}
       - name: "🗄️ Save dependency jar cache"
         if: ${{ success() && matrix.cache_writer && steps.dependency-cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
@@ -713,6 +719,12 @@ jobs:
             indy: false
             job_name: Java 25, indy=false
             gradle_task: 'bootJar check'
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=0'
+          - java: 25
+            indy: false
+            job_name: Java 25, indy=false, shard 1
+            gradle_task: testShard
+            shard_arguments: '-PtestShardCount=2 -PtestShardIndex=1'
     steps:
       - name: "Output Agent IP" # in the event RAO blocks this agent, this can be used to debug it
         run: curl -s https://api.ipify.org

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -102,6 +102,17 @@ jobs:
           retention-days: 1
   build_grails:
     needs: [build_groovy]
+    name: "Build Grails with Groovy snapshot (shard ${{ matrix.shard_index }})"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard_index: 0
+            gradle_task: build
+          - shard_index: 1
+            gradle_task: testShard
+          - shard_index: 2
+            gradle_task: testShard
     runs-on: ubuntu-latest
     services:
       mongodb:
@@ -133,10 +144,22 @@ jobs:
         with:
           java-version: 21
           distribution: liberica
+      - name: "🗄️ Restore dependency jar cache"
+        id: dependency-cache
+        uses: actions/cache/restore@v4
+        with:
+          # Cache only downloaded dependency jars and wrapper distributions, never Grails build outputs.
+          # Keyed by branch version so each release branch maintains its own warm cache.
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/wrapper
+          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
-          cache-disabled: true # this workflow rebuilds Groovy each run; a Gradle home cache is not useful here
+          cache-disabled: true # dependency jars are cached by the explicit branch-keyed step above
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY  }}
       - name: "🔍 Setup TestLens"
         uses: testlens-app/setup-testlens@3f82d2dc6cd5c03f02ce5f7885a21195d85f8d14 # v1.9.3
@@ -155,12 +178,22 @@ jobs:
         # which is incompatible with the Groovy 4.x snapshot this job swaps in above.
         # See https://github.com/apache/grails-core/issues/15613.
         run: >
-          ./gradlew build
+          ./gradlew ${{ matrix.gradle_task }}
           --continue
           --stacktrace
           -x groovydoc
           -PskipCodeStyle
           -PskipMicronautProjects
           -PmaxTestParallel=3
+          -PtestShardCount=3
+          -PtestShardIndex=${{ matrix.shard_index }}
         env:
           GRAILS_INCLUDE_MAVEN_LOCAL: true
+      - name: "🗄️ Save dependency jar cache"
+        if: ${{ success() && matrix.shard_index == 0 && steps.dependency-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/wrapper
+          key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}

--- a/build-logic/plugins/build.gradle
+++ b/build-logic/plugins/build.gradle
@@ -123,5 +123,9 @@ gradlePlugin {
             id = 'org.apache.grails.buildsrc.autoconfiguration-imports'
             implementationClass = 'org.apache.grails.buildsrc.AutoConfigurationImportsPlugin'
         }
+        register('testTaskShardingPlugin') {
+            id = 'org.apache.grails.buildsrc.test-task-sharding'
+            implementationClass = 'org.apache.grails.buildsrc.TestTaskShardingPlugin'
+        }
     }
 }

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/TestTaskShardingPlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/TestTaskShardingPlugin.groovy
@@ -1,0 +1,174 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.buildsrc
+
+import groovy.transform.CompileStatic
+
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.api.tasks.testing.Test
+
+/**
+ * Deterministically partitions root-build {@link Test} tasks across CI shards.
+ */
+@CompileStatic
+class TestTaskShardingPlugin implements Plugin<Project> {
+
+    static final String SHARD_COUNT_PROPERTY = 'testShardCount'
+    static final String SHARD_INDEX_PROPERTY = 'testShardIndex'
+    static final String SHARD_TASK_NAME = 'testShard'
+    private static final String MANIFEST_PREFIX = 'TEST_SHARD_MANIFEST'
+
+    @Override
+    void apply(Project project) {
+        if (project != project.rootProject) {
+            throw new GradleException('TestTaskShardingPlugin must be applied to the root project only.')
+        }
+
+        ShardConfiguration configuration = readConfiguration(project)
+        if (configuration == null) {
+            return
+        }
+
+        Set<Test> candidateTasks = new LinkedHashSet<>()
+        project.allprojects { Project candidateProject ->
+            candidateProject.tasks.withType(Test).configureEach { Test task ->
+                candidateTasks.add(task)
+                task.onlyIf {
+                    isSelectedForShard(task, configuration)
+                }
+            }
+        }
+        registerShardTask(project, candidateTasks, configuration)
+        project.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
+            emitManifest(project, candidateTasks, configuration)
+        }
+    }
+
+    private static ShardConfiguration readConfiguration(Project project) {
+        boolean hasCount = project.hasProperty(SHARD_COUNT_PROPERTY)
+        boolean hasIndex = project.hasProperty(SHARD_INDEX_PROPERTY)
+        if (!hasCount && !hasIndex) {
+            return null
+        }
+        if (hasCount != hasIndex) {
+            throw new GradleException("${SHARD_COUNT_PROPERTY} and ${SHARD_INDEX_PROPERTY} must be supplied together")
+        }
+
+        int shardCount = parseInteger(project, SHARD_COUNT_PROPERTY)
+        int shardIndex = parseInteger(project, SHARD_INDEX_PROPERTY)
+        if (shardCount < 1) {
+            throw new GradleException("${SHARD_COUNT_PROPERTY} must be at least 1")
+        }
+        if (shardIndex < 0 || shardIndex >= shardCount) {
+            throw new GradleException("${SHARD_INDEX_PROPERTY} must be in the range [0, ${shardCount})")
+        }
+        new ShardConfiguration(shardCount, shardIndex)
+    }
+
+    private static int parseInteger(Project project, String propertyName) {
+        String value = project.findProperty(propertyName)?.toString()
+        try {
+            Integer.parseInt(value)
+        } catch (NumberFormatException ignored) {
+            throw new GradleException("${propertyName} must be an integer")
+        }
+    }
+
+    private static void registerShardTask(Project rootProject, Set<Test> candidateTasks, ShardConfiguration configuration) {
+        rootProject.tasks.register(SHARD_TASK_NAME) { Task task ->
+            task.group = 'verification'
+            task.description = 'Runs the Test tasks assigned to the current deterministic shard.'
+            task.dependsOn {
+                collectCandidateTasks(rootProject, candidateTasks).findAll { Test testTask ->
+                    isSelectedForShard(testTask, configuration)
+                }
+            }
+        }
+    }
+
+    private static void emitManifest(Project rootProject, Set<Test> candidateTasks, ShardConfiguration configuration) {
+        List<Test> candidates = collectCandidateTasks(rootProject, candidateTasks)
+        List<String> candidatePaths = candidates.collect { Test task -> normalizeTaskPath(task.path) }
+        validateUniqueTaskPaths(candidatePaths)
+        if (candidates.empty) {
+            throw new GradleException('No Test tasks were found for sharding')
+        }
+
+        List<String> selectedPaths = candidates.findAll { Test task ->
+            isSelectedForShard(task, configuration)
+        }.collect { Test task -> normalizeTaskPath(task.path) }.sort()
+        rootProject.logger.lifecycle("${MANIFEST_PREFIX} totalCandidates=${candidatePaths.size()} shardIndex=${configuration.shardIndex} shardCount=${configuration.shardCount} selectedTasks=${selectedPaths.join(',')}")
+    }
+
+    private static List<Test> collectCandidateTasks(Project rootProject, Set<Test> candidateTasks) {
+        rootProject.allprojects.each { Project project ->
+            project.tasks.withType(Test).each { Test task ->
+                candidateTasks.add(task)
+            }
+        }
+        candidateTasks.toList().sort { Test left, Test right ->
+            normalizeTaskPath(left.path) <=> normalizeTaskPath(right.path)
+        }
+    }
+
+    private static boolean isSelectedForShard(Test task, ShardConfiguration configuration) {
+        if (task.project.path == ':grails-test-report') {
+            return configuration.shardIndex == 0
+        }
+        shardFor(normalizeTaskPath(task.path), configuration.shardCount) == configuration.shardIndex
+    }
+
+    static void validateUniqueTaskPaths(Collection<String> taskPaths) {
+        Set<String> seen = new LinkedHashSet<>()
+        taskPaths.each { String taskPath ->
+            String normalizedPath = normalizeTaskPath(taskPath)
+            if (!seen.add(normalizedPath)) {
+                throw new IllegalArgumentException("Duplicate normalized Gradle Test task path: ${normalizedPath}")
+            }
+        }
+    }
+
+    private static String normalizeTaskPath(String taskPath) {
+        String normalizedPath = taskPath.replace('\\', '/')
+        normalizedPath.startsWith(':') ? normalizedPath : ":${normalizedPath}"
+    }
+
+    static int shardFor(String taskPath, int shardCount) {
+        byte[] digest = MessageDigest.getInstance('SHA-256').digest(taskPath.getBytes(StandardCharsets.UTF_8))
+        new BigInteger(1, digest).mod(BigInteger.valueOf(shardCount)).intValue()
+    }
+
+    private static final class ShardConfiguration {
+        final int shardCount
+        final int shardIndex
+
+        ShardConfiguration(int shardCount, int shardIndex) {
+            this.shardCount = shardCount
+            this.shardIndex = shardIndex
+        }
+    }
+}

--- a/build-logic/plugins/src/test/groovy/org/apache/grails/buildsrc/TestTaskShardingPluginSpec.groovy
+++ b/build-logic/plugins/src/test/groovy/org/apache/grails/buildsrc/TestTaskShardingPluginSpec.groovy
@@ -1,0 +1,387 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.buildsrc
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Path
+
+class TestTaskShardingPluginSpec extends Specification {
+
+    @TempDir
+    Path testProjectDir
+
+    def setup() {
+        writeMultiProjectFixture(false)
+    }
+
+    def "does nothing when shard properties are absent"() {
+        when:
+        BuildResult result = run('build')
+
+        then:
+        !result.output.contains('TEST_SHARD_MANIFEST')
+        !result.output.contains('testShard')
+        result.task(':alpha:test').outcome == TaskOutcome.NO_SOURCE
+        result.task(':beta:test').outcome == TaskOutcome.NO_SOURCE
+        result.task(':gamma:test').outcome == TaskOutcome.NO_SOURCE
+        result.task(':disabled:test').outcome == TaskOutcome.SKIPPED
+    }
+
+    def "requires valid paired shard properties"() {
+        when:
+        BuildResult result = runFail(*arguments)
+
+        then:
+        result.output.contains(message)
+
+        where:
+        arguments                                                    | message
+        ['help', '-PtestShardCount=2']                              | 'testShardCount and testShardIndex must be supplied together'
+        ['help', '-PtestShardIndex=0']                              | 'testShardCount and testShardIndex must be supplied together'
+        ['help', '-PtestShardCount=0', '-PtestShardIndex=0']        | 'testShardCount must be at least 1'
+        ['help', '-PtestShardCount=2', '-PtestShardIndex=2']        | 'testShardIndex must be in the range [0, 2)'
+        ['help', '-PtestShardCount=two', '-PtestShardIndex=0']      | 'testShardCount must be an integer'
+        ['help', '-PtestShardCount=2', '-PtestShardIndex=zero']     | 'testShardIndex must be an integer'
+    }
+
+    def "rejects application to a non-root project"() {
+        given:
+        testProjectDir.resolve('settings.gradle').toFile().text = "include 'child'"
+        testProjectDir.resolve('build.gradle').toFile().text = ''
+        def childDir = testProjectDir.resolve('child').toFile()
+        childDir.mkdirs()
+        new File(childDir, 'build.gradle').text = """
+            plugins {
+                id 'org.apache.grails.buildsrc.test-task-sharding'
+            }
+        """
+
+        when:
+        BuildResult result = runFail('help')
+
+        then:
+        result.output.contains('TestTaskShardingPlugin must be applied to the root project only.')
+    }
+
+    def "assigns Test task candidates deterministically, disjointly, and exhaustively"() {
+        given:
+        Set<String> baseline = [':alpha:test', ':beta:test', ':disabled:test', ':gamma:test'] as Set
+
+        when:
+        Map<Integer, Set<String>> twoWayAssignments = assignmentsFor(2)
+        Map<Integer, Set<String>> threeWayAssignments = assignmentsFor(3)
+
+        then:
+        assignmentsAreDisjointAndExhaustive(twoWayAssignments, baseline)
+        assignmentsAreDisjointAndExhaustive(threeWayAssignments, baseline)
+
+        and: "repeated invocations select the same paths"
+        shardPaths(run('testShard', '-PtestShardCount=3', '-PtestShardIndex=1')) == threeWayAssignments[1]
+    }
+
+    def "preserves existing false onlyIf predicates and filters full builds to the current shard"() {
+        when:
+        BuildResult result = run('build', '-PtestShardCount=2', '-PtestShardIndex=0')
+        Set<String> selected = shardPaths(result)
+
+        then:
+        selected
+        result.task(':disabled:test').outcome == TaskOutcome.SKIPPED
+
+        and: "selected tasks remain enabled while the other eligible tasks are skipped"
+        [':alpha:test', ':beta:test', ':gamma:test'].each { String path ->
+            assert result.task(path).outcome == (selected.contains(path) ? TaskOutcome.NO_SOURCE : TaskOutcome.SKIPPED)
+        }
+    }
+
+    def "testShard depends only on selected Test task candidates and emits a manifest"() {
+        when:
+        BuildResult result = run('testShard', '-PtestShardCount=3', '-PtestShardIndex=2')
+        Set<String> selected = shardPaths(result)
+
+        then:
+        result.task(':testShard').outcome in [TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE]
+        result.output.contains('TEST_SHARD_MANIFEST totalCandidates=4 shardIndex=2 shardCount=3 selectedTasks=')
+
+        and:
+        [':alpha:test', ':beta:test', ':disabled:test', ':gamma:test'].each { String path ->
+            assert result.output.contains("> Task ${path}") == selected.contains(path)
+        }
+    }
+
+    def "fails when sharding is requested without Test tasks"() {
+        given:
+        writeEmptyFixture()
+
+        when:
+        BuildResult result = runFail('help', '-PtestShardCount=2', '-PtestShardIndex=0')
+
+        then:
+        result.output.contains('No Test tasks were found for sharding')
+    }
+
+    def "keeps existing onlyIf predicates for execution time"() {
+        given:
+        writeDynamicOnlyFixture()
+
+        when:
+        BuildResult result = run('testShard', '-PtestShardCount=1', '-PtestShardIndex=0')
+
+        then:
+        result.task(':dynamic:enableDynamic').outcome == TaskOutcome.SUCCESS
+        result.task(':dynamic:dynamicTest').outcome == TaskOutcome.NO_SOURCE
+    }
+
+    def "includes Test tasks registered by later projectsEvaluated callbacks"() {
+        given:
+        writeLifecycleFixture()
+
+        when:
+        BuildResult result = run('testShard', '-PtestShardCount=1', '-PtestShardIndex=0')
+
+        then:
+        shardPaths(result).contains(':late:lateTest')
+        result.task(':late:lateTest').outcome == TaskOutcome.NO_SOURCE
+    }
+
+    def "pins the aggregate Test facade to shard zero without scheduling its leaf closure in siblings"() {
+        given:
+        writeLifecycleFixture()
+
+        when:
+        BuildResult sibling = run('testShard', '-PtestShardCount=2', '-PtestShardIndex=1')
+        Set<String> selected = shardPaths(sibling)
+        String unselectedLeaf = [':alpha:leafTest', ':beta:leafTest', ':dynamic:dynamicTest', ':late:lateTest'].find { String path ->
+            TestTaskShardingPlugin.shardFor(path, 2) != 1
+        }
+
+        then:
+        !selected.contains(':grails-test-report:test')
+        !sibling.output.contains('> Task :grails-test-report:test')
+        unselectedLeaf != null
+        !sibling.output.contains("> Task ${unselectedLeaf}")
+
+        when:
+        BuildResult shardZeroBuild = run('build', '-PtestShardCount=2', '-PtestShardIndex=0')
+
+        then:
+        shardPaths(shardZeroBuild).contains(':grails-test-report:test')
+        shardZeroBuild.task(':grails-test-report:test').outcome == TaskOutcome.NO_SOURCE
+        shardZeroBuild.task(':buildMarker').outcome == TaskOutcome.SUCCESS
+
+        and: "the non-Test build marker is not part of sibling testShard jobs"
+        !sibling.output.contains('> Task :buildMarker')
+    }
+
+    def "rejects duplicate normalized task paths"() {
+        when:
+        TestTaskShardingPlugin.validateUniqueTaskPaths([':alpha:test', ':alpha:test'])
+
+        then:
+        def error = thrown(IllegalArgumentException)
+        error.message == 'Duplicate normalized Gradle Test task path: :alpha:test'
+    }
+
+    private Map<Integer, Set<String>> assignmentsFor(int shardCount) {
+        (0..<shardCount).collectEntries { int shardIndex ->
+            BuildResult result = run('testShard', "-PtestShardCount=${shardCount}", "-PtestShardIndex=${shardIndex}")
+            [(shardIndex): shardPaths(result)]
+        }
+    }
+
+    private static void assignmentsAreDisjointAndExhaustive(Map<Integer, Set<String>> assignments, Set<String> baseline) {
+        Set<String> union = assignments.values().flatten() as Set
+        assert union == baseline
+        assignments.each { int shardIndex, Set<String> paths ->
+            assignments.each { int otherShardIndex, Set<String> otherPaths ->
+                if (shardIndex < otherShardIndex) {
+                    assert paths.intersect(otherPaths).empty
+                }
+            }
+        }
+    }
+
+    private BuildResult run(String... arguments) {
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(arguments + ['--stacktrace'])
+                .withPluginClasspath()
+                .build()
+    }
+
+    private BuildResult runFail(String... arguments) {
+        GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(arguments + ['--stacktrace'])
+                .withPluginClasspath()
+                .buildAndFail()
+    }
+
+    private static Set<String> shardPaths(BuildResult result) {
+        String manifest = result.output.readLines().find { it.startsWith('TEST_SHARD_MANIFEST ') }
+        assert manifest != null
+        String selected = manifest.substring(manifest.indexOf('selectedTasks=') + 'selectedTasks='.length())
+        selected ? selected.split(',') as Set : [] as Set
+    }
+
+    private void writeMultiProjectFixture(boolean disableAllTests) {
+        testProjectDir.resolve('settings.gradle').toFile().text = "include 'alpha', 'beta', 'gamma', 'disabled'"
+        testProjectDir.resolve('build.gradle').toFile().text = """
+            plugins {
+                id 'base'
+                id 'org.apache.grails.buildsrc.test-task-sharding'
+            }
+
+            tasks.named('build') {
+                dependsOn(':alpha:test', ':beta:test', ':gamma:test', ':disabled:test')
+            }
+        """
+        ['alpha', 'beta', 'gamma', 'disabled'].each { String name ->
+            def projectDir = testProjectDir.resolve(name).toFile()
+            projectDir.mkdirs()
+            boolean disabled = disableAllTests || name == 'disabled'
+            new File(projectDir, 'build.gradle').text = """
+                plugins {
+                    id 'java'
+                }
+
+                tasks.named('test') {
+                    onlyIf { ${!disabled} }
+                }
+            """
+        }
+    }
+
+    private void writeEmptyFixture() {
+        testProjectDir.resolve('settings.gradle').toFile().text = ''
+        testProjectDir.resolve('build.gradle').toFile().text = """
+            plugins {
+                id 'base'
+                id 'org.apache.grails.buildsrc.test-task-sharding'
+            }
+        """
+    }
+
+    private void writeLifecycleFixture() {
+        testProjectDir.resolve('settings.gradle').toFile().text = "include 'alpha', 'beta', 'dynamic', 'grails-test-report', 'late'"
+        testProjectDir.resolve('build.gradle').toFile().text = """
+            import org.gradle.api.tasks.testing.Test
+
+            plugins {
+                id 'base'
+                id 'org.apache.grails.buildsrc.test-task-sharding'
+            }
+
+            tasks.register('buildMarker') {
+                doLast {
+                    logger.lifecycle('BUILD_MARKER')
+                }
+            }
+            tasks.named('build') {
+                dependsOn('buildMarker', ':grails-test-report:test')
+            }
+            gradle.projectsEvaluated {
+                project(':late').tasks.register('lateTest', Test) {
+                    testClassesDirs = files(layout.buildDirectory.dir('late-test-classes'))
+                    classpath = files()
+                }
+            }
+        """
+        writeTestTask('alpha', 'leafTest')
+        writeTestTask('beta', 'leafTest')
+        def dynamicDir = testProjectDir.resolve('dynamic').toFile()
+        dynamicDir.mkdirs()
+        new File(dynamicDir, 'build.gradle').text = """
+            import org.gradle.api.tasks.testing.Test
+
+            tasks.register('enableDynamic') {
+                doLast {
+                    rootProject.file('dynamic-enabled').text = 'enabled'
+                }
+            }
+            tasks.register('dynamicTest', Test) {
+                dependsOn('enableDynamic')
+                onlyIf {
+                    rootProject.file('dynamic-enabled').exists()
+                }
+                testClassesDirs = files(layout.buildDirectory.dir('dynamic-test-classes'))
+                classpath = files()
+            }
+        """
+        def reportDir = testProjectDir.resolve('grails-test-report').toFile()
+        reportDir.mkdirs()
+        new File(reportDir, 'build.gradle').text = """
+            import org.gradle.api.tasks.testing.Test
+
+            tasks.register('test', Test) {
+                dependsOn(':alpha:leafTest', ':beta:leafTest', ':dynamic:dynamicTest', ':late:lateTest')
+                testClassesDirs = files(layout.buildDirectory.dir('report-test-classes'))
+                classpath = files()
+            }
+        """
+        testProjectDir.resolve('late').toFile().mkdirs()
+    }
+
+    private void writeDynamicOnlyFixture() {
+        testProjectDir.resolve('settings.gradle').toFile().text = "include 'dynamic'"
+        testProjectDir.resolve('build.gradle').toFile().text = """
+            plugins {
+                id 'base'
+                id 'org.apache.grails.buildsrc.test-task-sharding'
+            }
+        """
+        def dynamicDir = testProjectDir.resolve('dynamic').toFile()
+        dynamicDir.mkdirs()
+        new File(dynamicDir, 'build.gradle').text = """
+            import org.gradle.api.tasks.testing.Test
+
+            tasks.register('enableDynamic') {
+                doLast {
+                    rootProject.file('dynamic-enabled').text = 'enabled'
+                }
+            }
+            tasks.register('dynamicTest', Test) {
+                dependsOn('enableDynamic')
+                onlyIf {
+                    rootProject.file('dynamic-enabled').exists()
+                }
+                testClassesDirs = files(layout.buildDirectory.dir('dynamic-test-classes'))
+                classpath = files()
+            }
+        """
+    }
+
+    private void writeTestTask(String projectName, String taskName) {
+        def projectDir = testProjectDir.resolve(projectName).toFile()
+        projectDir.mkdirs()
+        new File(projectDir, 'build.gradle').text = """
+            import org.gradle.api.tasks.testing.Test
+
+            tasks.register('${taskName}', Test) {
+                testClassesDirs = files(layout.buildDirectory.dir('${taskName}-classes'))
+                classpath = files()
+            }
+        """
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id 'org.apache.grails.gradle.grails-violation-aggregation'
     id 'org.apache.grails.gradle.grails-ij-formatter'
     id 'org.apache.grails.gradle.grails-validate-actions'
+    id 'org.apache.grails.buildsrc.test-task-sharding'
 }
 
 import java.time.Instant


### PR DESCRIPTION
## Summary

- add deterministic SHA-256 sharding for Gradle `Test` tasks while preserving existing `onlyIf` predicates
- split the Groovy Joint, Windows JDK 25, rerun, functional, Hibernate 7, and Spring Security test ceilings into targeted matrix shards
- retain one complete `build` or `bootJar check` primary for every configuration so non-test validation, reports, distributions, and documentation still run
- keep every OS/JDK leg, selector, validation task, and test-task candidate

## Verification

- `build-logic`: full TestKit suite passes, including deterministic, disjoint, and exhaustive two-way and three-way assignment coverage
- `validateActions`: all 23 workflow files pass
- Groovy Joint: 401 candidates split 132/129/140 with zero overlap
- selector families: hosted manifests prove exhaustive, non-overlapping partitions for Functional and Hibernate 7 configurations
- rerun no-test path: `:grails-test-report:check` succeeds with all `Test` tasks skipped and aggregate reports completing
- iteration 5: both same-SHA CI attempts passed every required check; PR merge state is clean

## Performance Gate

Baseline pull-request wall-clock was 117m24s. The declared keep gate was at least 15% and 10 minutes without reducing coverage.

| Measurement | Wall-clock | Improvement from baseline |
|---|---:|---:|
| Baseline | 117m24s | - |
| Iteration 2 | 62m09s | 55m15s / 47.1% |
| Iteration 4 | 56m40s | 60m44s / 51.7% |
| Iteration 5 attempt 1 | 55m12s | 62m12s / 53.0% |
| Iteration 5 attempt 2 | 61m29s | 55m55s / 47.6% |

The final targeted splits reduced their primary ceilings substantially. On the replication attempt, Functional Java 21 indy=false completed in 49m02s, Spring Security Java 25 in 47m57s, and Hibernate 7 Java 21 indy=false in 48m51s.

The remaining 55m12s-61m29s envelope is driven by unchanged non-test lifecycle work and hosted-runner variance: the forced no-test rerun build completed in 55m02s and 55m19s, while the identical Ubuntu JDK 25 job varied from 36m41s to 61m27s. Further reduction would require partitioning dependency-coupled non-test lifecycle tasks, increasing coverage risk and runner cost, so this draft stops at the validated iteration-5 topology.
