### PR TITLE
build(test): size the test fork heap from an explicit budget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,77 @@ ext {
     // this does not reduce CI fork counts - though CI forks do see fewer processors, below.
     configuredTestParallel = findProperty('maxTestParallel') as Integer ?:
             (isCiBuild ? 4 : Math.max(1, (Runtime.runtime.availableProcessors() / 2) as int))
+    // Forked test JVMs are children of the daemon, so org.gradle.jvmargs does not limit their
+    // heaps - each one claimed a flat 1G locally no matter how much memory the machine had.
+    // Size them from a budget instead: physical memory, less the daemon's own heap, halved to
+    // leave room for the OS, the compiler workers and the Docker containers the mongodb, redis
+    // and geb suites start per fork, then split across the forks that can be alive at once.
+    //
+    // An explicit -PtestForkHeapMb wins everywhere, mirroring -PmaxTestParallel above, and CI
+    // keeps its measured 768m. Both of those settle the value WITHOUT running the probe below,
+    // so the CI path stays trivially neutral and does no fallible work.
+    def resolvedTestForkHeapMb = findProperty('testForkHeapMb') as Integer
+    if (resolvedTestForkHeapMb != null && resolvedTestForkHeapMb < 768) {
+        // Reject rather than silently clamp: the property promises an exact value, so quietly
+        // substituting a different one would be worse than refusing. Below 768 the forks that
+        // GrailsGradlePlugin gives minHeapSize = 768m would start as -Xms768m -Xmx<less>, which
+        // the JVM rejects outright - a confusing failure at test time instead of here.
+        throw new GradleException(
+                "-PtestForkHeapMb must be at least 768 (got ${resolvedTestForkHeapMb}). Grails test " +
+                        'tasks are given minHeapSize = 768m, so a smaller maximum produces an ' +
+                        'unstartable JVM. To use less memory overall, lower the fork count with ' +
+                        '-PmaxTestParallel or --max-workers instead.')
+    }
+    if (resolvedTestForkHeapMb == null && isCiBuild) {
+        resolvedTestForkHeapMb = 768
+    }
+    if (resolvedTestForkHeapMb == null) {
+        // This script runs IN the daemon, so the daemon's own max heap is simply its runtime
+        // value. Reading it beats parsing org.gradle.jvmargs, which may carry several -Xmx
+        // options (the JVM honours the LAST) or a unit a regex would miss.
+        long daemonMaxHeapMb = (Runtime.runtime.maxMemory() / (1024L * 1024L)) as long
+        long totalPhysicalMemoryMb = 0L
+        try {
+            def operatingSystemMxBean = java.lang.management.ManagementFactory.operatingSystemMXBean
+            if (operatingSystemMxBean instanceof com.sun.management.OperatingSystemMXBean) {
+                totalPhysicalMemoryMb =
+                        ((operatingSystemMxBean as com.sun.management.OperatingSystemMXBean).totalMemorySize / (1024L * 1024L)) as long
+            }
+        } catch (Exception | LinkageError ignored) {
+            // A non-HotSpot JVM, a restricted management bean, or a module-access denial (which
+            // surfaces as an Error, not an Exception) leaves the previous fixed default below.
+        }
+        // Budget against the BUILD-WIDE worker count, never a per-task fork cap. With
+        // org.gradle.parallel=true several Test tasks each start forks until the shared worker
+        // pool is full, so a build with four tasks capped at two forks apiece still runs up to
+        // maxWorkerCount forks at once. Budgeting off the smaller number would hand every fork
+        // a heap the machine cannot actually honour - the same bound, and the same reasoning,
+        // as ActiveProcessorCountArgumentProvider below.
+        int concurrentTestForks = Math.max(1, gradle.startParameter.maxWorkerCount)
+        if (totalPhysicalMemoryMb <= 0L) {
+            // The probe did not run or told us nothing, so there is no budget to compute -
+            // keep the value this build used before rather than guess from a missing number.
+            resolvedTestForkHeapMb = 1024
+        } else {
+            // A machine whose whole RAM is inside the daemon's own heap yields a non-positive
+            // remainder. That is a real reading, not a failed probe, so it must NOT fall back
+            // to the old 1G: give those forks the floor instead.
+            long forkBudgetMb = Math.max(0L, totalPhysicalMemoryMb - daemonMaxHeapMb) / 2L
+            // The floor is 768m, not something smaller, for two reasons. It is the value CI
+            // already runs, so it is known to carry these suites. And GrailsGradlePlugin gives
+            // every Grails Test task minHeapSize = 768m when nothing else has set one, so a
+            // smaller maximum here would hand those forks -Xms768m -Xmx<less>, which the JVM
+            // rejects outright before a single test runs.
+            //
+            // That floor wins whenever the computed share falls below it, so on a host with
+            // many workers and little memory the forks together still exceed this budget. Heap
+            // alone cannot fix that; the knob that has to come down there is the FORK COUNT
+            // (-PmaxTestParallel, or --max-workers which bounds them build-wide). This budget
+            // lowers memory pressure, it does not by itself prove a constrained machine fits.
+            resolvedTestForkHeapMb = Math.min(1024, Math.max(768, (forkBudgetMb / concurrentTestForks) as int))
+        }
+    }
+    testForkHeapMb = resolvedTestForkHeapMb
     excludeUnusedTransDeps = findProperty('excludeUnusedTransDeps')
 
     testProjectsStartWith = [

--- a/gradle/test-config.gradle
+++ b/gradle/test-config.gradle
@@ -84,7 +84,16 @@ tasks.withType(Test).configureEach {
     }
     excludes = ['**/*TestCase.class', '**/*$*.class']
     maxParallelForks = rootProject.ext.configuredTestParallel
-    maxHeapSize = isCiBuild ? '768m' : '1024m'
+    // Test forks are child JVMs, not the Gradle daemon. The root build sizes their explicit
+    // per-fork memory budget from the worker-pool bound shared by parallel Test tasks.
+    //
+    // Not every Test task in this build honours it. gradle/mongodb-test-config.gradle and
+    // gradle/mongodb-forked-test-config.gradle ASSIGN jvmArgs wholesale with their own -Xmx,
+    // which beats maxHeapSize outright, and grails-test-suite-persistence sets a deliberate
+    // 2048m. Those are left exactly as they are here on purpose: folding them in would change
+    // CI heaps, and this change is deliberately CI-neutral. Unifying them is a follow-up that
+    // needs its own measurement.
+    maxHeapSize = "${rootProject.ext.testForkHeapMb}m"
     forkEvery = hasProperty('forkEveryUnitTest') ? getProperty('forkEveryUnitTest') as long : (isCiBuild ? 50 : 100)
     if (System.getProperty('debug.tests')) {
         jvmArgs += debugArguments

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -132,7 +132,11 @@ tasks.withType(Test).configureEach {
     useJUnitPlatform()
     maxParallelForks = rootProject.ext.configuredTestParallel
     forkEvery = isCiBuild ? 50 : 100
-    maxHeapSize = isCiBuild ? '768m' : '1024m'
+    // Same per-fork budget as the tasks using the shared test configuration (see the root
+    // build.gradle; the mongodb configs and persistence keep documented exceptions). This suite
+    // carried its own copy of the old 768m/1024m literal, which would have exempted the
+    // heaviest suite in the build from the budget meant to keep forks within the machine.
+    maxHeapSize = "${rootProject.ext.testForkHeapMb}m"
     jvmArgs('--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED')
 }
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #16158 - this branch is based on it, so review that one first. The diff here is only the heap change.

## What

Replace the hardcoded per-fork test heap with an explicit budget derived from the machine.

`gradle/test-config.gradle` has always said:

```groovy
maxHeapSize = isCiBuild ? '768m' : '1024m'
```

Those literals ignore the machine. Every forked test JVM claimed a gigabyte locally no matter how much RAM the developer actually had, and nothing tied that number to how many forks could be alive at once.

## The bound

Forked test JVMs are children of the daemon, so `org.gradle.jvmargs` does not limit them. With `org.gradle.parallel=true` several `Test` tasks run concurrently, so the live fork count is bounded by Gradle's **build-wide worker pool** (`maxWorkerCount`), not by any one task's `maxParallelForks`. A build with four tasks capped at two forks apiece still runs up to `maxWorkerCount` forks at once, so budgeting off the per-task cap would hand every fork a heap the machine cannot honour.

This is the same bound - and the same reasoning - that `ActiveProcessorCountArgumentProvider` already uses for CPU count a few lines below in `build.gradle`. This PR applies it to memory.

The budget: physical RAM, minus the daemon's own heap, halved to leave room for the OS, the compiler workers (`-Xmx2G` each via `CompilePlugin`) and the Docker containers the mongodb/redis/geb suites start per fork, divided by the worker count, clamped to `[512, 1024]`.

The daemon heap is read from `Runtime.runtime.maxMemory()` rather than parsed out of `org.gradle.jvmargs` - the build script runs *in* the daemon, so this sidesteps multiple `-Xmx` options (the JVM honours the last) and unit-parsing entirely.

## CI is unchanged, by construction

On CI the value is still exactly `768`. This is load-bearing: the PR makes the policy explicit and fixes **local** overcommit only. Changing CI numbers belongs in a later, measured PR - mixing them here would make any CI flake impossible to attribute ("was it the heap or the CPU cap?").

Both `-PtestForkHeapMb` and `isCiBuild` settle the value *before* the probe runs, so the CI path performs no fallible work at all.

## Measured

Real resolved `Test` task properties, captured with a throwaway init script (since deleted), not hand arithmetic:

| Scenario | workers | forks | `maxHeapSize` |
|---|---|---|---|
| local (64 GB, `-Xmx5G` daemon) | 20 | 10 | `1024m` (ceiling) |
| `CI=true` | 20 | 4 | **`768m`** |
| `CI=true -PmaxTestParallel=4` | 20 | 4 | **`768m`** |
| `-PtestForkHeapMb=900` | 20 | 10 | `900m` |
| `CI=true -PtestForkHeapMb=900` | 20 | 4 | `900m` |
| local `--max-workers=64` | 64 | 10 | `512m` (floor) |

Verified on both `grails-core:test` and `grails-test-suite-uber:test`.

## grails-test-suite-uber

That module carried its **own copy** of the same `768m`/`1024m` literal and never applied `gradle/test-config.gradle`, so the heaviest suite in the build would have been the one module exempt from the budget. It now reads the same property. `grails-test-suite-persistence` keeps its deliberate `2048m` - that is a specialized limit, not a copy-paste default.

## Known limit (deliberately not papered over)

When the computed share falls below the 512m floor, the floor wins and the forks collectively still exceed the budget. Heap alone cannot fix that: a fork below ~512m cannot run these suites. The knob that has to come down on such a host is the **fork count** (`-PmaxTestParallel`, or `--max-workers` which bounds them build-wide). This budget lowers memory pressure; it does not by itself prove a constrained machine fits. The code says so where it clamps.

## Why draft

The constants are judgement calls, not measurements, and I would rather agree the policy than defend the numbers:

- Is `512` a safe floor for the heaviest suites, or should the fork count drop instead once the share falls that low?
- Should the reserve be "half the remainder", or should the `-Xmx2G` compiler workers be subtracted explicitly?

## Scope

- Root build only. `grails-gradle` and `grails-forge` are separate Gradle builds with their own daemon settings, their own `configuredTestParallel` and their own heap literals - deliberately a follow-up, not silent collateral.
- No test is added, removed, skipped or weakened. Heap sizing does not change test selection.
- Reading physical RAM degrades safely: a failed probe keeps the previous `1024`, and a *successful* probe on a machine whose RAM sits inside the daemon heap drops to the floor rather than pretending the probe failed.

## Verification

- `./gradlew help` - EXIT 0
- `CI=true ./gradlew help -PmaxTestParallel=4` - EXIT 0
- `./gradlew help -PtestForkHeapMb=900` - EXIT 0
- `./gradlew validateActions` - EXIT 0

## Related

Follow-up to #16158 (CPU oversubscription) and #16167 (daemon heap vs runner RAM). Three separate knobs, deliberately three separate PRs: CPU, daemon heap, fork heap.
