### PR TITLE
Stop the embedded MongoDB once

### DIFF
--- a/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/FlapdoodleMongoBackend.java
+++ b/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/FlapdoodleMongoBackend.java
@@ -142,9 +142,20 @@ public class FlapdoodleMongoBackend implements EmbeddedMongoBackend {
             return this.address.getPort();
         }
 
+        /**
+         * Stopping twice is what an ordinary shutdown does: the lifecycle bean stops the server
+         * when the application context closes, and the JVM shutdown hook - which is there for a
+         * context that never closes - runs after it. Flapdoodle deletes the process directory as
+         * it tears the server down, so a second teardown fails on the files the first one removed.
+         */
         @Override
-        public void stop() {
-            this.running.close();
+        public synchronized void stop() {
+            TransitionWalker.ReachedState<RunningMongodProcess> current = this.running;
+            if (current == null) {
+                return;
+            }
+            this.running = null;
+            current.close();
         }
 
         /**
@@ -153,7 +164,10 @@ public class FlapdoodleMongoBackend implements EmbeddedMongoBackend {
          * mongod is a separate process, so a checkpoint image does not contain it.
          */
         @Override
-        public void restart() {
+        public synchronized void restart() {
+            if (this.running != null) {
+                return;
+            }
             this.running = this.mongod.start(this.version);
         }
     }

--- a/grails-data-mongodb/embedded/src/test/groovy/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoLifecycleSpec.groovy
+++ b/grails-data-mongodb/embedded/src/test/groovy/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoLifecycleSpec.groovy
@@ -139,6 +139,34 @@ class EmbeddedMongoLifecycleSpec extends Specification {
         lifecycle?.stop()
     }
 
+    void 'a server stopped by the context is stopped again by the shutdown hook'() {
+        given: 'a real mongod, whose process directory flapdoodle removes as it tears the server down'
+        RunningEmbeddedMongo running = new FlapdoodleMongoBackend()
+                .start(new EmbeddedMongoSettings(27979, null, null))
+
+        when: 'the context stops it, and the hook that covers a context that never closes follows'
+        running.stop()
+        running.stop()
+
+        then: 'the second stop finds the files the first one removed, and says nothing of it'
+        noExceptionThrown()
+        conditions.eventually { assert !listening(27979) }
+    }
+
+    void 'an in-memory server is stopped twice by the same pair'() {
+        given:
+        RunningEmbeddedMongo running = new InMemoryMongoBackend()
+                .start(new EmbeddedMongoSettings(27978, null, null))
+
+        when:
+        running.stop()
+        running.stop()
+
+        then:
+        noExceptionThrown()
+        conditions.eventually { assert !listening(27978) }
+    }
+
     void 'the flapdoodle backend keeps a persistent database across the same stop'() {
         given: 'a real mongod told to keep its data, which is how a production application runs'
         String databaseDir = temp.resolve('prodDb').toString()


### PR DESCRIPTION
Every run that starts a real mongod ends with this on a shutdown thread, against a build whose
tests all passed:

```
Exception in thread "Thread-77" de.flapdoodle.reverse.TearDownException: tearDown errors
	at de.flapdoodle.reverse.TransitionWalker.tearDown(TransitionWalker.java:298)
	at org.grails.datastore.gorm.mongodb.embedded.FlapdoodleMongoBackend$RunningMongod.stop
	Caused by: java.nio.file.NoSuchFileException: /tmp/temp--.../workingDir.../mongod.pid
```

The server is stopped twice. `EmbeddedMongoLifecycle` stops it when the application context closes,
and the JVM shutdown hook - which is there for a context that never closes - stops it again when the
process exits. Flapdoodle removes the process directory as it tears the server down, so the second
teardown fails on the files the first one deleted.

Stopping is idempotent now, and so is starting a server that is already running. The in-memory
backend already tolerated both; a spec covers each.
