### PR TITLE
Add an end-to-end module verifying message bundles resolve

### DIFF
--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -35,6 +35,8 @@ applications at via `GRAILS_REPO_URL`.
 | `legacy-g7-command-plugin` | A **standalone build**, not part of this one. Compiles against published Grails 7 / Groovy 4 to produce a genuine precompiled `grails.dev.commands.ApplicationCommand` binary. |
 | `legacy-commands-plugin` | A Grails 8 plugin whose legacy commands are recompiled under Groovy 5. |
 | `legacy-commands` | A Grails 8 application that consumes both and runs their commands through the registry. |
+| `native-i18n` | An application that resolves messages from three kinds of bundle, on a JVM always and inside a GraalVM binary when asked. |
+| `native-i18n-plugin` | A plugin shipping a namespaced message bundle (`native-messages.properties`), with a multi-word plugin name. |
 | `spring-dependency-management` | A Grails 8 application that manages its versions with the legacy `io.spring.dependency-management` plugin instead of the Grails Gradle plugin's native `platform(grails-bom)`, as an upgraded Grails 7 application does. |
 | `taglib-index-incremental` | Builds a Grails 8 application **twice, without a clean**, to prove a renamed or deleted tag library cannot survive in the published tag library index. Incremental behaviour is the whole point, so it cannot be expressed by a project the core build builds once for itself. |
 
@@ -50,6 +52,68 @@ what this build already provides. In the core build it had to be excluded whenev
 published yet (a reproducible release build, or a fresh release branch whose version has never been
 published), and otherwise silently fell back to whatever the Apache snapshot repository happened to
 hold rather than the working tree.
+
+## Native image verification
+
+`native-i18n` exists because AOT processing on a JVM cannot falsify a resource hint. Every bundle on
+a JVM classpath is readable whether it was registered or not, so a missing hint shows up only in a
+compiled image — as a code resolving to itself, for a message that resolved perfectly in every test.
+
+The application resolves one code from each way a bundle reaches the message source, and only the
+first is covered by Spring Boot's own hints, which register the two hardcoded patterns
+`messages.properties` and `messages_*.properties` and derive nothing from the configured base names:
+
+| Bundle | Base name | Why it is here |
+|---|---|---|
+| the application's own | `messages` | The case Boot already covers, as a control. |
+| the plugin's | `native-messages` | Namespaced, so Boot's patterns never reach it. The plugin name is multi-word, so this also covers the descriptor's hyphenated spelling being matched against the plugin's camel-case one. |
+| one the application configured | `config.i18n.custom` | Outside `grails-app/i18n`, and written dotted, so it also proves the base name is converted to `config/i18n/custom` before being registered. |
+
+Each is resolved in English and in a locale variant. The locale half is the assertion that would
+fail if the hints registered *bundles* rather than resource *patterns* and the image were built with
+a narrower locale set than the bundles cover — the open question recorded in
+https://github.com/apache/grails-core/issues/16176.
+
+```bash
+cd end-to-end
+./gradlew :native-i18n:check                 # the JVM half, part of `check`
+./gradlew :native-i18n:check -PnativeTests   # adds the native half
+```
+
+The JVM half runs in `check` and needs nothing special. It cannot falsify a hint; its value is as a
+fixture guard, keeping the bundles and the assertions from drifting apart. The native half is opt-in
+because it needs a GraalVM toolchain and minutes of CPU, not because it is expected to fail.
+
+### Why this runs here and not on 8.0.x
+
+Dynamic Groovy in a native image needs two things this branch has and 8.0.x deliberately does not:
+
+| | 8.0.x | here |
+|---|---|---|
+| `groovy.version` | 5.1.2 | 6.0.0-beta-2, which carries [GROOVY-12234](https://issues.apache.org/jira/browse/GROOVY-12234)'s AOT link mode for indy dispatch |
+| framework invokedynamic | forced off in `CompilePlugin`, because Groovy 5's indy default is a large runtime regression for dynamic Groovy (#15293) | Groovy's default, which is on |
+
+Without the AOT link mode, indy-compiled Groovy cannot link in an image: the runtime invokes
+`IndyInterface`'s bootstrap method without its `<clinit>` having run, so a `static final` handle is
+still null and it fails as `BootstrapMethodError: NullPointerException` at
+`IndyInterface.makeBootHandle`. Without invokedynamic at all, Groovy classes carry a `CallSiteArray`
+and define call-site classes as they run, which an image forbids: `UnsupportedFeatureError: Tried to
+define class`, naming a class nobody wrote. Either one on its own is fatal, which is why native
+image is not a Grails 8 capability and this module is not on that branch.
+
+### What it needs
+
+**A GraalVM JDK, and not necessarily the one that published the framework.** `GRAALVM_HOME` and
+`JAVA_HOME` must point at a GraalVM before the image is built; `toolchainDetection = false` makes the
+plugin honour it rather than resolving a toolchain, so the publish JDK and the image JDK do not have
+to agree. Use GraalVM 25 or later: on the 21 line `nativeCompile` fails during "Initializing" with
+`Could not find target method: ...IndyInterface.invalidateSwitchPoints()`, because GraalVM's bundled
+Groovy substitution targets a method Groovy 4+ removed
+([oracle/graal#10200](https://github.com/oracle/graal/issues/10200), fixed in the 25 line). What must
+not happen is publishing on a JDK *newer* than the one the image is built with: `GroovyCompile` has
+no `release` option, so the Groovy sources in `grails-gradle` are compiled for the running JDK, and a
+newer class file version makes the image fail at *configuration* time, naming a framework class as
+though the framework had regressed.
 
 ## JDKs
 

--- a/end-to-end/native-i18n-plugin/build.gradle
+++ b/end-to-end/native-i18n-plugin/build.gradle
@@ -1,0 +1,37 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.buildsrc.dependency-validator'
+    id 'org.apache.grails.buildsrc.compile'
+    id 'org.apache.grails.gradle.grails-plugin'
+}
+
+version = '0.0.1'
+group = 'nativei18n.plugin'
+
+dependencies {
+    implementation platform("org.apache.grails:grails-bom:$projectVersion")
+    implementation 'org.apache.grails:grails-core'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('../gradle/grails-extension-gradle-config.gradle')
+}

--- a/end-to-end/native-i18n-plugin/grails-app/i18n/native-messages.properties
+++ b/end-to-end/native-i18n-plugin/grails-app/i18n/native-messages.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.plugin.greeting=hello from the plugin bundle

--- a/end-to-end/native-i18n-plugin/grails-app/i18n/native-messages_fr.properties
+++ b/end-to-end/native-i18n-plugin/grails-app/i18n/native-messages_fr.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.plugin.greeting=bonjour depuis le paquet du plugin

--- a/end-to-end/native-i18n-plugin/src/main/groovy/nativei18n/plugin/NativeMessagesGrailsPlugin.groovy
+++ b/end-to-end/native-i18n-plugin/src/main/groovy/nativei18n/plugin/NativeMessagesGrailsPlugin.groovy
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package nativei18n.plugin
+
+import grails.plugins.Plugin
+
+/**
+ * A plugin whose Grails name is multi-word, so its bundle exercises both halves of the naming:
+ * the descriptor records the hyphenated {@code native-messages}, while the plugin the application
+ * discovers reports the logical {@code nativeMessages}.
+ */
+class NativeMessagesGrailsPlugin extends Plugin {
+
+    def grailsVersion = '9.0.0-SNAPSHOT > *'
+}

--- a/end-to-end/native-i18n/build.gradle
+++ b/end-to-end/native-i18n/build.gradle
@@ -1,0 +1,102 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+plugins {
+    id 'org.apache.grails.buildsrc.properties'
+    id 'org.apache.grails.buildsrc.dependency-validator'
+    id 'org.apache.grails.buildsrc.compile'
+    id 'org.apache.grails.buildsrc.vulnerability-scan'
+    id 'org.apache.grails.gradle.grails-web'
+    id 'org.graalvm.buildtools.native' version "$graalvmBuildtoolsVersion" apply false
+}
+
+version = '0.1'
+group = 'nativei18n'
+
+grails {
+    // The Grails Gradle plugin already sets this as a convention for any application that applies
+    // GraalVM's plugin, so the native half would get it anyway. It is set here so the JVM half is
+    // compiled the same way as the image, rather than being a second dialect of the same fixture.
+    indy = true
+}
+
+dependencies {
+    implementation platform("org.apache.grails:grails-bom:$projectVersion")
+    implementation project(':native-i18n-plugin')
+    implementation 'org.apache.grails:grails-dependencies-starter-web'
+}
+
+apply {
+    from rootProject.layout.projectDirectory.file('../gradle/grails-extension-gradle-config.gradle')
+}
+
+// Runs on any JDK, and proves only that the fixture and its assertions are self-consistent - on a
+// JVM every bundle is readable whether it was registered or not. Cheap enough to keep in `check` so
+// the assertions cannot drift from the bundles while the native job is not being run.
+tasks.register('i18nCheckOnJvm', JavaExec) {
+    group = 'verification'
+    description = 'Resolves every message bundle from the packaged application on a JVM'
+    dependsOn tasks.named('bootJar')
+    classpath = files(tasks.named('bootJar').flatMap { it.archiveFile })
+    mainClass = 'org.springframework.boot.loader.launch.JarLauncher'
+    args = ['--i18n-check', '--server.port=0', '--spring.main.banner-mode=off']
+}
+
+tasks.named('check') {
+    dependsOn tasks.named('i18nCheckOnJvm')
+}
+
+// The native half is opt-in: it needs a GraalVM toolchain and several minutes of CPU, which is too
+// much to ask of every run of this build. Enable with -PnativeTests.
+if (project.hasProperty('nativeTests')) {
+    pluginManager.apply('org.graalvm.buildtools.native')
+
+    graalvmNative {
+        binaries {
+            main {
+                imageName = 'native-i18n'
+                mainClass = 'nativei18n.Application'
+                // Measured on a 32GB machine with GraalVM CE 25.2.4: the default 16 threads
+                // exhausted the heap, 4 built in about six minutes.
+                buildArgs.add('--parallelism=4')
+            }
+        }
+        // Build the image with GRAALVM_HOME/JAVA_HOME rather than letting Gradle select a toolchain.
+        // The framework is published on the JDK the repository pins and the image is built on a
+        // GraalVM, so there is no one toolchain that could be detected for both.
+        toolchainDetection = false
+    }
+
+    tasks.register('i18nCheckOnNative', Exec) {
+        group = 'verification'
+        description = 'Resolves every message bundle from a compiled GraalVM binary'
+        // The path comes from the task that produces the binary, so the location and the dependency
+        // on its producer stay in one place rather than repeating the layout convention here.
+        Provider<RegularFile> binary = tasks.named('nativeCompile').flatMap { it.outputFile }
+        inputs.file(binary)
+        doFirst {
+            commandLine binary.get().asFile.absolutePath,
+                    '--i18n-check', '--server.port=0', '--spring.main.banner-mode=off'
+        }
+    }
+
+    tasks.named('check') {
+        dependsOn tasks.named('i18nCheckOnNative')
+    }
+}

--- a/end-to-end/native-i18n/grails-app/conf/application.yml
+++ b/end-to-end/native-i18n/grails-app/conf/application.yml
@@ -16,15 +16,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+spring:
+    messages:
+        # Dotted, so the run also proves a base name is converted to a resource path
+        # (config.i18n.custom -> config/i18n/custom.properties) before it is used.
+        basename: config.i18n.custom
+        fallback-to-system-locale: false
+        # Not a base name, so resolving an unknown code to itself proves the rest of
+        # MessageSourceProperties was bound too - they all arrive together or not at all.
+        use-code-as-default-message: true

--- a/end-to-end/native-i18n/grails-app/i18n/messages.properties
+++ b/end-to-end/native-i18n/grails-app/i18n/messages.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.app.greeting=hello from the application bundle

--- a/end-to-end/native-i18n/grails-app/i18n/messages_fr.properties
+++ b/end-to-end/native-i18n/grails-app/i18n/messages_fr.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.app.greeting=bonjour depuis le paquet de l'application

--- a/end-to-end/native-i18n/grails-app/init/nativei18n/Application.groovy
+++ b/end-to-end/native-i18n/grails-app/init/nativei18n/Application.groovy
@@ -1,0 +1,118 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package nativei18n
+
+import grails.boot.GrailsApp
+import grails.boot.config.GrailsAutoConfiguration
+
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.MessageSource
+
+/**
+ * Resolves one message from each way a bundle reaches the message source, and fails if any of them
+ * does not resolve.
+ *
+ * <p>Run on a JVM this proves two things. That every bundle is reachable at all — which is a real
+ * guard, because Spring Boot's message source is configured from {@code MessageSourceProperties},
+ * and a bean created before {@code ConfigurationPropertiesBindingPostProcessor} is registered keeps
+ * its defaults, silently losing every base name except {@code messages}. And, when compiled into a
+ * GraalVM binary, that each bundle was registered as a resource — a failure no JVM run can produce,
+ * because on a JVM every bundle on the classpath is readable whether it was registered or not. A
+ * bundle missing from an image surfaces as a code resolving to itself, not as an exception, because
+ * {@code spring.messages.use-code-as-default-message} is on.</p>
+ *
+ * <p>Only the first of the three is covered by Spring Boot's own hints, which register the two
+ * hardcoded patterns {@code messages.properties} and {@code messages_*.properties} and derive
+ * nothing from the configured base names.</p>
+ */
+class Application extends GrailsAutoConfiguration {
+
+    static void main(String[] args) {
+        if (!args.contains('--i18n-check')) {
+            GrailsApp.run(Application, args)
+            return
+        }
+
+        ConfigurableApplicationContext context = (ConfigurableApplicationContext) GrailsApp.run(Application, args)
+        int exitCode = 0
+        try {
+            MessageSource messages = context.getBean(MessageSource)
+
+            // The application's own bundle, base name 'messages' — the one case Boot's hints cover.
+            check(messages, 'native.app.greeting', Locale.ENGLISH, 'hello from the application bundle')
+
+            // A plugin's bundle, base name 'native-messages'. Namespaced, so Boot's messages*
+            // patterns never reach it; it survives only because the base names are recorded at build
+            // time and hinted from them. The plugin name is also multi-word, so this covers the
+            // descriptor's hyphenated spelling being matched against the plugin's camel-case one.
+            check(messages, 'native.plugin.greeting', Locale.ENGLISH, 'hello from the plugin bundle')
+
+            // A base name the application configured itself, written in dotted form, so this proves
+            // config.i18n.custom was converted to config/i18n/custom before being used.
+            check(messages, 'native.custom.greeting', Locale.ENGLISH, 'hello from a configured base name')
+
+            // A locale variant of each. In an image this is what would fail if the hints registered
+            // bundles instead of resource patterns and the image were built with a narrower locale
+            // set than the bundles cover.
+            check(messages, 'native.app.greeting', Locale.FRENCH, "bonjour depuis le paquet de l'application")
+            check(messages, 'native.plugin.greeting', Locale.FRENCH, 'bonjour depuis le paquet du plugin')
+            check(messages, 'native.custom.greeting', Locale.FRENCH, 'bonjour depuis un nom de base configure')
+
+            // Not a base name, so this proves the rest of MessageSourceProperties was bound too:
+            // the whole object binds at once or not at all.
+            String unknown = messages.getMessage('no.such.code', null, Locale.ENGLISH)
+            if (unknown != 'no.such.code') {
+                throw new IllegalStateException('spring.messages.use-code-as-default-message did not reach ' +
+                        "the message source; an unknown code gave '${unknown}'")
+            }
+
+            println 'i18n-check: every message bundle resolved'
+        }
+        catch (Throwable failure) {
+            failure.printStackTrace()
+            exitCode = 1
+        }
+        finally {
+            context.close()
+        }
+        // Exit explicitly rather than letting a throwable leave main, which would make the exit code
+        // wait on every non-daemon thread the application started - more of a risk for the binary
+        // than for the jar.
+        System.exit(exitCode)
+    }
+
+    /**
+     * {@code spring.messages.use-code-as-default-message} is on, so a bundle that never reached the
+     * message source does not raise anything — the code comes back as its own value. That is the
+     * shape a missing resource registration takes in an image, so it is reported as itself rather
+     * than as a plain mismatch.
+     */
+    private static void check(MessageSource messages, String code, Locale locale, String expected) {
+        String actual = messages.getMessage(code, null, locale)
+        if (actual == code) {
+            throw new IllegalStateException("'${code}' did not resolve for ${locale}; it came back as its own " +
+                    'code, so its bundle never reached the message source')
+        }
+        if (actual != expected) {
+            throw new IllegalStateException(
+                    "'${code}' for ${locale} resolved to '${actual}', expected '${expected}'")
+        }
+    }
+}

--- a/end-to-end/native-i18n/src/main/resources/config/i18n/custom.properties
+++ b/end-to-end/native-i18n/src/main/resources/config/i18n/custom.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.custom.greeting=hello from a configured base name

--- a/end-to-end/native-i18n/src/main/resources/config/i18n/custom_fr.properties
+++ b/end-to-end/native-i18n/src/main/resources/config/i18n/custom_fr.properties
@@ -16,15 +16,4 @@
 #  specific language governing permissions and limitations
 #  under the License.
 #
-
-projectVersion=9.0.0-SNAPSHOT
-
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx5G
-org.gradle.configuration-cache=false
-org.gradle.caching=true
-org.gradle.parallel=true
-
-# GraalVM Gradle plugin, used only by the opt-in native verification in native-i18n. It lives here
-# rather than in dependencies.gradle because nothing the framework publishes depends on it - it is a
-# build plugin for one fixture in this build, not a managed coordinate of the BOM.
-graalvmBuildtoolsVersion=1.1.12
+native.custom.greeting=bonjour depuis un nom de base configure

--- a/end-to-end/settings.gradle
+++ b/end-to-end/settings.gradle
@@ -104,6 +104,11 @@ rootProject.name = 'grails-end-to-end'
 include(
         'legacy-commands',
         'legacy-commands-plugin',
+        // Verifies message resolution inside a compiled GraalVM binary. The native half is opt-in
+        // (-PnativeTests) because it needs a GraalVM toolchain and minutes of CPU; without the flag
+        // the module still builds and checks the same assertions on a JVM.
+        'native-i18n',
+        'native-i18n-plugin',
         // Builds an application twice without a clean, to prove a renamed or deleted tag library
         // cannot survive in the index that is published. Incremental behaviour against real
         // published artifacts is not something the core build can express.


### PR DESCRIPTION
per request of @borinquenkid

Adds the end-to-end module #16176 asks for: an application that resolves messages from each way a bundle reaches the message source.

## What it checks

| Bundle | Base name | Why |
|---|---|---|
| the application's own | `messages` | The case Spring Boot's own hints already cover, as a control. |
| the plugin's | `native-messages` | Namespaced, so Boot's two hardcoded `messages*` patterns never reach it. The plugin name is multi-word, so it also covers the descriptor's hyphenated spelling being matched against the plugin's camel-case one. |
| one the application configured | `config.i18n.custom` | Outside `grails-app/i18n`, dotted, so it proves the base name is converted to `config/i18n/custom` before use. |

Each is resolved in English and in a locale variant. An unknown code is resolved too, under `use-code-as-default-message`, because base names alone would not prove `MessageSourceProperties` was bound — the whole object binds at once or not at all.

## Running it

The JVM half runs in `check` and needs nothing special:

```bash
cd end-to-end
./gradlew :native-i18n:check
```

The native half is opt-in, and **does not pass today**:

```bash
./gradlew :native-i18n:check -PnativeTests
```

## Limitations

- **The native half cannot pass on 8.0.x, for reasons upstream of Grails.** Dynamic Groovy does not run in a native image on any released Groovy, whichever way it was compiled: without invokedynamic an image refuses the call-site classes Groovy defines as it runs (`UnsupportedFeatureError: Tried to define class`), and with invokedynamic the bootstrap method runs before `IndyInterface.<clinit>` and NPEs at `makeBootHandle`. What closes it is [GROOVY-12234](https://issues.apache.org/jira/browse/GROOVY-12234), an AOT link mode on the Groovy 6 line — 5.1.2, which the BOM pins, carries neither `aotDispatch` nor the `ensureInitialized` guard. Building the image also needs GraalVM 25 or later; on the 21 line `nativeCompile` fails during "Initializing" because GraalVM's bundled Groovy substitution targets a method Groovy 4+ removed ([oracle/graal#10200](https://github.com/oracle/graal/issues/10200)). The module has been run successfully exactly once, against an unreleased build of GROOVY-12234 forced onto `runtimeClasspath`. The README says all of this; the wiring is here so that it starts passing the day those land rather than having to be written then.
- **Grails 8 publishes without indy on purpose.** `CompilePlugin` defaults `grailsIndy` to `false` because Groovy 5's indy default is a large runtime regression for dynamic Groovy (#15293); its own comment records Grails 9 / Groovy 6 as where that can flip. So a released Grails 8 could not produce an image even if Groovy were fixed.
- **The JVM half cannot falsify a resource hint.** On a JVM every bundle on the classpath is readable whether it was registered or not. Its value is as a fixture guard — it keeps the bundles and the assertions from drifting apart — and, as it turned out, at catching lifecycle bugs: it is what found #16179.
- **No native job in CI.** A full `nativeCompile` is minutes of CPU and needs a toolchain no other job uses.

Thanks to @matrei for running the native half and working out both upstream blockers.
