### PR TITLE
i18n: let a plugin that cannot rename downgrade the namespace check to a warning

### DIFF
--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -2577,6 +2577,22 @@ application's. Rename it into the plugin's namespace.
 
 Applications are unaffected — there is only one application, so its base names cannot collide.
 
+A plugin that genuinely cannot rename — a base name that is part of a published contract, or a bundle
+vendored from somewhere else — can downgrade the failure to a build warning:
+
+[source,groovy]
+----
+grails {
+    i18n {
+        enforceNamespace = false
+    }
+}
+----
+
+This silences the build, not the collision. Spring still resolves a base name to the first matching
+resource on the classpath, so the bundle will shadow, or be shadowed by, any other artifact shipping
+that name, and nothing at runtime reports which won. Rename where you can.
+
 A namespaced bundle still works under Grails 7, so a plugin does not need a separate source branch to
 support both. Grails 7 discovers a plugin's bundles by scanning the plugin jar's root for
 `*.properties` and matching locale suffixes; it never inspects the base name, so

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -1309,6 +1309,7 @@ ${importStatements}
             task.artifactName.set(grailsArtifactName(project))
             task.artifactVersion.set(project.provider { project.version?.toString() })
             task.declaredBasenames.set(grailsExt.i18n.basenames)
+            task.enforceNamespace.set(grailsExt.i18n.enforceNamespace)
             task.outputDirectory.set(project.layout.buildDirectory.dir('generated-resources/grails-i18n'))
         }
 

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsI18nOptions.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/core/GrailsI18nOptions.groovy
@@ -22,6 +22,7 @@ import groovy.transform.CompileStatic
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 
 /**
  * Message-bundle options, configured through the nested {@code grails { i18n { } }} block:
@@ -29,6 +30,7 @@ import org.gradle.api.provider.ListProperty
  * <pre><code>grails {
  *     i18n {
  *         basenames = ['api', 'api_errors']
+ *         enforceNamespace = false
  *     }
  * }</code></pre>
  *
@@ -56,9 +58,25 @@ class GrailsI18nOptions implements Serializable {
      */
     final ListProperty<String> basenames
 
+    /**
+     * Whether a plugin's base names must sit within its own namespace. Enabled by default; has no
+     * effect on an application, whose base names cannot collide with a sibling.
+     *
+     * <p>Turning it off downgrades the failure to a build warning and is meant for the plugin that
+     * cannot rename: a base name that is part of a published contract, or a bundle vendored from
+     * somewhere else. It does not make the collision safe. Spring still resolves a base name to the
+     * first match on the classpath, so such a bundle will shadow, or be shadowed by, any other
+     * artifact shipping that name — with no error at runtime to say which won:</p>
+     *
+     * <pre><code>grails { i18n { enforceNamespace = false } }</code></pre>
+     */
+    final Property<Boolean> enforceNamespace
+
     @Inject
     GrailsI18nOptions(ObjectFactory objects) {
         this.basenames = objects.listProperty(String)
         this.basenames.convention([])
+        this.enforceNamespace = objects.property(Boolean)
+        this.enforceNamespace.convention(true)
     }
 }

--- a/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/i18n/GenerateI18nDescriptorTask.groovy
+++ b/grails-gradle/plugins/src/main/groovy/org/grails/gradle/plugin/i18n/GenerateI18nDescriptorTask.groovy
@@ -105,9 +105,21 @@ abstract class GenerateI18nDescriptorTask extends DefaultTask {
     @Input
     abstract ListProperty<String> getDeclaredBasenames()
 
+    /**
+     * Whether a base name outside the plugin's namespace fails the build, from
+     * {@code grails { i18n { enforceNamespace } }}. When false the same diagnosis is logged as a
+     * warning and the descriptor is written as it stands.
+     */
+    @Input
+    abstract Property<Boolean> getEnforceNamespace()
+
     /** Directory contributed to {@code processResources}; holds {@link #DESCRIPTOR_PATH}. */
     @OutputDirectory
     abstract DirectoryProperty getOutputDirectory()
+
+    GenerateI18nDescriptorTask() {
+        enforceNamespace.convention(true)
+    }
 
     @TaskAction
     void generate() {
@@ -123,7 +135,13 @@ abstract class GenerateI18nDescriptorTask extends DefaultTask {
         String type = artifactType.get()
         String name = artifactName.get()
         if (type == TYPE_PLUGIN) {
-            validatePluginNamespace(index.basenames, name)
+            String problem = describeNamespaceViolation(index.basenames, name)
+            if (problem) {
+                if (enforceNamespace.get()) {
+                    throw new InvalidUserDataException(problem)
+                }
+                logger.warn('{}', problem)
+            }
         }
 
         File descriptor = outputDirectory.get().file(DESCRIPTOR_PATH).asFile
@@ -148,20 +166,26 @@ abstract class GenerateI18nDescriptorTask extends DefaultTask {
     }
 
     /**
-     * Requires every plugin base name to be {@code <plugin-name>} or {@code <plugin-name>-*}.
+     * Describes any plugin base name that is neither {@code <plugin-name>} nor {@code <plugin-name>-*},
+     * or {@code null} when every base name sits within the plugin's namespace.
      *
      * <p>Spring Boot's {@code ResourceBundleMessageSource} resolves a base name to the first matching
      * resource on the classpath, so two plugins sharing a base name would shadow one another instead
      * of both contributing. Plugin names are already unique within an application, so namespacing
      * base names on the plugin name makes collisions impossible while still allowing a plugin to ship
      * several logical bundles.</p>
+     *
+     * <p>Whether that is fatal is the caller's decision — see {@code enforceNamespace}. The wording is
+     * the same either way: what is wrong and how to fix it does not change with the severity.</p>
      */
-    private static void validatePluginNamespace(List<String> basenames, String pluginName) {
+    private static String describeNamespaceViolation(List<String> basenames, String pluginName) {
         List<String> offenders = basenames.findAll { String base ->
             base != pluginName && !base.startsWith(pluginName + '-')
         }
-        if (offenders) {
-            throw new InvalidUserDataException("""\
+        if (!offenders) {
+            return null
+        }
+        """\
 Plugin '${pluginName}' ships message bundles outside its own namespace: \
 ${offenders.collect { "'${it}${I18nBundleIndex.PROPERTIES_SUFFIX}'" }.join(', ')}.
 A plugin's base names must be '${pluginName}' or '${pluginName}-*' so they cannot collide with an \
@@ -171,7 +195,9 @@ Rename '${offenders.first()}${I18nBundleIndex.PROPERTIES_SUFFIX}' to \
 '${pluginName}${I18nBundleIndex.PROPERTIES_SUFFIX}', or to \
 '${pluginName}-<name>${I18nBundleIndex.PROPERTIES_SUFFIX}' if the plugin ships more than one bundle. \
 Locale variants follow the base name, so '${pluginName}_fr${I18nBundleIndex.PROPERTIES_SUFFIX}'.
-${I18nBundleIndex.UPGRADE_REFERENCE}""")
-        }
+A plugin that cannot rename — a base name that is part of a published contract, or a bundle vendored \
+from elsewhere — can downgrade this to a warning with \
+'grails { i18n { enforceNamespace = false } }'. That silences the build, not the collision.
+${I18nBundleIndex.UPGRADE_REFERENCE}"""
     }
 }

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/i18n/GenerateI18nDescriptorTaskSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/i18n/GenerateI18nDescriptorTaskSpec.groovy
@@ -29,7 +29,7 @@ class GenerateI18nDescriptorTaskSpec extends Specification {
     File projectDir
 
     private GenerateI18nDescriptorTask task(String type, String name, List<String> bundleNames,
-            List<String> declared = []) {
+            List<String> declared = [], Boolean enforceNamespace = null) {
         File bundles = new File(projectDir, 'grails-app/i18n')
         bundles.mkdirs()
         bundleNames.each { new File(bundles, it).text = 'a.code=value\n' }
@@ -41,6 +41,9 @@ class GenerateI18nDescriptorTaskSpec extends Specification {
             it.artifactName.set(name)
             it.artifactVersion.set('1.0.0')
             it.declaredBasenames.set(declared)
+            if (enforceNamespace != null) {
+                it.enforceNamespace.set(enforceNamespace)
+            }
             it.outputDirectory.set(new File(projectDir, 'out'))
         }
         project.tasks.named('generateI18nDescriptor', GenerateI18nDescriptorTask).get()
@@ -90,6 +93,36 @@ class GenerateI18nDescriptorTaskSpec extends Specification {
         InvalidUserDataException e = thrown()
         e.message.contains("ships message bundles outside its own namespace")
         e.message.contains("'messages.properties'")
+    }
+
+    void 'the namespace check is on unless a plugin turns it off'() {
+        when: 'nothing sets enforceNamespace, so the convention applies'
+        descriptorOf(task(GenerateI18nDescriptorTask.TYPE_PLUGIN, 'spring-security-oauth2',
+                ['messages.properties']))
+
+        then:
+        thrown(InvalidUserDataException)
+    }
+
+    void 'a plugin that cannot rename may downgrade the namespace check to a warning'() {
+        when: 'enforceNamespace = false, for a base name the plugin does not control'
+        Properties descriptor = descriptorOf(task(GenerateI18nDescriptorTask.TYPE_PLUGIN,
+                'spring-security-oauth2', ['messages.properties'], [], false))
+
+        then: 'the build carries on and the bundle is still recorded'
+        notThrown(InvalidUserDataException)
+        descriptor.basenames == 'messages'
+    }
+
+    void 'the opt-out says how to reach it, and that it silences the build rather than the collision'() {
+        when:
+        descriptorOf(task(GenerateI18nDescriptorTask.TYPE_PLUGIN, 'spring-security-oauth2',
+                ['messages.properties']))
+
+        then:
+        InvalidUserDataException e = thrown()
+        e.message.contains('enforceNamespace = false')
+        e.message.contains('silences the build, not the collision')
     }
 
     void 'an application is free to use any base name'() {

--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/i18n/I18nDescriptorFunctionalSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/i18n/I18nDescriptorFunctionalSpec.groovy
@@ -25,7 +25,8 @@ import org.grails.gradle.plugin.core.GradleSpecification
  * Exercises the i18n descriptor through the plugins an application or plugin author actually applies,
  * rather than by invoking the task directly: automatic registration, application-versus-plugin
  * dispatch, plugin-name derivation from the {@code *GrailsPlugin.groovy} descriptor, the
- * {@code grails { i18n { } }} block, and inclusion in {@code processResources}.
+ * {@code grails { i18n { } }} block including the namespace opt-out, and inclusion in
+ * {@code processResources}.
  */
 class I18nDescriptorFunctionalSpec extends GradleSpecification {
 
@@ -85,6 +86,21 @@ class I18nDescriptorFunctionalSpec extends GradleSpecification {
 
         then:
         result.output.contains('ships message bundles outside its own namespace')
+    }
+
+    void 'a plugin may downgrade the namespace check to a warning through the i18n block'() {
+        given: 'the same colliding bundle, with enforceNamespace = false'
+        GradleRunner runner = setupTestResourceProject('i18n-descriptor-plugin-namespace-off')
+
+        when:
+        BuildResult result = executeTask('processResources')
+
+        then: 'the build succeeds, and still says what the collision is'
+        assertTaskSuccess('generateI18nDescriptor', result)
+        result.output.contains('ships message bundles outside its own namespace')
+
+        and: 'the bundle is recorded as it stands'
+        descriptorFrom(runner).basenames == 'messages'
     }
 
     void 'declared base names override the inference the file names would produce'() {

--- a/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'org.apache.grails.gradle.grails-plugin'
+}
+
+grails {
+    i18n {
+        enforceNamespace = false
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/gradle.properties
+++ b/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/gradle.properties
@@ -1,0 +1,2 @@
+grailsVersion=__PROJECT_VERSION__
+org.gradle.jvmargs=-Xmx1g

--- a/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/grails-app/i18n/messages.properties
+++ b/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/grails-app/i18n/messages.properties
@@ -1,0 +1,1 @@
+demo.code=Demo

--- a/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/settings.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'i18n-descriptor-plugin-namespace-off'

--- a/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/src/main/groovy/demo/SpringSecurityDemoGrailsPlugin.groovy
+++ b/grails-gradle/plugins/src/test/resources/test-projects/i18n-descriptor-plugin-namespace-off/src/main/groovy/demo/SpringSecurityDemoGrailsPlugin.groovy
@@ -1,0 +1,5 @@
+package demo
+
+class SpringSecurityDemoGrailsPlugin {
+    String version = '1.0.0'
+}


### PR DESCRIPTION
Follow-up to #16102.

## The gap

`generateI18nDescriptor` fails a plugin build when a base name sits outside the plugin's namespace. That default is right, and this PR does not change it — Spring resolves a base name to the first match on the classpath rather than merging, so two artifacts shipping the same base name shadow one another with nothing at runtime to say which won. Failing the plugin's own build puts the error in front of the only person who can rename the bundle.

What it lacks is an escape hatch, and `grails { i18n { basenames } }` is not one: declared base names are folded into the index *before* `validatePluginNamespace` runs, so a plugin cannot declare its way past the check.

That leaves a plugin that genuinely cannot rename — a base name that is part of a published contract, or a bundle vendored from somewhere else — with two options:

- `-x generateI18nDescriptor`, which ships no descriptor at all and therefore drops the plugin's messages entirely, or
- a fork.

## The change

```groovy
grails {
    i18n {
        enforceNamespace = false
    }
}
```

Downgrades the same diagnosis to a build warning and writes the descriptor as it stands. Default unchanged (`true`).

The wording is identical whether it throws or warns — what is wrong and how to fix it do not depend on the severity — so `validatePluginNamespace` becomes `describeNamespaceViolation`, returning the message or `null`, and the caller decides. Both the message and the upgrade guide say plainly that the opt-out silences the build, not the collision.

## Tests

- `GenerateI18nDescriptorTaskSpec` — the check is on by convention; `enforceNamespace = false` records the bundle and does not throw; the message names the opt-out and its caveat.
- `I18nDescriptorFunctionalSpec` + a new `i18n-descriptor-plugin-namespace-off` test project — the same colliding bundle as `i18n-descriptor-plugin-collision`, plus the `i18n` block, exercised end to end through `processResources`: the build succeeds, still reports the collision, and the descriptor records `basenames=messages`.

`:grails-gradle-plugins:check` passes (including `validatePlugins`), and `rat` passes.

## Context

Found while upgrading an app to 8.0.0-M6. Its Spring Security fork shipped the base name it inherited from the upstream plugin — a real collision, and the check caught it, so this is not a complaint about the rule. Renaming was the right fix there. The opt-out is for the cases where it isn't available.