### PR TITLE
build(test): stop test forks oversubscribing the machine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,14 @@ ext {
     // needing --rerun-tasks. Useful for repeatedly running the same test command while
     // chasing flaky tests across runs.
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
-    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: (isCiBuild ? 4 : Runtime.runtime.availableProcessors() * 3 / 4 as int ?: 1)
+    // availableProcessors() reports LOGICAL processors: SMT threads on x64, and on Apple silicon
+    // every efficiency core as well as every performance core. Taking 3/4 of that therefore
+    // asked for more concurrent Grails/Spring test JVMs than the machine has real capacity for
+    // (each fork also holds a 1G heap, and the mongodb, redis and geb suites start a Docker
+    // container per fork). Half is the conservative fraction. CI keeps its existing budget, so
+    // this does not reduce CI fork counts - though CI forks do see fewer processors, below.
+    configuredTestParallel = findProperty('maxTestParallel') as Integer ?:
+            (isCiBuild ? 4 : Math.max(1, (Runtime.runtime.availableProcessors() / 2) as int))
     excludeUnusedTransDeps = findProperty('excludeUnusedTransDeps')
 
     testProjectsStartWith = [
@@ -60,7 +67,47 @@ ext {
     profileProjects = [ /* Will be populated by subprojects loop below */]
 }
 
+/**
+ * Tells a forked test JVM how many processors it may size its GC and JIT thread pools from.
+ *
+ * Every forked JVM otherwise sizes those pools for the WHOLE machine, because no fork knows the
+ * others exist. On a 20-processor host that is 15 ParallelGCThreads + 4 ConcGCThreads + 12
+ * CICompilerCount = 31 threads per fork before a single test runs, so N concurrent forks become
+ * N*31 threads competing for the same cores. Gradle cannot see this: it charges each fork one
+ * worker lease, as though a fork were a single thread.
+ *
+ * The share is availableProcessors / maxWorkerCount, i.e. the BUILD-WIDE worker limit, because
+ * that - not any one task's maxParallelForks - is what bounds how many forks can run at once.
+ * With org.gradle.parallel=true, Test tasks from several projects execute concurrently, so a
+ * per-task share would still oversubscribe the machine.
+ *
+ * Supplied as an argument provider rather than through jvmArgs because several modules assign
+ * jvmArgs wholesale in their own build scripts, which would discard anything added here first.
+ */
+final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentProvider {
+
+    @Input
+    final int processorCount
+
+    ActiveProcessorCountArgumentProvider(int availableProcessorCount, int maxWorkerCount) {
+        // Floor of 2: at ActiveProcessorCount=1 HotSpot's ergonomics select Serial GC, which
+        // costs more on a 1G test heap than the contention it saves. Two keeps G1 with a
+        // bounded worker count.
+        this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
+    }
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-XX:ActiveProcessorCount=$processorCount".toString()]
+    }
+}
+
 subprojects {
+
+    tasks.withType(Test).configureEach { testTask ->
+        testTask.jvmArgumentProviders.add(new ActiveProcessorCountArgumentProvider(
+                Runtime.runtime.availableProcessors(), gradle.startParameter.maxWorkerCount))
+    }
 
     for (String testPrefix : testProjectsStartWith) {
         if (name.startsWith(testPrefix)) {

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,11 @@ final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentP
         // Floor of 2: at ActiveProcessorCount=1 HotSpot's ergonomics select Serial GC, which
         // costs more on a 1G test heap than the contention it saves. Two keeps G1 with a
         // bounded worker count.
+        //
+        // That floor also means -PmaxTestParallel=1 still advertises 2 processors to the
+        // single fork whenever maxWorkerCount is larger than availableProcessors/2 (the
+        // usual local case: org.gradle.parallel=true with no org.gradle.workers.max).
+        // It is not a "give the one fork the whole machine" switch.
         this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
     }
 

--- a/gradle/functional-test-config.gradle
+++ b/gradle/functional-test-config.gradle
@@ -170,7 +170,7 @@ tasks.withType(Test).configureEach { Test task ->
         showStackTraces = true
     }
     if (findProperty('testForked')) {
-        task.maxParallelForks = configuredTestParallel
+        task.maxParallelForks = rootProject.ext.configuredTestParallel
         task.forkEvery = (findProperty('testForkEvery') ?: 0)
     }
     if (findProperty('testJvmArgs')) {

--- a/gradle/mongodb-forked-test-config.gradle
+++ b/gradle/mongodb-forked-test-config.gradle
@@ -50,7 +50,7 @@ tasks.withType(Test).configureEach {
     }
 
     useJUnitPlatform()
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     jvmArgs = ['-Xmx768M']
     addTestListener([
         afterSuite: { desc, result ->

--- a/gradle/test-config.gradle
+++ b/gradle/test-config.gradle
@@ -83,7 +83,7 @@ tasks.withType(Test).configureEach {
         showStackTraces = true
     }
     excludes = ['**/*TestCase.class', '**/*$*.class']
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     maxHeapSize = isCiBuild ? '768m' : '1024m'
     forkEvery = hasProperty('forkEveryUnitTest') ? getProperty('forkEveryUnitTest') as long : (isCiBuild ? 50 : 100)
     if (System.getProperty('debug.tests')) {

--- a/grails-core/src/test/groovy/grails/util/ActiveProcessorCountForkTests.java
+++ b/grails-core/src/test/groovy/grails/util/ActiveProcessorCountForkTests.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package grails.util;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Asserts that {@code -XX:ActiveProcessorCount} from the root build's
+ * {@code jvmArgumentProviders} actually reaches this forked test JVM.
+ * Wholesale {@code jvmArgs = ...} assignments in module scripts would drop a
+ * flag added via {@code jvmArgs}, which is why the build uses a provider.
+ */
+class ActiveProcessorCountForkTests {
+
+    private static final String FLAG_PREFIX = "-XX:ActiveProcessorCount=";
+
+    @Test
+    void forkedTestJvmReceivesActiveProcessorCount() {
+        String flag = findActiveProcessorCountFlag();
+        assertNotNull(flag,
+                "forked test JVM must receive -XX:ActiveProcessorCount from jvmArgumentProviders");
+        int advertised = Integer.parseInt(flag.substring(FLAG_PREFIX.length()));
+        assertTrue(advertised >= 2, "floor is 2 so HotSpot keeps G1: " + advertised);
+        assertEquals(advertised, Runtime.getRuntime().availableProcessors(),
+                "HotSpot must honour the advertised processor count");
+    }
+
+    private static String findActiveProcessorCountFlag() {
+        List<String> args = ManagementFactory.getRuntimeMXBean().getInputArguments();
+        for (String arg : args) {
+            if (arg.startsWith(FLAG_PREFIX)) {
+                return arg;
+            }
+        }
+        return null;
+    }
+}

--- a/grails-data-neo4j/grails-datastore-gorm-neo4j/build.gradle
+++ b/grails-data-neo4j/grails-datastore-gorm-neo4j/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     forkEvery = 10
 
     jvmArgs = ['-Xmx1028M']

--- a/grails-forge/build.gradle
+++ b/grails-forge/build.gradle
@@ -42,6 +42,10 @@ ext {
     // needing --rerun-tasks. Useful for repeatedly running the same test command while
     // chasing flaky tests across runs.
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
+    // Mirror grails-gradle: honour -PmaxTestParallel, and cap CI forks so a 4-vCPU
+    // runner does not inherit the local "half the logical processors" formula.
+    configuredTestParallel = findProperty('maxTestParallel') as Integer ?:
+            (isCiBuild ? 3 : Math.max(1, (Runtime.runtime.availableProcessors() / 2) as int))
 }
 
 /** Caps each test fork's view of the machine. See the root build.gradle for the rationale. */
@@ -51,6 +55,8 @@ final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentP
     final int processorCount
 
     ActiveProcessorCountArgumentProvider(int availableProcessorCount, int maxWorkerCount) {
+        // Floor of 2 keeps G1. -PmaxTestParallel=1 still sees 2 processors when
+        // maxWorkerCount is the usual unrestricted local worker pool.
         this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
     }
 

--- a/grails-forge/build.gradle
+++ b/grails-forge/build.gradle
@@ -44,8 +44,24 @@ ext {
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
 }
 
+/** Caps each test fork's view of the machine. See the root build.gradle for the rationale. */
+final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentProvider {
+
+    @Input
+    final int processorCount
+
+    ActiveProcessorCountArgumentProvider(int availableProcessorCount, int maxWorkerCount) {
+        this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
+    }
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-XX:ActiveProcessorCount=$processorCount".toString()]
+    }
+}
+
 allprojects {
-    tasks.withType(Test).configureEach { Task testTask ->
+    tasks.withType(Test).configureEach { testTask ->
         testTask.dependsOn(
                 gradle.includedBuild('grails-core').task(':publishAllPublicationsToTestCaseMavenRepoRepository'),
                 gradle.includedBuild('grails-gradle').task(':publishAllPublicationsToTestCaseMavenRepoRepository')
@@ -55,6 +71,8 @@ allprojects {
         // without --rerun-tasks (and without recompiling everything else).
         testTask.outputs.cacheIf { !doNotCacheTests }
         testTask.outputs.upToDateWhen { !doNotCacheTests }
+        testTask.jvmArgumentProviders.add(new ActiveProcessorCountArgumentProvider(
+                Runtime.runtime.availableProcessors(), gradle.startParameter.maxWorkerCount))
     }
 }
 

--- a/grails-forge/gradle/test-config.gradle
+++ b/grails-forge/gradle/test-config.gradle
@@ -49,7 +49,7 @@ tasks.withType(Test).configureEach {
     jvmArgs('-Duser.country=US', '-Duser.language=en',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED')
     forkEvery = 100
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     maxHeapSize = '2G'
 
     useJUnitPlatform()

--- a/grails-forge/gradle/test-config.gradle
+++ b/grails-forge/gradle/test-config.gradle
@@ -49,9 +49,7 @@ tasks.withType(Test).configureEach {
     jvmArgs('-Duser.country=US', '-Duser.language=en',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED')
     forkEvery = 100
-    // Honour -PmaxTestParallel here too, so the override behaves the same in all three builds.
-    maxParallelForks = findProperty('maxTestParallel') as Integer ?:
-            (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+    maxParallelForks = configuredTestParallel
     maxHeapSize = '2G'
 
     useJUnitPlatform()

--- a/grails-forge/gradle/test-config.gradle
+++ b/grails-forge/gradle/test-config.gradle
@@ -49,7 +49,9 @@ tasks.withType(Test).configureEach {
     jvmArgs('-Duser.country=US', '-Duser.language=en',
             '--add-opens', 'java.base/java.lang=ALL-UNNAMED')
     forkEvery = 100
-    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    // Honour -PmaxTestParallel here too, so the override behaves the same in all three builds.
+    maxParallelForks = findProperty('maxTestParallel') as Integer ?:
+            (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
     maxHeapSize = '2G'
 
     useJUnitPlatform()

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/ActiveProcessorCountForkSpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/ActiveProcessorCountForkSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.forge
+
+import java.lang.management.ManagementFactory
+
+import spock.lang.Specification
+
+class ActiveProcessorCountForkSpec extends Specification {
+
+    private static final String FLAG_PREFIX = '-XX:ActiveProcessorCount='
+
+    void 'forked test JVM receives ActiveProcessorCount from jvmArgumentProviders'() {
+        given:
+        String flag = ManagementFactory.runtimeMXBean.inputArguments.find { it.startsWith(FLAG_PREFIX) }
+
+        expect:
+        flag != null
+        int advertised = Integer.parseInt(flag.substring(FLAG_PREFIX.length()))
+        advertised >= 2
+        Runtime.runtime.availableProcessors() == advertised
+    }
+}

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -60,6 +60,8 @@ final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentP
     final int processorCount
 
     ActiveProcessorCountArgumentProvider(int availableProcessorCount, int maxWorkerCount) {
+        // Floor of 2 keeps G1. -PmaxTestParallel=1 still sees 2 processors when
+        // maxWorkerCount is the usual unrestricted local worker pool.
         this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
     }
 

--- a/grails-gradle/build.gradle
+++ b/grails-gradle/build.gradle
@@ -47,7 +47,33 @@ ext {
     // needing --rerun-tasks. Useful for repeatedly running the same test command while
     // chasing flaky tests across runs.
     doNotCacheTests = System.getenv('DO_NOT_CACHE_TESTS')?.toBoolean()
-    configuredTestParallel = findProperty('maxTestParallel') as Integer ?: (isCiBuild ? 3 : Runtime.runtime.availableProcessors() * 3/4 as int ?: 1)
+    // Half the LOGICAL processors, not 3/4. This separate Gradle build mirrors the root
+    // build.gradle - see it for the full rationale. CI keeps its existing budget.
+    configuredTestParallel = findProperty('maxTestParallel') as Integer ?:
+            (isCiBuild ? 3 : Math.max(1, (Runtime.runtime.availableProcessors() / 2) as int))
+}
+
+/** Caps each test fork's view of the machine. See the root build.gradle for the rationale. */
+final class ActiveProcessorCountArgumentProvider implements CommandLineArgumentProvider {
+
+    @Input
+    final int processorCount
+
+    ActiveProcessorCountArgumentProvider(int availableProcessorCount, int maxWorkerCount) {
+        this.processorCount = Math.max(2, (availableProcessorCount / Math.max(1, maxWorkerCount)) as int)
+    }
+
+    @Override
+    Iterable<String> asArguments() {
+        ["-XX:ActiveProcessorCount=$processorCount".toString()]
+    }
+}
+
+subprojects {
+    tasks.withType(Test).configureEach { testTask ->
+        testTask.jvmArgumentProviders.add(new ActiveProcessorCountArgumentProvider(
+                Runtime.runtime.availableProcessors(), gradle.startParameter.maxWorkerCount))
+    }
 }
 
 apply {

--- a/grails-gradle/gradle/test-config.gradle
+++ b/grails-gradle/gradle/test-config.gradle
@@ -59,7 +59,7 @@ tasks.withType(Test).configureEach {
         showStackTraces = true
     }
     excludes = ['**/*TestCase.class', '**/*$*.class']
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     maxHeapSize = isCiBuild ? '768m' : '1024m'
     if (System.getProperty('debug.tests')) {
         jvmArgs += debugArguments

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/ActiveProcessorCountForkSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/ActiveProcessorCountForkSpec.groovy
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.grails.gradle.plugin.core
+
+import java.lang.management.ManagementFactory
+
+import spock.lang.Specification
+
+class ActiveProcessorCountForkSpec extends Specification {
+
+    private static final String FLAG_PREFIX = '-XX:ActiveProcessorCount='
+
+    void 'forked test JVM receives ActiveProcessorCount from jvmArgumentProviders'() {
+        given:
+        String flag = ManagementFactory.runtimeMXBean.inputArguments.find { it.startsWith(FLAG_PREFIX) }
+
+        expect:
+        flag != null
+        int advertised = Integer.parseInt(flag.substring(FLAG_PREFIX.length()))
+        advertised >= 2
+        Runtime.runtime.availableProcessors() == advertised
+    }
+}

--- a/grails-test-suite-persistence/build.gradle
+++ b/grails-test-suite-persistence/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 }
 
 test {
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     forkEvery = isCiBuild ? 25 : 100
     if(!isCiBuild) {
         maxHeapSize = '2048m'

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -130,7 +130,7 @@ tasks.withType(Test).configureEach {
 
     onlyIf { !testSkippingProperties.any {project.hasProperty(it) } }
     useJUnitPlatform()
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     forkEvery = isCiBuild ? 50 : 100
     maxHeapSize = isCiBuild ? '768m' : '1024m'
     jvmArgs('--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED')

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -122,11 +122,6 @@ isolatedTestPatterns.keySet().each { taskName ->
     }
 }
 
-tasks.named('isolatedTestsTwo', Test) {
-    maxParallelForks = 1
-    forkEvery = 100
-}
-
 tasks.withType(Test).configureEach {
     // Honor DO_NOT_CACHE_TESTS=1 so developers can repeatedly invoke the same test command
     // without --rerun-tasks (and without recompiling everything else).
@@ -139,6 +134,14 @@ tasks.withType(Test).configureEach {
     forkEvery = isCiBuild ? 50 : 100
     maxHeapSize = isCiBuild ? '768m' : '1024m'
     jvmArgs('--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED')
+}
+
+// Must be configured AFTER the tasks.withType(Test) block above. Both are deferred
+// configuration actions and Gradle runs them in registration order, so a tasks.named
+// block registered first would be silently overwritten by the later configureEach.
+tasks.named('isolatedTestsTwo', Test) {
+    maxParallelForks = 1
+    forkEvery = 100
 }
 
 tasks.named('test', Test) {

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 }
 
 def defaultTestConfig = {
-    maxParallelForks = configuredTestParallel
+    maxParallelForks = rootProject.ext.configuredTestParallel
     forkEvery = isCiBuild ? 50 : 100
     excludes = ['**/*TestCase.class', '**/*$*.class']
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD033 MD041 -->

## The problem

A plain `./gradlew build` can leave a developer's workstation unusable. Observed on a 14-core / 20-thread machine: **23 JVMs, 12.4 GB**, with the desktop unresponsive.

Three multipliers stack, and each looks reasonable on its own.

**1. `availableProcessors()` counts logical processors.** SMT threads on x64, and on Apple silicon every efficiency core as well as every performance core. `* 3 / 4` of that is already measured against an inflated number - 15 forks on a 14-core host, and on an M-series Mac most of those forks land on efficiency cores.

**2. `maxParallelForks` is per Test task.** With `org.gradle.parallel=true`, several test-bearing modules run concurrently, so the real ceiling is Gradle's worker-lease pool (`--max-workers`, default = `availableProcessors`), not any single task's fork count.

**3. Each forked JVM sizes its own thread pools for the whole machine**, because no fork knows the others exist. Measured on JDK 21 at 20 visible processors:

| Setting | Value |
|---|---:|
| `ParallelGCThreads` | 15 |
| `ConcGCThreads` | 4 |
| `CICompilerCount` | 12 |
| **Total per fork** | **31** |

That is 31 threads per fork *before a single test runs*. Gradle cannot see it: it charges each fork **one worker lease**, as though a fork were a single thread. Gradle's own default for `Test.maxParallelForks` is **1** for precisely this reason - raising it opts out of the protection Gradle already provides.

15 forks x 31 threads is roughly **465 threads contending for 20 hardware threads**, plus 15 x 1 GB heaps (2 GB in `grails-test-suite-persistence`) against a 5 GB daemon. That is the thrashing.

### The oversubscription ratio scales with the machine

This is why the problem is felt on workstations and barely registers on CI. Each concurrent fork sizes its pools for every visible processor, so the "virtual processors" a build demands is *forks x visible processors*, against however many the host actually has:

| Host | Concurrent forks | Visible procs per fork | Virtual : real |
|---|---:|---:|---:|
| 20-thread workstation, before | up to 20 | 20 | **20x** |
| 4-vCPU CI runner, before | 4 | 4 | 4x |
| Any host, after this change | unchanged | 2 | **2x** |

The change normalises every host to roughly 2x. The benefit is therefore proportional to how oversubscribed the host was to begin with: dramatic on a large developer machine, modest on a small CI runner.

## The change

Applied to all three builds in this repository - root, `grails-gradle` and `grails-forge` each have their own `settings.gradle`, so the duplication is unavoidable.

1. **Local test forks: 3/4 of the logical processors → half.** CI keeps its existing budget (`isCiBuild ? 4` in root, `? 3` in `grails-gradle` and now also in `grails-forge`).
2. **Every test fork is told how many processors it may size its pools from**, as `availableProcessors / maxWorkerCount`, floored at 2. The denominator is the **build-wide** worker limit rather than any one task's `maxParallelForks`, because that is what actually bounds how many forks run at once. A floor of 2 keeps G1 rather than dropping to Serial GC. That also means `-PmaxTestParallel=1` still advertises 2 processors to the single fork when `maxWorkerCount` is the usual unrestricted local pool; it is not a "give the one fork the whole machine" switch.

Supplied via `jvmArgumentProviders` rather than `jvmArgs`, because several modules assign `jvmArgs` wholesale and would discard it.

Also fixes `grails-forge`, where `-PmaxTestParallel` was silently ignored.

## Measured result

### Full build

This is the workload the PR exists for. `DO_NOT_CACHE_TESTS=1 ./gradlew build --continue --profile --console=plain`, on a 14-core / 20-thread i7-12800H with 63.7 GB, Gradle daemons stopped before each run, and the **treatment run first** so that filesystem-cache warmth works *against* the change:

| | Baseline (`b964e60`) | This branch (`13c9641`) | Change |
|---|---:|---:|---:|
| Wall clock | 1h 14m 51s | **49m 35s** | **33.7% faster** |
| Peak live threads | 2,739 | **1,967** | **-28.2%** |
| Peak working set | 31.1 GB | **25.2 GB** | **-18.8%** |
| Peak JVMs | 30 | 32 | +2 |
| Actionable tasks executed | 593 / 2977 | 565 / 2976 | baseline +28 |

Thread and memory figures here are **live samples** taken every 2 seconds for the duration of each build, not projections.

**Peak JVM count barely moves, and that is the expected result.** With `org.gradle.parallel=true` and no `org.gradle.workers.max`, the number of concurrent forks is bounded by the worker-lease pool, not by any single task's `maxParallelForks`; lowering 15 → 10 mostly just frees leases for other modules to take. What changes is the thread count *inside* each fork. 1,967 versus 2,739 live threads against 20 hardware threads is essentially the whole effect.

The `--profile` reports confirm where the time goes: **83% of the reduction in task time is in `test` / `integrationTest` tasks.**

| Task | Baseline | This branch | Change |
|---|---:|---:|---:|
| `:grails-data-hibernate7-core:test` | 1h 01m 54s | 19m 07s | **-69.1%** |
| `:grails-fields:test` | 20m 40s | 10m 40s | -48.4% |
| `:grails-gsp:test` | 25m 08s | 14m 24s | -42.7% |
| `:grails-datamapping-core-test:test` | 22m 34s | 14m 00s | -37.9% |
| `:grails-datamapping-support:test` | 16m 09s | 12m 03s | -25.3% |
| `:grails-datastore-core:test` | 15m 33s | 13m 28s | -13.4% |
| `:grails-data-mongodb-core:test` | 23m 10s | 23m 39s | +2.1% |

Aggregate `test` + `integrationTest` task time fell from 21h 07m to 13h 57m. These are per-task wall-clock times in a parallel build, so they overlap and sum to far more than the elapsed time; treat them as a relative indicator.

Caveats, stated plainly:

- n = 1 per arm. The direction and rough magnitude are not in doubt; the exact percentage is a single sample.
- The baseline executed 28 more tasks and roughly 4m 35s more `groovydoc` / `javadoc` work, so of the 25-minute gap perhaps 4-5 minutes is task-set and cache-state noise rather than this change.
- Peak JVM counts include unrelated JVMs running on the machine, so the deltas are meaningful and the absolute counts are not.
- Both runs ended `exit 1` on flaky integration tests, `:grails-test-examples-mail:integrationTest` in both. With `--continue` neither build was shortened by them.

### Single module

`:grails-core:test --rerun-tasks`, daemons stopped between runs, comparing second runs:

| Order | Baseline | This branch | Change |
|---|---:|---:|---:|
| baseline first | 3m 25s | 2m 45s | **19.5% faster** |
| treatment first | 3m 05s | 2m 24s | **22.2% faster** |

Running this branch **first** rules out filesystem-cache ordering bias - the advantage held in both directions.

A single module *understates* the effect. With only one `Test` task in flight there is no cross-module contention to remove, so this measures little more than the fork-count reduction:

| | Baseline | This branch |
|---|---:|---:|
| Forks | 15 | 10 |
| `ActiveProcessorCount` | 20 (default) | 2 |
| Threads per fork | 31 | 5 |
| Projected total threads | ~465 | ~50 |
| Peak JVMs | 29 | 24 |

Per-fork thread figures are a computed projection from `java -XX:+PrintFlagsFinal -version`, not a live thread count.

## Second commit: `isolatedTestsTwo` was not actually isolated

`grails-test-suite-uber/build.gradle` set `maxParallelForks = 1` on `isolatedTestsTwo`, but registered that block **before** the `tasks.withType(Test).configureEach` block in the same script. Gradle runs both as deferred configuration actions in registration order, so the later `configureEach` overwrote it and the task ran fully parallel. Its test patterns have been deliberately serialized since 2013 because they are order sensitive.

Moving the override after the `configureEach` block fixes it. CI impact is negligible: the task filters three classes and sharding assigns it to a single shard.

## Third commit: prove the flag lands, and cap forge CI forks

`0f5f5b653a` adds a forked-JVM assertion in each of the three builds. The test reads `ManagementFactory.getRuntimeMXBean().getInputArguments()` and fails if `-XX:ActiveProcessorCount` is missing, and checks that `Runtime.availableProcessors()` equals the advertised count. That is the regression that would catch a future wholesale `jvmArgs = ...` assignment swallowing the provider.

Those tests passed locally:

- `:grails-core:test --tests grails.util.ActiveProcessorCountForkTests`
- `grails-gradle`: `:grails-gradle-plugins:test --tests org.grails.gradle.plugin.core.ActiveProcessorCountForkSpec`
- `grails-forge`: `:grails-forge-core:test --tests org.grails.forge.ActiveProcessorCountForkSpec`

`grails-forge` now uses the same `configuredTestParallel` formula as `grails-gradle` (`isCiBuild ? 3`, otherwise half the logical processors, still honouring `-PmaxTestParallel`). Previously forge always used `processors.intdiv(2)` with no CI cap.

## Measuring this on CI

Baseline for `gradle.yml` on `8.0.x`: **median 2h 14m, p90 3h 52m**, with core build jobs at 1h 20m - 1h 40m. Draft PRs do trigger the workflow, so this PR's own run is the measurement.

CI fork counts are unchanged on root and `grails-gradle`, so the only variable on those jobs is the per-fork processor cap: on a 4-vCPU runner each of the 4 forks goes from seeing 4 processors to seeing 2. Per the ratio table above that is 4x oversubscription down to 2x, against 20x down to 2x locally. **CI is therefore expected to show a much smaller effect than the local full-build numbers, and one that is easily buried by runner variance** - which is what the two samples collected so far look like.

**Windows JDK 25 shard 0** was slower in both samples (+23.7%, +25.3%). That job is not comparable to shards 1 and 2: it runs `build :grails-shell-cli:installDist groovydoc` plus shard 0 tests, while shards 1 and 2 run only `testShard`. `groovydoc` and `installDist` run in the **Gradle daemon**, which does not receive `-XX:ActiveProcessorCount`, so those extra tasks cannot be attributed to the processor cap. The remaining plausible causes are Windows cache-writer variance plus the shard 0 *tests* seeing 2 processors instead of 4. That is not a reason to revert the cap: it is the expected cost of the 4x → 2x change on the least contention-bound job in the matrix. Worth watching on the next CI run of this commit, not a blocker.

## Follow-ups, deliberately not in this PR

- **A memory budget.** An earlier revision budgeted forks against physical RAM, but a per-task budget cannot bind build-wide, so it was removed rather than shipped as a guarantee it could not keep. Bounding aggregate memory needs `org.gradle.workers.max` or a shared `BuildService`.
- **A 5 GB Gradle daemon on a 7 GB macOS runner** (GitHub's macOS runners are 3 vCPU / 7 GB, versus 4 vCPU / 16 GB on Linux and Windows) is already marginal and worth revisiting separately.
- **Testcontainers multiply with forks.** The Mongo, Redis and forked Geb suites hold containers in per-JVM statics with no `withReuse`, so N forks means N containers - and on macOS and Windows that memory comes from a Docker Desktop VM the JVM cannot see.
- **`grails-gradle` and `grails-forge` have not been benchmarked.** They are separate builds; the full-build numbers above cover the root build only.
