### PR TITLE
Reuse an embedded MongoDB only when it is running the backend being asked for

### DIFF
--- a/grails-data-mongodb/docs/src/docs/asciidoc/gettingStarted/embeddedMongo.adoc
+++ b/grails-data-mongodb/docs/src/docs/asciidoc/gettingStarted/embeddedMongo.adoc
@@ -195,12 +195,18 @@ restart reuses it instead of starting another. Only a server this module started
 reused: if anything else is already holding the port, startup fails with an error naming
 the port rather than connecting to an unrelated service.
 
-A restart that carries a different setting - a database directory, a version, a replica set,
-or transactions being switched on - is given a server that matches it, which means the
-previous one is replaced and anything it held in memory goes with it. Data in a
+A restart that carries a different setting - a backend, a database directory, a version, a
+replica set, or transactions being switched on - is given a server that matches it, which
+means the previous one is replaced and anything it held in memory goes with it. Data in a
 `database-dir` outlives the replacement, except across a change of `version`: MongoDB
 refuses to start against a directory written by a different release. To use a MongoDB started by hand,
 name its host in `grails.mongodb.url` as usual.
+
+Switching `backend` counts as much as the rest: an application handed the in-memory server
+after asking for flapdoodle would not fail at the switch but later, at the first transaction
+or `$text` query it ran. Naming a `backend` whose library is not on the classpath fails the
+restart rather than handing back the server already listening, which is what that
+configuration does when nothing is running yet.
 
 ==== Outside Grails
 

--- a/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializer.java
+++ b/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializer.java
@@ -293,9 +293,10 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
 
     /**
      * A server is reused only when it is the server this application is asking for. A restart that
-     * switched transactions on, named a different version, or moved the database directory wants
-     * something the running server is not, and being handed it anyway would fail later and further
-     * away - a transaction refused by a standalone server, say.
+     * chose another backend, switched transactions on, named a different version, or moved the
+     * database directory wants something the running server is not, and being handed it anyway
+     * would fail later and further away - a transaction refused by a standalone server, say, or a
+     * {@code $text} query refused by the in-memory backend.
      */
     private StartedServer discard(StartedServer started, EmbeddedMongoSettings settings, String backend) {
         if (started == null || (started.settings().equals(settings) && started.backend().equals(backend))) {
@@ -439,8 +440,11 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
     }
 
     /**
-     * A server this JVM started, and what it was asked for. The settings are what a later context
-     * compares against to decide whether the server it finds is the one it wants.
+     * A server this JVM started, and what it was asked for. The settings and the backend together
+     * are what a later context compares against to decide whether the server it finds is the one it
+     * wants. The backend is held beside the settings rather than within them because it selects the
+     * server rather than configures it, and {@link EmbeddedMongoSettings} is public API whose
+     * constructor should not change to carry it.
      */
     private record StartedServer(RunningEmbeddedMongo running, EmbeddedMongoSettings settings, String backend) {
     }

--- a/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializer.java
+++ b/grails-data-mongodb/embedded/src/main/java/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializer.java
@@ -211,9 +211,13 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
         String database = resolveDatabase(asked.group(2));
 
         EmbeddedMongoSettings settings = settings(environment, port);
+        // Resolved before the reuse check rather than inside start(): which backend is being asked
+        // for decides whether the running server is the one wanted, so it cannot wait until after
+        // that question has been answered.
+        EmbeddedMongoBackend backend = selectBackend(environment);
 
         String url;
-        StartedServer started = discard(STARTED.get(port), settings);
+        StartedServer started = discard(STARTED.get(port), settings, backend.getName());
         if (started != null) {
             // A devtools restart reuses this JVM and this class is loaded from a jar, so it
             // survives in the base classloader along with the server the previous
@@ -233,7 +237,7 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
             log.info("Reusing the embedded MongoDB this JVM already started at {}", url);
         }
         else {
-            url = start(environment, settings, database);
+            url = start(backend, settings, database);
         }
 
         Map<String, Object> published = new HashMap<>();
@@ -257,8 +261,7 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
      * properties pointing at whatever the application configured, which is exactly what
      * enabling this was meant to replace.
      */
-    private String start(ConfigurableEnvironment environment, EmbeddedMongoSettings settings, String database) {
-        EmbeddedMongoBackend backend = selectBackend(environment);
+    private String start(EmbeddedMongoBackend backend, EmbeddedMongoSettings settings, String database) {
         int port = settings.getPort();
 
         RunningEmbeddedMongo running;
@@ -275,7 +278,7 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
                     "instead of " + EMBEDDED_HOST + " to use an external MongoDB.", ex);
         }
 
-        STARTED.put(port, new StartedServer(running, settings));
+        STARTED.put(port, new StartedServer(running, settings, backend.getName()));
         stopEverythingAtExit();
 
         String url = "mongodb://" + running.getHost() + ":" + running.getPort() + "/" + database;
@@ -294,12 +297,12 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
      * something the running server is not, and being handed it anyway would fail later and further
      * away - a transaction refused by a standalone server, say.
      */
-    private StartedServer discard(StartedServer started, EmbeddedMongoSettings settings) {
-        if (started == null || started.settings().equals(settings)) {
+    private StartedServer discard(StartedServer started, EmbeddedMongoSettings settings, String backend) {
+        if (started == null || (started.settings().equals(settings) && started.backend().equals(backend))) {
             return started;
         }
-        log.info("Replacing the embedded MongoDB this JVM started ({}): it is now asked for with {}",
-                started.settings(), settings);
+        log.info("Replacing the embedded MongoDB this JVM started ({} on the {} backend): it is now " +
+                "asked for with {} on the {} backend", started.settings(), started.backend(), settings, backend);
         started.running().stop();
         // Keyed removal, so a server another thread has just started on this port is not the one
         // taken out of the registry.
@@ -439,7 +442,7 @@ public class EmbeddedMongoInitializer implements ApplicationContextInitializer<C
      * A server this JVM started, and what it was asked for. The settings are what a later context
      * compares against to decide whether the server it finds is the one it wants.
      */
-    private record StartedServer(RunningEmbeddedMongo running, EmbeddedMongoSettings settings) {
+    private record StartedServer(RunningEmbeddedMongo running, EmbeddedMongoSettings settings, String backend) {
     }
 
 }

--- a/grails-data-mongodb/embedded/src/test/groovy/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializerSpec.groovy
+++ b/grails-data-mongodb/embedded/src/test/groovy/org/grails/datastore/gorm/mongodb/embedded/EmbeddedMongoInitializerSpec.groovy
@@ -206,8 +206,9 @@ class EmbeddedMongoInitializerSpec extends Specification {
                 'grails.mongodb.url'              : 'mongodb://embedded:28003/bookstore',
         ])
         new EmbeddedMongoInitializer().initialize(first)
-        EmbeddedMongoLifecycle before = first.beanFactory
-                .getBean(EmbeddedMongoLifecycle.BEAN_NAME, EmbeddedMongoLifecycle)
+        try (MongoClient client = MongoClients.create('mongodb://localhost:28003/bookstore')) {
+            client.getDatabase('bookstore').getCollection('probe').insertOne(new Document('v', 'before'))
+        }
 
         when: 'the reloaded application asks for another version of MongoDB'
         GenericApplicationContext restarted = contextWith([
@@ -218,13 +219,44 @@ class EmbeddedMongoInitializerSpec extends Specification {
         new EmbeddedMongoInitializer().initialize(restarted)
 
         then: 'the server it is given is not the one that was started for the settings before'
-        EmbeddedMongoLifecycle replacement = restarted.beanFactory
-                .getBean(EmbeddedMongoLifecycle.BEAN_NAME, EmbeddedMongoLifecycle)
-        !replacement.is(before)
+        long carriedOver
+        try (MongoClient client = MongoClients.create('mongodb://localhost:28003/bookstore')) {
+            carriedOver = client.getDatabase('bookstore').getCollection('probe').countDocuments()
+        }
+        carriedOver == 0L
         restarted.environment.getProperty('grails.mongodb.url') == 'mongodb://localhost:28003/bookstore'
 
         cleanup:
-        replacement?.stop()
+        restarted.beanFactory.getBean(EmbeddedMongoLifecycle.BEAN_NAME, EmbeddedMongoLifecycle)?.stop()
+    }
+
+    void 'a restart that asks for a different backend is not handed the one already running'() {
+        given: 'a server started by the in-memory backend, holding a document'
+        GenericApplicationContext first = contextWith([
+                (EmbeddedMongoInitializer.BACKEND): InMemoryMongoBackend.NAME,
+                'grails.mongodb.url'              : 'mongodb://embedded:28017/bookstore',
+        ])
+        new EmbeddedMongoInitializer().initialize(first)
+        try (MongoClient client = MongoClients.create('mongodb://localhost:28017/bookstore')) {
+            client.getDatabase('bookstore').getCollection('probe').insertOne(new Document('backend', 'in-memory'))
+        }
+
+        when: 'the reloaded application asks for a real mongod instead, changing nothing else'
+        GenericApplicationContext restarted = contextWith([
+                (EmbeddedMongoInitializer.BACKEND): FlapdoodleMongoBackend.NAME,
+                'grails.mongodb.url'              : 'mongodb://embedded:28017/bookstore',
+        ])
+        new EmbeddedMongoInitializer().initialize(restarted)
+
+        then: 'what answers the url is a server that was started for this backend, not the last one'
+        long carriedOver
+        try (MongoClient client = MongoClients.create('mongodb://localhost:28017/bookstore')) {
+            carriedOver = client.getDatabase('bookstore').getCollection('probe').countDocuments()
+        }
+        carriedOver == 0L
+
+        cleanup:
+        restarted.beanFactory.getBean(EmbeddedMongoLifecycle.BEAN_NAME, EmbeddedMongoLifecycle)?.stop()
     }
 
     void 'the in-memory backend refuses to pretend it can be a replica set'() {


### PR DESCRIPTION
Follow-up to #16192.

### Problem

`EmbeddedMongoInitializer` hands a restart the server this JVM already started when the settings match the ones it was started with:

```java
StartedServer started = discard(STARTED.get(port), settings);
```

`EmbeddedMongoSettings.equals` compares `port`, `version`, `databaseDir` and `replicaSet`. **The backend is not among them**, and `StartedServer` does not carry it either, so nothing in the reuse path knows which backend is running.

Switching `embedded.mongodb.backend` between `in-memory` and `flapdoodle` across a devtools restart, changing nothing else, therefore keeps the old server. An application that asked for a real `mongod` carries on against the in-memory reimplementation, which implements neither transactions, change streams nor `$text` — so the failure surfaces later and somewhere else, as a missing feature rather than a backend that was never started.

Worth noting the shape of the omission: the check does compare `version`, which `InMemoryMongoBackend` ignores entirely. The one setting that decides what the server actually *is* was the one left out.

### Fix

Keep the backend the server was started with alongside its settings, and compare it:

```java
private record StartedServer(RunningEmbeddedMongo running, EmbeddedMongoSettings settings, String backend) { }

if (started == null || (started.settings().equals(settings) && started.backend().equals(backend))) {
    return started;
}
```

The backend is resolved in `initialize` before the reuse question rather than inside `start`, since it is part of that question, and passed to `start` so it is selected once.

`EmbeddedMongoSettings` is public API and its constructor is unchanged; the backend lives on the private `StartedServer` record instead.

**One behaviour change worth calling out:** asking for a backend whose library is absent now fails even when a server is already running on that port, because `selectBackend` runs before the reuse check. Previously such a restart was silently handed the running server. The new behaviour matches what the same configuration does when nothing is running.

### Tests

A restart that switches backend while holding version, database and replica set unchanged now gets a new server. The assertion is behavioural — a document written to the first server, then counted after the switch — because object identity does not distinguish the two cases here: `initialize` constructs a fresh `EmbeddedMongoLifecycle` on every call, reused server or not.

That last point applies to the existing test beside it. **`a restart that asks for a different server is not handed the one already running` was vacuous**: I removed `version` from `EmbeddedMongoSettings.equals` and it still passed, so it was not verifying replacement at all. It is rewritten here with the same behavioural assertion, and now fails when `version` is removed from the comparison.

Both tests fail on unmodified `8.0.x` and pass with the fix; `:grails-data-mongodb-embedded:test` is green.