### PR TITLE
Remove unintended @ReadOnly from GormService

### DIFF
--- a/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
+++ b/grails-scaffolding/src/main/groovy/grails/plugin/scaffolding/GormService.groovy
@@ -23,7 +23,6 @@ import groovy.transform.CompileStatic
 
 import grails.artefact.Artefact
 import grails.gorm.api.GormAllOperations
-import grails.gorm.transactions.ReadOnly
 import grails.gorm.transactions.Transactional
 import grails.util.GrailsNameUtils
 import org.grails.datastore.gorm.GormEnhancer
@@ -31,7 +30,6 @@ import org.grails.datastore.gorm.GormEntity
 import org.grails.datastore.gorm.GormEntityApi
 
 @Artefact('Service')
-@ReadOnly
 @CompileStatic
 class GormService<T extends GormEntity<T>> implements ScaffoldService<T, Serializable> {
 


### PR DESCRIPTION
When I originally created GormService, the purpose was to provide CRUD operations implemented using GORM.  It was modeled after `RestfulController` used by the scaffolding plugin. The intent was to have a `RestfulServiceController` that used a service layer instead of direct datastore access. I mistakenly added `@ReadOnly`.  `@ReadOnly` should not be there because GORM `get` does not happen in a transaction so GormService `get` should not either.

## Problem

`GormService` is annotated `@ReadOnly` at class level, so the transactional AST transform wraps `get`/`list`/`count` in a `GrailsTransactionTemplate`. With the default `REQUIRED` propagation, a read taken outside an existing transaction becomes the **outermost** transaction — and committing it flushes the session:

```java
// DatastoreTransactionManager.doCommit
if (!status.isReadOnly()) {
    if (session != null) { ... session.flush(); }   // skipped when read-only
}
transaction.commit();                               // ...but this flushes anyway
```

```java
// MongoTransaction.commit()
session.flush();
commitWithRetry();
```

So a read can write. `@ReadOnly` suppresses the transaction manager's own flush, but not the one inside `commit()`.

That becomes a hang when such a read runs *during* a flush. A referential check in a validator is the ordinary case:

```groovy
static constraints = {
    principalId validator: { String val -> Principal.get(val) != null ?: 'principal.missing' }
}
```

If `Principal.get(...)` reaches `GormService`, the commit of its read-only transaction flushes the session, the flush re-validates the entity being saved, the validator reads again, and the cycle repeats until the stack is exhausted. It surfaces well away from the cause — as `IllegalStateException: Transaction synchronization is not active` thrown out of the commit unwind, with the `StackOverflowError` lost. `beforeInsert`/`beforeUpdate` hooks are exposed the same way.

## Change

Drop the class-level `@ReadOnly` from `GormService`. The write methods keep their own `@Transactional`.

The annotation is redundant where scaffolded reads are actually served: `RestfulServiceController` already declares `@ReadOnly` at class level, so that path keeps its read-only boundary either way. The service annotation only takes effect when the service is called *outside* one — which is exactly where opening and committing a transaction is unwanted, and where callers reasonably expect `get(id)` to behave like the GORM static call it delegates to.

## Tests

`:grails-scaffolding:test` plus `check` on `:grails-test-examples-scaffolding`, `:grails-test-examples-scaffolding-fields`, and `:grails-test-examples-hibernate7-scaffolding-fields` (integration tests included) all pass.

## Related

#16214 aligns the behaviour underneath this. `@ReadOnly` suppresses the flush on Hibernate but not on the `DatastoreTransactionManager` path, where `doCommit`'s `if (!status.isReadOnly())` guard is defeated by `transaction.commit()` flushing unconditionally in both `MongoTransaction` and `SessionOnlyTransaction`.

The two are independent. This one removes a `@ReadOnly` that a scaffold service should not carry regardless of what read-only ends up meaning; #16214 makes read-only mean the same thing on both paths. Either can land without the other.

(Minor, noticed while tracing it: the `// Just set to NEVER in case of a new Session for this transaction.` comment in `doBegin` is inherited from Spring's `HibernateTransactionManager`, which sets Hibernate's own `FlushMode.MANUAL`. `jakarta.persistence.FlushModeType` offers only `AUTO` and `COMMIT`, so the code is already as strict as the enum allows and the comment is what is stale. #16214 corrects it.)
