### PR TITLE
Memoize system environment resolution in NavigableMapConfig

### DIFF
--- a/grails-core/src/main/groovy/org/grails/config/NavigableMapConfig.java
+++ b/grails-core/src/main/groovy/org/grails/config/NavigableMapConfig.java
@@ -20,14 +20,17 @@ package org.grails.config;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import groovy.util.ConfigObject;
 import org.codehaus.groovy.runtime.DefaultGroovyMethods;
@@ -53,8 +56,17 @@ import org.grails.core.exceptions.GrailsConfigurationException;
 @Deprecated
 public abstract class NavigableMapConfig implements Config {
     protected static final Logger LOG = LoggerFactory.getLogger(NavigableMapConfig.class);
+
+    /**
+     * Upper bound on each key-derived cache. Configuration keys come from a small fixed set of source
+     * literals; the bound only guards against a caller synthesising unbounded key strings at runtime.
+     */
+    private static final int MAX_CACHED_KEYS = 2048;
+
     protected ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     protected ConfigurableConversionService conversionService = new DefaultConversionService();
+    private final ConcurrentHashMap<String, Optional<String>> systemEnvironmentCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<String>> dotNotatedKeyCache = new ConcurrentHashMap<>();
     protected NavigableMap configMap = new NavigableMap() {
         @Override
         protected Object mergeMapEntry(NavigableMap targetMap, String sourceKey, Object newValue) {
@@ -231,8 +243,26 @@ public abstract class NavigableMapConfig implements Config {
     }
 
     private Object findInSystemEnvironment(String key) {
+        if (key == null) {
+            return null;
+        }
+        Optional<String> cached = systemEnvironmentCache.get(key);
+        if (cached != null) {
+            return cached.orElse(null);
+        }
         String propertyName = resolvePropertyName(key);
-        return propertyName != null ? System.getenv(propertyName) : null;
+        String value = propertyName != null ? System.getenv(propertyName) : null;
+        // Resolving a key to its environment value depends only on the key and on the process
+        // environment, which is fixed for the lifetime of this config, so the result is memoized per
+        // instance. Without this, every getProperty() call spends up to eight System.getenv() probes
+        // and six string allocations in resolvePropertyName()/checkPropertyName() re-deriving a
+        // constant answer. The cache is deliberately per-instance rather than static: tests that
+        // install environment variables reflectively build a fresh config afterwards and must observe
+        // the environment as it stands then.
+        if (systemEnvironmentCache.size() < MAX_CACHED_KEYS) {
+            systemEnvironmentCache.put(key, Optional.ofNullable(value));
+        }
+        return value;
     }
 
     private String resolvePropertyName(String name) {
@@ -404,8 +434,17 @@ public abstract class NavigableMapConfig implements Config {
             return null;
         }
 
-        List<String> keys = convertTokensIntoArrayList(new StringTokenizer(key, "."));
-        if (keys.size() == 0) {
+        List<String> keys = dotNotatedKeyCache.get(key);
+        if (keys == null) {
+            keys = convertTokensIntoArrayList(new StringTokenizer(key, "."));
+            // Splitting a dotted key is a pure function of the key, and configuration keys come from a
+            // small fixed set of source literals, so the token list is cached rather than rebuilt (with
+            // a fresh StringTokenizer and ArrayList) on every lookup.
+            if (dotNotatedKeyCache.size() < MAX_CACHED_KEYS) {
+                dotNotatedKeyCache.put(key, keys);
+            }
+        }
+        if (keys.isEmpty()) {
             return null;
         }
 
@@ -421,10 +460,10 @@ public abstract class NavigableMapConfig implements Config {
     }
 
     private List<String> convertTokensIntoArrayList(StringTokenizer st) {
-        List<String> elements = new ArrayList<>();
+        List<String> elements = new ArrayList<>(st.countTokens());
         while (st.hasMoreTokens()) {
             elements.add(st.nextToken());
         }
-        return elements;
+        return Collections.unmodifiableList(elements);
     }
 }

--- a/grails-core/src/test/groovy/org/grails/config/SystemEnvironmentConfigSpec.groovy
+++ b/grails-core/src/test/groovy/org/grails/config/SystemEnvironmentConfigSpec.groovy
@@ -73,6 +73,56 @@ property-with_mixed.symbols: from-yml
         'property-with_mixed.symbols' | 'PROPERTY_WITH_MIXED_SYMBOLS' | 'from-env'
     }
 
+    void 'a property read more than once keeps resolving to the system environment value'() {
+        given: 'configuration that is overridden by the environment'
+        def config = configFor('property.with.period: from-yml')
+        modifiableSystemEnvironment.put('PROPERTY_WITH_PERIOD', 'from-env')
+
+        expect: 'every read resolves to the environment value, not just the first'
+        config.getProperty('property.with.period') == 'from-env'
+        config.getProperty('property.with.period') == 'from-env'
+        config.getProperty('property.with.period') == 'from-env'
+
+        cleanup:
+        modifiableSystemEnvironment.remove('PROPERTY_WITH_PERIOD')
+    }
+
+    void 'a property that has already been read still reflects later configuration changes'() {
+        given: 'a property that has been read once'
+        def config = configFor('some.nested.value: original')
+        assert config.getProperty('some.nested.value') == 'original'
+
+        when: 'the configuration is changed'
+        config.merge(['some.nested.value': 'updated'])
+
+        then: 'the new value is returned rather than the previously resolved one'
+        config.getProperty('some.nested.value') == 'updated'
+    }
+
+    void 'a config created after an environment variable is installed observes it'() {
+        given: 'a config created and read before the variable exists'
+        def before = configFor('late.bound.property: from-yml')
+        assert before.getProperty('late.bound.property') == 'from-yml'
+
+        when: 'the variable is installed and a new config is created'
+        modifiableSystemEnvironment.put('LATE_BOUND_PROPERTY', 'from-env')
+        def after = configFor('late.bound.property: from-yml')
+
+        then: 'the new config resolves to the environment value'
+        after.getProperty('late.bound.property') == 'from-env'
+
+        cleanup:
+        modifiableSystemEnvironment.remove('LATE_BOUND_PROPERTY')
+    }
+
+    private static PropertySourcesConfig configFor(String yaml) {
+        def yamlPropertiesSource = new YamlPropertySourceLoader()
+                .load('application.yml', new ByteArrayResource(yaml.bytes, 'test.yml'), null)
+        def propertySources = new MutablePropertySources()
+        propertySources.addFirst(yamlPropertiesSource.first())
+        new PropertySourcesConfig(propertySources)
+    }
+
     // From https://github.com/spring-projects/spring-framework/blob/4.3.x/spring-core/src/test/java/org/springframework/core/env/StandardEnvironmentTests.java#L492
     @SuppressWarnings("unchecked")
     static Map<String, String> getModifiableSystemEnvironment() {


### PR DESCRIPTION
## What

`Config.getProperty` resolves every key against the process environment from scratch on each call.

`findInSystemEnvironment` asks `resolvePropertyName` for the environment spelling of the key, and `checkPropertyName` probes `System.getenv` up to four times per casing — as-is, dots replaced with underscores, hyphens replaced with underscores, both replaced — then repeats the whole sequence against the uppercased key:

```java
private String checkPropertyName(String name) {
    if (containsKey(name)) return name;                       // containsKey == System.getenv(name) != null
    String noDotName = name.replace('.', '_');
    if (!name.equals(noDotName) && containsKey(noDotName)) return noDotName;
    String noHyphenName = name.replace('-', '_');
    ...
}
```

That is up to eight `getenv` probes and six intermediate strings per lookup, and the answer cannot change — the process environment is fixed for the lifetime of a config.

This memoizes the resolution per config instance, along with the token list a dotted key splits into:

```groovy
config.getProperty('grails.views.gsp.encoding', String)   // resolves the environment once
config.getProperty('grails.views.gsp.encoding', String)   // subsequent calls reuse it
```

Property **values** are not cached, so configuration mutated at runtime is still observed:

```groovy
config.getProperty('some.nested.value')          // 'original'
config.merge(['some.nested.value': 'updated'])
config.getProperty('some.nested.value')          // 'updated'
```

The cache is per-instance rather than static on purpose. `SystemEnvironmentConfigSpec` installs environment variables reflectively and then builds a fresh config, which must observe the environment as it stands at that point; a static cache would leak a stale answer across those specs.

## Why it matters

Callers resolve configuration inside render loops. On a scaffolded page rendering 100 rows, `FormFieldsTemplateService` (`getShouldCache`, `findTemplate`, `getTemplateFor`) and asset-pipeline resolve configuration per rendered property, so this sits on a hot path that scales with rows × properties.

## Measurements

| | before | after |
|---|---|---|
| `getProperty`, 2M lookups over a 4-key set | 355.3 ns/op | 91.6 ns/op |
| `NavigableMapConfig` share of JFR execution samples, 100-row scaffolded page under load | 7.01% | 1.16% |

## Limitations

- **End-to-end request latency improvement was not demonstrated.** The CPU work is measurably removed (both figures above), but on the machine used for this the run-to-run variance across JVM restarts was larger than the effect, so wall-clock A/B could not resolve it. The dominant remaining costs on that page are `ExpandoMetaClass` read-lock contention (~9–10% of samples) and reflective tag dispatch, neither of which this touches.
- The caches are bounded at 2048 entries each. Configuration keys come from a small fixed set of source literals; the bound only guards against a caller synthesising unbounded key strings at runtime.

## On the `@Deprecated` marker

`NavigableMapConfig` carries a class-level `@Deprecated` since #11554 (May 2020), pointing at `grails.config.Config`. That target is the *interface* this class implements, and no alternative implementation exists in the tree, so the note reads as "code against the interface" rather than "a replacement is available".

The class is on the live path today:

- `PropertySourcesConfig extends NavigableMapConfig` and is not itself deprecated.
- `AbstractGrailsApplication` builds a `PropertySourcesConfig`, so this is `grailsApplication.config` for every running application.
- Profiling a running 8.0.0-M5 application put `NavigableMapConfig` at 7.01% of execution samples, entered through `getProperty`.

If the `NavigableMap`-backed implementation is replaced, this change goes with it. It is offered as a cost reduction on the path applications actually execute for the six years the marker has been in place, and is easy to drop if a replacement is in flight.
