### PR TITLE
feat!: make callsite caching the default and publish invokedynamic under a classifier

### DIFF
--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
@@ -55,6 +55,7 @@ class CompilePlugin implements Plugin<Project> {
         configureJars(project)
         configureCompiler(project)
         configureReproducible(project)
+        IndyVariants.configure(project)
     }
 
     private static void configureJavaVersion(Project project) {

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/CompilePlugin.groovy
@@ -84,8 +84,12 @@ class CompilePlugin implements Plugin<Project> {
                     'Implementation-Version': lookupPropertyByType(project, 'grailsVersion', String),
                     'Implementation-Vendor': 'grails.apache.org'
             )
-            // Explicitly fail since duplicates indicate a double configuration that needs fixed
-            jar.duplicatesStrategy = DuplicatesStrategy.FAIL
+            if (jar.name != IndyVariants.INDY_JAR_TASK_NAME) {
+                // Explicitly fail since duplicates indicate a double configuration that needs fixed.
+                // The indy jar is the exception: it deliberately layers its own Groovy classes over
+                // a copy of the main jar and drops the duplicates that produces.
+                jar.duplicatesStrategy = DuplicatesStrategy.FAIL
+            }
         }
     }
 
@@ -104,6 +108,11 @@ class CompilePlugin implements Plugin<Project> {
 
         project.plugins.withId('groovy') {
             project.tasks.withType(GroovyCompile).configureEach {
+                if (it.name != IndyVariants.INDY_COMPILE_TASK_NAME) {
+                    // The main artifact of every published module is the callsite-caching flavour;
+                    // IndyVariants supplies the invokedynamic one under a classifier.
+                    it.groovyOptions.optimizationOptions.put('indy', false)
+                }
                 // encoding needs to be the same since it's different across platforms
                 it.groovyOptions.encoding = StandardCharsets.UTF_8.name()
                 // Preserve method parameter names in Groovy/Java classes for IDE parameter hints & bean reflection metadata.

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
@@ -23,6 +23,9 @@ import groovy.transform.CompileStatic
 
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
@@ -38,8 +41,8 @@ import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.jvm.toolchain.JavaToolchainService
 
 /**
- * Publishes every Groovy module of the framework twice: the default artifact compiled with Groovy's
- * own {@code invokedynamic} default, and a {@code noindy} classifier artifact compiled without it.
+ * Publishes every Groovy module of the framework twice: the main artifact compiled with
+ * {@code invokedynamic} disabled, and an {@code indy} classifier artifact compiled with it enabled.
  * An application picks between them by setting {@code grails.indy}.
  *
  * <p>The second artifact is a plain Maven classifier and adds no variant to the published metadata,
@@ -58,17 +61,17 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 @CompileStatic
 class IndyVariants {
 
-    /** Must match {@code GrailsIndyVariants.NOINDY_CLASSIFIER}. */
-    static final String NOINDY_CLASSIFIER = 'noindy'
+    /** Must match {@code GrailsIndyVariants.INDY_CLASSIFIER}. */
+    static final String INDY_CLASSIFIER = 'indy'
 
-    /** Must match {@code GrailsIndyVariants.NOINDY_MANIFEST_ATTRIBUTE}. */
-    static final String NOINDY_MANIFEST_ATTRIBUTE = 'Grails-Noindy-Artifact'
+    /** Must match {@code GrailsIndyVariants.INDY_MANIFEST_ATTRIBUTE}. */
+    static final String INDY_MANIFEST_ATTRIBUTE = 'Grails-Indy-Artifact'
 
-    /** Must match {@code GrailsIndyVariants.NOINDY_COMPILE_TASK_NAME}. */
-    static final String NOINDY_COMPILE_TASK_NAME = 'compileNoindyGroovy'
+    /** Must match {@code GrailsIndyVariants.INDY_COMPILE_TASK_NAME}. */
+    static final String INDY_COMPILE_TASK_NAME = 'compileIndyGroovy'
 
-    /** Must match {@code GrailsIndyVariants.NOINDY_JAR_TASK_NAME}. */
-    static final String NOINDY_JAR_TASK_NAME = 'noindyJar'
+    /** Must match {@code GrailsIndyVariants.INDY_JAR_TASK_NAME}. */
+    static final String INDY_JAR_TASK_NAME = 'indyJar'
 
     private IndyVariants() {
     }
@@ -84,7 +87,7 @@ class IndyVariants {
     static void configure(Project project) {
         project.plugins.withId('groovy') {
             project.plugins.withId('maven-publish') {
-                if (project.tasks.names.contains(NOINDY_JAR_TASK_NAME)) {
+                if (project.tasks.names.contains(INDY_JAR_TASK_NAME)) {
                     return
                 }
                 if (GradleUtils.lookupPropertyByType(project, 'skipJavaComponent', Boolean)) {
@@ -97,16 +100,16 @@ class IndyVariants {
                     return
                 }
 
-                TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
-                TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
+                TaskProvider<GroovyCompile> indyCompile = registerIndyCompileTask(project, main)
+                TaskProvider<Jar> indyJar = registerIndyJarTask(project, indyCompile)
 
                 PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
                 publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
-                    publication.artifact(noindyJar)
+                    publication.artifact(indyJar)
                 }
 
                 project.tasks.named('jar', Jar).configure { Jar jar ->
-                    jar.manifest.attributes((NOINDY_MANIFEST_ATTRIBUTE): project.provider {
+                    jar.manifest.attributes((INDY_MANIFEST_ATTRIBUTE): project.provider {
                         "${project.group}:${project.name}".toString()
                     })
                 }
@@ -114,13 +117,13 @@ class IndyVariants {
         }
     }
 
-    private static TaskProvider<GroovyCompile> registerNoindyCompileTask(Project project, SourceSet main) {
+    private static TaskProvider<GroovyCompile> registerIndyCompileTask(Project project, SourceSet main) {
         GroovyRuntime groovyRuntime = project.extensions.getByType(GroovyRuntime)
         JavaPluginExtension javaExtension = project.extensions.getByType(JavaPluginExtension)
-        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${NOINDY_CLASSIFIER}")
+        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${INDY_CLASSIFIER}")
 
-        return project.tasks.register(NOINDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
-            compile.description = 'Compiles the main Groovy source set with invokedynamic disabled.'
+        return project.tasks.register(INDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
+            compile.description = 'Compiles the main Groovy source set with invokedynamic enabled.'
             compile.group = BasePlugin.BUILD_GROUP
 
             compile.source = main.extensions.getByType(GroovySourceDirectorySet)
@@ -131,7 +134,7 @@ class IndyVariants {
             // The one intentional difference from the default compilation. Everything else is left to
             // the conventions CompilePlugin applies to all GroovyCompile tasks, so this task shares
             // the encoding, fork settings and compiler configuration script of the default one.
-            compile.groovyOptions.optimizationOptions.put('indy', false)
+            compile.groovyOptions.optimizationOptions.put('indy', true)
 
             compile.sourceCompatibility = javaExtension.sourceCompatibility.toString()
             compile.targetCompatibility = javaExtension.targetCompatibility.toString()
@@ -142,17 +145,26 @@ class IndyVariants {
         }
     }
 
-    private static TaskProvider<Jar> registerNoindyJarTask(Project project, SourceSet main,
-                                                           TaskProvider<GroovyCompile> noindyCompile) {
-        return project.tasks.register(NOINDY_JAR_TASK_NAME, Jar) { Jar jar ->
-            jar.description = 'Assembles a jar whose Groovy classes are compiled without invokedynamic.'
+    private static TaskProvider<Jar> registerIndyJarTask(Project project, TaskProvider<GroovyCompile> indyCompile) {
+        return project.tasks.register(INDY_JAR_TASK_NAME, Jar) { Jar jar ->
+            jar.description = 'Assembles a jar whose Groovy classes are compiled with invokedynamic.'
             jar.group = BasePlugin.BUILD_GROUP
-            jar.archiveClassifier.set(NOINDY_CLASSIFIER)
+            jar.archiveClassifier.set(INDY_CLASSIFIER)
 
-            // Java bytecode holds no Groovy call sites, so it is reused rather than recompiled.
-            jar.from(noindyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
-            jar.from(main.java.classesDirectory)
-            jar.from(project.tasks.named(main.processResourcesTaskName))
+            // Mirror the main jar rather than reassembling it: a plugin's jar also carries AST
+            // classes copied in from another source set, plus staged command and template resources
+            // laid out at paths this task does not know. Listing the pieces would silently omit them,
+            // and reusing the main jar's own copy spec would import its duplicatesStrategy with it.
+            // Unpacking the finished jar keeps the two artifacts identical by construction: the indy
+            // classes are added first and duplicates dropped, so they win at the paths they share
+            // with the main jar's Groovy classes and everything else arrives untouched.
+            jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            jar.from(indyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
+            jar.from(project.tasks.named('jar', Jar).flatMap { Jar mainJar -> mainJar.archiveFile }
+                    .map { RegularFile mainArchive -> project.zipTree(mainArchive) }) { CopySpec spec ->
+                // The Jar task writes its own manifest.
+                spec.exclude('META-INF/MANIFEST.MF')
+            }
         }
     }
 

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
@@ -22,12 +22,11 @@ package org.apache.grails.buildsrc
 import groovy.transform.CompileStatic
 
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationVariant
-import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.GroovyRuntime
 import org.gradle.api.tasks.GroovySourceDirectorySet
@@ -41,8 +40,11 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 /**
  * Publishes every Groovy module of the framework twice: the default artifact compiled with Groovy's
  * own {@code invokedynamic} default, and a {@code noindy} classifier artifact compiled without it.
- * An application picks between them by setting {@code grails.indy}, and the choice propagates
- * across the dependency graph through Gradle Module Metadata.
+ * An application picks between them by setting {@code grails.indy}.
+ *
+ * <p>The second artifact is a plain Maven classifier and adds no variant to the published metadata,
+ * so nothing about how anyone else resolves these modules changes. The application side turns the
+ * classifier into something selectable.
  *
  * <p>Mirrors {@code GrailsIndyVariants} from the Grails Gradle plugins, which does the same for
  * plugins built outside this repository. That class is not on build-logic's classpath — the two
@@ -56,14 +58,11 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 @CompileStatic
 class IndyVariants {
 
-    /** Must match {@code GrailsIndyVariants.INDY_ATTRIBUTE}. */
-    static final Attribute<Boolean> INDY_ATTRIBUTE = Attribute.of('org.apache.grails.indy', Boolean)
-
     /** Must match {@code GrailsIndyVariants.NOINDY_CLASSIFIER}. */
     static final String NOINDY_CLASSIFIER = 'noindy'
 
-    /** Must match {@code GrailsIndyVariants.NOINDY_VARIANT_NAME}. */
-    static final String NOINDY_VARIANT_NAME = 'noindy'
+    /** Must match {@code GrailsIndyVariants.NOINDY_MANIFEST_ATTRIBUTE}. */
+    static final String NOINDY_MANIFEST_ATTRIBUTE = 'Grails-Noindy-Artifact'
 
     /** Must match {@code GrailsIndyVariants.NOINDY_COMPILE_TASK_NAME}. */
     static final String NOINDY_COMPILE_TASK_NAME = 'compileNoindyGroovy'
@@ -101,8 +100,16 @@ class IndyVariants {
                 TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
                 TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
 
-                addNoindyVariant(project, 'apiElements', noindyJar)
-                addNoindyVariant(project, 'runtimeElements', noindyJar)
+                PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+                publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
+                    publication.artifact(noindyJar)
+                }
+
+                project.tasks.named('jar', Jar).configure { Jar jar ->
+                    jar.manifest.attributes((NOINDY_MANIFEST_ATTRIBUTE): project.provider {
+                        "${project.group}:${project.name}".toString()
+                    })
+                }
             }
         }
     }
@@ -149,12 +156,4 @@ class IndyVariants {
         }
     }
 
-    private static void addNoindyVariant(Project project, String configurationName, TaskProvider<Jar> noindyJar) {
-        project.configurations.named(configurationName).configure { Configuration elements ->
-            elements.outgoing.variants.create(NOINDY_VARIANT_NAME) { ConfigurationVariant variant ->
-                variant.attributes.attribute(INDY_ATTRIBUTE, false)
-                variant.artifact(noindyJar)
-            }
-        }
-    }
 }

--- a/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
+++ b/build-logic/plugins/src/main/groovy/org/apache/grails/buildsrc/IndyVariants.groovy
@@ -1,0 +1,160 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.grails.buildsrc
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationVariant
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.Directory
+import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.GroovyRuntime
+import org.gradle.api.tasks.GroovySourceDirectorySet
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.GroovyCompile
+import org.gradle.jvm.toolchain.JavaToolchainService
+
+/**
+ * Publishes every Groovy module of the framework twice: the default artifact compiled with Groovy's
+ * own {@code invokedynamic} default, and a {@code noindy} classifier artifact compiled without it.
+ * An application picks between them by setting {@code grails.indy}, and the choice propagates
+ * across the dependency graph through Gradle Module Metadata.
+ *
+ * <p>Mirrors {@code GrailsIndyVariants} from the Grails Gradle plugins, which does the same for
+ * plugins built outside this repository. That class is not on build-logic's classpath — the two
+ * builds are independent — so the attribute name, classifier and task names are duplicated here and
+ * must be kept in step. The same duplication already exists for {@code BaseDirArgumentProvider}.
+ *
+ * <p>Both implementations are idempotent and agree on their task names, so the modules of this
+ * repository that apply the {@code grails-plugin} Gradle plugin are configured exactly once no
+ * matter which of the two reaches them first.
+ */
+@CompileStatic
+class IndyVariants {
+
+    /** Must match {@code GrailsIndyVariants.INDY_ATTRIBUTE}. */
+    static final Attribute<Boolean> INDY_ATTRIBUTE = Attribute.of('org.apache.grails.indy', Boolean)
+
+    /** Must match {@code GrailsIndyVariants.NOINDY_CLASSIFIER}. */
+    static final String NOINDY_CLASSIFIER = 'noindy'
+
+    /** Must match {@code GrailsIndyVariants.NOINDY_VARIANT_NAME}. */
+    static final String NOINDY_VARIANT_NAME = 'noindy'
+
+    /** Must match {@code GrailsIndyVariants.NOINDY_COMPILE_TASK_NAME}. */
+    static final String NOINDY_COMPILE_TASK_NAME = 'compileNoindyGroovy'
+
+    /** Must match {@code GrailsIndyVariants.NOINDY_JAR_TASK_NAME}. */
+    static final String NOINDY_JAR_TASK_NAME = 'noindyJar'
+
+    private IndyVariants() {
+    }
+
+    /**
+     * Adds the second compilation and its published variants to a module.
+     *
+     * <p>Only modules that are actually published are configured: an unpublished module has no
+     * consumer that could ask for the other flavour, so compiling it twice would be wasted work.
+     *
+     * @param project the module to configure
+     */
+    static void configure(Project project) {
+        project.plugins.withId('groovy') {
+            project.plugins.withId('maven-publish') {
+                if (project.tasks.names.contains(NOINDY_JAR_TASK_NAME)) {
+                    return
+                }
+                if (GradleUtils.lookupPropertyByType(project, 'skipJavaComponent', Boolean)) {
+                    return
+                }
+
+                SourceSet main = project.extensions.getByType(SourceSetContainer)
+                        .findByName(SourceSet.MAIN_SOURCE_SET_NAME)
+                if (main == null) {
+                    return
+                }
+
+                TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
+                TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
+
+                addNoindyVariant(project, 'apiElements', noindyJar)
+                addNoindyVariant(project, 'runtimeElements', noindyJar)
+            }
+        }
+    }
+
+    private static TaskProvider<GroovyCompile> registerNoindyCompileTask(Project project, SourceSet main) {
+        GroovyRuntime groovyRuntime = project.extensions.getByType(GroovyRuntime)
+        JavaPluginExtension javaExtension = project.extensions.getByType(JavaPluginExtension)
+        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${NOINDY_CLASSIFIER}")
+
+        return project.tasks.register(NOINDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
+            compile.description = 'Compiles the main Groovy source set with invokedynamic disabled.'
+            compile.group = BasePlugin.BUILD_GROUP
+
+            compile.source = main.extensions.getByType(GroovySourceDirectorySet)
+            compile.classpath = main.compileClasspath
+            compile.groovyClasspath = groovyRuntime.inferGroovyClasspath(main.compileClasspath)
+            compile.destinationDirectory.set(destination)
+
+            // The one intentional difference from the default compilation. Everything else is left to
+            // the conventions CompilePlugin applies to all GroovyCompile tasks, so this task shares
+            // the encoding, fork settings and compiler configuration script of the default one.
+            compile.groovyOptions.optimizationOptions.put('indy', false)
+
+            compile.sourceCompatibility = javaExtension.sourceCompatibility.toString()
+            compile.targetCompatibility = javaExtension.targetCompatibility.toString()
+            if (javaExtension.toolchain.languageVersion.present) {
+                JavaToolchainService toolchains = project.extensions.getByType(JavaToolchainService)
+                compile.javaLauncher.set(toolchains.launcherFor(javaExtension.toolchain))
+            }
+        }
+    }
+
+    private static TaskProvider<Jar> registerNoindyJarTask(Project project, SourceSet main,
+                                                           TaskProvider<GroovyCompile> noindyCompile) {
+        return project.tasks.register(NOINDY_JAR_TASK_NAME, Jar) { Jar jar ->
+            jar.description = 'Assembles a jar whose Groovy classes are compiled without invokedynamic.'
+            jar.group = BasePlugin.BUILD_GROUP
+            jar.archiveClassifier.set(NOINDY_CLASSIFIER)
+
+            // Java bytecode holds no Groovy call sites, so it is reused rather than recompiled.
+            jar.from(noindyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
+            jar.from(main.java.classesDirectory)
+            jar.from(project.tasks.named(main.processResourcesTaskName))
+        }
+    }
+
+    private static void addNoindyVariant(Project project, String configurationName, TaskProvider<Jar> noindyJar) {
+        project.configurations.named(configurationName).configure { Configuration elements ->
+            elements.outgoing.variants.create(NOINDY_VARIANT_NAME) { ConfigurationVariant variant ->
+                variant.attributes.attribute(INDY_ATTRIBUTE, false)
+                variant.artifact(noindyJar)
+            }
+        }
+    }
+}

--- a/gradle/grails-extension-gradle-config.gradle
+++ b/gradle/grails-extension-gradle-config.gradle
@@ -35,6 +35,10 @@ grails {
     // Allow CI to toggle Groovy invokedynamic (indy) via -PgrailsIndy=true
     // This enables testing functional tests with both indy enabled and disabled.
     // See: https://github.com/apache/grails-core/issues/15321
+    //
+    // Since 8.0 this governs compilation only for the application-type projects here. A module
+    // applying the grails-plugin plugin compiles both flavours regardless and publishes the second
+    // one under the noindy classifier, so the property does not change how it is compiled.
     if (project.hasProperty('grailsIndy')) {
         indy = Boolean.parseBoolean(project.property('grailsIndy') as String)
     }

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
@@ -19,73 +19,66 @@ under the License.
 
 Groovy compiles a dynamic method call in one of two ways. It can emit an `invokedynamic` instruction and let
 the JVM link the call site, or it can emit the older call-site caching bytecode. Both dispatch through the
-same metaclass machinery and behave identically; they differ only in performance, and which one is faster
-depends on the application and the JVM it runs on.
+same metaclass machinery and behave identically; they differ in performance, and which is faster depends on
+the application and the JVM it runs on.
 
-The `grails` extension chooses for your application:
+Grails compiles applications with `invokedynamic` disabled, and every Grails module and plugin publishes its
+main artifact the same way.
 
-[source,groovy]
-.build.gradle
-----
-grails {
-    indy = false
-}
-----
+=== Enabling invokedynamic
 
-The default follows Groovy's own default, which enables `invokedynamic`. Set it to `false` to compile against
-call-site caching instead.
-
-=== Framework and plugin artifacts
-
-Your own code is only part of what runs. The framework and the plugins you depend on are compiled ahead of
-time, so the setting above cannot reach them by recompiling. Instead, Grails modules and plugins built with
-the `org.apache.grails.gradle.grails-plugin` plugin publish their classes twice: the main artifact compiled
-with `invokedynamic`, and a second artifact carrying the `noindy` classifier compiled without it.
-
-Setting `indy = false` makes the application resolve the `noindy` artifact of every dependency you list as
-publishing one:
+An application turns it on for its own sources with:
 
 [source,groovy]
 .build.gradle
 ----
 grails {
-    indy = false
-    noindyModules = ['org.apache.grails:grails-core', 'com.example:my-plugin']
+    indy = true
 }
 ----
 
-The list is required, and listing a module that publishes no such artifact makes resolution fail when the
-missing file is fetched. A module advertises that it publishes one through the `Grails-Noindy-Artifact`
-attribute of its main jar's manifest.
+That covers the application's own classes. The framework and the plugins it depends on are already compiled,
+so the setting cannot reach them by recompiling. They each publish a second artifact carrying the `indy`
+classifier, compiled with `invokedynamic` enabled, and an application selects those by naming the modules
+that provide one:
 
-Dependencies you leave off the list keep their main artifact, which is always safe: classes compiled the two
-ways interoperate freely on the same classpath.
+[source,groovy]
+.build.gradle
+----
+grails {
+    indy = true
+    indyModules = ['org.apache.grails:grails-core', 'com.example:my-plugin']
+}
+----
+
+Dependencies left off the list keep their main artifact, which is always safe: classes compiled the two ways
+interoperate freely on the same classpath, so a partially converted classpath still runs correctly.
+
+WARNING: Listing a module that publishes no `indy` classifier — or a platform such as `grails-bom`, which
+publishes no jar at all — makes resolution fail when the missing file is fetched. A module advertises that it
+publishes one through the `Grails-Indy-Artifact` attribute of its main jar's manifest.
 
 NOTE: This applies to dependencies resolved as published modules. A project dependency inside a composite or
-multi-project build always uses its main artifact.
+multi-project build always uses the main artifact.
 
 === Publishing both flavours from a plugin
 
-A plugin applying the `org.apache.grails.gradle.grails-plugin` plugin publishes both flavours automatically,
-and `indy` has no effect on how it compiles its own sources — it always builds both. The extra artifact is
-produced by the `noindyJar` task and published as a variant of the plugin's API and runtime, so applications
-resolve it through normal dependency resolution rather than by naming the classifier.
+A plugin applying the `org.apache.grails.gradle.grails-plugin` plugin publishes both automatically: its main
+jar is compiled without `invokedynamic`, and the `indyJar` task produces the `indy` classifier artifact
+alongside it. `grails.indy` has no effect on how a plugin compiles its own sources, because it builds both
+regardless and the resolving application chooses.
 
-Consumers that are not Grails applications are unaffected. A plain Gradle project depending on a Grails
-artifact resolves the default artifact exactly as it did before.
+The classifier adds nothing to the module's published metadata, so builds that do not opt in — including
+projects that are not Grails applications at all — resolve these modules exactly as they would otherwise.
 
-=== Native compilation requires invokedynamic
+=== Native compilation
 
-Ahead-of-time native compilation does not support call-site caching bytecode, which generates and links
-call-site classes at runtime. An application intended for a native image must therefore leave `indy` at its
-default, and every artifact on its classpath must be the `invokedynamic` flavour -- which is what the default
-artifacts are.
-
-WARNING: Setting `indy = false` forfeits native compilation for that application. It is a choice between
-call-site caching and a native image, not something that can be decided per artifact afterwards.
+Ahead-of-time native compilation cannot use call-site caching bytecode, which links call sites at runtime. A
+native image therefore requires the `indy` flavour of the application and of everything on its classpath, so
+an application targeting one sets `indy = true` and lists every Grails module and plugin it depends on. An
+omission surfaces as a native image build failure rather than as anything visible on the JVM.
 
 === Measuring the difference
 
 Whether `invokedynamic` helps or hurts depends on the workload, so treat the setting as something to measure
-rather than assume. Build the application both ways and compare it under a representative load; a benchmark
-of dynamic dispatch on its own rarely predicts what an application does.
+rather than assume. A benchmark of dynamic dispatch on its own rarely predicts what an application does.

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
@@ -1,0 +1,64 @@
+////
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+////
+
+Groovy compiles a dynamic method call in one of two ways. It can emit an `invokedynamic` instruction and let
+the JVM link the call site, or it can emit the older call-site caching bytecode. Both dispatch through the
+same metaclass machinery and behave identically; they differ only in performance, and which one is faster
+depends on the application and the JVM it runs on.
+
+The `grails` extension chooses for your application:
+
+[source,groovy]
+.build.gradle
+----
+grails {
+    indy = true
+}
+----
+
+The default is `false`, which compiles your application with call-site caching.
+
+=== Framework and plugin artifacts
+
+Your own code is only part of what runs. The framework and the plugins you depend on are compiled ahead of
+time, so the setting above cannot reach them by recompiling. Instead, Grails modules and plugins built with
+the `org.apache.grails.gradle.grails-plugin` plugin publish their classes twice: a default artifact compiled
+with `invokedynamic`, and a second artifact carrying the `noindy` classifier compiled without it. Setting
+`indy` selects between them for the whole dependency graph, so the artifacts on your classpath match the way
+your own code is compiled. No per-dependency configuration is needed.
+
+A dependency that publishes only one artifact — a plugin built before this existed, or one that chose not to
+publish both — stays usable either way. Its single artifact is used whichever setting you choose, because
+classes compiled the two ways interoperate freely on the same classpath.
+
+=== Publishing both flavours from a plugin
+
+A plugin applying the `org.apache.grails.gradle.grails-plugin` plugin publishes both flavours automatically,
+and `indy` has no effect on how it compiles its own sources — it always builds both. The extra artifact is
+produced by the `noindyJar` task and published as a variant of the plugin's API and runtime, so applications
+resolve it through normal dependency resolution rather than by naming the classifier.
+
+Consumers that are not Grails applications are unaffected. A plain Gradle project depending on a Grails
+artifact resolves the default artifact exactly as it did before.
+
+=== Measuring the difference
+
+Whether `invokedynamic` helps or hurts depends on the workload, so treat the setting as something to measure
+rather than assume. Build the application both ways and compare it under a representative load; a benchmark
+of dynamic dispatch on its own rarely predicts what an application does.

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
@@ -39,14 +39,30 @@ call-site caching instead.
 
 Your own code is only part of what runs. The framework and the plugins you depend on are compiled ahead of
 time, so the setting above cannot reach them by recompiling. Instead, Grails modules and plugins built with
-the `org.apache.grails.gradle.grails-plugin` plugin publish their classes twice: a default artifact compiled
-with `invokedynamic`, and a second artifact carrying the `noindy` classifier compiled without it. Setting
-`indy` selects between them for the whole dependency graph, so the artifacts on your classpath match the way
-your own code is compiled. No per-dependency configuration is needed.
+the `org.apache.grails.gradle.grails-plugin` plugin publish their classes twice: the main artifact compiled
+with `invokedynamic`, and a second artifact carrying the `noindy` classifier compiled without it.
 
-A dependency that publishes only one artifact — a plugin built before this existed, or one that chose not to
-publish both — stays usable either way. Its single artifact is used whichever setting you choose, because
-classes compiled the two ways interoperate freely on the same classpath.
+Setting `indy = false` makes the application resolve the `noindy` artifact of every dependency you list as
+publishing one:
+
+[source,groovy]
+.build.gradle
+----
+grails {
+    indy = false
+    noindyModules = ['org.apache.grails:grails-core', 'com.example:my-plugin']
+}
+----
+
+The list is required, and listing a module that publishes no such artifact makes resolution fail when the
+missing file is fetched. A module advertises that it publishes one through the `Grails-Noindy-Artifact`
+attribute of its main jar's manifest.
+
+Dependencies you leave off the list keep their main artifact, which is always safe: classes compiled the two
+ways interoperate freely on the same classpath.
+
+NOTE: This applies to dependencies resolved as published modules. A project dependency inside a composite or
+multi-project build always uses its main artifact.
 
 === Publishing both flavours from a plugin
 

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
@@ -58,6 +58,16 @@ resolve it through normal dependency resolution rather than by naming the classi
 Consumers that are not Grails applications are unaffected. A plain Gradle project depending on a Grails
 artifact resolves the default artifact exactly as it did before.
 
+=== Native compilation requires invokedynamic
+
+Ahead-of-time native compilation does not support call-site caching bytecode, which generates and links
+call-site classes at runtime. An application intended for a native image must therefore leave `indy` at its
+default, and every artifact on its classpath must be the `invokedynamic` flavour -- which is what the default
+artifacts are.
+
+WARNING: Setting `indy = false` forfeits native compilation for that application. It is a choice between
+call-site caching and a native image, not something that can be decided per artifact afterwards.
+
 === Measuring the difference
 
 Whether `invokedynamic` helps or hurts depends on the workload, so treat the setting as something to measure

--- a/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
+++ b/grails-doc/src/en/guide/commandLine/gradleBuild/invokedynamic.adoc
@@ -28,11 +28,12 @@ The `grails` extension chooses for your application:
 .build.gradle
 ----
 grails {
-    indy = true
+    indy = false
 }
 ----
 
-The default is `false`, which compiles your application with call-site caching.
+The default follows Groovy's own default, which enables `invokedynamic`. Set it to `false` to compile against
+call-site caching instead.
 
 === Framework and plugin artifacts
 

--- a/grails-doc/src/en/guide/toc.yml
+++ b/grails-doc/src/en/guide/toc.yml
@@ -85,6 +85,7 @@ commandLine:
     gradleDependencies: Defining Dependencies with Gradle
     gradleTasks: Working with Gradle Tasks
     gradlePlugins: Grails plugins for Gradle
+    invokedynamic: Choosing Groovy Call Site Bytecode
 profiles:
   title: Application Profiles
   standardProfiles:

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2633,31 +2633,37 @@ used to apply to its own message source.
 Adding or removing a base name now needs a restart, because Spring Boot reads the configured base names
 once when it builds the message source.
 
-==== 48. invokedynamic is Selected Per Application
+==== 48. invokedynamic is Enabled by Default and Selected Per Application
 
-Grails modules and plugins are now published in two flavours: a default artifact compiled with Groovy's
-`invokedynamic`, and a second artifact carrying the `noindy` classifier compiled with call-site caching
-instead. An application picks one with the existing setting, and the choice now applies to the framework and
-plugin artifacts on its classpath as well as to its own sources:
+Two related changes.
+
+First, `grails.indy` now defaults to `true`, following Groovy's own default. Grails 7.x defaulted it to
+`false`, so an application that never set it compiled with call-site caching; it now compiles with
+`invokedynamic`. To keep the 7.x behaviour, set it explicitly:
 
 [source,groovy]
 .build.gradle
 ----
 grails {
-    indy = true
+    indy = false
 }
 ----
 
-The default is unchanged — `false` — so an application that does not touch this setting compiles the same way
-it did in 7.x. What changes is that it now also resolves the `noindy` artifacts of the framework and of the
-plugins it depends on, rather than the `invokedynamic` ones it received before.
+Second, the setting now reaches precompiled dependencies as well as your own sources. Grails modules and
+plugins are published in two flavours -- a default artifact compiled with `invokedynamic` and a second
+artifact carrying the `noindy` classifier compiled without it -- and the application's setting selects
+between them across the whole dependency graph.
+
+Neither change alters behaviour: the two flavours dispatch through the same metaclass machinery and
+interoperate on the same classpath. They differ in performance, and which is faster depends on the
+application and the JVM it runs on, so measure before choosing.
 
 Two consequences are worth knowing about:
 
-* A plugin built with the `org.apache.grails.gradle.grails-plugin` plugin now compiles its own sources with
-Groovy's default and publishes both flavours, so `indy` no longer governs how the plugin itself is compiled.
-Plugin authors do not need to change anything; the second artifact is produced by the new `noindyJar` task.
+* A plugin built with the `org.apache.grails.gradle.grails-plugin` plugin now publishes both flavours, so
+`indy` no longer governs how the plugin itself is compiled. Plugin authors need to change nothing; the second
+artifact comes from the new `noindyJar` task.
 * A plugin published before 8.0, or one that opts out, publishes a single artifact. It stays resolvable under
-either setting, since classes compiled the two ways interoperate on the same classpath.
+either setting, since classes compiled the two ways interoperate.
 
 See <<invokedynamic,Choosing Groovy Call Site Bytecode>> for details.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2649,10 +2649,22 @@ grails {
 }
 ----
 
-Second, the setting now reaches precompiled dependencies as well as your own sources. Grails modules and
-plugins are published in two flavours -- a default artifact compiled with `invokedynamic` and a second
-artifact carrying the `noindy` classifier compiled without it -- and the application's setting selects
-between them across the whole dependency graph.
+Second, the setting can now reach precompiled dependencies as well as your own sources. Grails modules and
+plugins publish a second artifact carrying the `noindy` classifier, compiled without `invokedynamic`. An
+application that sets `indy = false` and lists the modules publishing one resolves those artifacts instead of
+the main ones:
+
+[source,groovy]
+.build.gradle
+----
+grails {
+    indy = false
+    noindyModules = ['org.apache.grails:grails-core']
+}
+----
+
+The extra artifact is a plain Maven classifier and adds no variant to the published metadata, so builds that
+do not opt in resolve these modules exactly as before.
 
 Native compilation is the reason the default moved. Call-site caching bytecode cannot be compiled ahead of
 time into a native image, so every artifact on a native application's classpath has to be the `invokedynamic`

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2654,7 +2654,11 @@ plugins are published in two flavours -- a default artifact compiled with `invok
 artifact carrying the `noindy` classifier compiled without it -- and the application's setting selects
 between them across the whole dependency graph.
 
-Neither change alters behaviour: the two flavours dispatch through the same metaclass machinery and
+Native compilation is the reason the default moved. Call-site caching bytecode cannot be compiled ahead of
+time into a native image, so every artifact on a native application's classpath has to be the `invokedynamic`
+flavour. Applications that set `indy = false` opt out of native compilation.
+
+Otherwise neither change alters behaviour: the two flavours dispatch through the same metaclass machinery and
 interoperate on the same classpath. They differ in performance, and which is faster depends on the
 application and the JVM it runs on, so measure before choosing.
 

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2633,53 +2633,38 @@ used to apply to its own message source.
 Adding or removing a base name now needs a restart, because Spring Boot reads the configured base names
 once when it builds the message source.
 
-==== 48. invokedynamic is Enabled by Default and Selected Per Application
+==== 48. invokedynamic Available Under a Classifier
 
-Two related changes.
+Grails still compiles applications with `invokedynamic` disabled, as 7.x did, and every Grails module and
+plugin still publishes its main artifact that way. Nothing changes for an application that leaves the setting
+alone.
 
-First, `grails.indy` now defaults to `true`, following Groovy's own default. Grails 7.x defaulted it to
-`false`, so an application that never set it compiled with call-site caching; it now compiles with
-`invokedynamic`. To keep the 7.x behaviour, set it explicitly:
-
-[source,groovy]
-.build.gradle
-----
-grails {
-    indy = false
-}
-----
-
-Second, the setting can now reach precompiled dependencies as well as your own sources. Grails modules and
-plugins publish a second artifact carrying the `noindy` classifier, compiled without `invokedynamic`. An
-application that sets `indy = false` and lists the modules publishing one resolves those artifacts instead of
-the main ones:
+What is new is that each module and plugin also publishes a second artifact carrying the `indy` classifier,
+compiled with `invokedynamic` enabled, so an application that wants it can have it throughout rather than
+only in its own classes:
 
 [source,groovy]
 .build.gradle
 ----
 grails {
-    indy = false
-    noindyModules = ['org.apache.grails:grails-core']
+    indy = true
+    indyModules = ['org.apache.grails:grails-core', 'com.example:my-plugin']
 }
 ----
+
+Dependencies left off the list keep their main artifact. That is safe — classes compiled the two ways
+interoperate on the same classpath — but a native image needs the `indy` flavour of everything, so an
+application targeting one has to list every Grails module and plugin it uses.
+
+Listing a module that publishes no `indy` classifier, or a platform such as `grails-bom`, makes resolution
+fail when the missing file is fetched. A module advertises its classifier through the `Grails-Indy-Artifact`
+manifest attribute of its main jar.
+
+For plugin authors, `grails.indy` no longer affects how a plugin compiles its own sources: a plugin builds
+both flavours regardless, through the new `indyJar` task, and the resolving application chooses. A plugin
+build that sets `grails { indy = ... }` can drop it.
 
 The extra artifact is a plain Maven classifier and adds no variant to the published metadata, so builds that
 do not opt in resolve these modules exactly as before.
-
-Native compilation is the reason the default moved. Call-site caching bytecode cannot be compiled ahead of
-time into a native image, so every artifact on a native application's classpath has to be the `invokedynamic`
-flavour. Applications that set `indy = false` opt out of native compilation.
-
-Otherwise neither change alters behaviour: the two flavours dispatch through the same metaclass machinery and
-interoperate on the same classpath. They differ in performance, and which is faster depends on the
-application and the JVM it runs on, so measure before choosing.
-
-Two consequences are worth knowing about:
-
-* A plugin built with the `org.apache.grails.gradle.grails-plugin` plugin now publishes both flavours, so
-`indy` no longer governs how the plugin itself is compiled. Plugin authors need to change nothing; the second
-artifact comes from the new `noindyJar` task.
-* A plugin published before 8.0, or one that opts out, publishes a single artifact. It stays resolvable under
-either setting, since classes compiled the two ways interoperate.
 
 See <<invokedynamic,Choosing Groovy Call Site Bytecode>> for details.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2632,3 +2632,32 @@ used to apply to its own message source.
 
 Adding or removing a base name now needs a restart, because Spring Boot reads the configured base names
 once when it builds the message source.
+
+==== 48. invokedynamic is Selected Per Application
+
+Grails modules and plugins are now published in two flavours: a default artifact compiled with Groovy's
+`invokedynamic`, and a second artifact carrying the `noindy` classifier compiled with call-site caching
+instead. An application picks one with the existing setting, and the choice now applies to the framework and
+plugin artifacts on its classpath as well as to its own sources:
+
+[source,groovy]
+.build.gradle
+----
+grails {
+    indy = true
+}
+----
+
+The default is unchanged — `false` — so an application that does not touch this setting compiles the same way
+it did in 7.x. What changes is that it now also resolves the `noindy` artifacts of the framework and of the
+plugins it depends on, rather than the `invokedynamic` ones it received before.
+
+Two consequences are worth knowing about:
+
+* A plugin built with the `org.apache.grails.gradle.grails-plugin` plugin now compiles its own sources with
+Groovy's default and publishes both flavours, so `indy` no longer governs how the plugin itself is compiled.
+Plugin authors do not need to change anything; the second artifact is produced by the new `noindyJar` task.
+* A plugin published before 8.0, or one that opts out, publishes a single artifact. It stays resolvable under
+either setting, since classes compiled the two ways interoperate on the same classpath.
+
+See <<invokedynamic,Choosing Groovy Call Site Bytecode>> for details.

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -24,6 +24,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 import grails.util.Environment
 
@@ -48,6 +49,7 @@ class GrailsExtension {
         this.project = project
         this.pluginDefiner = new PluginDefiner(project)
         this.indy = project.objects.property(Boolean).convention(true)
+        this.noindyModules = project.objects.setProperty(String).convention([] as List<String>)
         this.preserveParameterNames = project.objects.property(Boolean).convention(true)
         this.compileStatic = project.objects.newInstance(GrailsCompileStaticOptions)
         this.i18n = project.objects.newInstance(GrailsI18nOptions)
@@ -229,6 +231,17 @@ class GrailsExtension {
      * @see GrailsIndyVariants
      */
     final Property<Boolean> indy
+
+    /**
+     * Coordinates, as {@code group:name}, of the dependencies that publish a {@code noindy}
+     * classifier alongside their main artifact. Consulted only when {@link #indy} is {@code false},
+     * to decide which dependencies can supply the other flavour.
+     *
+     * <p>Listing a module that publishes no such classifier — or a platform, which publishes no jar
+     * at all — makes resolution fail when the missing file is fetched. A module advertises its
+     * classifier through the {@code Grails-Noindy-Artifact} attribute of its main jar's manifest.
+     */
+    final SetProperty<String> noindyModules
 
     void setIndy(boolean enabled) {
         this.indy.set(enabled)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -47,7 +47,7 @@ class GrailsExtension {
     GrailsExtension(Project project) {
         this.project = project
         this.pluginDefiner = new PluginDefiner(project)
-        this.indy = project.objects.property(Boolean).convention(false)
+        this.indy = project.objects.property(Boolean).convention(true)
         this.preserveParameterNames = project.objects.property(Boolean).convention(true)
         this.compileStatic = project.objects.newInstance(GrailsCompileStaticOptions)
         this.i18n = project.objects.newInstance(GrailsI18nOptions)
@@ -219,10 +219,14 @@ class GrailsExtension {
     boolean micronautAutoSetup = true
 
     /**
-     * Whether to enable Groovy's invokedynamic (indy) bytecode instruction for dynamic Groovy method dispatch.
-     * Disabled by default to improve performance (see GitHub issue #15293).
-     * When enabled, Groovy uses JVM invokedynamic instead of traditional callsite caching.
-     * To enable invokedynamic in build.gradle: grails { indy = true }
+     * Whether Groovy compiles dynamic method dispatch to the JVM's invokedynamic instruction rather
+     * than to callsite caching. Follows Groovy's own default, which enables it.
+     *
+     * <p>The setting also chooses which flavour of the framework and plugin artifacts the
+     * application resolves, so precompiled dependencies match how the application itself is
+     * compiled. To compile against callsite caching throughout: {@code grails { indy = false }}.
+     *
+     * @see GrailsIndyVariants
      */
     final Property<Boolean> indy
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsExtension.groovy
@@ -48,8 +48,8 @@ class GrailsExtension {
     GrailsExtension(Project project) {
         this.project = project
         this.pluginDefiner = new PluginDefiner(project)
-        this.indy = project.objects.property(Boolean).convention(true)
-        this.noindyModules = project.objects.setProperty(String).convention([] as List<String>)
+        this.indy = project.objects.property(Boolean).convention(false)
+        this.indyModules = project.objects.setProperty(String).convention([] as List<String>)
         this.preserveParameterNames = project.objects.property(Boolean).convention(true)
         this.compileStatic = project.objects.newInstance(GrailsCompileStaticOptions)
         this.i18n = project.objects.newInstance(GrailsI18nOptions)
@@ -222,7 +222,7 @@ class GrailsExtension {
 
     /**
      * Whether Groovy compiles dynamic method dispatch to the JVM's invokedynamic instruction rather
-     * than to callsite caching. Follows Groovy's own default, which enables it.
+     * than to callsite caching. Disabled by default.
      *
      * <p>The setting also chooses which flavour of the framework and plugin artifacts the
      * application resolves, so precompiled dependencies match how the application itself is
@@ -233,15 +233,15 @@ class GrailsExtension {
     final Property<Boolean> indy
 
     /**
-     * Coordinates, as {@code group:name}, of the dependencies that publish a {@code noindy}
-     * classifier alongside their main artifact. Consulted only when {@link #indy} is {@code false},
+     * Coordinates, as {@code group:name}, of the dependencies that publish an {@code indy}
+     * classifier alongside their main artifact. Consulted only when {@link #indy} is {@code true},
      * to decide which dependencies can supply the other flavour.
      *
      * <p>Listing a module that publishes no such classifier — or a platform, which publishes no jar
      * at all — makes resolution fail when the missing file is fetched. A module advertises its
-     * classifier through the {@code Grails-Noindy-Artifact} attribute of its main jar's manifest.
+     * classifier through the {@code Grails-Indy-Artifact} attribute of its main jar's manifest.
      */
-    final SetProperty<String> noindyModules
+    final SetProperty<String> indyModules
 
     void setIndy(boolean enabled) {
         this.indy.set(enabled)

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -284,7 +284,7 @@ class GrailsGradlePlugin implements Plugin<Project> {
         }
 
         project.afterEvaluate {
-            boolean indyEnabled = grailsExtension.indy.getOrElse(false)
+            boolean indyEnabled = grailsExtension.indy.getOrElse(true)
             Boolean preserveParameterNames = grailsExtension.preserveParameterNames.getOrNull()
 
             project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
@@ -299,8 +299,8 @@ class GrailsGradlePlugin implements Plugin<Project> {
             }
 
             if (!indyEnabled && !publishesIndyVariants()) {
-                project.logger.info('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
-                project.logger.info('        To enable invokedynamic: grails { indy = true } in build.gradle')
+                project.logger.info('Grails: Groovy invokedynamic (indy) is disabled; callsite caching will be used instead.')
+                project.logger.info('        Framework and plugin artifacts resolve to their noindy variants to match.')
             }
         }
     }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -275,12 +275,22 @@ class GrailsGradlePlugin implements Plugin<Project> {
 
         // Configure indy and log status after evaluation so user's grails { } block has been applied
         GrailsExtension grailsExtension = project.extensions.findByType(GrailsExtension)
+
+        // A project that publishes both flavours compiles both regardless of grails.indy, and picks
+        // its own dependencies by the default rules; a project that publishes neither compiles the
+        // one flavour it was asked for and resolves artifacts to match.
+        if (!publishesIndyVariants()) {
+            GrailsIndyVariants.configureConsumer(project, grailsExtension.indy)
+        }
+
         project.afterEvaluate {
             boolean indyEnabled = grailsExtension.indy.getOrElse(false)
             Boolean preserveParameterNames = grailsExtension.preserveParameterNames.getOrNull()
 
             project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
-                c.groovyOptions.optimizationOptions.indy = indyEnabled
+                if (!publishesIndyVariants()) {
+                    c.groovyOptions.optimizationOptions.indy = indyEnabled
+                }
 
                 if (preserveParameterNames != null) {
                     project.logger.info('Grails: Configuring Groovy compilation to preserve parameter names: {}', preserveParameterNames)
@@ -288,11 +298,25 @@ class GrailsGradlePlugin implements Plugin<Project> {
                 }
             }
 
-            if (!indyEnabled) {
+            if (!indyEnabled && !publishesIndyVariants()) {
                 project.logger.info('Grails: Groovy invokedynamic (indy) is disabled to improve performance (see issue #15293).')
                 project.logger.info('        To enable invokedynamic: grails { indy = true } in build.gradle')
             }
         }
+    }
+
+    /**
+     * Whether this project publishes its classes both with and without {@code invokedynamic}.
+     *
+     * <p>A library consumed by applications publishes both flavours and lets the consuming
+     * application choose, so {@code grails.indy} does not govern how it compiles its own sources.
+     * An application publishes nothing and is the one that chooses.
+     *
+     * @return {@code false} for applications; overridden to {@code true} for plugins
+     * @see GrailsIndyVariants
+     */
+    protected boolean publishesIndyVariants() {
+        false
     }
 
     protected Closure<String> getGroovyCompilerScript(GroovyCompile compile, Project project) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -280,16 +280,18 @@ class GrailsGradlePlugin implements Plugin<Project> {
         // its own dependencies by the default rules; a project that publishes neither compiles the
         // one flavour it was asked for and resolves artifacts to match.
         if (!publishesIndyVariants()) {
-            GrailsIndyVariants.configureConsumer(project, grailsExtension.indy, grailsExtension.noindyModules)
+            GrailsIndyVariants.configureConsumer(project, grailsExtension.indy, grailsExtension.indyModules)
         }
 
         project.afterEvaluate {
-            boolean indyEnabled = grailsExtension.indy.getOrElse(true)
+            boolean indyEnabled = grailsExtension.indy.getOrElse(false)
             Boolean preserveParameterNames = grailsExtension.preserveParameterNames.getOrNull()
 
             project.tasks.withType(GroovyCompile).configureEach { GroovyCompile c ->
-                if (!publishesIndyVariants()) {
-                    c.groovyOptions.optimizationOptions.indy = indyEnabled
+                if (c.name != GrailsIndyVariants.INDY_COMPILE_TASK_NAME) {
+                    // A project that publishes both flavours compiles its main artifact the way
+                    // every consumer gets it by default; the second task supplies the other one.
+                    c.groovyOptions.optimizationOptions.indy = publishesIndyVariants() ? false : indyEnabled
                 }
 
                 if (preserveParameterNames != null) {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -280,7 +280,7 @@ class GrailsGradlePlugin implements Plugin<Project> {
         // its own dependencies by the default rules; a project that publishes neither compiles the
         // one flavour it was asked for and resolves artifacts to match.
         if (!publishesIndyVariants()) {
-            GrailsIndyVariants.configureConsumer(project, grailsExtension.indy)
+            GrailsIndyVariants.configureConsumer(project, grailsExtension.indy, grailsExtension.noindyModules)
         }
 
         project.afterEvaluate {

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyClassifierRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyClassifierRule.groovy
@@ -28,28 +28,28 @@ import org.gradle.api.artifacts.ComponentMetadataRule
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 
 /**
- * Derives a {@code noindy} variant from a module's classifier artifact, inside the build that asked
+ * Derives an {@code indy} variant from a module's classifier artifact, inside the build that asked
  * for one.
  *
  * <p>The rule runs against every module on the graph but changes only those named in
- * {@code coordinates}. A module that publishes no {@code noindy} classifier must not be touched:
+ * {@code coordinates}. A module that publishes no {@code indy} classifier must not be touched:
  * the derived variant would point at a file that does not exist, and resolution fails when the
  * artifact is fetched rather than when the rule runs. Platforms are the same story — they publish
  * no jar at all.
  *
- * <p>The existing variants are stamped with {@code indy = true} as well as the derived one with
- * {@code false}, so that both candidates carry a value. A disambiguation rule can then pick between
- * them; without a value on both, the default variant would be invisible to that rule.
+ * <p>The existing variants are stamped with {@code indy = false} as well as the derived one with
+ * {@code true}, so that both candidates carry a value. A disambiguation rule can then pick between
+ * them; without a value on both, the main variant would be invisible to that rule.
  *
  * @since 8.0
  */
 @CompileStatic
-abstract class GrailsNoindyClassifierRule implements ComponentMetadataRule {
+abstract class GrailsIndyClassifierRule implements ComponentMetadataRule {
 
     private final Set<String> coordinates
 
     @Inject
-    GrailsNoindyClassifierRule(Set<String> coordinates) {
+    GrailsIndyClassifierRule(Set<String> coordinates) {
         this.coordinates = coordinates
     }
 
@@ -62,13 +62,13 @@ abstract class GrailsNoindyClassifierRule implements ComponentMetadataRule {
 
         ['apiElements', 'runtimeElements'].each { String base ->
             context.details.withVariant(base) { variant ->
-                variant.attributes { it.attribute(GrailsIndyVariants.INDY_ATTRIBUTE, true) }
-            }
-            context.details.addVariant("noindy${base.capitalize()}", base) { variant ->
                 variant.attributes { it.attribute(GrailsIndyVariants.INDY_ATTRIBUTE, false) }
+            }
+            context.details.addVariant("indy${base.capitalize()}", base) { variant ->
+                variant.attributes { it.attribute(GrailsIndyVariants.INDY_ATTRIBUTE, true) }
                 variant.withFiles {
                     it.removeAllFiles()
-                    it.addFile("${id.name}-${id.version}-${GrailsIndyVariants.NOINDY_CLASSIFIER}.jar".toString())
+                    it.addFile("${id.name}-${id.version}-${GrailsIndyVariants.INDY_CLASSIFIER}.jar".toString())
                 }
             }
         }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyDisambiguationRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyDisambiguationRule.groovy
@@ -23,8 +23,8 @@ import org.gradle.api.attributes.AttributeDisambiguationRule
 import org.gradle.api.attributes.MultipleCandidatesDetails
 
 /**
- * Chooses a Groovy call-site flavour once {@link GrailsNoindyClassifierRule} has given a module
- * both. The requested flavour wins where it exists; otherwise the default one does.
+ * Chooses a Groovy call-site flavour once {@link GrailsIndyClassifierRule} has given a module both.
+ * The requested flavour wins where it exists; otherwise the main artifact does.
  */
 class GrailsIndyDisambiguationRule implements AttributeDisambiguationRule<Boolean> {
 
@@ -33,8 +33,8 @@ class GrailsIndyDisambiguationRule implements AttributeDisambiguationRule<Boolea
         Boolean requested = details.consumerValue
         if (requested != null && details.candidateValues.contains(requested)) {
             details.closestMatch(requested)
-        } else if (details.candidateValues.contains(Boolean.TRUE)) {
-            details.closestMatch(Boolean.TRUE)
+        } else if (details.candidateValues.contains(Boolean.FALSE)) {
+            details.closestMatch(Boolean.FALSE)
         }
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyDisambiguationRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyDisambiguationRule.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gradle.plugin.core
+
+import org.gradle.api.attributes.AttributeDisambiguationRule
+import org.gradle.api.attributes.MultipleCandidatesDetails
+
+/**
+ * Chooses a Groovy call-site flavour once {@link GrailsNoindyClassifierRule} has given a module
+ * both. The requested flavour wins where it exists; otherwise the default one does.
+ */
+class GrailsIndyDisambiguationRule implements AttributeDisambiguationRule<Boolean> {
+
+    @Override
+    void execute(MultipleCandidatesDetails<Boolean> details) {
+        Boolean requested = details.consumerValue
+        if (requested != null && details.candidateValues.contains(requested)) {
+            details.closestMatch(requested)
+        } else if (details.candidateValues.contains(Boolean.TRUE)) {
+            details.closestMatch(Boolean.TRUE)
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
@@ -23,11 +23,12 @@ import groovy.transform.CompileStatic
 
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationVariant
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.GroovyRuntime
 import org.gradle.api.tasks.GroovySourceDirectorySet
@@ -49,17 +50,18 @@ import org.grails.gradle.plugin.util.SourceSets
  * Both artifacts contain the same classes compiled from the same sources with the same AST
  * transformations; only the bytecode used to dispatch dynamic Groovy calls differs.
  *
- * <p>Selection happens through Gradle Module Metadata rather than through the classifier alone.
- * A Maven classifier shares the POM of the main artifact, so asking for one by classifier would
- * pull the default flavour of everything it depends on. The {@code noindy} artifact is instead
- * published as a secondary variant of {@code apiElements} and {@code runtimeElements}, which
- * inherits their dependencies, so a single request propagates across the whole graph.
+ * <p>The {@code noindy} jar is published as a plain Maven classifier artifact and nothing else:
+ * the module's published metadata keeps exactly the variants it always had. Publishing a second
+ * variant instead would make the module ambiguous to any configuration that requests no attributes
+ * at all — the shape used by tck and probe configurations, here and in other people's builds — and
+ * no attribute rule can repair that, because the variant lacking the attribute never appears among
+ * the candidate values a disambiguation rule is given.
  *
- * <p>Only the {@code noindy} variant carries the {@link #INDY_ATTRIBUTE} attribute; the default
- * variants deliberately leave it absent. A consumer that never asks for the attribute — any plain
- * Gradle project that does not apply a Grails plugin — therefore sees exactly one candidate and
- * resolves the default artifact as it always has. Declaring the attribute on both variants would
- * make every such build fail with a variant ambiguity error.
+ * <p>Selection is therefore assembled on the consuming side. An application that asks for
+ * {@code noindy} registers a {@link org.gradle.api.artifacts.ComponentMetadataRule} that derives a
+ * variant from the classifier artifact for the modules that publish one. Because that variant only
+ * ever exists inside a build that opted in, the schema there also carries the rules needed to
+ * choose, and nobody else's resolution changes in any way.
  *
  * @since 8.0
  */
@@ -83,6 +85,9 @@ class GrailsIndyVariants {
 
     /** Name of the {@link Jar} task that packages the {@code noindy} classes. */
     public static final String NOINDY_JAR_TASK_NAME = 'noindyJar'
+
+    /** Manifest attribute through which a module advertises that it publishes a noindy classifier. */
+    public static final String NOINDY_MANIFEST_ATTRIBUTE = 'Grails-Noindy-Artifact'
 
     private GrailsIndyVariants() {
     }
@@ -110,8 +115,8 @@ class GrailsIndyVariants {
             TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
             TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
 
-            addNoindyVariant(project, 'apiElements', noindyJar)
-            addNoindyVariant(project, 'runtimeElements', noindyJar)
+            publishNoindyClassifier(project, noindyJar)
+            advertiseNoindyArtifact(project)
         }
     }
 
@@ -127,10 +132,36 @@ class GrailsIndyVariants {
      * @param project the application project
      * @param indy provider for the value of {@code grails.indy}
      */
-    static void configureConsumer(Project project, Provider<Boolean> indy) {
-        project.configurations.configureEach { Configuration configuration ->
-            if (configuration.canBeResolved) {
-                configuration.attributes.attributeProvider(INDY_ATTRIBUTE, indy)
+    static void configureConsumer(Project project, Provider<Boolean> indy, Provider<Set<String>> noindyModules) {
+        project.dependencies.attributesSchema { schema ->
+            schema.attribute(INDY_ATTRIBUTE) { strategy ->
+                strategy.disambiguationRules.add(GrailsIndyDisambiguationRule)
+            }
+        }
+
+        project.afterEvaluate {
+            if (indy.getOrElse(true)) {
+                // Nothing to select: the default artifacts are already what everyone resolves.
+                return
+            }
+
+            Set<String> coordinates = noindyModules.getOrElse([] as Set)
+            if (!coordinates) {
+                project.logger.warn('Grails: indy is disabled but no modules are listed as publishing a noindy artifact, so the dependencies on the classpath remain the invokedynamic ones.')
+                project.logger.warn('        List them with grails { noindyModules = [\'group:name\'] } in build.gradle.')
+                return
+            }
+
+            project.dependencies.components { components ->
+                components.all(GrailsNoindyClassifierRule) { rule ->
+                    rule.params(coordinates)
+                }
+            }
+
+            project.configurations.configureEach { Configuration configuration ->
+                if (configuration.canBeResolved) {
+                    configuration.attributes.attribute(INDY_ATTRIBUTE, false)
+                }
             }
         }
     }
@@ -182,12 +213,29 @@ class GrailsIndyVariants {
         }
     }
 
-    private static void addNoindyVariant(Project project, String configurationName, TaskProvider<Jar> noindyJar) {
-        project.configurations.named(configurationName).configure { Configuration elements ->
-            elements.outgoing.variants.create(NOINDY_VARIANT_NAME) { ConfigurationVariant variant ->
-                variant.attributes.attribute(INDY_ATTRIBUTE, false)
-                variant.artifact(noindyJar)
+    /**
+     * Attaches the {@code noindy} jar to the module's publication as an ordinary classifier
+     * artifact, leaving the published variants untouched.
+     */
+    private static void publishNoindyClassifier(Project project, TaskProvider<Jar> noindyJar) {
+        project.pluginManager.withPlugin('maven-publish') {
+            PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
+            publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
+                publication.artifact(noindyJar)
             }
+        }
+    }
+
+    /**
+     * Records in the main jar's manifest that a {@code noindy} classifier accompanies it, so an
+     * application can discover which of its dependencies publish one instead of being told.
+     * Mirrors how a plugin advertises its CLI companion through {@code Grails-Cli-Artifact}.
+     */
+    private static void advertiseNoindyArtifact(Project project) {
+        project.tasks.named('jar', Jar).configure { Jar jar ->
+            jar.manifest.attributes((NOINDY_MANIFEST_ATTRIBUTE): project.provider {
+                "${project.group}:${project.name}".toString()
+            })
         }
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
@@ -25,6 +25,9 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.file.Directory
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.file.RegularFile
 import org.gradle.api.plugins.BasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
@@ -44,11 +47,11 @@ import org.grails.gradle.plugin.util.SourceSets
  * Publishes a Grails library in two flavours so that a consuming application can pick the Groovy
  * call-site implementation it wants without every producer having to agree on one.
  *
- * <p>The <em>default</em> artifact is compiled with Groovy's own default, which enables
- * {@code invokedynamic}. A second artifact carrying the {@code noindy} Maven classifier is compiled
- * with {@code invokedynamic} disabled, so its call sites use the older call-site-caching bytecode.
- * Both artifacts contain the same classes compiled from the same sources with the same AST
- * transformations; only the bytecode used to dispatch dynamic Groovy calls differs.
+ * <p>The <em>main</em> artifact is compiled with {@code invokedynamic} disabled, so its call sites
+ * use call-site-caching bytecode. A second artifact carrying the {@code indy} Maven classifier is
+ * compiled with Groovy's own default, which enables {@code invokedynamic}. Both artifacts contain
+ * the same classes compiled from the same sources with the same AST transformations; only the
+ * bytecode used to dispatch dynamic Groovy calls differs.
  *
  * <p>The {@code noindy} jar is published as a plain Maven classifier artifact and nothing else:
  * the module's published metadata keeps exactly the variants it always had. Publishing a second
@@ -75,19 +78,19 @@ class GrailsIndyVariants {
     public static final Attribute<Boolean> INDY_ATTRIBUTE = Attribute.of('org.apache.grails.indy', Boolean)
 
     /** Maven classifier of the artifact compiled without {@code invokedynamic}. */
-    public static final String NOINDY_CLASSIFIER = 'noindy'
+    public static final String INDY_CLASSIFIER = 'indy'
 
     /** Name of the secondary variant added to {@code apiElements} and {@code runtimeElements}. */
     public static final String NOINDY_VARIANT_NAME = 'noindy'
 
     /** Name of the {@link GroovyCompile} task that compiles the {@code noindy} classes. */
-    public static final String NOINDY_COMPILE_TASK_NAME = 'compileNoindyGroovy'
+    public static final String INDY_COMPILE_TASK_NAME = 'compileIndyGroovy'
 
     /** Name of the {@link Jar} task that packages the {@code noindy} classes. */
-    public static final String NOINDY_JAR_TASK_NAME = 'noindyJar'
+    public static final String INDY_JAR_TASK_NAME = 'indyJar'
 
     /** Manifest attribute through which a module advertises that it publishes a noindy classifier. */
-    public static final String NOINDY_MANIFEST_ATTRIBUTE = 'Grails-Noindy-Artifact'
+    public static final String INDY_MANIFEST_ATTRIBUTE = 'Grails-Indy-Artifact'
 
     private GrailsIndyVariants() {
     }
@@ -103,7 +106,7 @@ class GrailsIndyVariants {
      */
     static void configureProducer(Project project) {
         project.pluginManager.withPlugin('groovy') {
-            if (project.tasks.names.contains(NOINDY_JAR_TASK_NAME)) {
+            if (project.tasks.names.contains(INDY_JAR_TASK_NAME)) {
                 return
             }
 
@@ -112,11 +115,11 @@ class GrailsIndyVariants {
                 return
             }
 
-            TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
-            TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
+            TaskProvider<GroovyCompile> indyCompile = registerIndyCompileTask(project, main)
+            TaskProvider<Jar> indyJar = registerIndyJarTask(project, indyCompile)
 
-            publishNoindyClassifier(project, noindyJar)
-            advertiseNoindyArtifact(project)
+            publishIndyClassifier(project, indyJar)
+            advertiseIndyArtifact(project)
         }
     }
 
@@ -132,7 +135,7 @@ class GrailsIndyVariants {
      * @param project the application project
      * @param indy provider for the value of {@code grails.indy}
      */
-    static void configureConsumer(Project project, Provider<Boolean> indy, Provider<Set<String>> noindyModules) {
+    static void configureConsumer(Project project, Provider<Boolean> indy, Provider<Set<String>> indyModules) {
         project.dependencies.attributesSchema { schema ->
             schema.attribute(INDY_ATTRIBUTE) { strategy ->
                 strategy.disambiguationRules.add(GrailsIndyDisambiguationRule)
@@ -140,39 +143,39 @@ class GrailsIndyVariants {
         }
 
         project.afterEvaluate {
-            if (indy.getOrElse(true)) {
-                // Nothing to select: the default artifacts are already what everyone resolves.
+            if (!indy.getOrElse(false)) {
+                // Nothing to select: the main artifacts are already what everyone resolves.
                 return
             }
 
-            Set<String> coordinates = noindyModules.getOrElse([] as Set)
+            Set<String> coordinates = indyModules.getOrElse([] as Set)
             if (!coordinates) {
-                project.logger.warn('Grails: indy is disabled but no modules are listed as publishing a noindy artifact, so the dependencies on the classpath remain the invokedynamic ones.')
-                project.logger.warn('        List them with grails { noindyModules = [\'group:name\'] } in build.gradle.')
+                project.logger.warn('Grails: indy is enabled but no modules are listed as publishing an indy artifact, so the dependencies on the classpath remain the callsite-caching ones.')
+                project.logger.warn('        List them with grails { indyModules = [\'group:name\'] } in build.gradle.')
                 return
             }
 
             project.dependencies.components { components ->
-                components.all(GrailsNoindyClassifierRule) { rule ->
+                components.all(GrailsIndyClassifierRule) { rule ->
                     rule.params(coordinates)
                 }
             }
 
             project.configurations.configureEach { Configuration configuration ->
                 if (configuration.canBeResolved) {
-                    configuration.attributes.attribute(INDY_ATTRIBUTE, false)
+                    configuration.attributes.attribute(INDY_ATTRIBUTE, true)
                 }
             }
         }
     }
 
-    private static TaskProvider<GroovyCompile> registerNoindyCompileTask(Project project, SourceSet main) {
+    private static TaskProvider<GroovyCompile> registerIndyCompileTask(Project project, SourceSet main) {
         GroovyRuntime groovyRuntime = project.extensions.getByType(GroovyRuntime)
         JavaPluginExtension javaExtension = project.extensions.getByType(JavaPluginExtension)
-        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${NOINDY_CLASSIFIER}")
+        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${INDY_CLASSIFIER}")
 
-        return project.tasks.register(NOINDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
-            compile.description = 'Compiles the main Groovy source set with invokedynamic disabled.'
+        return project.tasks.register(INDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
+            compile.description = 'Compiles the main Groovy source set with invokedynamic enabled.'
             compile.group = BasePlugin.BUILD_GROUP
 
             compile.source = main.extensions.getByType(GroovySourceDirectorySet)
@@ -183,8 +186,8 @@ class GrailsIndyVariants {
             // The whole point of the second compilation. Every other GroovyCompile option is left to
             // the conventions that GrailsGradlePlugin applies to all GroovyCompile tasks, so this
             // task picks up the same AST transforms, compiler configuration script and fork settings
-            // as the default compilation and differs only in call-site bytecode.
-            compile.groovyOptions.optimizationOptions.put('indy', false)
+            // as the main compilation and differs only in call-site bytecode.
+            compile.groovyOptions.optimizationOptions.put('indy', true)
 
             // Registered tasks do not inherit the java extension's release/toolchain wiring that the
             // java plugin applies to the source set's own compile tasks.
@@ -197,19 +200,26 @@ class GrailsIndyVariants {
         }
     }
 
-    private static TaskProvider<Jar> registerNoindyJarTask(Project project, SourceSet main,
-                                                           TaskProvider<GroovyCompile> noindyCompile) {
-        return project.tasks.register(NOINDY_JAR_TASK_NAME, Jar) { Jar jar ->
-            jar.description = 'Assembles a jar whose Groovy classes are compiled without invokedynamic.'
+    private static TaskProvider<Jar> registerIndyJarTask(Project project, TaskProvider<GroovyCompile> indyCompile) {
+        return project.tasks.register(INDY_JAR_TASK_NAME, Jar) { Jar jar ->
+            jar.description = 'Assembles a jar whose Groovy classes are compiled with invokedynamic.'
             jar.group = BasePlugin.BUILD_GROUP
-            jar.archiveClassifier.set(NOINDY_CLASSIFIER)
+            jar.archiveClassifier.set(INDY_CLASSIFIER)
 
-            // Groovy classes come from the noindy compilation; everything else in the source set
-            // output is unaffected by the call-site flavour and is reused as-is. Java bytecode does
-            // not contain Groovy call sites, so recompiling it would produce identical classes.
-            jar.from(noindyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
-            jar.from(main.java.classesDirectory)
-            jar.from(project.tasks.named(main.processResourcesTaskName))
+            // Mirror the main jar rather than reassembling it: a plugin's jar also carries AST
+            // classes copied in from another source set, plus staged command and template resources
+            // laid out at paths this task does not know. Listing the pieces would silently omit them,
+            // and reusing the main jar's own copy spec would import its duplicatesStrategy with it.
+            // Unpacking the finished jar keeps the two artifacts identical by construction: the indy
+            // classes are added first and duplicates dropped, so they win at the paths they share
+            // with the main jar's Groovy classes and everything else arrives untouched.
+            jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+            jar.from(indyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
+            jar.from(project.tasks.named('jar', Jar).flatMap { Jar mainJar -> mainJar.archiveFile }
+                    .map { RegularFile mainArchive -> project.zipTree(mainArchive) }) { CopySpec spec ->
+                // The Jar task writes its own manifest.
+                spec.exclude('META-INF/MANIFEST.MF')
+            }
         }
     }
 
@@ -217,11 +227,11 @@ class GrailsIndyVariants {
      * Attaches the {@code noindy} jar to the module's publication as an ordinary classifier
      * artifact, leaving the published variants untouched.
      */
-    private static void publishNoindyClassifier(Project project, TaskProvider<Jar> noindyJar) {
+    private static void publishIndyClassifier(Project project, TaskProvider<Jar> indyJar) {
         project.pluginManager.withPlugin('maven-publish') {
             PublishingExtension publishing = project.extensions.getByType(PublishingExtension)
             publishing.publications.withType(MavenPublication).configureEach { MavenPublication publication ->
-                publication.artifact(noindyJar)
+                publication.artifact(indyJar)
             }
         }
     }
@@ -231,9 +241,9 @@ class GrailsIndyVariants {
      * application can discover which of its dependencies publish one instead of being told.
      * Mirrors how a plugin advertises its CLI companion through {@code Grails-Cli-Artifact}.
      */
-    private static void advertiseNoindyArtifact(Project project) {
+    private static void advertiseIndyArtifact(Project project) {
         project.tasks.named('jar', Jar).configure { Jar jar ->
-            jar.manifest.attributes((NOINDY_MANIFEST_ATTRIBUTE): project.provider {
+            jar.manifest.attributes((INDY_MANIFEST_ATTRIBUTE): project.provider {
                 "${project.group}:${project.name}".toString()
             })
         }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsIndyVariants.groovy
@@ -1,0 +1,193 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gradle.plugin.core
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationVariant
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.Directory
+import org.gradle.api.plugins.BasePlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.GroovyRuntime
+import org.gradle.api.tasks.GroovySourceDirectorySet
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.GroovyCompile
+import org.gradle.jvm.toolchain.JavaToolchainService
+
+import org.grails.gradle.plugin.util.SourceSets
+
+/**
+ * Publishes a Grails library in two flavours so that a consuming application can pick the Groovy
+ * call-site implementation it wants without every producer having to agree on one.
+ *
+ * <p>The <em>default</em> artifact is compiled with Groovy's own default, which enables
+ * {@code invokedynamic}. A second artifact carrying the {@code noindy} Maven classifier is compiled
+ * with {@code invokedynamic} disabled, so its call sites use the older call-site-caching bytecode.
+ * Both artifacts contain the same classes compiled from the same sources with the same AST
+ * transformations; only the bytecode used to dispatch dynamic Groovy calls differs.
+ *
+ * <p>Selection happens through Gradle Module Metadata rather than through the classifier alone.
+ * A Maven classifier shares the POM of the main artifact, so asking for one by classifier would
+ * pull the default flavour of everything it depends on. The {@code noindy} artifact is instead
+ * published as a secondary variant of {@code apiElements} and {@code runtimeElements}, which
+ * inherits their dependencies, so a single request propagates across the whole graph.
+ *
+ * <p>Only the {@code noindy} variant carries the {@link #INDY_ATTRIBUTE} attribute; the default
+ * variants deliberately leave it absent. A consumer that never asks for the attribute — any plain
+ * Gradle project that does not apply a Grails plugin — therefore sees exactly one candidate and
+ * resolves the default artifact as it always has. Declaring the attribute on both variants would
+ * make every such build fail with a variant ambiguity error.
+ *
+ * @since 8.0
+ */
+@CompileStatic
+class GrailsIndyVariants {
+
+    /**
+     * Attribute used to request a Groovy call-site flavour. Declared only on the {@code noindy}
+     * variants; see the class javadoc for why the default variants leave it unset.
+     */
+    public static final Attribute<Boolean> INDY_ATTRIBUTE = Attribute.of('org.apache.grails.indy', Boolean)
+
+    /** Maven classifier of the artifact compiled without {@code invokedynamic}. */
+    public static final String NOINDY_CLASSIFIER = 'noindy'
+
+    /** Name of the secondary variant added to {@code apiElements} and {@code runtimeElements}. */
+    public static final String NOINDY_VARIANT_NAME = 'noindy'
+
+    /** Name of the {@link GroovyCompile} task that compiles the {@code noindy} classes. */
+    public static final String NOINDY_COMPILE_TASK_NAME = 'compileNoindyGroovy'
+
+    /** Name of the {@link Jar} task that packages the {@code noindy} classes. */
+    public static final String NOINDY_JAR_TASK_NAME = 'noindyJar'
+
+    private GrailsIndyVariants() {
+    }
+
+    /**
+     * Adds the {@code noindy} compilation, jar and published variants to a library project.
+     *
+     * <p>Safe to call more than once and from more than one plugin: the second call returns without
+     * doing anything. In this repository both the {@code grails-plugin} Gradle plugin and the
+     * mono-repo's own build conventions can reach the same project.
+     *
+     * @param project the library project whose artifacts should be published in both flavours
+     */
+    static void configureProducer(Project project) {
+        project.pluginManager.withPlugin('groovy') {
+            if (project.tasks.names.contains(NOINDY_JAR_TASK_NAME)) {
+                return
+            }
+
+            SourceSet main = SourceSets.findMainSourceSet(project)
+            if (main == null) {
+                return
+            }
+
+            TaskProvider<GroovyCompile> noindyCompile = registerNoindyCompileTask(project, main)
+            TaskProvider<Jar> noindyJar = registerNoindyJarTask(project, main, noindyCompile)
+
+            addNoindyVariant(project, 'apiElements', noindyJar)
+            addNoindyVariant(project, 'runtimeElements', noindyJar)
+        }
+    }
+
+    /**
+     * Makes every resolvable configuration of an application request a Groovy call-site flavour, so
+     * that the framework and plugin artifacts on its classpath match the way the application itself
+     * is compiled.
+     *
+     * <p>Dependencies that publish only the default artifact — a plugin built before this existed,
+     * or one that opted out — stay resolvable: their single variant does not declare the attribute
+     * and so remains a valid candidate whichever flavour is requested.
+     *
+     * @param project the application project
+     * @param indy provider for the value of {@code grails.indy}
+     */
+    static void configureConsumer(Project project, Provider<Boolean> indy) {
+        project.configurations.configureEach { Configuration configuration ->
+            if (configuration.canBeResolved) {
+                configuration.attributes.attributeProvider(INDY_ATTRIBUTE, indy)
+            }
+        }
+    }
+
+    private static TaskProvider<GroovyCompile> registerNoindyCompileTask(Project project, SourceSet main) {
+        GroovyRuntime groovyRuntime = project.extensions.getByType(GroovyRuntime)
+        JavaPluginExtension javaExtension = project.extensions.getByType(JavaPluginExtension)
+        Provider<Directory> destination = project.layout.buildDirectory.dir("classes/groovy/${NOINDY_CLASSIFIER}")
+
+        return project.tasks.register(NOINDY_COMPILE_TASK_NAME, GroovyCompile) { GroovyCompile compile ->
+            compile.description = 'Compiles the main Groovy source set with invokedynamic disabled.'
+            compile.group = BasePlugin.BUILD_GROUP
+
+            compile.source = main.extensions.getByType(GroovySourceDirectorySet)
+            compile.classpath = main.compileClasspath
+            compile.groovyClasspath = groovyRuntime.inferGroovyClasspath(main.compileClasspath)
+            compile.destinationDirectory.set(destination)
+
+            // The whole point of the second compilation. Every other GroovyCompile option is left to
+            // the conventions that GrailsGradlePlugin applies to all GroovyCompile tasks, so this
+            // task picks up the same AST transforms, compiler configuration script and fork settings
+            // as the default compilation and differs only in call-site bytecode.
+            compile.groovyOptions.optimizationOptions.put('indy', false)
+
+            // Registered tasks do not inherit the java extension's release/toolchain wiring that the
+            // java plugin applies to the source set's own compile tasks.
+            compile.sourceCompatibility = javaExtension.sourceCompatibility.toString()
+            compile.targetCompatibility = javaExtension.targetCompatibility.toString()
+            if (javaExtension.toolchain.languageVersion.present) {
+                JavaToolchainService toolchains = project.extensions.getByType(JavaToolchainService)
+                compile.javaLauncher.set(toolchains.launcherFor(javaExtension.toolchain))
+            }
+        }
+    }
+
+    private static TaskProvider<Jar> registerNoindyJarTask(Project project, SourceSet main,
+                                                           TaskProvider<GroovyCompile> noindyCompile) {
+        return project.tasks.register(NOINDY_JAR_TASK_NAME, Jar) { Jar jar ->
+            jar.description = 'Assembles a jar whose Groovy classes are compiled without invokedynamic.'
+            jar.group = BasePlugin.BUILD_GROUP
+            jar.archiveClassifier.set(NOINDY_CLASSIFIER)
+
+            // Groovy classes come from the noindy compilation; everything else in the source set
+            // output is unaffected by the call-site flavour and is reused as-is. Java bytecode does
+            // not contain Groovy call sites, so recompiling it would produce identical classes.
+            jar.from(noindyCompile.flatMap { GroovyCompile compile -> compile.destinationDirectory })
+            jar.from(main.java.classesDirectory)
+            jar.from(project.tasks.named(main.processResourcesTaskName))
+        }
+    }
+
+    private static void addNoindyVariant(Project project, String configurationName, TaskProvider<Jar> noindyJar) {
+        project.configurations.named(configurationName).configure { Configuration elements ->
+            elements.outgoing.variants.create(NOINDY_VARIANT_NAME) { ConfigurationVariant variant ->
+                variant.attributes.attribute(INDY_ATTRIBUTE, false)
+                variant.artifact(noindyJar)
+            }
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsNoindyClassifierRule.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsNoindyClassifierRule.groovy
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gradle.plugin.core
+
+import javax.inject.Inject
+
+import groovy.transform.CompileStatic
+
+import org.gradle.api.artifacts.ComponentMetadataContext
+import org.gradle.api.artifacts.ComponentMetadataRule
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+
+/**
+ * Derives a {@code noindy} variant from a module's classifier artifact, inside the build that asked
+ * for one.
+ *
+ * <p>The rule runs against every module on the graph but changes only those named in
+ * {@code coordinates}. A module that publishes no {@code noindy} classifier must not be touched:
+ * the derived variant would point at a file that does not exist, and resolution fails when the
+ * artifact is fetched rather than when the rule runs. Platforms are the same story — they publish
+ * no jar at all.
+ *
+ * <p>The existing variants are stamped with {@code indy = true} as well as the derived one with
+ * {@code false}, so that both candidates carry a value. A disambiguation rule can then pick between
+ * them; without a value on both, the default variant would be invisible to that rule.
+ *
+ * @since 8.0
+ */
+@CompileStatic
+abstract class GrailsNoindyClassifierRule implements ComponentMetadataRule {
+
+    private final Set<String> coordinates
+
+    @Inject
+    GrailsNoindyClassifierRule(Set<String> coordinates) {
+        this.coordinates = coordinates
+    }
+
+    @Override
+    void execute(ComponentMetadataContext context) {
+        ModuleVersionIdentifier id = context.details.id
+        if (!coordinates.contains("${id.group}:${id.name}".toString())) {
+            return
+        }
+
+        ['apiElements', 'runtimeElements'].each { String base ->
+            context.details.withVariant(base) { variant ->
+                variant.attributes { it.attribute(GrailsIndyVariants.INDY_ATTRIBUTE, true) }
+            }
+            context.details.addVariant("noindy${base.capitalize()}", base) { variant ->
+                variant.attributes { it.attribute(GrailsIndyVariants.INDY_ATTRIBUTE, false) }
+                variant.withFiles {
+                    it.removeAllFiles()
+                    it.addFile("${id.name}-${id.version}-${GrailsIndyVariants.NOINDY_CLASSIFIER}.jar".toString())
+                }
+            }
+        }
+    }
+}

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsPluginGradlePlugin.groovy
@@ -109,6 +109,16 @@ class GrailsPluginGradlePlugin extends GrailsGradlePlugin {
         configurePluginResources(project)
         configureJarTask(project)
         configureSourcesJarTask(project)
+        GrailsIndyVariants.configureProducer(project)
+    }
+
+    /**
+     * A plugin is consumed by applications that may compile either way, so it publishes both
+     * flavours and leaves the choice to the application resolving it.
+     */
+    @Override
+    protected boolean publishesIndyVariants() {
+        true
     }
 
     @Override

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
@@ -27,19 +27,19 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
         when:
         def result = executeTask(':plugin:inspectIndyVariants')
 
-        then: 'the default compilation is left on Groovy\'s own default and the second one disables indy'
-        result.output.contains('MAIN_INDY=null')
-        result.output.contains('NOINDY_INDY=false')
+        then: 'the main compilation disables indy and the second one enables it'
+        result.output.contains('MAIN_INDY=false')
+        result.output.contains('INDY_INDY=true')
 
-        and: 'the second compilation is packaged under the noindy classifier'
-        result.output.contains('NOINDY_JAR=plugin-1.0.0-noindy.jar')
+        and: 'the second compilation is packaged under the indy classifier'
+        result.output.contains('INDY_JAR=plugin-1.0.0-indy.jar')
 
         and: 'only the call-site bytecode differs between the two jars'
-        result.output.contains('MAIN_BYTECODE=indy=true,callsite=false')
-        result.output.contains('NOINDY_BYTECODE=indy=false,callsite=true')
+        result.output.contains('MAIN_BYTECODE=indy=false,callsite=true')
+        result.output.contains('INDY_BYTECODE=indy=true,callsite=false')
     }
 
-    def "the noindy artifact is a plain classifier and adds no variant"() {
+    def "the indy artifact is a plain classifier and adds no variant"() {
         given:
         setupTestResourceProject('indy-variants')
 
@@ -47,8 +47,8 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
         def result = executeTask(':plugin:inspectIndyVariants')
 
         then: 'the published variants are exactly the ones the module always had'
-        result.output.contains('API_HAS_NOINDY=false')
-        result.output.contains('RUNTIME_HAS_NOINDY=false')
+        result.output.contains('API_HAS_INDY=false')
+        result.output.contains('RUNTIME_HAS_INDY=false')
 
         and: 'the module advertises the classifier so applications can discover it'
         result.output.contains('ADVERTISED=org.example.test:plugin')
@@ -66,11 +66,11 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
 
         where:
         indy    || resolved
-        'false' || 'legacy-1.0.0.jar,plugin-1.0.0-noindy.jar'
-        'true'  || 'legacy-1.0.0.jar,plugin-1.0.0.jar'
+        'true'  || 'legacy-1.0.0.jar,plugin-1.0.0-indy.jar'
+        'false' || 'legacy-1.0.0.jar,plugin-1.0.0.jar'
     }
 
-    def "a dependency that publishes only the default artifact stays resolvable either way"() {
+    def "a dependency that publishes only a main artifact stays resolvable either way"() {
         given: 'the application also depends on a library with no noindy variant'
         setupTestResourceProject('indy-variants')
 
@@ -84,17 +84,17 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
         indy << ['false', 'true']
     }
 
-    def "an application that configures nothing follows Groovy's own default"() {
+    def "an application that configures nothing gets invokedynamic disabled"() {
         given:
         setupTestResourceProject('indy-variants')
 
         when:
         def result = executeTask(':defaultapp:inspectDefault')
 
-        then: 'the compiler option is left unset, so Groovy decides'
-        result.output.contains('DEFAULT_INDY=true')
+        then: 'invokedynamic is off'
+        result.output.contains('DEFAULT_INDY=false')
 
-        and: 'and the default artifacts are the ones resolved'
+        and: 'and the main artifacts are the ones resolved'
         result.output.contains('DEFAULT_RESOLVED=plugin-1.0.0.jar')
     }
 
@@ -120,7 +120,7 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
         result.output.contains('PROBE=plugin-1.0.0.jar')
     }
 
-    def "a plain Gradle consumer still resolves the default artifact"() {
+    def "a plain Gradle consumer still resolves the main artifact"() {
         given:
         setupTestResourceProject('indy-variants')
 

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
@@ -63,8 +63,36 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
 
         where:
         indy    || resolved
-        'false' || 'plugin-1.0.0-noindy.jar'
-        'true'  || 'plugin-1.0.0.jar'
+        'false' || 'legacy-1.0.0.jar,plugin-1.0.0-noindy.jar'
+        'true'  || 'legacy-1.0.0.jar,plugin-1.0.0.jar'
+    }
+
+    def "a dependency that publishes only the default artifact stays resolvable either way"() {
+        given: 'the application also depends on a library with no noindy variant'
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':app:inspectResolved', ["-PappIndy=${indy}".toString()])
+
+        then: 'that library resolves to its single artifact rather than failing to match'
+        result.output.contains('legacy-1.0.0.jar')
+
+        where:
+        indy << ['false', 'true']
+    }
+
+    def "an application that configures nothing follows Groovy's own default"() {
+        given:
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':defaultapp:inspectDefault')
+
+        then: 'the compiler option is left unset, so Groovy decides'
+        result.output.contains('DEFAULT_INDY=true')
+
+        and: 'and the default artifacts are the ones resolved'
+        result.output.contains('DEFAULT_RESOLVED=plugin-1.0.0.jar')
     }
 
     def "a plain Gradle consumer still resolves the default artifact"() {

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.gradle.plugin.core
+
+class GrailsIndyVariantsSpec extends GradleSpecification {
+
+    def "a plugin compiles its classes both with and without invokedynamic"() {
+        given:
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':plugin:inspectIndyVariants')
+
+        then: 'the default compilation is left on Groovy\'s own default and the second one disables indy'
+        result.output.contains('MAIN_INDY=null')
+        result.output.contains('NOINDY_INDY=false')
+
+        and: 'the second compilation is packaged under the noindy classifier'
+        result.output.contains('NOINDY_JAR=plugin-1.0.0-noindy.jar')
+
+        and: 'only the call-site bytecode differs between the two jars'
+        result.output.contains('MAIN_BYTECODE=indy=true,callsite=false')
+        result.output.contains('NOINDY_BYTECODE=indy=false,callsite=true')
+    }
+
+    def "the noindy artifact is published as a secondary variant of both element configurations"() {
+        given:
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':plugin:inspectIndyVariants')
+
+        then:
+        result.output.contains('API_HAS_NOINDY=true')
+        result.output.contains('RUNTIME_HAS_NOINDY=true')
+    }
+
+    def "an application resolves the artifacts matching how it compiles its own code"() {
+        given:
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':app:inspectResolved', ["-PappIndy=${indy}".toString()])
+
+        then:
+        result.output.contains("RESOLVED=${resolved}")
+
+        where:
+        indy    || resolved
+        'false' || 'plugin-1.0.0-noindy.jar'
+        'true'  || 'plugin-1.0.0.jar'
+    }
+
+    def "a plain Gradle consumer still resolves the default artifact"() {
+        given:
+        setupTestResourceProject('indy-variants')
+
+        when: 'a consumer that never requests the attribute resolves the plugin'
+        def result = executeTask(':plain:inspectResolved')
+
+        then: 'it sees a single candidate rather than an ambiguity failure'
+        result.output.contains('RESOLVED=plugin-1.0.0.jar')
+    }
+}

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsIndyVariantsSpec.groovy
@@ -39,16 +39,19 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
         result.output.contains('NOINDY_BYTECODE=indy=false,callsite=true')
     }
 
-    def "the noindy artifact is published as a secondary variant of both element configurations"() {
+    def "the noindy artifact is a plain classifier and adds no variant"() {
         given:
         setupTestResourceProject('indy-variants')
 
         when:
         def result = executeTask(':plugin:inspectIndyVariants')
 
-        then:
-        result.output.contains('API_HAS_NOINDY=true')
-        result.output.contains('RUNTIME_HAS_NOINDY=true')
+        then: 'the published variants are exactly the ones the module always had'
+        result.output.contains('API_HAS_NOINDY=false')
+        result.output.contains('RUNTIME_HAS_NOINDY=false')
+
+        and: 'the module advertises the classifier so applications can discover it'
+        result.output.contains('ADVERTISED=org.example.test:plugin')
     }
 
     def "an application resolves the artifacts matching how it compiles its own code"() {
@@ -93,6 +96,28 @@ class GrailsIndyVariantsSpec extends GradleSpecification {
 
         and: 'and the default artifacts are the ones resolved'
         result.output.contains('DEFAULT_RESOLVED=plugin-1.0.0.jar')
+    }
+
+    def "an artifact view that constrains nothing resolves a single artifact"() {
+        given: 'a consumer resolving the way the CLI companion probe does'
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':plain:inspectArtifactView')
+
+        then:
+        result.output.contains('VIEW=plugin-1.0.0.jar')
+    }
+
+    def "a configuration that declares no attributes resolves a single artifact"() {
+        given: 'the shape used by ad-hoc configurations such as tck and the CLI probe'
+        setupTestResourceProject('indy-variants')
+
+        when:
+        def result = executeTask(':plain:inspectProbe')
+
+        then: 'publishing no second variant leaves nothing to be ambiguous about'
+        result.output.contains('PROBE=plugin-1.0.0.jar')
     }
 
     def "a plain Gradle consumer still resolves the default artifact"() {

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
@@ -1,0 +1,22 @@
+// An application selects the flavour it wants; the plugin's artifacts follow that choice.
+plugins {
+    id 'org.apache.grails.gradle.grails-app'
+}
+
+grails {
+    bom = null
+    cliAutoProvision = false
+    indy = project.hasProperty('appIndy') ? Boolean.parseBoolean(appIndy) : false
+}
+
+dependencies {
+    implementation localGroovy()
+    implementation project(':plugin')
+}
+
+tasks.register('inspectResolved') {
+    def runtime = configurations.runtimeClasspath
+    doLast {
+        println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
@@ -6,8 +6,8 @@ plugins {
 grails {
     bom = null
     cliAutoProvision = false
-    indy = project.hasProperty('appIndy') ? Boolean.parseBoolean(appIndy) : false
-    noindyModules = ['org.example.test:plugin']
+    indy = project.hasProperty('appIndy') ? Boolean.parseBoolean(appIndy) : true
+    indyModules = ['org.example.test:plugin']
 }
 
 repositories {

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
@@ -7,15 +7,23 @@ grails {
     bom = null
     cliAutoProvision = false
     indy = project.hasProperty('appIndy') ? Boolean.parseBoolean(appIndy) : false
+    noindyModules = ['org.example.test:plugin']
+}
+
+repositories {
+    maven { url = rootProject.layout.buildDirectory.dir('repo') }
 }
 
 dependencies {
     implementation localGroovy()
-    implementation project(':plugin')
+    // A real application consumes a plugin as a published module. Component metadata rules, which
+    // is how the noindy classifier becomes selectable, do not apply to project dependencies.
+    implementation 'org.example.test:plugin:1.0.0'
     implementation project(':legacy')
 }
 
 tasks.register('inspectResolved') {
+    dependsOn ':plugin:publishAllPublicationsToTestRepository'
     def runtime = configurations.runtimeClasspath
     doLast {
         println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') || it.startsWith('legacy') }.sort().join(',')}"

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/app/build.gradle
@@ -12,11 +12,12 @@ grails {
 dependencies {
     implementation localGroovy()
     implementation project(':plugin')
+    implementation project(':legacy')
 }
 
 tasks.register('inspectResolved') {
     def runtime = configurations.runtimeClasspath
     doLast {
-        println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+        println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') || it.startsWith('legacy') }.sort().join(',')}"
     }
 }

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/defaultapp/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/defaultapp/build.gradle
@@ -1,0 +1,24 @@
+// An application that says nothing about indy follows Groovy's default and resolves the default
+// artifacts to match.
+plugins {
+    id 'org.apache.grails.gradle.grails-app'
+}
+
+grails {
+    bom = null
+    cliAutoProvision = false
+}
+
+dependencies {
+    implementation localGroovy()
+    implementation project(':plugin')
+}
+
+tasks.register('inspectDefault') {
+    def compile = tasks.named('compileGroovy', GroovyCompile)
+    def runtime = configurations.runtimeClasspath
+    doLast {
+        println "DEFAULT_INDY=${compile.get().groovyOptions.optimizationOptions.indy}"
+        println "DEFAULT_RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/gradle.properties
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/gradle.properties
@@ -1,0 +1,2 @@
+version=1.0.0
+grailsVersion=__PROJECT_VERSION__

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/legacy/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/legacy/build.gradle
@@ -1,0 +1,10 @@
+// A dependency that publishes a single artifact: a plugin built before both flavours existed, or
+// one that opted out. It must stay resolvable whichever flavour the application asks for.
+plugins {
+    id 'groovy'
+    id 'java-library'
+}
+
+dependencies {
+    implementation localGroovy()
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/legacy/src/main/groovy/demo/LegacyGreeter.groovy
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/legacy/src/main/groovy/demo/LegacyGreeter.groovy
@@ -1,0 +1,9 @@
+package demo
+
+class LegacyGreeter {
+
+    String greet(String name) {
+        def shouted = name.toUpperCase()
+        'hello ' + shouted
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plain/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plain/build.gradle
@@ -1,0 +1,16 @@
+// A plain Gradle consumer that knows nothing about Grails must keep resolving the default
+// artifact: adding a second variant must not make it ambiguous.
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation project(':plugin')
+}
+
+tasks.register('inspectResolved') {
+    def runtime = configurations.runtimeClasspath
+    doLast {
+        println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plain/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plain/build.gradle
@@ -14,3 +14,23 @@ tasks.register('inspectResolved') {
         println "RESOLVED=${runtime.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
     }
 }
+
+// The two shapes that a published second variant breaks: an artifact view constraining nothing,
+// and an ad-hoc configuration with no attributes at all (as tck and CLI probe configurations have).
+tasks.register('inspectArtifactView') {
+    def view = configurations.runtimeClasspath.incoming.artifactView { it.lenient = false }.files
+    doLast {
+        println "VIEW=${view*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+    }
+}
+
+configurations { probe }
+
+dependencies { probe project(':plugin') }
+
+tasks.register('inspectProbe') {
+    def files = configurations.probe
+    doLast {
+        println "PROBE=${files.files*.name.findAll { it.startsWith('plugin') }.sort().join(',')}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
@@ -2,6 +2,12 @@
 // invokedynamic default, and a `noindy` classifier artifact is compiled without it.
 plugins {
     id 'org.apache.grails.gradle.grails-plugin'
+    id 'maven-publish'
+}
+
+publishing {
+    publications { maven(MavenPublication) { from components.java } }
+    repositories { maven { name = 'test'; url = rootProject.layout.buildDirectory.dir('repo') } }
 }
 
 group = 'org.example.test'
@@ -22,12 +28,14 @@ tasks.register('inspectIndyVariants') {
     def noindyJarTask = tasks.named('noindyJar', Jar)
     def apiHasNoindy = configurations.apiElements.outgoing.variants.names.contains('noindy')
     def runtimeHasNoindy = configurations.runtimeElements.outgoing.variants.names.contains('noindy')
+    def jarFileProvider = tasks.named('jar', Jar).flatMap { it.archiveFile }
     doLast {
         println "MAIN_INDY=${mainCompile.get().groovyOptions.optimizationOptions.indy}"
         println "NOINDY_INDY=${noindyCompile.get().groovyOptions.optimizationOptions.indy}"
         println "NOINDY_JAR=${noindyJarTask.get().archiveFile.get().asFile.name}"
         println "API_HAS_NOINDY=${apiHasNoindy}"
         println "RUNTIME_HAS_NOINDY=${runtimeHasNoindy}"
+        println "ADVERTISED=${manifestValue(jarFileProvider.get().asFile, 'Grails-Noindy-Artifact')}"
 
         def counts = [:]
         [main: tasks.named('jar', Jar).get(), noindy: noindyJarTask.get()].each { label, jarTask ->
@@ -38,6 +46,12 @@ tasks.register('inspectIndyVariants') {
         }
         println "MAIN_BYTECODE=${counts.main}"
         println "NOINDY_BYTECODE=${counts.noindy}"
+    }
+}
+
+static String manifestValue(File jarFile, String name) {
+    new java.util.jar.JarFile(jarFile).withCloseable { jar ->
+        jar.manifest?.mainAttributes?.getValue(name)
     }
 }
 

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
@@ -1,0 +1,65 @@
+// A Grails plugin publishes its classes twice: the default artifact uses Groovy's own
+// invokedynamic default, and a `noindy` classifier artifact is compiled without it.
+plugins {
+    id 'org.apache.grails.gradle.grails-plugin'
+}
+
+group = 'org.example.test'
+
+grails {
+    bom = null
+    cliAutoProvision = false
+}
+
+dependencies {
+    implementation localGroovy()
+}
+
+tasks.register('inspectIndyVariants') {
+    dependsOn 'jar', 'noindyJar'
+    def mainCompile = tasks.named('compileGroovy', GroovyCompile)
+    def noindyCompile = tasks.named('compileNoindyGroovy', GroovyCompile)
+    def noindyJarTask = tasks.named('noindyJar', Jar)
+    def apiHasNoindy = configurations.apiElements.outgoing.variants.names.contains('noindy')
+    def runtimeHasNoindy = configurations.runtimeElements.outgoing.variants.names.contains('noindy')
+    doLast {
+        println "MAIN_INDY=${mainCompile.get().groovyOptions.optimizationOptions.indy}"
+        println "NOINDY_INDY=${noindyCompile.get().groovyOptions.optimizationOptions.indy}"
+        println "NOINDY_JAR=${noindyJarTask.get().archiveFile.get().asFile.name}"
+        println "API_HAS_NOINDY=${apiHasNoindy}"
+        println "RUNTIME_HAS_NOINDY=${runtimeHasNoindy}"
+
+        def counts = [:]
+        [main: tasks.named('jar', Jar).get(), noindy: noindyJarTask.get()].each { label, jarTask ->
+            def classFile = new File(jarTask.destinationDirectory.get().asFile, 'unpacked')
+            classFile.deleteDir()
+            copyClass(jarTask.archiveFile.get().asFile, classFile)
+            counts[label] = describe(new File(classFile, 'demo/PluginGreeter.class'))
+        }
+        println "MAIN_BYTECODE=${counts.main}"
+        println "NOINDY_BYTECODE=${counts.noindy}"
+    }
+}
+
+static void copyClass(File jarFile, File targetDir) {
+    targetDir.mkdirs()
+    new java.util.zip.ZipFile(jarFile).withCloseable { zip ->
+        zip.entries().each { entry ->
+            if (entry.name.endsWith('.class')) {
+                def out = new File(targetDir, entry.name)
+                out.parentFile.mkdirs()
+                out.bytes = zip.getInputStream(entry).bytes
+            }
+        }
+    }
+}
+
+// `invokedynamic` appears in the constant pool of indy-compiled classes only; classes compiled
+// without it reference the CallSite runtime instead. Reading the raw bytes keeps the check free of
+// any dependency on a bytecode library.
+static String describe(File classFile) {
+    def text = new String(classFile.bytes, 'ISO-8859-1')
+    def hasCallSite = text.contains('org/codehaus/groovy/runtime/callsite/CallSite')
+    def hasIndy = text.contains('org/codehaus/groovy/vmplugin/v8/IndyInterface')
+    "indy=${hasIndy},callsite=${hasCallSite}"
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/build.gradle
@@ -1,5 +1,5 @@
-// A Grails plugin publishes its classes twice: the default artifact uses Groovy's own
-// invokedynamic default, and a `noindy` classifier artifact is compiled without it.
+// A Grails plugin publishes its classes twice: the main artifact is compiled without
+// invokedynamic, and an `indy` classifier artifact is compiled with it.
 plugins {
     id 'org.apache.grails.gradle.grails-plugin'
     id 'maven-publish'
@@ -22,30 +22,30 @@ dependencies {
 }
 
 tasks.register('inspectIndyVariants') {
-    dependsOn 'jar', 'noindyJar'
+    dependsOn 'jar', 'indyJar'
     def mainCompile = tasks.named('compileGroovy', GroovyCompile)
-    def noindyCompile = tasks.named('compileNoindyGroovy', GroovyCompile)
-    def noindyJarTask = tasks.named('noindyJar', Jar)
-    def apiHasNoindy = configurations.apiElements.outgoing.variants.names.contains('noindy')
-    def runtimeHasNoindy = configurations.runtimeElements.outgoing.variants.names.contains('noindy')
+    def indyCompile = tasks.named('compileIndyGroovy', GroovyCompile)
+    def indyJarTask = tasks.named('indyJar', Jar)
+    def apiHasNoindy = configurations.apiElements.outgoing.variants.names.contains('indy')
+    def runtimeHasNoindy = configurations.runtimeElements.outgoing.variants.names.contains('indy')
     def jarFileProvider = tasks.named('jar', Jar).flatMap { it.archiveFile }
     doLast {
         println "MAIN_INDY=${mainCompile.get().groovyOptions.optimizationOptions.indy}"
-        println "NOINDY_INDY=${noindyCompile.get().groovyOptions.optimizationOptions.indy}"
-        println "NOINDY_JAR=${noindyJarTask.get().archiveFile.get().asFile.name}"
-        println "API_HAS_NOINDY=${apiHasNoindy}"
-        println "RUNTIME_HAS_NOINDY=${runtimeHasNoindy}"
-        println "ADVERTISED=${manifestValue(jarFileProvider.get().asFile, 'Grails-Noindy-Artifact')}"
+        println "INDY_INDY=${indyCompile.get().groovyOptions.optimizationOptions.indy}"
+        println "INDY_JAR=${indyJarTask.get().archiveFile.get().asFile.name}"
+        println "API_HAS_INDY=${apiHasNoindy}"
+        println "RUNTIME_HAS_INDY=${runtimeHasNoindy}"
+        println "ADVERTISED=${manifestValue(jarFileProvider.get().asFile, 'Grails-Indy-Artifact')}"
 
         def counts = [:]
-        [main: tasks.named('jar', Jar).get(), noindy: noindyJarTask.get()].each { label, jarTask ->
+        [main: tasks.named('jar', Jar).get(), indy: indyJarTask.get()].each { label, jarTask ->
             def classFile = new File(jarTask.destinationDirectory.get().asFile, 'unpacked')
             classFile.deleteDir()
             copyClass(jarTask.archiveFile.get().asFile, classFile)
             counts[label] = describe(new File(classFile, 'demo/PluginGreeter.class'))
         }
         println "MAIN_BYTECODE=${counts.main}"
-        println "NOINDY_BYTECODE=${counts.noindy}"
+        println "INDY_BYTECODE=${counts.indy}"
     }
 }
 

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/src/main/groovy/demo/PluginGreeter.groovy
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/plugin/src/main/groovy/demo/PluginGreeter.groovy
@@ -1,0 +1,9 @@
+package demo
+
+class PluginGreeter {
+
+    String greet(String name) {
+        def shouted = name.toUpperCase()
+        'hello ' + shouted
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/settings.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/settings.gradle
@@ -1,3 +1,3 @@
 rootProject.name = 'indy-variants'
 
-include 'plugin', 'app', 'plain'
+include 'plugin', 'app', 'plain', 'legacy', 'defaultapp'

--- a/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/settings.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/indy-variants/settings.gradle
@@ -1,0 +1,3 @@
+rootProject.name = 'indy-variants'
+
+include 'plugin', 'app', 'plain'


### PR DESCRIPTION
Rebased onto latest `8.0.x` (`d0c68dc`, which brings Groovy 5.1.0) and reworked to the design the Grails team asked for: **the main artifact is the callsite-caching flavour, and `invokedynamic` ships under the `indy` classifier.**

### What an application sees

Nothing, unless it opts in. `grails.indy` defaults to `false`, exactly as 7.x behaved, and every Grails module and plugin publishes its main artifact compiled that way.

An application that wants `invokedynamic` gets it for its own classes *and* its dependencies:

```groovy
grails {
    indy = true
    indyModules = ['org.apache.grails:grails-core', 'com.example:my-plugin']
}
```

Dependencies left off the list keep their main artifact. That is safe on the JVM — the two flavours interoperate on the same classpath — but a native image needs the `indy` flavour of everything, so an application targeting one lists every Grails module and plugin it uses.

### Plugins publish both

A project applying `org.apache.grails.gradle.grails-plugin` builds both flavours through the new `indyJar` task, so any application that wants indy can have it. `grails.indy` no longer affects how a plugin compiles its own sources; plugin authors need to change nothing, and a plugin build that sets `indy` can drop it.

### Why a classifier and not a variant

The previous revision of this PR published the `indy` jar as a secondary Gradle variant, and CI failed across the board:

```
Could not resolve all dependencies for configuration ':grails-data-hibernate5-core:tck'.
   > More than one variant of project ':grails-datamapping-tck' matches the consumer attributes:
```

A configuration that requests **no attributes at all** — the shape `tck` and the CLI companion probe use, here and in other people's builds — finds every variant equally good. No attribute rule repairs it: a disambiguation rule only receives the values candidates declare, so the variant *without* the attribute never appears among them (`consumer=null candidates=[false]`), and declaring it on both variants breaks every plain consumer instead.

A plain Maven classifier adds nothing to the published metadata, so the ambiguity is unreachable rather than fixed. Selection is assembled on the consuming side: an application that opts in registers a `ComponentMetadataRule` deriving a variant from the classifier for the modules it lists. That variant exists only inside the opted-in build, whose schema also carries the rules needed to choose.

### Verification

10 functional tests in `GrailsIndyVariantsSpec`, including the two shapes that broke CI last time — an artifact view constraining nothing, and a configuration with no attributes — both now resolving a single artifact.

On `grails-cache`, a real plugin module with an `ast` source set:

| | entries | classes | with `invokedynamic` | AST classes |
|---|---|---|---|---|
| main | 56 | 37 | 1 | 5 |
| `-indy` | 56 | 37 | 11 | 5 |

Entry lists identical; only the Groovy call-site bytecode differs. (The 1 in the main jar is `makeConcatWithConstants` in a `.java` source file — javac's string concatenation, not a Groovy call site.)

Suite: 188/191. The 3 `GroovyPageToolchainSpec` failures need a JDK 21 toolchain that is not installed on the machine I ran them on and fail identically on unmodified `8.0.x`. `codeStyle` clean.

### Known limitations

- **`indyModules` must be listed explicitly.** An unguarded rule fails hard trying to fetch e.g. `groovy-5.1.0-indy.jar`, and platforms fail the same way — `grails-bom` is a platform every application depends on — so there is no safe group-wide default. Modules advertise their classifier through `Grails-Indy-Artifact` (mirroring `Grails-Cli-Artifact`) so the list can later be discovered by a probe rather than written; that discovery is not implemented here.
- **Component metadata rules do not apply to project dependencies**, so a composite or multi-project build always resolves the main artifact.

### Reviewer notes

Full `./gradlew build` has not been run; `grails-cache` was built and inspected locally. The `indyJar` task assembles by unpacking the finished main jar rather than listing source directories — enumerating them omitted the AST classes and staged command/template resources, and reusing the main jar's copy spec imported its `duplicatesStrategy`. Both were caught only by building a real module, not by the functional tests.