### PR TITLE
fix(grails-data-graphql): replace deprecated getContext() in DefaultGraphQLErrorsResponseHandler

### DIFF
--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/response/errors/DefaultGraphQLErrorsResponseHandler.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/response/errors/DefaultGraphQLErrorsResponseHandler.groovy
@@ -66,17 +66,21 @@ class DefaultGraphQLErrorsResponseHandler implements GraphQLErrorsResponseHandle
     }
 
     protected Locale getLocale(DataFetchingEnvironment environment) {
-        if (environment.context instanceof Map) {
-            Map context = (Map)environment.context
+        // environment.context is deprecated in favor of environment.graphQlContext, but the latter
+        // can only carry Map entries - it cannot hold an arbitrary GraphQLContextBuilder result such
+        // as a LocaleAwareContext. GraphqlController sets both context and root to the same object
+        // for this reason, so environment.root is used here instead as the non-deprecated equivalent.
+        if (environment.root instanceof Map) {
+            Map context = (Map) environment.root
             if (context.containsKey('locale')) {
                 Object localContext = context.get('locale')
                 if (localContext instanceof Locale) {
-                    return (Locale)localContext
+                    return (Locale) localContext
                 }
             }
         }
-        if (environment.context instanceof LocaleAwareContext) {
-            return ((LocaleAwareContext) environment.context).locale
+        if (environment.root instanceof LocaleAwareContext) {
+            return ((LocaleAwareContext) environment.root).locale
         }
         Locale.default
     }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/response/errors/DefaultGraphQLErrorsResponseHandlerSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/response/errors/DefaultGraphQLErrorsResponseHandlerSpec.groovy
@@ -117,7 +117,7 @@ class DefaultGraphQLErrorsResponseHandlerSpec extends Specification implements G
         1 * messageSource.getMessage(fieldError, contextLocale) >> 'bonjour'
         DataFetchingEnvironment mockFieldEnv = new MockDataFetchingEnvironment(
                 source: fieldError,
-                context: new LocaleAwareContext() {
+                root: new LocaleAwareContext() {
                     @Override
                     Locale getLocale() {
                         contextLocale
@@ -126,6 +126,31 @@ class DefaultGraphQLErrorsResponseHandlerSpec extends Specification implements G
 
         expect:
         handler.messageFetcher.get(mockFieldEnv) == 'bonjour'
+    }
+
+    void "test getLocale uses the locale from a root Map"() {
+        given:
+        Locale mapLocale = Locale.CANADA_FRENCH
+        FieldError fieldError = Mock(FieldError)
+        1 * messageSource.getMessage(fieldError, mapLocale) >> 'bonjour'
+        DataFetchingEnvironment mockFieldEnv = new MockDataFetchingEnvironment(
+                source: fieldError,
+                root: [locale: mapLocale])
+
+        expect:
+        handler.messageFetcher.get(mockFieldEnv) == 'bonjour'
+    }
+
+    void "test getLocale falls back to the default locale when the root Map has no locale entry"() {
+        given:
+        FieldError fieldError = Mock(FieldError)
+        1 * messageSource.getMessage(fieldError, Locale.default) >> 'hello'
+        DataFetchingEnvironment mockFieldEnv = new MockDataFetchingEnvironment(
+                source: fieldError,
+                root: [:])
+
+        expect:
+        handler.messageFetcher.get(mockFieldEnv) == 'hello'
     }
 
     class MockValidateable implements GormValidateable {


### PR DESCRIPTION
## Summary
Stacked on #16201. `DefaultGraphQLErrorsResponseHandler#getLocale()` used the deprecated `DataFetchingEnvironment#getContext()`. `getGraphQlContext()` (the modern replacement) can't hold arbitrary objects like this method's supported `LocaleAwareContext`, but `GraphqlController` already sets both `.context(context)` and `.root(context)` to the same value specifically for this migration path - so `getLocale()` now reads `environment.root` instead, covering both the Map-of-locale and `LocaleAwareContext` cases with no behavior change. Added the previously-missing root-Map and no-locale-entry test branches.

## Test plan
- [x] `./gradlew :grails-data-graphql-core:test :grails-data-graphql:test :grails-data-graphql-core:codeStyle :grails-data-graphql:codeStyle` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)