### PR TITLE
refactor(grails-data-graphql): clean up the fetcher package

### DIFF
--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.groovy
@@ -48,6 +48,10 @@ import org.grails.gorm.graphql.entity.EntityFetchOptions
 @Slf4j
 abstract class DefaultGormDataFetcher<T> implements DataFetcher<T> {
 
+    // Association<?> (not Association<? extends Property>, its declared bound) to match the
+    // exact generic type EntityFetchOptions#getAssociations() returns - Groovy's static type
+    // checker treats the bounded and unbounded wildcard forms as distinct types, so writing out
+    // the bound here would make the assignment in initializeEntity() fail to compile.
     protected Map<String, Association<?>> associations = [:]
     protected PersistentEntity entity
     protected String propertyName

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/DefaultGormDataFetcher.groovy
@@ -48,7 +48,7 @@ import org.grails.gorm.graphql.entity.EntityFetchOptions
 @Slf4j
 abstract class DefaultGormDataFetcher<T> implements DataFetcher<T> {
 
-    protected Map<String, Association> associations = [:]
+    protected Map<String, Association<?>> associations = [:]
     protected PersistentEntity entity
     protected String propertyName
     protected EntityFetchOptions entityFetchOptions
@@ -61,10 +61,10 @@ abstract class DefaultGormDataFetcher<T> implements DataFetcher<T> {
         this.entity = entity
         this.propertyName = projectionName
         this.entityFetchOptions = new EntityFetchOptions(entity, projectionName)
-        initializeEntity(entity)
+        initializeEntity()
     }
 
-    protected void initializeEntity(PersistentEntity entity) {
+    protected void initializeEntity() {
         this.associations = this.entityFetchOptions.associations
     }
 
@@ -120,20 +120,20 @@ abstract class DefaultGormDataFetcher<T> implements DataFetcher<T> {
     }
 
     protected Object withTransaction(boolean readOnly, Closure closure) {
-        Datastore datastore
-        if (entity.multiTenant && this.datastore instanceof MultiTenantCapableDatastore) {
-            MultiTenantCapableDatastore multiTenantCapableDatastore = (MultiTenantCapableDatastore)this.datastore
-            Serializable currentTenantId = Tenants.currentId(multiTenantCapableDatastore)
-            datastore = multiTenantCapableDatastore.getDatastoreForTenantId(currentTenantId)
-        }
-        else {
-            datastore = this.datastore
-        }
-
-        TransactionService txService = datastore.getService(TransactionService)
+        TransactionService txService = resolveDatastore().getService(TransactionService)
         CustomizableRollbackTransactionAttribute transactionAttribute = new CustomizableRollbackTransactionAttribute()
         transactionAttribute.setReadOnly(readOnly)
         txService.withTransaction(transactionAttribute, closure)
+    }
+
+    private Datastore resolveDatastore() {
+        Datastore datastore = this.datastore
+        if (entity.multiTenant && datastore instanceof MultiTenantCapableDatastore) {
+            MultiTenantCapableDatastore multiTenantCapableDatastore = (MultiTenantCapableDatastore) datastore
+            Serializable currentTenantId = Tenants.currentId(multiTenantCapableDatastore)
+            return multiTenantCapableDatastore.getDatastoreForTenantId(currentTenantId)
+        }
+        datastore
     }
 
     protected Datastore getDatastore() {

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/impl/DeleteEntityDataFetcher.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/impl/DeleteEntityDataFetcher.groovy
@@ -53,15 +53,12 @@ class DeleteEntityDataFetcher<T> extends DefaultGormDataFetcher<T> implements De
 
     @Override
     T get(DataFetchingEnvironment environment) {
-        boolean success = false
-        Exception exception
         try {
             delete(environment)
-            success = true
-        } catch (Exception e) {
-            exception = e
+            (T) responseHandler.createResponse(environment, true, null)
         }
-
-        (T)responseHandler.createResponse(environment, success, exception)
+        catch (Exception e) {
+            (T) responseHandler.createResponse(environment, false, e)
+        }
     }
 }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/impl/EntityDataFetcher.groovy
@@ -81,7 +81,7 @@ class EntityDataFetcher<T> extends DefaultGormDataFetcher<T> implements ReadingG
     }
 
     protected T executeQuery(DataFetchingEnvironment environment, Map queryArgs) {
-        buildCriteria(environment).list(queryArgs)
+        (T) buildCriteria(environment).list(queryArgs)
     }
 
     @Override

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/CustomInterceptorInvoker.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/CustomInterceptorInvoker.groovy
@@ -21,7 +21,6 @@ package org.grails.gorm.graphql.fetcher.interceptor
 
 import graphql.schema.DataFetchingEnvironment
 import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import org.grails.gorm.graphql.fetcher.GraphQLDataFetcherType
 import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
 
@@ -32,17 +31,12 @@ import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
  * @since 1.0.0
  */
 @CompileStatic
-@Slf4j
 abstract class CustomInterceptorInvoker extends InterceptorInvoker {
 
     @Override
     final boolean invoke(GraphQLFetcherInterceptor interceptor, DataFetchingEnvironment environment, GraphQLDataFetcherType type) {
         final String name = getName(environment)
-        boolean result = invoke(interceptor, name, environment)
-        if (!result) {
-            log.info("Execution of ${name} was prevented by an interceptor")
-        }
-        result
+        logIfPrevented(name, invoke(interceptor, name, environment))
     }
 
     abstract boolean invoke(GraphQLFetcherInterceptor interceptor, String name, DataFetchingEnvironment environment)

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/InterceptorInvoker.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/InterceptorInvoker.groovy
@@ -20,6 +20,8 @@
 package org.grails.gorm.graphql.fetcher.interceptor
 
 import graphql.schema.DataFetchingEnvironment
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 import org.grails.gorm.graphql.fetcher.GraphQLDataFetcherType
 import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
 
@@ -30,10 +32,27 @@ import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
  * @author James Kleeh
  * @since 1.0.0
  */
+@CompileStatic
+@Slf4j
 abstract class InterceptorInvoker {
 
     protected String getName(DataFetchingEnvironment environment) {
         environment.fields.empty ? 'UNKNOWN' : environment.fields[0].name
+    }
+
+    /**
+     * Logs when an interceptor prevents execution, shared by every
+     * {@link #invoke} implementation.
+     *
+     * @param name The name used to identify the operation in the log message
+     * @param result Whether the interceptor allowed execution to proceed
+     * @return {@code result}, unchanged
+     */
+    protected final boolean logIfPrevented(String name, boolean result) {
+        if (!result) {
+            log.info("Execution of ${name} was prevented by an interceptor")
+        }
+        result
     }
 
     abstract boolean invoke(GraphQLFetcherInterceptor interceptor, DataFetchingEnvironment environment, GraphQLDataFetcherType type)

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/InterceptorInvoker.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/InterceptorInvoker.groovy
@@ -19,6 +19,7 @@
 
 package org.grails.gorm.graphql.fetcher.interceptor
 
+import graphql.execution.MergedField
 import graphql.schema.DataFetchingEnvironment
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -37,7 +38,8 @@ import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
 abstract class InterceptorInvoker {
 
     protected String getName(DataFetchingEnvironment environment) {
-        environment.fields.empty ? 'UNKNOWN' : environment.fields[0].name
+        MergedField mergedField = environment.mergedField
+        mergedField == null ? 'UNKNOWN' : mergedField.name
     }
 
     /**

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/ProvidedInterceptorInvoker.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/fetcher/interceptor/ProvidedInterceptorInvoker.groovy
@@ -21,7 +21,6 @@ package org.grails.gorm.graphql.fetcher.interceptor
 
 import graphql.schema.DataFetchingEnvironment
 import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import org.grails.gorm.graphql.fetcher.GraphQLDataFetcherType
 import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
 
@@ -32,17 +31,11 @@ import org.grails.gorm.graphql.interceptor.GraphQLFetcherInterceptor
  * @since 1.0.0
  */
 @CompileStatic
-@Slf4j
 abstract class ProvidedInterceptorInvoker extends InterceptorInvoker {
 
     @Override
     final boolean invoke(GraphQLFetcherInterceptor interceptor, DataFetchingEnvironment environment, GraphQLDataFetcherType type) {
-        final String name = getName(environment)
-        boolean result = call(interceptor, environment, type)
-        if (!result) {
-            log.info("Execution of ${name} was prevented by an interceptor")
-        }
-        result
+        logIfPrevented(getName(environment), call(interceptor, environment, type))
     }
 
     abstract boolean call(GraphQLFetcherInterceptor interceptor, DataFetchingEnvironment environment, GraphQLDataFetcherType type)

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/impl/InterceptingDataFetcherSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/impl/InterceptingDataFetcherSpec.groovy
@@ -19,7 +19,7 @@
 
 package org.grails.gorm.graphql.fetcher.impl
 
-import graphql.language.Field
+import graphql.execution.MergedField
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import org.grails.gorm.graphql.GraphQLServiceManager
@@ -36,9 +36,9 @@ class InterceptingDataFetcherSpec extends Specification {
 
     private DataFetchingEnvironment buildMockEnvironment() {
         Stub(DataFetchingEnvironment) {
-            getFields() >> [Stub(Field) {
+            getMergedField() >> Stub(MergedField) {
                 getName() >> 'foo'
-            }]
+            }
         }
     }
 

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/interceptor/MutationInterceptorInvokerSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/interceptor/MutationInterceptorInvokerSpec.groovy
@@ -30,7 +30,7 @@ class MutationInterceptorInvokerSpec extends Specification {
         given:
         GraphQLFetcherInterceptor interceptor = Mock(GraphQLFetcherInterceptor)
         DataFetchingEnvironment environment = Mock(DataFetchingEnvironment) {
-            getFields() >> []
+            getMergedField() >> null
         }
 
         when:
@@ -45,7 +45,7 @@ class MutationInterceptorInvokerSpec extends Specification {
         given:
         GraphQLFetcherInterceptor interceptor = Mock(GraphQLFetcherInterceptor)
         DataFetchingEnvironment environment = Mock(DataFetchingEnvironment) {
-            getFields() >> []
+            getMergedField() >> null
         }
 
         when:

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/interceptor/QueryInterceptorInvokerSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/fetcher/interceptor/QueryInterceptorInvokerSpec.groovy
@@ -30,7 +30,7 @@ class QueryInterceptorInvokerSpec extends Specification {
         given:
         GraphQLFetcherInterceptor interceptor = Mock(GraphQLFetcherInterceptor)
         DataFetchingEnvironment environment = Mock(DataFetchingEnvironment) {
-            getFields() >> []
+            getMergedField() >> null
         }
 
         when:
@@ -45,7 +45,7 @@ class QueryInterceptorInvokerSpec extends Specification {
         given:
         GraphQLFetcherInterceptor interceptor = Mock(GraphQLFetcherInterceptor)
         DataFetchingEnvironment environment = Mock(DataFetchingEnvironment) {
-            getFields() >> []
+            getMergedField() >> null
         }
 
         when:


### PR DESCRIPTION
## Summary
Stacked on #16201. Fixes a series of IntelliJ-flagged issues in `org.grails.gorm.graphql.fetcher.*`:
- `DeleteEntityDataFetcher`/`EntityDataFetcher`: simplified branch-per-response construction and added a missing `(T)` cast on `executeQuery`'s `DetachedCriteria#list` result, matching the cast convention every sibling fetcher already uses.
- `CustomInterceptorInvoker`/`ProvidedInterceptorInvoker`: deduplicated an identical 9-line "resolve name → invoke → log if prevented → return" fragment into a shared `logIfPrevented` method on `InterceptorInvoker`.
- `InterceptorInvoker`: replaced deprecated `DataFetchingEnvironment#getFields()` with `getMergedField()`.
- `DefaultGormDataFetcher`: fixed a type mismatch (`Map<String, Association>` → `Map<String, Association<?>>`... with a documented reason it can't be fully parameterized under Groovy's static type checker), dropped an unused constructor parameter, and extracted `resolveDatastore()` to eliminate an ambiguous "might not be assigned" local variable.

## Test plan
- [x] `./gradlew :grails-data-graphql-core:test :grails-data-graphql:test :grails-data-graphql-core:codeStyle :grails-data-graphql:codeStyle` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)