### PR TITLE
Fix `@ManagedEntity` compilation for Grails domains

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformation.groovy
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformation.groovy
@@ -87,6 +87,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.varX
 class HibernateEntityTransformation implements ASTTransformation, CompilationUnitAware, TransformWithPriority {
 
     private static final ClassNode MY_TYPE = new ClassNode(grails.gorm.hibernate.annotation.ManagedEntity)
+    private static final Object HIBERNATE_TRANSFORM_APPLIED_MARKER = new Object()
     private static final Object APPLIED_MARKER = new Object()
 
 //    final boolean available = ClassUtils.isPresent("org.hibernate.SessionFactory") && Boolean.valueOf(System.getProperty("hibernate.enhance", "true"))
@@ -111,7 +112,7 @@ class HibernateEntityTransformation implements ASTTransformation, CompilationUni
     }
 
     void visit(ClassNode classNode, SourceUnit sourceUnit) {
-        if (classNode.getNodeMetaData(AstUtils.TRANSFORM_APPLIED_MARKER) == APPLIED_MARKER) {
+        if (classNode.getNodeMetaData(HIBERNATE_TRANSFORM_APPLIED_MARKER) == APPLIED_MARKER) {
             return
         }
 
@@ -337,7 +338,7 @@ class HibernateEntityTransformation implements ASTTransformation, CompilationUni
             }
         }
 
-        classNode.putNodeMetaData(AstUtils.TRANSFORM_APPLIED_MARKER, APPLIED_MARKER)
+        classNode.putNodeMetaData(HIBERNATE_TRANSFORM_APPLIED_MARKER, APPLIED_MARKER)
     }
 
     @Override

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformation.groovy
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/compiler/HibernateEntityTransformation.groovy
@@ -87,6 +87,7 @@ import static org.codehaus.groovy.ast.tools.GeneralUtils.varX
 class HibernateEntityTransformation implements ASTTransformation, CompilationUnitAware {
 
     private static final ClassNode MY_TYPE = new ClassNode(grails.gorm.hibernate.annotation.ManagedEntity)
+    private static final Object HIBERNATE_TRANSFORM_APPLIED_MARKER = new Object()
     private static final Object APPLIED_MARKER = new Object()
 
 //    final boolean available = ClassUtils.isPresent("org.hibernate.SessionFactory") && Boolean.valueOf(System.getProperty("hibernate.enhance", "true"))
@@ -111,7 +112,7 @@ class HibernateEntityTransformation implements ASTTransformation, CompilationUni
     }
 
     void visit(ClassNode classNode, SourceUnit sourceUnit) {
-        if (classNode.getNodeMetaData(AstUtils.TRANSFORM_APPLIED_MARKER) == APPLIED_MARKER) {
+        if (classNode.getNodeMetaData(HIBERNATE_TRANSFORM_APPLIED_MARKER) == APPLIED_MARKER) {
             return
         }
 
@@ -428,6 +429,6 @@ class HibernateEntityTransformation implements ASTTransformation, CompilationUni
             }
         }
 
-        classNode.putNodeMetaData(AstUtils.TRANSFORM_APPLIED_MARKER, APPLIED_MARKER)
+        classNode.putNodeMetaData(HIBERNATE_TRANSFORM_APPLIED_MARKER, APPLIED_MARKER)
     }
 }

--- a/grails-test-examples/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
+++ b/grails-test-examples/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package functionaltests
 
 import grails.gorm.hibernate.annotation.ManagedEntity

--- a/grails-test-examples/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
+++ b/grails-test-examples/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
@@ -1,0 +1,9 @@
+package functionaltests
+
+import grails.gorm.hibernate.annotation.ManagedEntity
+
+@ManagedEntity
+class ManagedEntityDomain {
+
+    String name
+}

--- a/grails-test-examples/hibernate7/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
+++ b/grails-test-examples/hibernate7/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
@@ -1,3 +1,21 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package functionaltests
 
 import grails.gorm.hibernate.annotation.ManagedEntity

--- a/grails-test-examples/hibernate7/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
+++ b/grails-test-examples/hibernate7/app1/grails-app/domain/functionaltests/ManagedEntityDomain.groovy
@@ -1,0 +1,9 @@
+package functionaltests
+
+import grails.gorm.hibernate.annotation.ManagedEntity
+
+@ManagedEntity
+class ManagedEntityDomain {
+
+    String name
+}


### PR DESCRIPTION
Fixes compilation failures when `@ManagedEntity` is used on a Grails domain class.

`HibernateEntityTransformation` and `GormEntityTransformation` were sharing the same `ClassNode` metadata key for their “transformation applied” markers.

The Hibernate transformation overwrote GORM’s marker after invoking it, allowing GORM transformation to run again. Under Grails 8/Groovy 5, the second pass could fail in `DirtyCheckingTransformer` while collecting getter/setter pairs.

Hibernate transformations now use a dedicated metadata marker, preserving GORM’s marker and making the transformations idempotent.

Changes
- Added a Hibernate-specific transformation marker for Hibernate 5.
- Added the same fix for Hibernate 7.
- Verified compilation of the grails-test-examples-app1 reproducer.
- Verified the Hibernate 5 and Hibernate 7 transformation tests.

Closes #16107 