### PR TITLE
chore(grails-data-graphql): root-level cleanup (GraphQLEntityHelper, GraphQLServiceManager, Schema)

### DIFF
--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/GraphQLEntityHelper.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/GraphQLEntityHelper.groovy
@@ -73,35 +73,48 @@ class GraphQLEntityHelper {
         if (mappings.containsKey(entity)) {
             return mappings.get(entity)
         }
-        Object graphql
-        for (Method method: entity.javaClass.declaredMethods) {
-            if (Modifier.isStatic(method.modifiers) && method.name.equalsIgnoreCase('getgraphql')) {
-                graphql = method.invoke(null)
-                break
-            }
-        }
-        GraphQLMapping mapping = null
-        if (graphql != null) {
-            if (graphql == Boolean.TRUE) {
-                mapping = new GraphQLMapping()
-            }
-            else if (graphql instanceof Closure) {
-                mapping = new GraphQLMapping().build((Closure)graphql)
-            }
-            else if (graphql instanceof LazyGraphQLMapping) {
-                mapping = ((LazyGraphQLMapping)graphql).initialize()
-            }
-            else if (graphql instanceof GraphQLMapping) {
-                mapping = (GraphQLMapping)graphql
-            }
-
-            if (!(mapping instanceof GraphQLMapping)) {
-                throw new IllegalMappingException("The static graphql property on ${entity.name} is not a Boolean, Closure, or GraphQLMapping")
-            }
-            verifyMapping(mapping, entity)
-        }
+        GraphQLMapping mapping = buildMapping(entity)
         mappings.put(entity, mapping)
         mapping
+    }
+
+    private static GraphQLMapping buildMapping(PersistentEntity entity) {
+        Object graphql = findGraphqlProperty(entity)
+        if (graphql == null) {
+            return null
+        }
+
+        GraphQLMapping mapping = toGraphQLMapping(graphql)
+        if (!(mapping instanceof GraphQLMapping)) {
+            throw new IllegalMappingException("The static graphql property on ${entity.name} is not a Boolean, Closure, or GraphQLMapping")
+        }
+        verifyMapping(mapping, entity)
+        mapping
+    }
+
+    private static Object findGraphqlProperty(PersistentEntity entity) {
+        for (Method method: entity.javaClass.declaredMethods) {
+            if (Modifier.isStatic(method.modifiers) && method.name.equalsIgnoreCase('getgraphql')) {
+                return method.invoke(null)
+            }
+        }
+        null
+    }
+
+    private static GraphQLMapping toGraphQLMapping(Object graphql) {
+        if (graphql == Boolean.TRUE) {
+            return new GraphQLMapping()
+        }
+        if (graphql instanceof Closure) {
+            return new GraphQLMapping().build((Closure) graphql)
+        }
+        if (graphql instanceof LazyGraphQLMapping) {
+            return ((LazyGraphQLMapping) graphql).initialize()
+        }
+        if (graphql instanceof GraphQLMapping) {
+            return (GraphQLMapping) graphql
+        }
+        null
     }
 
     static void verifyMapping(GraphQLMapping mapping, PersistentEntity entity) {

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/GraphQLServiceManager.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/GraphQLServiceManager.groovy
@@ -39,7 +39,7 @@ class GraphQLServiceManager {
         services.put(clazz, service)
     }
 
-    public <T extends Object> T getService(Class<T> serviceType) throws ServiceNotFoundException {
+    <T extends Object> T getService(Class<T> serviceType) throws ServiceNotFoundException {
         if (services.containsKey(serviceType)) {
             return (T)services.get(serviceType)
         }

--- a/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
+++ b/grails-data-graphql/core/src/main/groovy/org/grails/gorm/graphql/Schema.groovy
@@ -544,6 +544,7 @@ class Schema {
             schema.query(query)
             return schema.build()
         }
+        null
     }
 
 }

--- a/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/GraphQLEntityHelperSpec.groovy
+++ b/grails-data-graphql/core/src/test/groovy/org/grails/gorm/graphql/GraphQLEntityHelperSpec.groovy
@@ -19,10 +19,12 @@
 
 package org.grails.gorm.graphql
 
+import org.grails.datastore.mapping.model.IllegalMappingException
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.gorm.graphql.domain.general.description.Annotation
 import org.grails.gorm.graphql.domain.hibernate.description.MappingComment
 import org.grails.gorm.graphql.domain.general.description.MappingDescription
+import org.grails.gorm.graphql.entity.dsl.GraphQLMapping
 
 /**
  * Created by jameskleeh on 7/25/17.
@@ -55,5 +57,61 @@ class GraphQLEntityHelperSpec extends HibernateSpec {
 
         expect:
         GraphQLEntityHelper.getDescription(entity) == 'MappingDescription class'
+    }
+
+    void "test getMapping returns null when no static graphql property is present"() {
+        given:
+        PersistentEntity entity = Stub(PersistentEntity) {
+            getJavaClass() >> NoGraphqlMapping
+        }
+
+        expect:
+        GraphQLEntityHelper.getMapping(entity) == null
+    }
+
+    void "test getMapping builds a default mapping from a Boolean true"() {
+        given:
+        PersistentEntity entity = Stub(PersistentEntity) {
+            getJavaClass() >> BooleanGraphqlMapping
+        }
+
+        expect:
+        GraphQLEntityHelper.getMapping(entity) instanceof GraphQLMapping
+    }
+
+    void "test getMapping throws for an unsupported graphql property type"() {
+        given:
+        PersistentEntity entity = Stub(PersistentEntity) {
+            getJavaClass() >> InvalidGraphqlMapping
+            getName() >> 'InvalidGraphqlMapping'
+        }
+
+        when:
+        GraphQLEntityHelper.getMapping(entity)
+
+        then:
+        IllegalMappingException ex = thrown(IllegalMappingException)
+        ex.message.contains('InvalidGraphqlMapping')
+    }
+
+    void "test getMapping caches the result for repeated calls with the same entity"() {
+        given:
+        PersistentEntity entity = Stub(PersistentEntity) {
+            getJavaClass() >> BooleanGraphqlMapping
+        }
+
+        expect:
+        GraphQLEntityHelper.getMapping(entity).is(GraphQLEntityHelper.getMapping(entity))
+    }
+
+    static class NoGraphqlMapping {
+    }
+
+    static class BooleanGraphqlMapping {
+        static graphql = true
+    }
+
+    static class InvalidGraphqlMapping {
+        static graphql = 42
     }
 }


### PR DESCRIPTION
## Summary
Stacked on #16201. Three small root-package fixes:
- `GraphQLEntityHelper#getMapping`: consolidated a four-branch reassignment of `mapping` into single-return helper methods (`findGraphqlProperty`, `toGraphQLMapping`, `buildMapping`), fixing a false "assignment is not used" flag. Added direct unit coverage (previously only exercised indirectly via `getDescription`).
- `GraphQLServiceManager#getService`: removed a redundant `public` modifier (Groovy methods are public by default).
- `Schema#generate()`: made the implicit `null` return explicit when no entity contributes any query fields, satisfying "not all execution paths return a value" with no behavior change (already covered by `DisableAllOpSpec`).

## Test plan
- [x] `./gradlew :grails-data-graphql-core:test :grails-data-graphql:test :grails-data-graphql-core:codeStyle :grails-data-graphql:codeStyle` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)