### PR TITLE
Bump Hibernate 7 versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -297,7 +297,7 @@ ext {
                 // Management, and Hibernate ORM 7.4.x requires hibernate-models 1.1.x.
                 'hibernate-models.version'      : '1.1.2',
                 'hibernate-tools.version'       : '7.3.13.Final',
-                'hibernate.version'             : '7.4.6.Final',
+                'hibernate.version'             : '7.4.7.Final',
                 'jandex.version'                : '3.2.3',
                 'liquibase-hibernate.version'   : '4.27.0',
                 'liquibase-test-harness.version': '1.0.11',
@@ -394,7 +394,7 @@ ext {
                 'groovy.version'                : bomDependencyVersions['groovy.version'],
                 'hibernate-models.version'      : '1.1.2',
                 'hibernate-tools.version'       : '7.3.13.Final',
-                'hibernate.version'             : '7.4.6.Final',
+                'hibernate.version'             : '7.4.7.Final',
                 'jandex.version'                : '3.2.3',
                 'liquibase-hibernate.version'   : '4.27.0',
                 'liquibase-test-harness.version': '1.0.11',

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -295,9 +295,9 @@ ext {
                 'derby.version'                 : '10.17.1.0',
                 // Spring Boot 4.1 can select Hibernate ORM 7.4.x through Spring Dependency
                 // Management, and Hibernate ORM 7.4.x requires hibernate-models 1.1.x.
-                'hibernate-models.version'      : '1.1.1',
-                'hibernate-tools.version'       : '7.3.8.Final',
-                'hibernate.version'             : '7.4.1.Final',
+                'hibernate-models.version'      : '1.1.2',
+                'hibernate-tools.version'       : '7.3.13.Final',
+                'hibernate.version'             : '7.4.6.Final',
                 'jandex.version'                : '3.2.3',
                 'liquibase-hibernate.version'   : '4.27.0',
                 'liquibase-test-harness.version': '1.0.11',
@@ -392,9 +392,9 @@ ext {
         customBomVersions = [
                 'cache-ri-impl.version'         : '1.1.1',
                 'groovy.version'                : bomDependencyVersions['groovy.version'],
-                'hibernate-models.version'      : '1.1.1',
-                'hibernate-tools.version'       : '7.3.8.Final',
-                'hibernate.version'             : '7.4.1.Final',
+                'hibernate-models.version'      : '1.1.2',
+                'hibernate-tools.version'       : '7.3.13.Final',
+                'hibernate.version'             : '7.4.6.Final',
                 'jandex.version'                : '3.2.3',
                 'liquibase-hibernate.version'   : '4.27.0',
                 'liquibase-test-harness.version': '1.0.11',


### PR DESCRIPTION
Hibernate ORM 7.4.7.Final was released August 30. The [[7.4.6–7.4.7 comparison](https://github.com/hibernate/hibernate-orm/compare/7.4.6...7.4.7)](https://github.com/hibernate/hibernate-orm/compare/7.4.6...7.4.7) includes:

* Correct handling of initialized lazy fields during second-level-cache disassembly.
* Retaining a superclass-table join when a to-one foreign key targets an ancestor table in a `JOINED` inheritance hierarchy, avoiding invalid SQL.
* Additional `StatelessSession` delegation SPI work.
* Jakarta Data/CDI annotation-processor fixes, which are less directly relevant to GORM.

The broader [[7.4.1–7.4.7 comparison](https://github.com/hibernate/hibernate-orm/compare/7.4.1...7.4.7)](https://github.com/hibernate/hibernate-orm/compare/7.4.1...7.4.7) also includes:

* Fixes for lazy proxies, bytecode-enhanced entities, dynamic updates, multi-level cascade deletion and second-level-cache state handling.
* Mapping and inheritance fixes involving mapped-superclass identifiers, `@Access`, `@OneToOne(mappedBy)`, collection index columns and native-query alias expansion.
* Query fixes covering copied CTEs in count queries, collection-pagination formulas, filtered associations, enum literals and `locate()` with a starting position.
* Envers fixes for proxied entities and inherited auditing metadata.
* Improved generic type resolution for converters, generators, aggregate elements and JSON-mapped generic collections.
* JSON handling fixes for UUID, binary and temporal values across several database dialects.
* Jakarta Data fixes, including generated identifiers in `saveAll()`, plus annotation-processor improvements.

Hibernate Tools 7.3.13.Final was released August 4. The [[7.3.8–7.3.13 comparison](https://github.com/hibernate/hibernate-tools/compare/7.3.8.Final...7.3.13.Final)](https://github.com/hibernate/hibernate-tools/compare/7.3.8.Final...7.3.13.Final) contains no implementation changes; the intervening releases update the Hibernate ORM dependency and release documentation.

Hibernate Models 1.1.2 was released July 21. The [[1.1.1–1.1.2 comparison](https://github.com/hibernate/hibernate-models/compare/1.1.1...1.1.2)](https://github.com/hibernate/hibernate-models/compare/1.1.1...1.1.2) includes:

* Fixing generic-array resolution that could leave type details only partially resolved.
* Resolving collection and map type arguments through generic type hierarchies.