### PR TITLE
Support escaping a GSP expression with a backslash  \${}

### DIFF
--- a/grails-doc/src/en/guide/theWebLayer/gsp/GSPBasics/expressions.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/GSPBasics/expressions.adoc
@@ -30,4 +30,16 @@ In GSP the `<%= %>` syntax introduced earlier is rarely used due to the support 
 
 However, unlike JSP EL you can have any Groovy expression within the `${..}` block.
 
+A backslash immediately before an expression escapes it: the expression is not evaluated, and the page renders a literal `${..}` without the backslash. This matters most for JavaScript template literals, whose interpolation placeholders share the `${..}` syntax and would otherwise be evaluated on the server:
+
+[source,xml]
+----
+<script>
+    const name = 'Grails';
+    console.log(`Hello \${name}`);
+</script>
+----
+
+The browser receives the template literal with its `${name}` placeholder intact, to be interpolated by JavaScript. Only the backslash performing the escape is removed, and each expression must be escaped individually. Expressions in the attributes of GSP tags cannot be escaped this way.
+
 WARNING: Embedding data received from user input has the risk of making your application vulnerable to a Cross Site Scripting (XSS) attack. Please read the documentation under link:security.html#xssPrevention[XSS prevention] for information on how to prevent XSS attacks.

--- a/grails-gsp/core/build.gradle
+++ b/grails-gsp/core/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.slf4j:slf4j-nop' // Prevents warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 apply {

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageParser.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageParser.java
@@ -670,6 +670,9 @@ public class GroovyPageParser implements Tokens {
             return;
         }
 
+        // A \${ the scanner left in the text is an escaped expression: render a literal ${
+        text = text.replace("\\${", "${");
+
         // If we detect it is all whitespace, we need to keep it for later
         // If it is not whitespace, we need to flush any whitespace we do have
         boolean contentIsWhitespace = !NON_WHITESPACE_PATTERN.matcher(text).find();

--- a/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageScanner.java
+++ b/grails-gsp/core/src/main/groovy/org/grails/gsp/compiler/GroovyPageScanner.java
@@ -157,7 +157,7 @@ class GroovyPageScanner implements Tokens {
                             return foundStartOrEndTag(GEND_TAG, tagNameSpace.length() + 3, tagNameSpace);
                         }
                     }
-                    else if (isStartOfGExpression(c, c1)) {
+                    else if (isStartOfGExpression(c, c1) && !isEscapedGExpression()) {
                         return found(GEXPR, 2);
                     }
 
@@ -274,6 +274,17 @@ class GroovyPageScanner implements Tokens {
 
     private boolean isStartOfGExpression(char c, char c1) {
         return c == '$' && c1 == '{';
+    }
+
+    /**
+     * A backslash immediately before <code>${</code> escapes the expression in template text: the
+     * whole sequence stays in the surrounding HTML token, and {@link GroovyPageParser} drops the
+     * backslash when it writes the token out, so the page renders a literal <code>${</code>.
+     * Expressions in tag attributes are scanned in {@link Tokens#GSTART_TAG} state and cannot be
+     * escaped this way.
+     */
+    private boolean isEscapedGExpression() {
+        return end1 > 1 && text.charAt(end1 - 2) == '\\';
     }
 
     private boolean skipComment(char c3, char c4) {

--- a/grails-gsp/core/src/test/groovy/org/grails/gsp/GroovyPagesTemplateEngineTests.groovy
+++ b/grails-gsp/core/src/test/groovy/org/grails/gsp/GroovyPagesTemplateEngineTests.groovy
@@ -455,6 +455,64 @@ hello
     }
 
     @Test
+    void testEscapedExpressionRendersLiteralDollarBrace() {
+        def gpte = new GroovyPagesTemplateEngine()
+        gpte.afterPropertiesSet()
+
+        def t = gpte.createTemplate('Hello \\${foo}', "escaped_expression_test")
+        def w = t.make(foo: "World")
+
+        def sw = new StringWriter()
+        w.writeTo(new PrintWriter(sw))
+
+        assertEquals 'Hello ${foo}', sw.toString()
+    }
+
+    @Test
+    void testEscapedExpressionNextToEvaluatedExpression() {
+        def gpte = new GroovyPagesTemplateEngine()
+        gpte.afterPropertiesSet()
+
+        def t = gpte.createTemplate('${foo} \\${foo}', "escaped_and_evaluated_test")
+        def w = t.make(foo: "World")
+
+        def sw = new StringWriter()
+        w.writeTo(new PrintWriter(sw))
+
+        assertEquals 'World ${foo}', sw.toString()
+    }
+
+    @Test
+    void testEscapedExpressionInJavaScriptTemplateLiteral() {
+        def gpte = new GroovyPagesTemplateEngine()
+        gpte.afterPropertiesSet()
+
+        def t = gpte.createTemplate(
+                '<script>console.log(`Hello \\${name}`);</script>', "escaped_js_template_literal_test")
+        def w = t.make()
+
+        def sw = new StringWriter()
+        w.writeTo(new PrintWriter(sw))
+
+        assertEquals '<script>console.log(`Hello ${name}`);</script>', sw.toString()
+    }
+
+    @Test
+    void testBackslashBeforeEscapedExpressionIsPreserved() {
+        def gpte = new GroovyPagesTemplateEngine()
+        gpte.afterPropertiesSet()
+
+        // Only the backslash doing the escaping is dropped: \\${foo} renders \${foo}
+        def t = gpte.createTemplate('\\\\${foo}', "double_backslash_expression_test")
+        def w = t.make(foo: "World")
+
+        def sw = new StringWriter()
+        w.writeTo(new PrintWriter(sw))
+
+        assertEquals '\\${foo}', sw.toString()
+    }
+
+    @Test
     void testInlineScriptWithValidUnmatchedBrackets() {
         def gpte = new GroovyPagesTemplateEngine()
         gpte.afterPropertiesSet()

--- a/grails-gsp/core/src/test/groovy/org/grails/gsp/GspCompileStaticSpec.groovy
+++ b/grails-gsp/core/src/test/groovy/org/grails/gsp/GspCompileStaticSpec.groovy
@@ -174,6 +174,15 @@ out.print(messageClosure('World'))
         noExceptionThrown()
     }
 
+    def "an escaped expression is invisible to static compilation"() {
+        given:
+        def template = '''<%@ compileStatic="true"%>console.log(`Hello \\${undeclaredJsVariable}`);'''
+        when:
+        def rendered = renderTemplate(template, [:], true)
+        then:
+        rendered == 'console.log(`Hello ${undeclaredJsVariable}`);'
+    }
+
     def "should support multi-line model declaration"() {
         given:
         def template = '''<%@ model="""

--- a/grails-gsp/plugin/src/test/groovy/org/grails/gsp/compiler/ScanTests.java
+++ b/grails-gsp/plugin/src/test/groovy/org/grails/gsp/compiler/ScanTests.java
@@ -64,6 +64,39 @@ public class ScanTests {
     }
 
     @Test
+    public void testExpressionIsTokenized() {
+        GroovyPageScanner s = new GroovyPageScanner("a ${foo} b");
+        Assertions.assertEquals(Tokens.HTML, s.nextToken());
+        Assertions.assertEquals("a ", s.getToken());
+        Assertions.assertEquals(Tokens.GEXPR, s.nextToken());
+        Assertions.assertEquals("foo", s.getToken());
+        Assertions.assertEquals(Tokens.HTML, s.nextToken());
+        Assertions.assertEquals(" b", s.getToken());
+        Assertions.assertEquals(Tokens.EOF, s.nextToken());
+    }
+
+    @Test
+    public void testEscapedExpressionStaysInHtml() {
+        String gsp = "console.log(`Hello \\${name}`);";
+        GroovyPageScanner s = new GroovyPageScanner(gsp);
+        Assertions.assertEquals(Tokens.HTML, s.nextToken());
+        Assertions.assertEquals(gsp, s.getToken());
+        Assertions.assertEquals(Tokens.EOF, s.nextToken());
+    }
+
+    @Test
+    public void testEscapedAndUnescapedExpressionsSideBySide() {
+        GroovyPageScanner s = new GroovyPageScanner("\\${literal}${expr}");
+        Assertions.assertEquals(Tokens.HTML, s.nextToken());
+        Assertions.assertEquals("\\${literal}", s.getToken());
+        Assertions.assertEquals(Tokens.GEXPR, s.nextToken());
+        Assertions.assertEquals("expr", s.getToken());
+        Assertions.assertEquals(Tokens.HTML, s.nextToken());
+        Assertions.assertEquals("", s.getToken());
+        Assertions.assertEquals(Tokens.EOF, s.nextToken());
+    }
+
+    @Test
     public void testMaxHtmlLength() {
         String gsp = "0123456789ABCDEFGHIJK";
         GroovyPageScanner scanner = new GroovyPageScanner(gsp);


### PR DESCRIPTION
### Summary

A backslash immediately before a GSP expression now escapes it: `\${...}` renders a literal `${...}` with the backslash removed, instead of the expression being evaluated on the server.

GSP previously had no escape syntax at all — `\${x}` rendered a stray `\` followed by the evaluated expression. The motivating case is JavaScript template literals, whose interpolation placeholders share the `${}` syntax and are today either evaluated against the page binding (an unbound name silently renders as empty) or blow up the whole page render:

```html
<script>
    const name = 'Grails';
    console.log(`Hello \${name}`);
</script>
```

The browser now receives the template literal with its `${name}` placeholder intact, to be interpolated by JavaScript.

### Implementation

Escaping is resolved entirely at parse time, in two small pieces:

- `GroovyPageScanner` no longer starts an expression token when the `${` is immediately preceded by a backslash in template text — the sequence stays in the surrounding HTML token.
- `GroovyPageParser.html()` rewrites `\${` to `${` when writing the HTML token out.

Because this happens before code generation, behavior is identical in development, production, and `compileStatic` modes, and escaped text is invisible to static type checking — an escaped `${undeclaredName}` under `<%@ page compileStatic="true" %>` neither fails compilation nor evaluates (covered by a new test in `GspCompileStaticSpec`).

### Semantics

- Only the backslash performing the escape is removed: `\\${x}` renders `\${x}`.
- Each expression is escaped individually.
- Expressions in the attributes of GSP tags are scanned in a different lexer state and cannot be escaped this way.

### Also in this PR

`grails-gsp-core` declared `junit-jupiter-api` but never the Jupiter engine, so the JUnit Platform silently skipped every Jupiter-annotated test class in the module — all of `GroovyPagesTemplateEngineTests` (23 tests) never ran. Added the repo-standard `testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'`; all resurrected tests pass. The other engine-less modules with Jupiter tests (`grails-gsp/plugin`, `grails-gsp/grails-taglib`) receive the engine transitively and were already running them.

### Tests and docs

- `ScanTests`: escaped `${` stays in the HTML token; unescaped expressions still tokenize; mixed escaped/unescaped side by side.
- `GroovyPagesTemplateEngineTests`: literal render, escaped next to evaluated, JavaScript template literal end-to-end, double-backslash semantics.
- `GspCompileStaticSpec`: escaped expressions are invisible to static compilation.
- Guide: escaping documented in the GSP Basics "Expressions" section with the JavaScript template literal example.

Full `:grails-gsp-core:test` and `:grails-gsp:test` suites plus downstream `:grails-taglib`, `:grails-sitemesh3`, `:grails-layout`, and `:grails-web-gsp` all pass; `codeStyle` is clean on the touched modules.

https://claude.ai/code/session_01WtCxMe9pfmy7tiHCUr5THN
