### PR TITLE
fix: fill the login form until the values stay filled (does not fix #16217)

### DIFF
--- a/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/LoginPage.groovy
+++ b/grails-test-examples/scaffolding/src/integrationTest/groovy/com/example/pages/LoginPage.groovy
@@ -31,11 +31,25 @@ class LoginPage extends NavigationPage {
     }
 
     void login(String username = 'test@grails.org', String password = 'letmein') {
-        this.username = username
-        this.password = password
+        // Filled again until the values stay. This page is rendered because a protected page
+        // asked for it, and the document can be replaced under the driver after it is first
+        // parsed - taking the typed values with it. What is left is a form whose two required
+        // fields are empty, which the browser will not submit, so nothing reaches the server
+        // and the wait below waits for a page that will never change.
+        waitFor { fillCredentials(username, password) }
         loginButton.click()
         // Wait for a definitive authenticated signal: the login page must be fully replaced
         // (title changed AND the login form is gone), not merely a transient title change.
         waitFor { title != pageTitle && $('input', name: 'username').empty }
+    }
+
+    /**
+     * @return whether the credentials are in the form now, which is false while a replaced
+     *         document is still being filled in again
+     */
+    private boolean fillCredentials(String username, String password) {
+        this.username = username
+        this.password = password
+        this.username.value() == username && this.password.value() == password
     }
 }

--- a/grails-test-examples/spring-security/core/misc-functional-test-app/group/src/integration-test/groovy/demo/LoginPage.groovy
+++ b/grails-test-examples/spring-security/core/misc-functional-test-app/group/src/integration-test/groovy/demo/LoginPage.groovy
@@ -33,8 +33,11 @@ class LoginPage extends Page {
     }
 
     void login(String username, String password) {
-        usernameInputField << username
-        passwordInputField << password
+        // Set rather than appended, and set again until the values stay: this page is rendered
+        // because a secured page asked for it, and a document replaced under the driver after it
+        // was first parsed takes the typed values with it, leaving a form that submits nothing
+        // useful. Appending would also double the text on a second attempt.
+        waitFor { fillCredentials(username, password) }
         loginButton.click()
         // Submitting the form is a navigation, and the browser goes on showing this page until the
         // response lands. Returning before that leaves whatever the specification asserts next
@@ -42,6 +45,16 @@ class LoginPage extends Page {
         // left, where the title would only say the page reads differently - and a page reads
         // differently in another language.
         waitFor { !browser.currentUrl.contains('/login/') }
+    }
+
+    /**
+     * @return whether the credentials are in the form now, which is false while a replaced
+     *         document is still being filled in again
+     */
+    private boolean fillCredentials(String username, String password) {
+        usernameInputField.value(username)
+        passwordInputField.value(password)
+        usernameInputField.value() == username && passwordInputField.value() == password
     }
 
     @Override

--- a/grails-test-examples/spring-security/core/misc-functional-test-app/roles/src/integration-test/groovy/demo/LoginPage.groovy
+++ b/grails-test-examples/spring-security/core/misc-functional-test-app/roles/src/integration-test/groovy/demo/LoginPage.groovy
@@ -33,8 +33,11 @@ class LoginPage extends Page {
     }
 
     void login(String username, String password) {
-        usernameInputField << username
-        passwordInputField << password
+        // Set rather than appended, and set again until the values stay: this page is rendered
+        // because a secured page asked for it, and a document replaced under the driver after it
+        // was first parsed takes the typed values with it, leaving a form that submits nothing
+        // useful. Appending would also double the text on a second attempt.
+        waitFor { fillCredentials(username, password) }
         loginButton.click()
         // Submitting the form is a navigation, and the browser goes on showing this page until the
         // response lands. Returning before that leaves whatever the specification asserts next
@@ -42,5 +45,15 @@ class LoginPage extends Page {
         // left, where the title would only say the page reads differently - and a page reads
         // differently in another language.
         waitFor { !browser.currentUrl.contains('/login/') }
+    }
+
+    /**
+     * @return whether the credentials are in the form now, which is false while a replaced
+     *         document is still being filled in again
+     */
+    private boolean fillCredentials(String username, String password) {
+        usernameInputField.value(username)
+        passwordInputField.value(password)
+        usernameInputField.value() == username && passwordInputField.value() == password
     }
 }


### PR DESCRIPTION
> **This does not fix the flake it was opened for, and the mechanism it originally described was wrong.** The failure is tracked in #16217. Draft, pending a decision on whether any of this is worth keeping on its own merits.

## What this claimed, and why it was wrong

It claimed `UserControllerSpec > User list` fails because the login page is replaced under the driver while the form is being filled, leaving two empty `required` fields that the browser refuses to submit.

That was asserted from the captured page rather than tested, and this branch's own CI disproved it: the same test failed here, at `login_closure2` - the wait *after* the click. The fill retry added by this branch had already passed, so the form was filled and the click did submit. The failure is downstream of anything this changes.

## What is actually known

Established afterwards by injecting faults locally and comparing the captured page with CI's, byte for byte (see #16217):

| Injected fault | Page produced | Matches CI |
|---|---|---|
| Session cookie deleted between filling and submitting | 1089 bytes, login page, no error, autofocus | yes, byte for byte |
| Valid session, `_csrf` overwritten with a stale value | 283 bytes, Whitelabel Error Page (403) | no |

The form reaches the server **without a session cookie**. Why is not known. Resubmitting is not a fix either: without the session the saved request is gone too, so a successful retry lands on `/` and the test then fails on `at(UserListPage)`.

## What is still in this branch

Two things that stand or fall on their own merits, neither of which addresses the failure above:

- filling the form until the values stay, which guards against a document replaced mid-fill. The mechanism is real - an empty `required` form is silently unsubmittable - but it has not been observed happening in this application.
- the misc functional test application's page objects setting the fields rather than appending to them, so a second attempt cannot double the text.

Both are hardening against something unobserved. On the evidence available they should not be merged as a fix for #16217, and arguably not at all.
