### PR TITLE
Binding empties a raw collection in applications that never opted in to deny-by-default

### DIFF
--- a/grails-databinding-core/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding-core/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -426,6 +426,16 @@ class SimpleDataBinder implements DataBinder {
     }
 
     protected Object instantiateAndBindOrUseMapConstructor(Class referencedType, Map values, DataBindingListener listener) {
+        if (referencedType == null || referencedType == Object) {
+            // A raw collection -- List/Set/Map written without a type argument -- reports Object as
+            // its component type: Basic#componentType falls back to Object.class when a property
+            // carries no generic signature. Object declares no properties, so instantiating one and
+            // binding into it has nowhere to put the element's data and the element silently becomes
+            // an empty Object. A value that is never used as a property source cannot mass-assign
+            // anything, so it is kept as it stands, which is also how these collections bound before
+            // deny-by-default.
+            return values
+        }
         def instance
         try {
             instance = referencedType.getDeclaredConstructor().newInstance()

--- a/grails-databinding-core/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
+++ b/grails-databinding-core/src/main/groovy/grails/databinding/SimpleDataBinder.groovy
@@ -426,16 +426,6 @@ class SimpleDataBinder implements DataBinder {
     }
 
     protected Object instantiateAndBindOrUseMapConstructor(Class referencedType, Map values, DataBindingListener listener) {
-        if (referencedType == null || referencedType == Object) {
-            // A raw collection -- List/Set/Map written without a type argument -- reports Object as
-            // its component type: Basic#componentType falls back to Object.class when a property
-            // carries no generic signature. Object declares no properties, so instantiating one and
-            // binding into it has nowhere to put the element's data and the element silently becomes
-            // an empty Object. A value that is never used as a property source cannot mass-assign
-            // anything, so it is kept as it stands, which is also how these collections bound before
-            // deny-by-default.
-            return values
-        }
         def instance
         try {
             instance = referencedType.getDeclaredConstructor().newInstance()

--- a/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
@@ -51,7 +51,7 @@ class GrailsWebDataBinderSpec extends Specification implements DataTest {
         mockDomains(
                 AssociationBindingAuthor, AssociationBindingBook, AssociationBindingPage, Author, BinderNullabilityEntity,
                 Child, CollectionContainer, DataBindingBook, Fidget, Foo, GeneratedBindingChild, GeneratedBindingParent,
-                Parent, Publication, Publisher, Team, Widget
+                Parent, Publication, Publisher, RawCollectionContainer, Team, Widget
         )
     }
 
@@ -1962,6 +1962,31 @@ class GrailsWebDataBinderSpec extends Specification implements DataTest {
         obj.publishers.find { it.name == 'Pub One' }
         obj.publishers.find { it.name == 'Pub Three' }
     }
+
+    void 'test binding maps into a raw collection preserves the map elements'() {
+        given: 'a domain with a raw (non-generic) collection, whose component type falls back to Object'
+        def obj = new RawCollectionContainer()
+
+        when: 'a list of maps is bound to it'
+        binder.bind(obj, new SimpleMapDataBindingSource([
+            rawList: [[label: 'Answered', param: 'status=resolved'],
+                      [label: 'Pending', param: 'status=pending']]
+        ]))
+
+        then: 'the maps survive binding rather than being replaced by empty Object instances'
+        obj.rawList.size() == 2
+        obj.rawList.every { it instanceof Map }
+        obj.rawList[0].label == 'Answered'
+        obj.rawList[0].param == 'status=resolved'
+        obj.rawList[1].label == 'Pending'
+        obj.rawList[1].param == 'status=pending'
+    }
+}
+
+@Entity
+class RawCollectionContainer {
+
+    List rawList = []
 }
 
 @Entity

--- a/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
@@ -1981,12 +1981,42 @@ class GrailsWebDataBinderSpec extends Specification implements DataTest {
         obj.rawList[1].label == 'Pending'
         obj.rawList[1].param == 'status=pending'
     }
+
+    void 'test binding maps into a raw Map property preserves the map values'() {
+        given:
+        def obj = new RawCollectionContainer()
+
+        when:
+        binder.bind(obj, new SimpleMapDataBindingSource([
+            rawMap: [first: [label: 'Answered', param: 'status=resolved']]
+        ]))
+
+        then:
+        obj.rawMap.first instanceof Map
+        obj.rawMap.first.label == 'Answered'
+    }
+
+    void 'test binding maps into a raw Set property preserves the map elements'() {
+        given:
+        def obj = new RawCollectionContainer()
+
+        when:
+        binder.bind(obj, new SimpleMapDataBindingSource([
+            rawSet: [[label: 'Answered', param: 'status=resolved']]
+        ]))
+
+        then:
+        obj.rawSet.every { it instanceof Map }
+        obj.rawSet.first().label == 'Answered'
+    }
 }
 
 @Entity
 class RawCollectionContainer {
 
     List rawList = []
+    Map rawMap = [:]
+    Set rawSet = []
 }
 
 @Entity

--- a/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
+++ b/grails-test-suite-persistence/src/test/groovy/grails/web/databinding/GrailsWebDataBinderSpec.groovy
@@ -28,6 +28,7 @@ import spock.lang.Unroll
 import org.springframework.context.support.StaticMessageSource
 
 import grails.config.Settings
+import grails.util.Holders
 import grails.databinding.BindUsing
 import grails.databinding.BindingFormat
 import grails.databinding.DataBindingSource
@@ -1982,20 +1983,6 @@ class GrailsWebDataBinderSpec extends Specification implements DataTest {
         obj.rawList[1].param == 'status=pending'
     }
 
-    void 'test binding maps into a raw Map property preserves the map values'() {
-        given:
-        def obj = new RawCollectionContainer()
-
-        when:
-        binder.bind(obj, new SimpleMapDataBindingSource([
-            rawMap: [first: [label: 'Answered', param: 'status=resolved']]
-        ]))
-
-        then:
-        obj.rawMap.first instanceof Map
-        obj.rawMap.first.label == 'Answered'
-    }
-
     void 'test binding maps into a raw Set property preserves the map elements'() {
         given:
         def obj = new RawCollectionContainer()
@@ -2009,6 +1996,54 @@ class GrailsWebDataBinderSpec extends Specification implements DataTest {
         obj.rawSet.every { it instanceof Map }
         obj.rawSet.first().label == 'Answered'
     }
+
+    void 'test binding maps into a raw Collection-typed property'() {
+        given:
+        def obj = new RawCollectionContainer()
+
+        when:
+        binder.bind(obj, new SimpleMapDataBindingSource([rawCollection: [[label: 'Answered']]]))
+
+        then:
+        obj.rawCollection.every { it instanceof Map }
+        obj.rawCollection[0].label == 'Answered'
+    }
+
+    void 'test binding DataBindingSource items into a raw collection'() {
+        given:
+        def obj = new RawCollectionContainer()
+
+        when:
+        binder.bind(obj, new SimpleMapDataBindingSource([
+            rawList: [new SimpleMapDataBindingSource([label: 'Answered'])]
+        ]))
+
+        then:
+        obj.rawList.size() == 1
+        obj.rawList[0].getClass() != Object
+    }
+
+    void 'test binding maps into a raw collection with deny-by-default enabled'() {
+        given: 'the opt-in hardening turned on, and the property explicitly allowlisted'
+        def originalConfig = Holders.config
+        Holders.setConfig(new PropertySourcesConfig([(Settings.DATABINDING_DENY_BY_DEFAULT): true]))
+        DataBindingUtils.clearBindingCaches()
+        def obj = new RawCollectionContainer()
+
+        when:
+        binder.bind(obj, new SimpleMapDataBindingSource([
+            rawList: [[label: 'Answered', param: 'status=resolved']]
+        ]), null, ['rawList'], null, null)
+
+        then: 'the elements are still maps, as they are with the hardening off'
+        obj.rawList.size() == 1
+        obj.rawList[0] instanceof Map
+        obj.rawList[0].label == 'Answered'
+
+        cleanup:
+        Holders.setConfig(originalConfig)
+        DataBindingUtils.clearBindingCaches()
+    }
 }
 
 @Entity
@@ -2017,6 +2052,7 @@ class RawCollectionContainer {
     List rawList = []
     Map rawMap = [:]
     Set rawSet = []
+    Collection rawCollection = []
 }
 
 @Entity

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -505,7 +505,7 @@ class GrailsWebDataBinder extends SimpleDataBinder {
             } else if (Collection.isAssignableFrom(metaProperty.type)) {
                 def referencedType = getReferencedTypeForCollection(propName, obj)
                 if (referencedType) {
-                    def listValue
+                    List listValue
                     if (val instanceof List) {
                         listValue = (List) val
                     } else if (val instanceof GPathResultMap && ((GPathResultMap) val).size() == 1) {

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -634,6 +634,16 @@ class GrailsWebDataBinder extends SimpleDataBinder {
 
     private Object instantiateAndBindNestedOrUseMapConstructor(Class referencedType, Object value,
             DataBindingSource source, List includeList, DataBindingListener listener) {
+        if (referencedType == null || referencedType == Object) {
+            // A raw collection -- List/Set/Map written without a type argument -- reports Object as
+            // its component type: Basic#componentType falls back to Object.class when a property
+            // carries no generic signature. Object declares no properties, so instantiating one and
+            // binding into it has nowhere to put the element's data and the element silently becomes
+            // an empty Object. A value that is never used as a property source cannot mass-assign
+            // anything, so it is kept as it stands, which is also how these collections bound before
+            // deny-by-default.
+            return value
+        }
         def instance
         try {
             instance = referencedType.getDeclaredConstructor().newInstance()

--- a/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
+++ b/grails-web-databinding/src/main/groovy/grails/web/databinding/GrailsWebDataBinder.groovy
@@ -545,7 +545,17 @@ class GrailsWebDataBinder extends SimpleDataBinder {
                                 }
                             }
                             if (persistentInstance == null) {
-                                if (item instanceof Map || item instanceof DataBindingSource) {
+                                if (item == null || referencedType.isAssignableFrom(item.getClass())) {
+                                    // Already of the element type, so there is nothing to instantiate
+                                    // and nothing to bind into. A raw collection always lands here:
+                                    // Basic#componentType falls back to Object.class when a property
+                                    // carries no generic signature, and Object is assignable from
+                                    // everything. The array branch above and the Map branch below ask
+                                    // the same question before instantiating; only this one did not,
+                                    // so a map element was replaced by an empty Object and its
+                                    // contents were dropped.
+                                    itemsWhichNeedBinding << item
+                                } else if (item instanceof Map || item instanceof DataBindingSource) {
                                     DataBindingSource itemBindingSource = item instanceof DataBindingSource ?
                                             (DataBindingSource) item : new SimpleMapDataBindingSource((Map) item)
                                     def instance = instantiateAndBindNestedOrUseMapConstructor(
@@ -634,16 +644,6 @@ class GrailsWebDataBinder extends SimpleDataBinder {
 
     private Object instantiateAndBindNestedOrUseMapConstructor(Class referencedType, Object value,
             DataBindingSource source, List includeList, DataBindingListener listener) {
-        if (referencedType == null || referencedType == Object) {
-            // A raw collection -- List/Set/Map written without a type argument -- reports Object as
-            // its component type: Basic#componentType falls back to Object.class when a property
-            // carries no generic signature. Object declares no properties, so instantiating one and
-            // binding into it has nowhere to put the element's data and the element silently becomes
-            // an empty Object. A value that is never used as a property source cannot mass-assign
-            // anything, so it is kept as it stands, which is also how these collections bound before
-            // deny-by-default.
-            return value
-        }
         def instance
         try {
             instance = referencedType.getDeclaredConstructor().newInstance()


### PR DESCRIPTION
### Impact

**Silent data loss, in applications that did not opt in to the change that causes it.**

- A domain's raw `List` / `Set` / `Collection` has **every** element it binds replaced by an empty `java.lang.Object`. The values are gone before validation or persistence can see them.
- **Regression:** correct in 8.0.0-M5, broken in 8.0.0-M6. Not mentioned in `upgrading80x.adoc`.
- **Not gated by the opt-in.** #15947 states the mode is opt-in and that "unconfigured applications continue binding permissively." An application that never set `grails.databinding.legacyBindableDefault=false` loses the data anyway, because the instantiation happens in the `try` while `isDenyByDefaultEnabled()` guards only the `catch`. There is a test for both settings.
- **It surfaces nowhere near its cause.** On GORM for MongoDB it appears as `Can't find a codec for … java.lang.Object` from the BSON encoder, three modules from the data binder that destroyed the value. Tracing it took eliminating the MongoDB driver version, the embedded-MongoDB module, the codec registry and the datastore bean wiring first.

8.0.0-M6 is staged but not yet on Maven Central, so this is still fixable before it becomes immutable.

### Problem

A domain property declared as a **raw** collection loses its data during binding on 8.0.0-M6. Given:

```groovy
class TopicType {
    List statusFilters = []          // no type argument
}

new TopicType(statusFilters: [[label: 'Answered', param: 'status=resolved']])
```

every map element is replaced by an empty `new java.lang.Object()`. With GORM for MongoDB the write then fails:

```
org.bson.codecs.configuration.CodecConfigurationException:
    Can't find a codec for CodecCacheKey{clazz=class java.lang.Object, types=null}
  at CodecExtensions$ListCodec.encode(CodecExtensions.groovy:362)
  at BasicCollectionTypeEncoder.encode(BasicCollectionTypeEncoder.groovy:64)
  at BsonPersistentEntityCodec.encode(BsonPersistentEntityCodec.groovy:229)
```

The exception is incidental — it is the first thing to notice that the elements are no longer maps. Without a codec in the path the empty objects would simply be persisted, so the data is lost either way. This worked on 8.0.0-M5.

### Cause

#15947 changed collection binding so a `Map` element is instantiated as the component type and bound through the allowlist, rather than passed to a map constructor:

```diff
- itemsWhichNeedBinding << item
+ def instance = instantiateAndBindNestedOrUseMapConstructor(referencedType, item, itemBindingSource, ...)
+ if (instance != null) { itemsWhichNeedBinding << instance }
```

That is right for a real nested type, but the component type is not always one. `Basic#componentType` falls back to `Object.class` when a property carries no generic signature, so a raw collection arrives with `referencedType == Object`. `Object` has a public no-arg constructor, so `getDeclaredConstructor().newInstance()` succeeds, and `Object` declares no properties, so `bindNested` has nowhere to put the map's contents.

It is not gated by the opt-in, either: the instantiation is in the `try`, while `isDenyByDefaultEnabled()` guards only the map-constructor fallback in the `catch`. The data is destroyed with the hardening on and with it off — there is a test for both.

### Fix

Three places bind an element into a collection, and the other two already keep the item when the element type is assignable from it:

- the array branch — `if (item == null || componentType.isAssignableFrom(item.getClass()))`
- the `Map` branch — `if (item == null || referencedType.isAssignableFrom(item.getClass()))`
- `SimpleDataBinder` also asks, at `genericType.isAssignableFrom(val?.getClass())`

Only the collection branch went straight to instantiating. This asks the same question there:

```groovy
if (item == null || referencedType.isAssignableFrom(item.getClass())) {
    itemsWhichNeedBinding << item
} else if (item instanceof Map || item instanceof DataBindingSource) {
    ...
}
```

`Object` is assignable from everything, so a raw collection's elements are kept. No special case for `Object`, no change to `instantiateAndBindNestedOrUseMapConstructor`, and no change for any other component type — a `Map` element whose target is a real nested type is not assignable from it and still instantiates and binds through the allowlist. `bindable: false` is unaffected.

That is the whole production change: one branch, in one file.

### Scope

Only GORM domain classes, and only raw `List` / `Set` / `Collection` properties whose elements are maps.

A non-domain target (command object, `Validateable`) is unaffected: `SimpleDataBinder` resolves a component type only from a `ParameterizedType`, so a raw field yields `null`, and `GrailsWebDataBinder` reaches `Basic#componentType` only through a `PersistentEntity`. With `referencedType` null the branch is skipped by its own guard. A raw `Map` property is likewise unaffected, because its branch already asks the assignability question.

### Tests

Five tests in `GrailsWebDataBinderSpec`, against a `RawCollectionContainer` domain. **Every one of them fails on an unmodified `8.0.x` binder and passes with the fix**, each covering a distinct way into the branch:

| test | what it covers |
|---|---|
| raw `List` of maps | the reported case |
| raw `Set` of maps | the same branch via a different collection type |
| raw `Collection`-typed property | a third declared type |
| `DataBindingSource` elements | the other item shape the branch instantiates |
| deny-by-default enabled, property allowlisted | the loss is not gated by the opt-in |

The failures report exactly the production symptom, e.g.

```
obj.rawList[0] instanceof Map
|   |      |   false
|   |      <java.lang.Object@32a074ed> (java.lang.Object)
```

In the deny-by-default case `size() == 1` holds first, so the property does bind and the failure is the data being destroyed rather than the binding being denied.

`:grails-databinding-core:test`, `:grails-web-databinding:test` (including `DenyByDefaultConfigSpec`) and the `grails.web.databinding.*` suite in `grails-test-suite-persistence` are all green.

Also verified end to end against the application that hit this: with this jar built at `8.0.0-M6` and substituted into an otherwise stock M6 app, the raw-collection domain that previously failed boots and persists its maps intact.
