### PR TITLE
BUGFIX:  message bundles silently failing to resolve in development

### DIFF
--- a/grails-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsBeanDefinitionsPostProcessor.groovy
+++ b/grails-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsBeanDefinitionsPostProcessor.groovy
@@ -27,6 +27,8 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
 import org.springframework.beans.factory.support.GenericBeanDefinition
 import org.springframework.core.Ordered
+import org.springframework.aop.target.HotSwappableTargetSource
+import org.springframework.beans.factory.FactoryBean
 import org.springframework.core.PriorityOrdered
 
 import grails.web.mapping.UrlMappings
@@ -37,15 +39,26 @@ import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
 /**
  * Registers the URL-mapping bean definitions the url-mappings plugin previously contributed through
  * the {@code doWithSpring()} bean DSL. The {@code grailsUrlMappingsHolder} bean is a
- * {@link ProxyFactoryBean} (in reload mode) whose produced type — {@link UrlMappings}, which
- * extends {@link grails.web.mapping.UrlMappingsHolder} — is only known from its
- * {@code proxyInterfaces} property, and {@link UrlMappingsHandlerMapping} takes a constructor
- * reference to it. Neither the property-driven factory-bean type nor the constructor reference can
- * be expressed through the {@link org.springframework.beans.factory.BeanRegistry} API without hiding
- * the produced type inside an instance supplier — which breaks by-type autowiring of
- * {@code UrlMappingsHolder} (e.g. {@code DefaultLinkGenerator}). The definitions are therefore
- * contributed here, mirroring the original DSL so Spring's factory-bean type prediction behaves
- * identically.
+ * {@link ProxyFactoryBean} (in reload mode), and {@link UrlMappingsHandlerMapping} takes a
+ * constructor reference to it. Neither can be expressed through the
+ * {@link org.springframework.beans.factory.BeanRegistry} API without hiding the produced type inside
+ * an instance supplier — which breaks by-type autowiring of {@code UrlMappingsHolder} (e.g.
+ * {@code DefaultLinkGenerator}, and {@code UrlMappingsErrorPageCustomizer}'s bare
+ * {@code @Autowired UrlMappings}). The definitions are therefore contributed here.
+ *
+ * <p>Each factory-bean definition declares what it produces through
+ * {@link FactoryBean#OBJECT_TYPE_ATTRIBUTE}. That is not decoration: a factory bean's produced type
+ * must be answerable from the <em>definition</em>, because a property value cannot be. Asked for the
+ * type without it, Spring builds a constructor-only instance of the proxy — no property values
+ * applied, so no {@code targetSource} and no {@code proxyInterfaces} — whose
+ * {@code getObjectType()} returns {@code null}. Spring then falls back to creating the factory bean
+ * in full, which resolves the target source and the inner {@link UrlMappingsHolderFactoryBean},
+ * evaluates every mapping, and reaches the constraints machinery and its
+ * {@code List<MessageSource>} injection. All of that would happen while bean definition registry
+ * post-processors are still running, so any {@code @ConfigurationProperties} bean created along the
+ * way is built before {@code ConfigurationPropertiesBindingPostProcessor} exists and is silently
+ * left at its defaults — which is how Spring Boot's message source lost every base name except
+ * {@code messages}, and with it every plugin and application-configured bundle.</p>
  *
  * <p>Runs as a {@link PriorityOrdered} post-processor with highest precedence so the definitions
  * are registered before Spring Boot's configuration-class post-processor evaluates auto-configuration
@@ -87,6 +100,7 @@ class UrlMappingsBeanDefinitionsPostProcessor implements BeanDefinitionRegistryP
             GenericBeanDefinition targetSource = new GenericBeanDefinition()
             targetSource.beanClass = HotSwappableTargetSourceFactoryBean
             targetSource.lazyInit = true
+            targetSource.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, HotSwappableTargetSource)
             targetSource.propertyValues.addPropertyValue('target', innerHolderFactory)
             registry.registerBeanDefinition('urlMappingsTargetSource', targetSource)
 
@@ -95,11 +109,13 @@ class UrlMappingsBeanDefinitionsPostProcessor implements BeanDefinitionRegistryP
             proxy.lazyInit = true
             proxy.propertyValues.addPropertyValue('targetSource', new RuntimeBeanReference('urlMappingsTargetSource'))
             proxy.propertyValues.addPropertyValue('proxyInterfaces', [UrlMappings] as Class[])
+            proxy.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, UrlMappings)
             registry.registerBeanDefinition('grailsUrlMappingsHolder', proxy)
         } else {
             GenericBeanDefinition holder = new GenericBeanDefinition()
             holder.beanClass = UrlMappingsHolderFactoryBean
             holder.lazyInit = true
+            holder.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, UrlMappings)
             registry.registerBeanDefinition('grailsUrlMappingsHolder', holder)
         }
     }

--- a/grails-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsGrailsPlugin.groovy
+++ b/grails-url-mappings/src/main/groovy/org/grails/plugins/web/mapping/UrlMappingsGrailsPlugin.groovy
@@ -21,6 +21,7 @@ package org.grails.plugins.web.mapping
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 
+import org.springframework.aot.AotDetector
 import org.springframework.aop.target.HotSwappableTargetSource
 import org.springframework.beans.factory.BeanRegistrar
 import org.springframework.beans.factory.BeanRegistry
@@ -117,14 +118,18 @@ class UrlMappingsGrailsPlugin extends Plugin {
                 grailsApplication.addArtefact(UrlMappingsArtefactHandler.TYPE, DefaultUrlMappings)
             }
 
-            boolean reloadEnabled = GrailsEnvironment.developmentMode ||
-                    GrailsEnvironment.current.reloadEnabled
+            // Never proxy for hot-swapping when the bean definitions are the generated ones: AOT
+            // code generation drops the custom definition attributes that tell Spring what a factory
+            // bean produces, and hot-swapping mappings is meaningless in an image anyway.
+            boolean reloadEnabled = !AotDetector.useGeneratedArtifacts() &&
+                    (GrailsEnvironment.developmentMode || GrailsEnvironment.current.reloadEnabled)
             boolean corsFilterEnabled = environment.getProperty(Settings.SETTING_CORS_FILTER, Boolean, true)
 
             // The url-mapping holder is a ProxyFactoryBean (reload mode) whose produced UrlMappings
-            // type must stay visible to Spring's factory-bean type prediction for by-type autowiring
-            // of UrlMappingsHolder — which an instance supplier would hide — so the definitions are
-            // contributed by a dedicated post-processor instead.
+            // type must stay answerable from the bean definition for by-type autowiring of
+            // UrlMappingsHolder — which an instance supplier would hide — so the definitions are
+            // contributed by a dedicated post-processor that declares the produced type through
+            // FactoryBean.OBJECT_TYPE_ATTRIBUTE. See that class for why the attribute is load-bearing.
             registry.registerBean('urlMappingsBeanDefinitionsPostProcessor', UrlMappingsBeanDefinitionsPostProcessor) {
                 it.infrastructure().supplier {
                     new UrlMappingsBeanDefinitionsPostProcessor(reloadEnabled, corsFilterEnabled)

--- a/grails-url-mappings/src/test/groovy/org/grails/plugins/web/mapping/UrlMappingsGrailsPluginSpec.groovy
+++ b/grails-url-mappings/src/test/groovy/org/grails/plugins/web/mapping/UrlMappingsGrailsPluginSpec.groovy
@@ -108,4 +108,39 @@ class UrlMappingsGrailsPluginSpec extends Specification {
         def registrar = plugin.beanRegistrar()
         new BeanRegistryAdapter(beanFactory, new StandardEnvironment(), registrar.getClass()).register(registrar)
     }
+    void "an eager by-type lookup finds the reload-mode holder without creating anything"() {
+        given: 'the definitions as the post-processor registers them in reload mode'
+        DefaultListableBeanFactory registry = new DefaultListableBeanFactory()
+        new UrlMappingsBeanDefinitionsPostProcessor(true, true).postProcessBeanDefinitionRegistry(registry)
+
+        when: "a by-type scan runs with eager initialisation, as GrailsApplicationPostProcessor's \
+constructor does while bean definition registry post-processors are still running"
+        String[] names = registry.getBeanNamesForType(UrlMappings, true, true)
+
+        then: 'by-type autowiring of UrlMappings still resolves the holder'
+        names.contains('grailsUrlMappingsHolder')
+
+        and: "nothing was created in order to answer that. Without the produced type declared on the \
+definition, Spring builds a constructor-only ProxyFactoryBean whose getObjectType() returns null, \
+then falls back to creating the factory bean in full - which resolves the target source, the inner \
+holder factory and the constraints machinery, creating @ConfigurationProperties beans before their \
+binding post-processor exists"
+        !registry.containsSingleton('grailsUrlMappingsHolder')
+        !registry.containsSingleton('urlMappingsTargetSource')
+    }
+
+    void "an eager by-type lookup finds the non-reload holder without creating anything"() {
+        given:
+        DefaultListableBeanFactory registry = new DefaultListableBeanFactory()
+        new UrlMappingsBeanDefinitionsPostProcessor(false, true).postProcessBeanDefinitionRegistry(registry)
+
+        when:
+        String[] names = registry.getBeanNamesForType(UrlMappings, true, true)
+
+        then:
+        names.contains('grailsUrlMappingsHolder')
+
+        and:
+        !registry.containsSingleton('grailsUrlMappingsHolder')
+    }
 }


### PR DESCRIPTION
In development, every message bundle contributed by a plugin, and every base name an application configured itself, silently fails to resolve. Spring Boot's `messageSource` is built with only the default `messages` base name, and nothing warns:

```
NoSuchMessageException: No message found under code 'my.plugin.message' for locale 'en'
```

Deployed applications are unaffected — only reload mode builds the holder as a proxy — so this is `grails run-app`, every Gradle `JavaExec`, and every integration run.

## Cause

A factory bean's produced type has to be answerable from the bean *definition*, because a property value cannot be. Asked for the type of `grailsUrlMappingsHolder`, Spring builds a constructor-only `ProxyFactoryBean` — no property values applied, so no `targetSource` and no `proxyInterfaces` — whose `getObjectType()` returns `null`. Spring then falls back to creating the factory bean in full.

That resolves the target source and the inner `UrlMappingsHolderFactoryBean`, evaluates every URL mapping, reaches the constraints machinery and its `List<MessageSource>` injection, and so creates Spring Boot's message source — all while bean definition registry post-processors are still running. Anything created that early misses `ConfigurationPropertiesBindingPostProcessor`, so `MessageSourceProperties` is never bound and keeps its constructor defaults.

It is not only the base names: `encoding`, `cache-duration` and `fallback-to-system-locale` are lost with them.

## Fix

Each factory-bean definition declares what it produces through `FactoryBean.OBJECT_TYPE_ATTRIBUTE`, which Spring consults before instantiating anything:

```groovy
proxy.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, UrlMappings)
```

By-type autowiring of `UrlMappingsHolder` keeps working — that is why these definitions live in a post-processor rather than the `BeanRegistry` API — and the hot-swap target source is untouched, so reload still works.

Reload mode is additionally switched off when running generated bean definitions: AOT code generation drops custom definition attributes, and hot-swapping mappings is meaningless in an image.

## Test

The regression test issues the eager by-type lookup directly against a bare `DefaultListableBeanFactory`, so it reproduces with no Grails runtime and no ordering luck. It fails without the fix.

## Notes

- `setLazyInit(true)` cannot help here: the lazy-init gate is bypassed when a by-type scan runs with `allowEagerInit`, and these definitions were already lazy.
- Promoting the inner holder to a named top-level bean does not work — it adds a second `UrlMappings` candidate and the application fails to start with `required a single bean, but 2 were found`.
