### PR TITLE
Add specs for ClasspathEntityScanner and ReflectionUtils

### DIFF
--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/utils/ReflectionUtils.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/utils/ReflectionUtils.java
@@ -42,10 +42,8 @@ public class ReflectionUtils {
 
         if (superClass != null) {
             try {
-                final Method superMethod = superClass.getMethod(method.getName(), method.getParameterTypes());
-                if (superMethod != null) {
-                    return true;
-                }
+                superClass.getMethod(method.getName(), method.getParameterTypes());
+                return true;
             } catch (NoSuchMethodException e) {
                 // ignore
             }

--- a/grails-datamapping-core/src/test/groovy/com/IgnoredPackageEntity.groovy
+++ b/grails-datamapping-core/src/test/groovy/com/IgnoredPackageEntity.groovy
@@ -1,0 +1,27 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package com
+
+import grails.gorm.annotation.Entity
+
+// Lives directly in the top-level "com" package, one of ClasspathEntityScanner's ignoredPackages.
+@Entity
+class IgnoredPackageEntity {
+    String name
+}

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/utils/ClasspathEntityScannerSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/utils/ClasspathEntityScannerSpec.groovy
@@ -16,29 +16,86 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-
 package org.grails.datastore.gorm.utils
 
 import grails.gorm.annotation.Entity
 import spock.lang.Specification
 
-/**
- * Created by graemerocher on 18/11/16.
- */
+import org.grails.datastore.jakartafixture.JakartaTestEntity
+
 class ClasspathEntityScannerSpec extends Specification {
 
-    void "test classpath entity scanner"() {
-        when:"the classpath is scanned"
+    void "test classpath entity scanner finds a class annotated with grails.gorm.annotation.Entity"() {
+        when: "the classpath is scanned"
         def scanner = new ClasspathEntityScanner()
         def results = scanner.scan(ClasspathEntityScannerSpec.package)
 
-        then:"The results are correct"
+        then: "the results are correct"
         results.size() == 1
         results.first() == TestEntity
+    }
+
+    void "test classpath entity scanner finds a class annotated with jakarta.persistence.Entity"() {
+        when: "the classpath is scanned"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan(JakartaTestEntity.package)
+
+        then: "the jakarta annotated entity is found"
+        results.contains(JakartaTestEntity)
+    }
+
+    void "test classpath entity scanner ignores non-entity classes in the scanned package"() {
+        when: "the classpath is scanned"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan(ClasspathEntityScannerSpec.package)
+
+        then: "only the annotated entity is returned"
+        !results.contains(NotAnEntity)
+    }
+
+    void "test classpath entity scanner returns no results when no packages are given"() {
+        when: "the scanner is invoked with no packages"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan()
+
+        then: "the result is empty"
+        results.length == 0
+    }
+
+    void "test classpath entity scanner de-duplicates results when the same package is scanned twice"() {
+        when: "the same package is passed in more than once"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan(ClasspathEntityScannerSpec.package, ClasspathEntityScannerSpec.package)
+
+        then: "the entity is only returned once"
+        results.count { it == TestEntity } == 1
+    }
+
+    void "test classpath entity scanner combines results from multiple packages"() {
+        when: "two distinct packages are scanned together"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan(ClasspathEntityScannerSpec.package, JakartaTestEntity.package)
+
+        then: "entities from both packages are returned"
+        results.contains(TestEntity)
+        results.contains(JakartaTestEntity)
+    }
+
+    void "test classpath entity scanner does not scan a package that is too generic"() {
+        when: "a top-level package on the ignore list is scanned"
+        def scanner = new ClasspathEntityScanner()
+        def results = scanner.scan(com.IgnoredPackageEntity.package)
+
+        then: "no entities are returned for that package"
+        results.length == 0
     }
 }
 
 @Entity
 class TestEntity {
+    String name
+}
+
+class NotAnEntity {
     String name
 }

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/utils/ReflectionUtilsSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/utils/ReflectionUtilsSpec.groovy
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.gorm.utils
+
+import groovy.transform.PackageScope
+import spock.lang.Specification
+
+class ReflectionUtilsSpec extends Specification {
+
+    void "test a method overridden from a public parent method is detected as overridden"() {
+        given: "a method overridden from a public superclass"
+        def method = ReflectionUtilsChild.getDeclaredMethod('greet')
+
+        expect: "the method is reported as overridden"
+        ReflectionUtils.isMethodOverriddenFromParent(method)
+    }
+
+    void "test a method unique to the subclass is not detected as overridden"() {
+        given: "a method that is only declared on the subclass"
+        def method = ReflectionUtilsChild.getDeclaredMethod('onlyOnChild')
+
+        expect: "the method is not reported as overridden"
+        !ReflectionUtils.isMethodOverriddenFromParent(method)
+    }
+
+    void "test a method whose declaring class has no superclass is not detected as overridden"() {
+        given: "a method declared on a class with no superclass"
+        def method = Object.getMethod('toString')
+
+        expect: "the method is not reported as overridden"
+        !ReflectionUtils.isMethodOverriddenFromParent(method)
+    }
+
+    void "test a method that only shadows a non-public parent method is not detected as overridden"() {
+        given: "a package-private method also declared on the superclass"
+        def method = ReflectionUtilsChild.getDeclaredMethod('hidden')
+
+        expect: "the method is not reported as overridden because the superclass method is not public"
+        !ReflectionUtils.isMethodOverriddenFromParent(method)
+    }
+}
+
+class ReflectionUtilsParent {
+    void greet() {
+    }
+
+    @PackageScope
+    void hidden() {
+    }
+}
+
+class ReflectionUtilsChild extends ReflectionUtilsParent {
+    @Override
+    void greet() {
+    }
+
+    void onlyOnChild() {
+    }
+
+    @PackageScope
+    @Override
+    void hidden() {
+    }
+}

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/jakartafixture/JakartaTestEntity.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/jakartafixture/JakartaTestEntity.groovy
@@ -1,0 +1,26 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.jakartafixture
+
+import jakarta.persistence.Entity
+
+@Entity
+class JakartaTestEntity {
+    String name
+}


### PR DESCRIPTION
## Summary
- Add `ReflectionUtilsSpec` covering `isMethodOverriddenFromParent`: a genuinely overridden public method, a method unique to the subclass, a method whose declaring class has no superclass (e.g. `Object`), and a package-private method that only shadows a same-named parent method.
- Expand `ClasspathEntityScannerSpec` from a single happy-path test to cover `jakarta.persistence.Entity` detection, non-entity classes being excluded, empty package input, de-duplication across a repeated package, combining results across multiple packages, and the previously-untested "ignored package" branch (`com`, `org`, etc. are skipped rather than scanned).
- Minor cleanup in `ReflectionUtils.isMethodOverriddenFromParent`: drop a dead null check — `Class#getMethod` never returns null, it throws `NoSuchMethodException` instead.

## Test plan
- [x] `./gradlew :grails-datamapping-core:test --tests "org.grails.datastore.gorm.utils.ClasspathEntityScannerSpec" --tests "org.grails.datastore.gorm.utils.ReflectionUtilsSpec"`
- [x] `./gradlew :grails-datamapping-core:test :grails-datamapping-core:codenarcMain :grails-datamapping-core:codenarcTest`