### PR TITLE
refactor(grails-data-graphql): clean up the types package

### DIFF
--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/output/AbstractObjectTypeBuilder.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/output/AbstractObjectTypeBuilder.groovy
@@ -101,44 +101,36 @@ abstract class AbstractObjectTypeBuilder implements ObjectTypeBuilder {
 
     @Override
     GraphQLOutputType build(PersistentEntity entity) {
-
-        GraphQLOutputType objectType
-
         if (objectTypeCache.containsKey(entity)) {
-            objectTypeCache.get(entity)
+            return objectTypeCache.get(entity)
         }
-        else {
-            final String description = GraphQLEntityHelper.getDescription(entity)
-            final String name = typeManager.namingConvention.getType(entity, type)
 
-            List<GraphQLFieldDefinition> fields = new ArrayList<>(properties.size() + 1)
+        final String description = GraphQLEntityHelper.getDescription(entity)
+        final String name = typeManager.namingConvention.getType(entity, type)
 
-            List<GraphQLDomainProperty> properties = builder.getProperties(entity)
-            for (GraphQLDomainProperty prop: properties) {
-                if (prop.output) {
-                    GraphQLFieldDefinition.Builder field = buildField(prop, name)
-                    addFieldArgs(field, prop, entity.mappingContext)
-                    fields.add(field.build())
-                }
+        List<GraphQLDomainProperty> properties = builder.getProperties(entity)
+        List<GraphQLFieldDefinition> fields = new ArrayList<>(properties.size() + 1)
+        for (GraphQLDomainProperty prop: properties) {
+            if (prop.output) {
+                GraphQLFieldDefinition.Builder field = buildField(prop, name)
+                addFieldArgs(field, prop, entity.mappingContext)
+                fields.add(field.build())
             }
-
-            if (errorsResponseHandler != null) {
-                GraphQLFieldDefinition fieldDefinition = errorsResponseHandler.getFieldDefinition(typeManager, name)
-                fields.add(fieldDefinition)
-            }
-
-            boolean hasChildEntities = entity.root && !entity.mappingContext.getDirectChildEntities(entity).empty
-
-            if (hasChildEntities && !type.embedded) {
-                objectType = buildInterfaceType(entity, name, description, fields)
-            }
-            else {
-                objectType = buildObjectType(entity, name, description, fields)
-            }
-
-            objectTypeCache.put(entity, objectType)
-            objectType
         }
+
+        if (errorsResponseHandler != null) {
+            GraphQLFieldDefinition fieldDefinition = errorsResponseHandler.getFieldDefinition(typeManager, name)
+            fields.add(fieldDefinition)
+        }
+
+        boolean hasChildEntities = entity.root && !entity.mappingContext.getDirectChildEntities(entity).empty
+
+        GraphQLOutputType objectType = hasChildEntities && !type.embedded ?
+                buildInterfaceType(name, description, fields) :
+                buildObjectType(entity, name, description, fields)
+
+        objectTypeCache.put(entity, objectType)
+        objectType
     }
 
     GraphQLObjectType buildObjectType(final PersistentEntity entity, final String name, final String description, final List<GraphQLFieldDefinition> fields) {
@@ -155,15 +147,16 @@ abstract class AbstractObjectTypeBuilder implements ObjectTypeBuilder {
         obj.build()
     }
 
-    GraphQLInterfaceType buildInterfaceType(final PersistentEntity entity, final String name, final String description, final List<GraphQLFieldDefinition> fields) {
+    GraphQLInterfaceType buildInterfaceType(final String name, final String description, final List<GraphQLFieldDefinition> fields) {
 
         GraphQLInterfaceType.Builder obj = newInterface()
                 .name(name)
                 .description(description)
                 .fields(fields)
-                .typeResolver(buildEntityTypeResolver())
 
-        obj.build()
+        GraphQLInterfaceType interfaceType = obj.build()
+        codeRegistry.typeResolver(name, buildEntityTypeResolver())
+        interfaceType
     }
 
     protected TypeResolver buildEntityTypeResolver() {

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/ByteArrayCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/ByteArrayCoercion.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import graphql.language.Value
@@ -67,14 +69,14 @@ class ByteArrayCoercion implements Coercing<Byte[], Byte[]> {
     }
 
     @Override
-    Byte[] serialize(Object input) {
+    Byte[] serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a Byte[]")
         }
     }
 
     @Override
-    Byte[] parseValue(Object input) {
+    Byte[] parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a Byte[]")
         }
@@ -93,7 +95,7 @@ class ByteArrayCoercion implements Coercing<Byte[], Byte[]> {
     }
 
     @Override
-    Byte[] parseLiteral(Object input) {
+    Byte[] parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof ArrayValue) {
             List<Byte> returnList = []
             List<Value> values = ((ArrayValue) input).values
@@ -101,7 +103,7 @@ class ByteArrayCoercion implements Coercing<Byte[], Byte[]> {
                 Byte parsedValue = parse(value)
                 returnList.add(parsedValue)
             }
-            (Byte[])returnList.toArray()
+            returnList.toArray(new Byte[0])
         }
         else {
             null

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/CharacterArrayCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/CharacterArrayCoercion.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.StringValue
 import graphql.language.Value
@@ -45,14 +47,14 @@ class CharacterArrayCoercion implements Coercing<Character[], Character[]> {
             Collection c = (Collection) input
             Character[] converted = new Character[c.size()]
             for (int i = 0; i < c.size(); i++) {
-                converted[i] = new Character((char)c[i])
+                converted[i] = Character.valueOf((char)c[i])
             }
             Optional.of(converted)
         }
         else if (input.class.array) {
             Character[] chars = new Character[Array.getLength(input)]
             for (int i = 0; i < chars.length; i++) {
-                chars[i] = new Character((char)Array.get(input, i))
+                chars[i] = Character.valueOf((char)Array.get(input, i))
             }
             Optional.of(chars)
         }
@@ -62,14 +64,14 @@ class CharacterArrayCoercion implements Coercing<Character[], Character[]> {
     }
 
     @Override
-    Character[] serialize(Object input) {
+    Character[] serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a Character[]")
         }
     }
 
     @Override
-    Character[] parseValue(Object input) {
+    Character[] parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a Character[]")
         }
@@ -83,11 +85,11 @@ class CharacterArrayCoercion implements Coercing<Character[], Character[]> {
         if (value.length() != 1) {
             return null
         }
-        new Character(value.charAt(0))
+        Character.valueOf(value.charAt(0))
     }
 
     @Override
-    Character[] parseLiteral(Object input) {
+    Character[] parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof ArrayValue) {
             List<Value> values = ((ArrayValue) input).values
             Character[] returnArray = new Character[values.size()]

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/CurrencyCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/CurrencyCoercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -47,21 +50,21 @@ class CurrencyCoercion implements Coercing<Currency, Currency> {
     }
 
     @Override
-    Currency serialize(Object input) {
+    Currency serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a Currency")
         }
     }
 
     @Override
-    Currency parseValue(Object input) {
+    Currency parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a Currency")
         }
     }
 
     @Override
-    Currency parseLiteral(Object input) {
+    Currency parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             Currency.getInstance(((StringValue)input).value)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercion.groovy
@@ -89,7 +89,7 @@ class DateCoercion implements Coercing<Date, Date> {
     protected Optional<Date> parseDate(String value) {
         Date dateValue
         if (!value || !formats) {
-            return null
+            return Optional.empty()
         }
         Exception firstException
         for (String format: formats) {

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercion.groovy
@@ -19,8 +19,11 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -60,21 +63,21 @@ class DateCoercion implements Coercing<Date, Date> {
     }
 
     @Override
-    Date serialize(Object input) {
+    Date serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a Date")
         }
     }
 
     @Override
-    Date parseValue(Object input) {
+    Date parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a Date")
         }
     }
 
     @Override
-    Date parseLiteral(Object input) {
+    Date parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof IntValue) {
             new Date(((IntValue) input).value.longValue())
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/SqlDateCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/SqlDateCoercion.groovy
@@ -19,8 +19,11 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -53,21 +56,21 @@ class SqlDateCoercion implements Coercing<Date, Date> {
     }
 
     @Override
-    Date serialize(Object input) {
+    Date serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.sql.Date")
         }
     }
 
     @Override
-    Date parseValue(Object input) {
+    Date parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.sql.Date")
         }
     }
 
     @Override
-    Date parseLiteral(Object input) {
+    Date parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof IntValue) {
             new Date(((IntValue) input).value.longValue())
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeCoercion.groovy
@@ -19,8 +19,11 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -50,21 +53,21 @@ class TimeCoercion implements Coercing<Time, Time> {
     }
 
     @Override
-    Time serialize(Object input) {
+    Time serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.sql.Time")
         }
     }
 
     @Override
-    Time parseValue(Object input) {
+    Time parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.sql.Time")
         }
     }
 
     @Override
-    Time parseLiteral(Object input) {
+    Time parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof IntValue) {
             new Time(((IntValue) input).value.longValue())
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeZoneCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeZoneCoercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -47,21 +50,21 @@ class TimeZoneCoercion implements Coercing<TimeZone, TimeZone> {
     }
 
     @Override
-    TimeZone serialize(Object input) {
+    TimeZone serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.util.TimeZone")
         }
     }
 
     @Override
-    TimeZone parseValue(Object input) {
+    TimeZone parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.util.TimeZone")
         }
     }
 
     @Override
-    TimeZone parseLiteral(Object input) {
+    TimeZone parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             parseTimeZone(((StringValue)input).value).orElse(null)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimestampCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimestampCoercion.groovy
@@ -19,8 +19,11 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -50,21 +53,21 @@ class TimestampCoercion implements Coercing<Timestamp, Timestamp> {
     }
 
     @Override
-    Timestamp serialize(Object input) {
+    Timestamp serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.sql.Timestamp")
         }
     }
 
     @Override
-    Timestamp parseValue(Object input) {
+    Timestamp parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.sql.Timestamp")
         }
     }
 
     @Override
-    Timestamp parseLiteral(Object input) {
+    Timestamp parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof IntValue) {
             new Timestamp(((IntValue) input).value.longValue())
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/URICoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/URICoercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -47,21 +50,21 @@ class URICoercion implements Coercing<URI, URI> {
     }
 
     @Override
-    URI serialize(Object input) {
+    URI serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.net.URI")
         }
     }
 
     @Override
-    URI parseValue(Object input) {
+    URI parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.net.URI")
         }
     }
 
     @Override
-    URI parseLiteral(Object input) {
+    URI parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             parseURI(((StringValue)input).value).orElse(null)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/URLCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/URLCoercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -47,21 +50,21 @@ class URLCoercion implements Coercing<URL, URL> {
     }
 
     @Override
-    URL serialize(Object input) {
+    URL serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.net.URL")
         }
     }
 
     @Override
-    URL parseValue(Object input) {
+    URL parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.net.URL")
         }
     }
 
     @Override
-    URL parseLiteral(Object input) {
+    URL parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             parseURL(((StringValue)input).value).orElse(null)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/UUIDCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/UUIDCoercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -47,21 +50,21 @@ class UUIDCoercion implements Coercing<UUID, UUID> {
     }
 
     @Override
-    UUID serialize(Object input) {
+    UUID serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to a java.util.UUID")
         }
     }
 
     @Override
-    UUID parseValue(Object input) {
+    UUID parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to a java.util.UUID")
         }
     }
 
     @Override
-    UUID parseLiteral(Object input) {
+    UUID parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             parseUUID(((StringValue)input).value).orElse(null)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/InstantCoercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/InstantCoercion.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.language.Value
@@ -53,31 +55,26 @@ class InstantCoercion implements Coercing<Instant, Instant> {
     }
 
     @Override
-    Instant serialize(Object input) {
+    Instant serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to an Instant")
         }
     }
 
     @Override
-    Instant parseValue(Object input) {
+    Instant parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convert(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to an Instant")
         }
     }
 
     @Override
-    Instant parseLiteral(Object input) {
-
-        if (input instanceof Value) {
-            Object value
-            if (input instanceof IntValue) {
-                value = ((IntValue) input).value.longValue()
-            }
-            else if (input instanceof StringValue) {
-                value = ((StringValue) input).value
-            }
-            parseInstant(value).orElse(null)
+    Instant parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
+        if (input instanceof IntValue) {
+            parseInstant(((IntValue) input).value.longValue()).orElse(null)
+        }
+        else if (input instanceof StringValue) {
+            parseInstant(((StringValue) input).value).orElse(null)
         }
         else {
             null

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/Jsr310Coercion.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/Jsr310Coercion.groovy
@@ -19,7 +19,10 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.StringValue
+import graphql.language.Value
 import graphql.schema.Coercing
 import graphql.schema.CoercingParseValueException
 import graphql.schema.CoercingSerializeException
@@ -44,21 +47,21 @@ abstract class Jsr310Coercion<T> implements Coercing<T, T> {
     }
 
     @Override
-    T serialize(Object input) {
+    T serialize(Object input, GraphQLContext graphQLContext, Locale locale) {
         convertValue(input).orElseThrow {
             throw new CoercingSerializeException("Could not convert ${input.class.name} to the required date type")
         }
     }
 
     @Override
-    T parseValue(Object input) {
+    T parseValue(Object input, GraphQLContext graphQLContext, Locale locale) {
         convertValue(input).orElseThrow {
             throw new CoercingParseValueException("Could not convert ${input.class.name} to the required date type")
         }
     }
 
     @Override
-    T parseLiteral(Object input) {
+    T parseLiteral(Value<?> input, CoercedVariables variables, GraphQLContext graphQLContext, Locale locale) {
         if (input instanceof StringValue) {
             convert(((StringValue) input).value).orElse(null)
         }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/Animal.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/Animal.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gorm.graphql.domain.inheritance
+
+import grails.gorm.annotation.Entity
+
+@Entity
+class Animal {
+    String name
+
+    static graphql = true
+}

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/Dog.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/Dog.groovy
@@ -1,0 +1,29 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gorm.graphql.domain.inheritance
+
+import grails.gorm.annotation.Entity
+
+@Entity
+class Dog extends Animal {
+    String breed
+
+    static graphql = true
+}

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/InheritancePackage.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/domain/inheritance/InheritancePackage.groovy
@@ -1,0 +1,23 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.grails.gorm.graphql.domain.inheritance
+
+class InheritancePackage {
+}

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/output/AbstractObjectTypeBuilderSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/output/AbstractObjectTypeBuilderSpec.groovy
@@ -1,0 +1,72 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.gorm.graphql.types.output
+
+import graphql.schema.GraphQLInterfaceType
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
+import org.grails.datastore.mapping.config.Settings
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.gorm.graphql.Schema
+import org.grails.gorm.graphql.domain.inheritance.InheritancePackage
+import org.grails.orm.hibernate.HibernateDatastore
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * Exercises AbstractObjectTypeBuilder#build(PersistentEntity) through a real
+ * Schema, covering the interface-type branch (a root entity with child
+ * entities) which none of the other object type builder specs reach, since
+ * they construct their builders with a null GraphQLTypeManager.
+ */
+class AbstractObjectTypeBuilderSpec extends Specification {
+
+    @Shared @AutoCleanup HibernateDatastore hibernateDatastore
+    @Shared GraphQLSchema schema
+
+    void setupSpec() {
+        hibernateDatastore = new HibernateDatastore(
+                DatastoreUtils.createPropertyResolver(Collections.singletonMap(Settings.SETTING_DB_CREATE, 'create-drop')),
+                InheritancePackage.getPackage())
+        schema = new Schema(hibernateDatastore.mappingContext).generate()
+    }
+
+    void "test a root entity with child entities builds an interface type"() {
+        expect:
+        schema.getType('Animal') instanceof GraphQLInterfaceType
+    }
+
+    void "test a child entity builds an object type that implements the root interface"() {
+        given:
+        GraphQLInterfaceType animalType = (GraphQLInterfaceType) schema.getType('Animal')
+        GraphQLObjectType dogType = (GraphQLObjectType) schema.getType('Dog')
+
+        expect:
+        dogType.interfaces.contains(animalType)
+    }
+
+    void "test a type resolver is registered for the interface type"() {
+        given:
+        GraphQLInterfaceType animalType = (GraphQLInterfaceType) schema.getType('Animal')
+
+        expect:
+        schema.codeRegistry.getTypeResolver(animalType) != null
+    }
+}

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/ByteArrayCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/ByteArrayCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import spock.lang.Specification
@@ -31,7 +33,7 @@ class ByteArrayCoercionSpec extends Specification {
         ByteArrayCoercion coercion = new ByteArrayCoercion()
 
         when:
-        def result = coercion.parseLiteral(value)
+        def result = coercion.parseLiteral(value, CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default)
 
         then:
         result == [1,22,32,54] as Byte[]

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/CharacterArrayCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/CharacterArrayCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.StringValue
 import spock.lang.Specification
@@ -31,13 +33,13 @@ class CharacterArrayCoercionSpec extends Specification {
         CharacterArrayCoercion coercion = new CharacterArrayCoercion()
 
         when:
-        def result = coercion.parseLiteral(value)
+        def result = coercion.parseLiteral(value, CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default)
 
         then:
         result == ['x', 'y', 'z', 'a'] as Character[]
 
         when: 'the values are too long for Character'
-        result = coercion.parseLiteral(new ArrayValue([new StringValue('xy'), new StringValue('a')]))
+        result = coercion.parseLiteral(new ArrayValue([new StringValue('xy'), new StringValue('a')]), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default)
 
         then:
         result == [null, 'a'] as Character[]

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/CurrencyCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/CurrencyCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -34,17 +36,17 @@ class CurrencyCoercionSpec extends Specification {
         Currency currency = Currency.getInstance('USD')
 
         expect:
-        coercion.serialize(currency).is(currency)
+        coercion.serialize(currency, GraphQLContext.default, Locale.default).is(currency)
     }
 
     void "test serialize with a currency code string"() {
         expect:
-        coercion.serialize('USD') == Currency.getInstance('USD')
+        coercion.serialize('USD', GraphQLContext.default, Locale.default) == Currency.getInstance('USD')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,17 +57,17 @@ class CurrencyCoercionSpec extends Specification {
         Currency currency = Currency.getInstance('EUR')
 
         expect:
-        coercion.parseValue(currency).is(currency)
+        coercion.parseValue(currency, GraphQLContext.default, Locale.default).is(currency)
     }
 
     void "test parseValue with a currency code string"() {
         expect:
-        coercion.parseValue('EUR') == Currency.getInstance('EUR')
+        coercion.parseValue('EUR', GraphQLContext.default, Locale.default) == Currency.getInstance('EUR')
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -73,11 +75,11 @@ class CurrencyCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('GBP')) == Currency.getInstance('GBP')
+        coercion.parseLiteral(new StringValue('GBP'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Currency.getInstance('GBP')
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import graphql.language.StringValue
@@ -41,17 +43,17 @@ class DateCoercionSpec extends Specification {
         Date date = new Date()
 
         expect:
-        coercion.serialize(date).is(date)
+        coercion.serialize(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('2020-01-15') == parse('yyyy-MM-dd', '2020-01-15')
+        coercion.serialize('2020-01-15', GraphQLContext.default, Locale.default) == parse('yyyy-MM-dd', '2020-01-15')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -59,7 +61,7 @@ class DateCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a date')
+        coercion.serialize('not a date', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -70,17 +72,17 @@ class DateCoercionSpec extends Specification {
         Date date = new Date()
 
         expect:
-        coercion.parseValue(date).is(date)
+        coercion.parseValue(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test parseValue with a string matching a configured format"() {
         expect:
-        coercion.parseValue('2020-01-15') == parse('yyyy-MM-dd', '2020-01-15')
+        coercion.parseValue('2020-01-15', GraphQLContext.default, Locale.default) == parse('yyyy-MM-dd', '2020-01-15')
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -91,22 +93,22 @@ class DateCoercionSpec extends Specification {
         long millis = 1600000000000
 
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis))) == new Date(millis)
+        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis)), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new Date(millis)
     }
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15')) == parse('yyyy-MM-dd', '2020-01-15')
+        coercion.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == parse('yyyy-MM-dd', '2020-01-15')
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date')) == null
+        coercion.parseLiteral(new StringValue('not a date'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with an unsupported value type returns null"() {
         expect:
-        coercion.parseLiteral(new ArrayValue([])) == null
+        coercion.parseLiteral(new ArrayValue([]), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral falls back to a later format when an earlier one fails to match"() {
@@ -114,7 +116,7 @@ class DateCoercionSpec extends Specification {
         DateCoercion multiFormat = new DateCoercion(['yyyy/MM/dd', 'yyyy-MM-dd'], false)
 
         expect:
-        multiFormat.parseLiteral(new StringValue('2020-01-15')) == parse('yyyy-MM-dd', '2020-01-15')
+        multiFormat.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == parse('yyyy-MM-dd', '2020-01-15')
     }
 
     void "test parseLiteral with a StringValue returns null instead of throwing when no formats are configured"() {
@@ -122,7 +124,7 @@ class DateCoercionSpec extends Specification {
         DateCoercion noFormats = new DateCoercion([], false)
 
         expect:
-        noFormats.parseLiteral(new StringValue('2020-01-15')) == null
+        noFormats.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test serialize with a string and no configured formats throws a CoercingSerializeException instead of an NPE"() {
@@ -130,7 +132,7 @@ class DateCoercionSpec extends Specification {
         DateCoercion noFormats = new DateCoercion([], false)
 
         when:
-        noFormats.serialize('2020-01-15')
+        noFormats.serialize('2020-01-15', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/DateCoercionSpec.groovy
@@ -116,4 +116,23 @@ class DateCoercionSpec extends Specification {
         expect:
         multiFormat.parseLiteral(new StringValue('2020-01-15')) == parse('yyyy-MM-dd', '2020-01-15')
     }
+
+    void "test parseLiteral with a StringValue returns null instead of throwing when no formats are configured"() {
+        given:
+        DateCoercion noFormats = new DateCoercion([], false)
+
+        expect:
+        noFormats.parseLiteral(new StringValue('2020-01-15')) == null
+    }
+
+    void "test serialize with a string and no configured formats throws a CoercingSerializeException instead of an NPE"() {
+        given:
+        DateCoercion noFormats = new DateCoercion([], false)
+
+        when:
+        noFormats.serialize('2020-01-15')
+
+        then:
+        thrown(CoercingSerializeException)
+    }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/SqlDateCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/SqlDateCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import graphql.language.StringValue
@@ -37,12 +39,12 @@ class SqlDateCoercionSpec extends Specification {
         Date date = Date.valueOf('2020-01-15')
 
         expect:
-        coercion.serialize(date).is(date)
+        coercion.serialize(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test serialize with a valid date string"() {
         expect:
-        coercion.serialize('2020-01-15') == Date.valueOf('2020-01-15')
+        coercion.serialize('2020-01-15', GraphQLContext.default, Locale.default) == Date.valueOf('2020-01-15')
     }
 
     void "test serialize with a millis Long"() {
@@ -50,12 +52,12 @@ class SqlDateCoercionSpec extends Specification {
         long millis = 1600000000000
 
         expect:
-        coercion.serialize(millis) == new Date(millis)
+        coercion.serialize(millis, GraphQLContext.default, Locale.default) == new Date(millis)
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(true)
+        coercion.serialize(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -63,7 +65,7 @@ class SqlDateCoercionSpec extends Specification {
 
     void "test serialize with an invalid date string throws"() {
         when:
-        coercion.serialize('not a date')
+        coercion.serialize('not a date', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -74,12 +76,12 @@ class SqlDateCoercionSpec extends Specification {
         Date date = Date.valueOf('2020-01-15')
 
         expect:
-        coercion.parseValue(date).is(date)
+        coercion.parseValue(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(true)
+        coercion.parseValue(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -90,21 +92,21 @@ class SqlDateCoercionSpec extends Specification {
         long millis = 1600000000000
 
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis))) == new Date(millis)
+        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis)), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new Date(millis)
     }
 
     void "test parseLiteral with a valid StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15')) == Date.valueOf('2020-01-15')
+        coercion.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Date.valueOf('2020-01-15')
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date')) == null
+        coercion.parseLiteral(new StringValue('not a date'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with an unsupported value type returns null"() {
         expect:
-        coercion.parseLiteral(new ArrayValue([])) == null
+        coercion.parseLiteral(new ArrayValue([]), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import graphql.language.StringValue
@@ -37,17 +39,17 @@ class TimeCoercionSpec extends Specification {
         Time time = Time.valueOf('10:15:30')
 
         expect:
-        coercion.serialize(time).is(time)
+        coercion.serialize(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test serialize with a valid time string"() {
         expect:
-        coercion.serialize('10:15:30') == Time.valueOf('10:15:30')
+        coercion.serialize('10:15:30', GraphQLContext.default, Locale.default) == Time.valueOf('10:15:30')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(true)
+        coercion.serialize(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class TimeCoercionSpec extends Specification {
 
     void "test serialize with an invalid time string throws"() {
         when:
-        coercion.serialize('not a time')
+        coercion.serialize('not a time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class TimeCoercionSpec extends Specification {
         Time time = Time.valueOf('10:15:30')
 
         expect:
-        coercion.parseValue(time).is(time)
+        coercion.parseValue(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(true)
+        coercion.parseValue(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -82,21 +84,21 @@ class TimeCoercionSpec extends Specification {
         long millis = 1600000000000
 
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis))) == new Time(millis)
+        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis)), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new Time(millis)
     }
 
     void "test parseLiteral with a valid StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('10:15:30')) == Time.valueOf('10:15:30')
+        coercion.parseLiteral(new StringValue('10:15:30'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Time.valueOf('10:15:30')
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a time')) == null
+        coercion.parseLiteral(new StringValue('not a time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with an unsupported value type returns null"() {
         expect:
-        coercion.parseLiteral(new ArrayValue([])) == null
+        coercion.parseLiteral(new ArrayValue([]), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeZoneCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimeZoneCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -34,17 +36,17 @@ class TimeZoneCoercionSpec extends Specification {
         TimeZone timeZone = TimeZone.getTimeZone('America/New_York')
 
         expect:
-        coercion.serialize(timeZone).is(timeZone)
+        coercion.serialize(timeZone, GraphQLContext.default, Locale.default).is(timeZone)
     }
 
     void "test serialize with a time zone id string"() {
         expect:
-        coercion.serialize('America/New_York') == TimeZone.getTimeZone('America/New_York')
+        coercion.serialize('America/New_York', GraphQLContext.default, Locale.default) == TimeZone.getTimeZone('America/New_York')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,12 +57,12 @@ class TimeZoneCoercionSpec extends Specification {
         TimeZone timeZone = TimeZone.getTimeZone('Europe/Paris')
 
         expect:
-        coercion.parseValue(timeZone).is(timeZone)
+        coercion.parseValue(timeZone, GraphQLContext.default, Locale.default).is(timeZone)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -68,11 +70,11 @@ class TimeZoneCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('Europe/Paris')) == TimeZone.getTimeZone('Europe/Paris')
+        coercion.parseLiteral(new StringValue('Europe/Paris'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == TimeZone.getTimeZone('Europe/Paris')
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimestampCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/TimestampCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.ArrayValue
 import graphql.language.IntValue
 import graphql.language.StringValue
@@ -37,17 +39,17 @@ class TimestampCoercionSpec extends Specification {
         Timestamp timestamp = Timestamp.valueOf('2020-01-15 10:15:30')
 
         expect:
-        coercion.serialize(timestamp).is(timestamp)
+        coercion.serialize(timestamp, GraphQLContext.default, Locale.default).is(timestamp)
     }
 
     void "test serialize with a valid timestamp string"() {
         expect:
-        coercion.serialize('2020-01-15 10:15:30') == Timestamp.valueOf('2020-01-15 10:15:30')
+        coercion.serialize('2020-01-15 10:15:30', GraphQLContext.default, Locale.default) == Timestamp.valueOf('2020-01-15 10:15:30')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(true)
+        coercion.serialize(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class TimestampCoercionSpec extends Specification {
 
     void "test serialize with an invalid timestamp string throws"() {
         when:
-        coercion.serialize('not a timestamp')
+        coercion.serialize('not a timestamp', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class TimestampCoercionSpec extends Specification {
         Timestamp timestamp = Timestamp.valueOf('2020-01-15 10:15:30')
 
         expect:
-        coercion.parseValue(timestamp).is(timestamp)
+        coercion.parseValue(timestamp, GraphQLContext.default, Locale.default).is(timestamp)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(true)
+        coercion.parseValue(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -82,21 +84,21 @@ class TimestampCoercionSpec extends Specification {
         long millis = 1600000000000
 
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis))) == new Timestamp(millis)
+        coercion.parseLiteral(new IntValue(BigInteger.valueOf(millis)), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new Timestamp(millis)
     }
 
     void "test parseLiteral with a valid StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15 10:15:30')) == Timestamp.valueOf('2020-01-15 10:15:30')
+        coercion.parseLiteral(new StringValue('2020-01-15 10:15:30'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Timestamp.valueOf('2020-01-15 10:15:30')
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a timestamp')) == null
+        coercion.parseLiteral(new StringValue('not a timestamp'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with an unsupported value type returns null"() {
         expect:
-        coercion.parseLiteral(new ArrayValue([])) == null
+        coercion.parseLiteral(new ArrayValue([]), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/URICoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/URICoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -34,17 +36,17 @@ class URICoercionSpec extends Specification {
         URI uri = new URI('https://grails.apache.org')
 
         expect:
-        coercion.serialize(uri).is(uri)
+        coercion.serialize(uri, GraphQLContext.default, Locale.default).is(uri)
     }
 
     void "test serialize with a valid uri string"() {
         expect:
-        coercion.serialize('https://grails.apache.org') == new URI('https://grails.apache.org')
+        coercion.serialize('https://grails.apache.org', GraphQLContext.default, Locale.default) == new URI('https://grails.apache.org')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -52,7 +54,7 @@ class URICoercionSpec extends Specification {
 
     void "test serialize with an invalid uri string throws"() {
         when:
-        coercion.serialize(' ')
+        coercion.serialize(' ', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -63,12 +65,12 @@ class URICoercionSpec extends Specification {
         URI uri = new URI('https://grails.apache.org')
 
         expect:
-        coercion.parseValue(uri).is(uri)
+        coercion.parseValue(uri, GraphQLContext.default, Locale.default).is(uri)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -76,16 +78,16 @@ class URICoercionSpec extends Specification {
 
     void "test parseLiteral with a valid StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('https://grails.apache.org')) == new URI('https://grails.apache.org')
+        coercion.parseLiteral(new StringValue('https://grails.apache.org'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new URI('https://grails.apache.org')
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue(' ')) == null
+        coercion.parseLiteral(new StringValue(' '), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/URLCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/URLCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -34,17 +36,17 @@ class URLCoercionSpec extends Specification {
         URL url = new URL('https://grails.apache.org')
 
         expect:
-        coercion.serialize(url).is(url)
+        coercion.serialize(url, GraphQLContext.default, Locale.default).is(url)
     }
 
     void "test serialize with a valid url string"() {
         expect:
-        coercion.serialize('https://grails.apache.org') == new URL('https://grails.apache.org')
+        coercion.serialize('https://grails.apache.org', GraphQLContext.default, Locale.default) == new URL('https://grails.apache.org')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -52,7 +54,7 @@ class URLCoercionSpec extends Specification {
 
     void "test serialize with an invalid url string throws"() {
         when:
-        coercion.serialize('not a url')
+        coercion.serialize('not a url', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -63,12 +65,12 @@ class URLCoercionSpec extends Specification {
         URL url = new URL('https://grails.apache.org')
 
         expect:
-        coercion.parseValue(url).is(url)
+        coercion.parseValue(url, GraphQLContext.default, Locale.default).is(url)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -76,16 +78,16 @@ class URLCoercionSpec extends Specification {
 
     void "test parseLiteral with a valid StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('https://grails.apache.org')) == new URL('https://grails.apache.org')
+        coercion.parseLiteral(new StringValue('https://grails.apache.org'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == new URL('https://grails.apache.org')
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a url')) == null
+        coercion.parseLiteral(new StringValue('not a url'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/UUIDCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/UUIDCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -34,7 +36,7 @@ class UUIDCoercionSpec extends Specification {
         UUID uuid = UUID.randomUUID()
 
         expect:
-        coercion.serialize(uuid).is(uuid)
+        coercion.serialize(uuid, GraphQLContext.default, Locale.default).is(uuid)
     }
 
     void "test serialize with a valid uuid string"() {
@@ -42,12 +44,12 @@ class UUIDCoercionSpec extends Specification {
         UUID uuid = UUID.randomUUID()
 
         expect:
-        coercion.serialize(uuid.toString()) == uuid
+        coercion.serialize(uuid.toString(), GraphQLContext.default, Locale.default) == uuid
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class UUIDCoercionSpec extends Specification {
 
     void "test serialize with an invalid uuid string throws"() {
         when:
-        coercion.serialize('not-a-uuid')
+        coercion.serialize('not-a-uuid', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class UUIDCoercionSpec extends Specification {
         UUID uuid = UUID.randomUUID()
 
         expect:
-        coercion.parseValue(uuid).is(uuid)
+        coercion.parseValue(uuid, GraphQLContext.default, Locale.default).is(uuid)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -82,16 +84,16 @@ class UUIDCoercionSpec extends Specification {
         UUID uuid = UUID.randomUUID()
 
         expect:
-        coercion.parseLiteral(new StringValue(uuid.toString())) == uuid
+        coercion.parseLiteral(new StringValue(uuid.toString()), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == uuid
     }
 
     void "test parseLiteral with an invalid StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not-a-uuid')) == null
+        coercion.parseLiteral(new StringValue('not-a-uuid'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/InstantCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/InstantCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.BooleanValue
 import graphql.language.IntValue
 import graphql.language.StringValue
@@ -37,22 +39,22 @@ class InstantCoercionSpec extends Specification {
         Instant instant = Instant.ofEpochSecond(1600000000)
 
         expect:
-        coercion.serialize(instant).is(instant)
+        coercion.serialize(instant, GraphQLContext.default, Locale.default).is(instant)
     }
 
     void "test serialize with an epoch seconds number"() {
         expect:
-        coercion.serialize(1600000000L) == Instant.ofEpochSecond(1600000000)
+        coercion.serialize(1600000000L, GraphQLContext.default, Locale.default) == Instant.ofEpochSecond(1600000000)
     }
 
     void "test serialize with an ISO-8601 string"() {
         expect:
-        coercion.serialize('2020-09-13T12:26:40Z') == Instant.parse('2020-09-13T12:26:40Z')
+        coercion.serialize('2020-09-13T12:26:40Z', GraphQLContext.default, Locale.default) == Instant.parse('2020-09-13T12:26:40Z')
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(true)
+        coercion.serialize(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -63,12 +65,12 @@ class InstantCoercionSpec extends Specification {
         Instant instant = Instant.ofEpochSecond(1600000000)
 
         expect:
-        coercion.parseValue(instant).is(instant)
+        coercion.parseValue(instant, GraphQLContext.default, Locale.default).is(instant)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(true)
+        coercion.parseValue(true, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -76,21 +78,16 @@ class InstantCoercionSpec extends Specification {
 
     void "test parseLiteral with an IntValue"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.valueOf(1600000000))) == Instant.ofEpochSecond(1600000000)
+        coercion.parseLiteral(new IntValue(BigInteger.valueOf(1600000000)), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Instant.ofEpochSecond(1600000000)
     }
 
     void "test parseLiteral with a StringValue"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-09-13T12:26:40Z')) == Instant.parse('2020-09-13T12:26:40Z')
+        coercion.parseLiteral(new StringValue('2020-09-13T12:26:40Z'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == Instant.parse('2020-09-13T12:26:40Z')
     }
 
     void "test parseLiteral with an unrecognized Value type returns null"() {
         expect:
-        coercion.parseLiteral(new BooleanValue(true)) == null
-    }
-
-    void "test parseLiteral with a non Value type returns null"() {
-        expect:
-        coercion.parseLiteral('2020-09-13T12:26:40Z') == null
+        coercion.parseLiteral(new BooleanValue(true), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalDateCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalDateCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -36,17 +38,17 @@ class LocalDateCoercionSpec extends Specification {
         LocalDate date = LocalDate.of(2020, 1, 15)
 
         expect:
-        coercion.serialize(date).is(date)
+        coercion.serialize(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('2020-01-15') == LocalDate.of(2020, 1, 15)
+        coercion.serialize('2020-01-15', GraphQLContext.default, Locale.default) == LocalDate.of(2020, 1, 15)
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -54,7 +56,7 @@ class LocalDateCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a date')
+        coercion.serialize('not a date', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -65,12 +67,12 @@ class LocalDateCoercionSpec extends Specification {
         LocalDate date = LocalDate.of(2020, 1, 15)
 
         expect:
-        coercion.parseValue(date).is(date)
+        coercion.parseValue(date, GraphQLContext.default, Locale.default).is(date)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -78,17 +80,17 @@ class LocalDateCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15')) == LocalDate.of(2020, 1, 15)
+        coercion.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == LocalDate.of(2020, 1, 15)
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date')) == null
+        coercion.parseLiteral(new StringValue('not a date'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral falls back to a later format when an earlier one fails to match"() {
@@ -96,6 +98,6 @@ class LocalDateCoercionSpec extends Specification {
         LocalDateCoercion multiFormat = new LocalDateCoercion(['yyyy/MM/dd', 'yyyy-MM-dd'])
 
         expect:
-        multiFormat.parseLiteral(new StringValue('2020-01-15')) == LocalDate.of(2020, 1, 15)
+        multiFormat.parseLiteral(new StringValue('2020-01-15'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == LocalDate.of(2020, 1, 15)
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalDateTimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalDateTimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -36,17 +38,17 @@ class LocalDateTimeCoercionSpec extends Specification {
         LocalDateTime dateTime = LocalDateTime.of(2020, 1, 15, 10, 15, 30)
 
         expect:
-        coercion.serialize(dateTime).is(dateTime)
+        coercion.serialize(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('2020-01-15 10:15:30') == LocalDateTime.of(2020, 1, 15, 10, 15, 30)
+        coercion.serialize('2020-01-15 10:15:30', GraphQLContext.default, Locale.default) == LocalDateTime.of(2020, 1, 15, 10, 15, 30)
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -54,7 +56,7 @@ class LocalDateTimeCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a date time')
+        coercion.serialize('not a date time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -65,12 +67,12 @@ class LocalDateTimeCoercionSpec extends Specification {
         LocalDateTime dateTime = LocalDateTime.of(2020, 1, 15, 10, 15, 30)
 
         expect:
-        coercion.parseValue(dateTime).is(dateTime)
+        coercion.parseValue(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -78,16 +80,16 @@ class LocalDateTimeCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15 10:15:30')) == LocalDateTime.of(2020, 1, 15, 10, 15, 30)
+        coercion.parseLiteral(new StringValue('2020-01-15 10:15:30'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == LocalDateTime.of(2020, 1, 15, 10, 15, 30)
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date time')) == null
+        coercion.parseLiteral(new StringValue('not a date time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalTimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/LocalTimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -36,17 +38,17 @@ class LocalTimeCoercionSpec extends Specification {
         LocalTime time = LocalTime.of(10, 15, 30)
 
         expect:
-        coercion.serialize(time).is(time)
+        coercion.serialize(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('10:15:30') == LocalTime.of(10, 15, 30)
+        coercion.serialize('10:15:30', GraphQLContext.default, Locale.default) == LocalTime.of(10, 15, 30)
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -54,7 +56,7 @@ class LocalTimeCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a time')
+        coercion.serialize('not a time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -65,12 +67,12 @@ class LocalTimeCoercionSpec extends Specification {
         LocalTime time = LocalTime.of(10, 15, 30)
 
         expect:
-        coercion.parseValue(time).is(time)
+        coercion.parseValue(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -78,16 +80,16 @@ class LocalTimeCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('10:15:30')) == LocalTime.of(10, 15, 30)
+        coercion.parseLiteral(new StringValue('10:15:30'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == LocalTime.of(10, 15, 30)
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a time')) == null
+        coercion.parseLiteral(new StringValue('not a time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/OffsetDateTimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/OffsetDateTimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -37,17 +39,17 @@ class OffsetDateTimeCoercionSpec extends Specification {
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.serialize(dateTime).is(dateTime)
+        coercion.serialize(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('2020-01-15T10:15:30+02:00') == OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.serialize('2020-01-15T10:15:30+02:00', GraphQLContext.default, Locale.default) == OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class OffsetDateTimeCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a date time')
+        coercion.serialize('not a date time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class OffsetDateTimeCoercionSpec extends Specification {
         OffsetDateTime dateTime = OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.parseValue(dateTime).is(dateTime)
+        coercion.parseValue(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -79,16 +81,16 @@ class OffsetDateTimeCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15T10:15:30+02:00')) == OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.parseLiteral(new StringValue('2020-01-15T10:15:30+02:00'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == OffsetDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date time')) == null
+        coercion.parseLiteral(new StringValue('not a date time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/OffsetTimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/OffsetTimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -37,17 +39,17 @@ class OffsetTimeCoercionSpec extends Specification {
         OffsetTime time = OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.serialize(time).is(time)
+        coercion.serialize(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('10:15:30+02:00') == OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.serialize('10:15:30+02:00', GraphQLContext.default, Locale.default) == OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class OffsetTimeCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a time')
+        coercion.serialize('not a time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class OffsetTimeCoercionSpec extends Specification {
         OffsetTime time = OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.parseValue(time).is(time)
+        coercion.parseValue(time, GraphQLContext.default, Locale.default).is(time)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -79,16 +81,16 @@ class OffsetTimeCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('10:15:30+02:00')) == OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.parseLiteral(new StringValue('10:15:30+02:00'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == OffsetTime.of(10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a time')) == null
+        coercion.parseLiteral(new StringValue('not a time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/ZonedDateTimeCoercionSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/types/scalars/coercing/jsr310/ZonedDateTimeCoercionSpec.groovy
@@ -19,6 +19,8 @@
 
 package org.grails.gorm.graphql.types.scalars.coercing.jsr310
 
+import graphql.GraphQLContext
+import graphql.execution.CoercedVariables
 import graphql.language.IntValue
 import graphql.language.StringValue
 import graphql.schema.CoercingParseValueException
@@ -37,17 +39,17 @@ class ZonedDateTimeCoercionSpec extends Specification {
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.serialize(dateTime).is(dateTime)
+        coercion.serialize(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test serialize with a string matching a configured format"() {
         expect:
-        coercion.serialize('2020-01-15T10:15:30+02:00') == ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.serialize('2020-01-15T10:15:30+02:00', GraphQLContext.default, Locale.default) == ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test serialize with an unsupported type throws"() {
         when:
-        coercion.serialize(42)
+        coercion.serialize(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -55,7 +57,7 @@ class ZonedDateTimeCoercionSpec extends Specification {
 
     void "test serialize with a non matching string throws"() {
         when:
-        coercion.serialize('not a date time')
+        coercion.serialize('not a date time', GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingSerializeException)
@@ -66,12 +68,12 @@ class ZonedDateTimeCoercionSpec extends Specification {
         ZonedDateTime dateTime = ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
 
         expect:
-        coercion.parseValue(dateTime).is(dateTime)
+        coercion.parseValue(dateTime, GraphQLContext.default, Locale.default).is(dateTime)
     }
 
     void "test parseValue with an unsupported type throws"() {
         when:
-        coercion.parseValue(42)
+        coercion.parseValue(42, GraphQLContext.default, Locale.default)
 
         then:
         thrown(CoercingParseValueException)
@@ -79,16 +81,16 @@ class ZonedDateTimeCoercionSpec extends Specification {
 
     void "test parseLiteral with a StringValue matching a configured format"() {
         expect:
-        coercion.parseLiteral(new StringValue('2020-01-15T10:15:30+02:00')) == ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
+        coercion.parseLiteral(new StringValue('2020-01-15T10:15:30+02:00'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == ZonedDateTime.of(2020, 1, 15, 10, 15, 30, 0, ZoneOffset.ofHours(2))
     }
 
     void "test parseLiteral with a StringValue that matches no configured format returns null"() {
         expect:
-        coercion.parseLiteral(new StringValue('not a date time')) == null
+        coercion.parseLiteral(new StringValue('not a date time'), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 
     void "test parseLiteral with a non StringValue returns null"() {
         expect:
-        coercion.parseLiteral(new IntValue(BigInteger.ONE)) == null
+        coercion.parseLiteral(new IntValue(BigInteger.ONE), CoercedVariables.emptyVariables(), GraphQLContext.default, Locale.default) == null
     }
 }


### PR DESCRIPTION
## Summary
Stacked on #16201. Fixes a series of IntelliJ-flagged issues in `org.grails.gorm.graphql.types.*`:
- `DateCoercion`: fixed an NPE when no date formats are configured.
- `AbstractObjectTypeBuilder`: fixed a control-flow issue where `build()`'s declared-then-reassigned `objectType` local confused Groovy's static type checker on `objectTypeCache.put(...)`; fixed an unrelated latent bug where an `ArrayList` capacity was computed from a not-yet-declared `properties` variable (which actually resolved to the unrelated `GroovyObject#getProperties()` bean map); removed an unused parameter from `buildInterfaceType`; and migrated the deprecated `GraphQLInterfaceType.Builder#typeResolver` call to registration via `GraphQLCodeRegistry.Builder`. Added the first direct coverage of the interface-type branch (a root entity with child entities), which no other spec reached.
- All `Coercing` implementations in `types.scalars.coercing`: migrated off the deprecated 1-arg `serialize`/`parseValue`/`parseLiteral` overrides to the context/locale-aware overloads, fixing a `ClassCastException`-in-waiting in `ByteArrayCoercion#parseLiteral`, a deprecated `Character` constructor usage in `CharacterArrayCoercion`, and an unassigned-variable branch in `InstantCoercion#parseLiteral` along the way.

## Test plan
- [x] `./gradlew :grails-data-graphql-core:test :grails-data-graphql:test :grails-data-graphql-core:codeStyle :grails-data-graphql:codeStyle` passes, including `SchemaSpec` which exercises these coercions through real GraphQL query execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)