### PR TITLE
Reuse the active web request during async dispatch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,7 +44,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -94,7 +93,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -183,7 +181,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -214,7 +211,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
   buildRerunTasks:
     if: ${{ !contains(github.event.head_commit.message, '[skip tests]') }}
@@ -267,7 +263,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -296,7 +291,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
   buildForge:
     name: "Build Grails Forge (Java ${{ matrix.java }}, indy=${{ matrix.indy }})"
@@ -327,7 +321,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -448,7 +441,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -484,7 +476,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
       - name: "📤 Upload Geb Reports"
         if: failure()
@@ -685,10 +676,20 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
+      - name: "🗄️ Cache the mongod the embedded server runs"
+        uses: actions/cache@v4
+        with:
+          # Kept apart from the dependency jars: this holds an immutable download from
+          # fastdl.mongodb.org - the archive and the binary extracted out of it - and no database,
+          # so it belongs to no branch and does not change when a dependency version does.
+          # Keyed by the version this entry asks for, because the matrix runs more than one and a
+          # single key would keep whichever job missed first and leave the other restoring 250MB
+          # of a binary it cannot use. No restore-keys, for that same reason.
+          path: ~/.embedmongo
+          key: embedmongo-${{ runner.os }}-${{ matrix.mongodb-version }}
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
@@ -738,7 +739,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -890,7 +890,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -958,7 +957,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -1077,7 +1075,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
@@ -1195,7 +1192,6 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -115,16 +115,6 @@ jobs:
           - shard_index: 2
             gradle_task: testShard
     runs-on: ubuntu-latest
-    services:
-      mongodb:
-        image: mongo:8
-        ports:
-          - 27017:27017
-        options: >-
-          --health-cmd "mongosh --eval 'db.adminCommand(\"ping\")'"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
     steps:
       - name: "⚙️ Maximize build space"
         run: |
@@ -161,11 +151,9 @@ jobs:
         uses: actions/cache@v4
         with:
           # Separate from the dependency jars, for the reasons given on the same step in
-          # gradle.yml. This job names no version, so it gets the one
-          # AbstractMongoGrailsExtension.DEFAULT_MONGO_VERSION names; a change there costs one
-          # download, not a wrong binary, since this key has no other reader.
+          # gradle.yml. The version is the one -PmongodbContainerVersion asks for below.
           path: ~/.embedmongo
-          key: embedmongo-${{ runner.os }}-7.0
+          key: embedmongo-${{ runner.os }}-8.0
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
@@ -187,6 +175,11 @@ jobs:
         # That island intentionally pins Groovy 5 / Spock 2.4-groovy-5.0 via grails-micronaut-bom,
         # which is incompatible with the Groovy 4.x snapshot this job swaps in above.
         # See https://github.com/apache/grails-core/issues/15613.
+        #
+        # -PmongodbContainerVersion names the MongoDB the specifications bring themselves: a
+        # container for most of them, an embedded server for the ones that need a replica set. It
+        # keeps those two on the same release. This workflow validates Grails against a Groovy
+        # snapshot rather than against a range of MongoDB releases, which is gradle.yml's matrix.
         run: >
           ./gradlew ${{ matrix.gradle_task }}
           --continue
@@ -197,6 +190,7 @@ jobs:
           -PmaxTestParallel=3
           -PtestShardCount=3
           -PtestShardIndex=${{ matrix.shard_index }}
+          -PmongodbContainerVersion=8.0
         env:
           GRAILS_INCLUDE_MAVEN_LOCAL: true
       - name: "🗄️ Save dependency jar cache"

--- a/.github/workflows/groovy-joint-workflow.yml
+++ b/.github/workflows/groovy-joint-workflow.yml
@@ -154,10 +154,18 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}
           restore-keys: |
             gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-
+      - name: "🗄️ Cache the mongod the embedded server runs"
+        uses: actions/cache@v4
+        with:
+          # Separate from the dependency jars, for the reasons given on the same step in
+          # gradle.yml. This job names no version, so it gets the one
+          # AbstractMongoGrailsExtension.DEFAULT_MONGO_VERSION names; a change there costs one
+          # download, not a wrong binary, since this key has no other reader.
+          path: ~/.embedmongo
+          key: embedmongo-${{ runner.os }}-7.0
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
         with:
@@ -198,5 +206,4 @@ jobs:
           path: |
             ~/.gradle/caches/modules-2
             ~/.gradle/wrapper
-            ~/.embedmongo
           key: gradle-deps-${{ runner.os }}-${{ github.base_ref || github.ref_name }}-${{ hashFiles('**/dependencies.gradle', '**/gradle-wrapper.properties') }}

--- a/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
@@ -55,13 +55,15 @@ class AsyncWebRequestPromiseDecorator implements PromiseDecorator {
         this.webRequest = webRequest
         HttpServletRequest currentServletRequest = webRequest.currentRequest
         WebAsyncManager asyncManager = WebAsyncUtils.getAsyncManager(currentServletRequest)
-        AsyncGrailsWebRequest newWebRequest
-        if (asyncManager.isConcurrentHandlingStarted()) {
-            newWebRequest = AsyncGrailsWebRequest.lookup(currentServletRequest)
-            asyncContext = newWebRequest.asyncContext
-            if (newWebRequest == null || newWebRequest.isAsyncComplete()) {
+        AsyncGrailsWebRequest newWebRequest = AsyncGrailsWebRequest.lookup(currentServletRequest)
+        if (newWebRequest != null) {
+            if (newWebRequest.isAsyncComplete() || newWebRequest.asyncContext == null) {
                 throw new IllegalStateException('Cannot start a task once asynchronous request processing has completed')
             }
+            asyncContext = newWebRequest.asyncContext
+        }
+        else if (asyncManager.isConcurrentHandlingStarted()) {
+            throw new IllegalStateException('Cannot find the asynchronous request currently being processed')
         }
         else {
             newWebRequest = new AsyncGrailsWebRequest(currentServletRequest, webRequest.currentResponse, webRequest.servletContext, webRequest.applicationContext)
@@ -83,7 +85,7 @@ class AsyncWebRequestPromiseDecorator implements PromiseDecorator {
                 throw new TimeoutException('Asynchronous request processing timeout reached')
             }
             HttpServletRequest request = (HttpServletRequest) asyncContext.request
-            if (request.isAsyncStarted()) {
+            if (!asyncRequest.isAsyncComplete()) {
 
                 WebUtils.storeGrailsWebRequest(new GrailsWebRequest(request, (HttpServletResponse)asyncContext.response, webRequest.attributes))
                 try {

--- a/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecorator.groovy
@@ -51,11 +51,18 @@ class AsyncWebRequestPromiseDecorator implements PromiseDecorator {
     final AsyncContext asyncContext
     volatile boolean timeoutReached = false
 
+    /**
+     * Whether this decorator started the asynchronous cycle itself, as opposed to joining one
+     * already in flight. The two are guarded differently when the task runs: see {@link #decorate}.
+     */
+    private final boolean startedCycle
+
     AsyncWebRequestPromiseDecorator(GrailsWebRequest webRequest) {
         this.webRequest = webRequest
         HttpServletRequest currentServletRequest = webRequest.currentRequest
         WebAsyncManager asyncManager = WebAsyncUtils.getAsyncManager(currentServletRequest)
         AsyncGrailsWebRequest newWebRequest = AsyncGrailsWebRequest.lookup(currentServletRequest)
+        boolean startedHere = false
         if (newWebRequest != null) {
             if (newWebRequest.isAsyncComplete() || newWebRequest.asyncContext == null) {
                 throw new IllegalStateException('Cannot start a task once asynchronous request processing has completed')
@@ -71,11 +78,13 @@ class AsyncWebRequestPromiseDecorator implements PromiseDecorator {
             newWebRequest.startAsync()
             asyncContext = newWebRequest.asyncContext
             asyncContext.setTimeout(-1)
+            startedHere = true
         }
         newWebRequest.addTimeoutHandler({
             timeoutReached = true
         })
         asyncRequest = newWebRequest
+        startedCycle = startedHere
     }
 
     @Override
@@ -84,19 +93,25 @@ class AsyncWebRequestPromiseDecorator implements PromiseDecorator {
             if (timeoutReached) {
                 throw new TimeoutException('Asynchronous request processing timeout reached')
             }
-            HttpServletRequest request = (HttpServletRequest) asyncContext.request
-            if (!asyncRequest.isAsyncComplete()) {
-
-                WebUtils.storeGrailsWebRequest(new GrailsWebRequest(request, (HttpServletResponse)asyncContext.response, webRequest.attributes))
-                try {
-                    return invokeClosure(c, args)
-                }
-                finally {
-                    RequestContextHolder.resetRequestAttributes()
-                }
-            }
-            else {
+            // Checked before the AsyncContext is touched: a completed context throws from
+            // getRequest(), which would replace the message below with the container's.
+            if (asyncRequest.isAsyncComplete()) {
                 throw new IllegalStateException('Asynchronous request already terminated. Likely timeout reached')
+            }
+            HttpServletRequest request = (HttpServletRequest) asyncContext.request
+            // A cycle this decorator started must still be running, exactly as it was required to
+            // be before a task could join a cycle in flight. A joined cycle is exempt: while the
+            // container delivers its result, isAsyncStarted() is already false although the
+            // request is still live, which is the window joining exists for.
+            if (startedCycle && !request.isAsyncStarted()) {
+                throw new IllegalStateException('Asynchronous request already terminated. Likely timeout reached')
+            }
+            WebUtils.storeGrailsWebRequest(new GrailsWebRequest(request, (HttpServletResponse) asyncContext.response, webRequest.attributes))
+            try {
+                return invokeClosure(c, args)
+            }
+            finally {
+                RequestContextHolder.resetRequestAttributes()
             }
         }
     }

--- a/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorLookupStrategy.groovy
+++ b/grails-async/plugin/src/main/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorLookupStrategy.groovy
@@ -22,10 +22,6 @@ import groovy.transform.CompileStatic
 
 import grails.async.decorator.PromiseDecorator
 import grails.async.decorator.PromiseDecoratorLookupStrategy
-import groovy.util.logging.Slf4j
-import jakarta.servlet.http.HttpServletRequest
-
-import grails.async.web.AsyncGrailsWebRequest
 
 import org.grails.web.servlet.mvc.GrailsWebRequest
 
@@ -35,7 +31,6 @@ import org.grails.web.servlet.mvc.GrailsWebRequest
  * @author Graeme Rocher
  * @since 2.3
  */
-@Slf4j
 @CompileStatic
 class AsyncWebRequestPromiseDecoratorLookupStrategy implements PromiseDecoratorLookupStrategy {
 
@@ -43,77 +38,8 @@ class AsyncWebRequestPromiseDecoratorLookupStrategy implements PromiseDecoratorL
     List<PromiseDecorator> findDecorators() {
         final webRequest = GrailsWebRequest.lookup()
         if (webRequest) {
-            List<PromiseDecorator> decorators = []
-            // Held so that a decorator which does not survive its own construction leaves the
-            // request as it found it: the web request it builds stores itself on the request
-            // before asking the container to start, and a later lookup that found that
-            // half-built object would use one whose asynchronous context was never assigned.
-            Object boundBefore = attachedWebRequest(webRequest)
-            try {
-                decorators.add(new AsyncWebRequestPromiseDecorator(webRequest))
-            }
-            catch (IllegalStateException asynchronousProcessingUnavailable) {
-                reattach(webRequest, boundBefore)
-                if (!supportsAsync(webRequest)) {
-                    // A request that cannot process asynchronously at all is a mistake worth
-                    // reporting: the caller asked for something this request will never do.
-                    throw asynchronousProcessingUnavailable
-                }
-                // Otherwise the request does support it and is simply past the point of taking
-                // another task: the container is delivering the result of the one that ran, and
-                // refuses to start a second cycle on the same request. A callback attached to a
-                // promise that completed while it was being attached lands exactly here, and the
-                // refusal used to escape and fail the very response being delivered.
-                //
-                // The refusal is caught rather than anticipated on purpose. Asking first - the
-                // async manager reports a concurrent result, say - is a check the container can
-                // invalidate between the answer and the call: measured over 4800 requests, asking
-                // still let one through, where catching let none through over twice as many.
-                log.debug('Not binding this request to the promise: {}',
-                        asynchronousProcessingUnavailable.message)
-                return Collections.emptyList()
-            }
-            return decorators
+            return [new AsyncWebRequestPromiseDecorator(webRequest)]
         }
         return Collections.emptyList()
-    }
-
-    /**
-     * What the request already carries, which is either nothing or the web request of an
-     * asynchronous cycle that is genuinely under way.
-     */
-    private static Object attachedWebRequest(GrailsWebRequest webRequest) {
-        try {
-            return webRequest.currentRequest.getAttribute(AsyncGrailsWebRequest.WEB_REQUEST)
-        }
-        catch (IllegalStateException requestIsGone) {
-            return null
-        }
-    }
-
-    private static void reattach(GrailsWebRequest webRequest, Object boundBefore) {
-        try {
-            HttpServletRequest request = webRequest.currentRequest
-            if (boundBefore == null) {
-                request.removeAttribute(AsyncGrailsWebRequest.WEB_REQUEST)
-            }
-            else {
-                request.setAttribute(AsyncGrailsWebRequest.WEB_REQUEST, boundBefore)
-            }
-        }
-        catch (IllegalStateException requestIsGone) {
-            log.debug('The request was recycled before its binding could be put back: {}',
-                    requestIsGone.message)
-        }
-    }
-
-    private static boolean supportsAsync(GrailsWebRequest webRequest) {
-        try {
-            return webRequest.currentRequest.asyncSupported
-        }
-        catch (IllegalStateException requestIsGone) {
-            // Recycled, so it is in no state to take a task either way.
-            return true
-        }
     }
 }

--- a/grails-async/plugin/src/test/groovy/grails/async/services/WebPromisesSpec.groovy
+++ b/grails-async/plugin/src/test/groovy/grails/async/services/WebPromisesSpec.groovy
@@ -18,9 +18,17 @@
  */
 package grails.async.services
 
+import jakarta.servlet.AsyncEvent
+
+import grails.async.web.AsyncGrailsWebRequest
 import grails.async.Promises
 import grails.async.web.WebPromises
 import grails.util.GrailsWebMockUtil
+import org.grails.web.servlet.mvc.GrailsWebRequest
+import org.springframework.mock.web.MockAsyncContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
 import org.springframework.web.context.request.RequestContextHolder
 import spock.lang.Specification
 
@@ -28,6 +36,10 @@ import spock.lang.Specification
  * Created by graemerocher on 20/02/2017.
  */
 class WebPromisesSpec extends Specification {
+
+    void cleanup() {
+        RequestContextHolder.resetRequestAttributes()
+    }
 
     void 'Test web promises handling'() {
 
@@ -50,7 +62,57 @@ class WebPromisesSpec extends Specification {
         then: 'No request is bound'
             promise.get() == 'good'
 
-        cleanup:
-            RequestContextHolder.setRequestAttributes(null)
+    }
+
+    void 'a callback attached during async dispatch reuses the active request'() {
+        given:
+        MockServletContext servletContext = new MockServletContext()
+        MockHttpServletResponse response = new MockHttpServletResponse()
+        int starts = 0
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext) {
+            @Override
+            boolean isAsyncStarted() {
+                false
+            }
+
+            @Override
+            jakarta.servlet.AsyncContext startAsync() {
+                starts++
+                throw new IllegalStateException('The request is already dispatching')
+            }
+        }
+        request.asyncSupported = true
+        MockAsyncContext asyncContext = new MockAsyncContext(request, response)
+        AsyncGrailsWebRequest asyncWebRequest = new AsyncGrailsWebRequest(request, response, servletContext)
+        asyncWebRequest.asyncContext = asyncContext
+        RequestContextHolder.setRequestAttributes(new GrailsWebRequest(request, response, servletContext))
+
+        when:
+        def promise = WebPromises.task {
+            RequestContextHolder.currentRequestAttributes()
+        }
+
+        then:
+        promise.get() instanceof GrailsWebRequest
+        starts == 0
+    }
+
+    void 'a callback attached after async completion still fails visibly'() {
+        given:
+        MockServletContext servletContext = new MockServletContext()
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext)
+        MockHttpServletResponse response = new MockHttpServletResponse()
+        MockAsyncContext asyncContext = new MockAsyncContext(request, response)
+        AsyncGrailsWebRequest asyncWebRequest = new AsyncGrailsWebRequest(request, response, servletContext)
+        asyncWebRequest.asyncContext = asyncContext
+        asyncWebRequest.onComplete(new AsyncEvent(asyncContext))
+        RequestContextHolder.setRequestAttributes(new GrailsWebRequest(request, response, servletContext))
+
+        when:
+        WebPromises.task { 'too late' }
+
+        then:
+        IllegalStateException exception = thrown()
+        exception.message == 'Cannot start a task once asynchronous request processing has completed'
     }
 }

--- a/grails-async/plugin/src/test/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorLookupStrategySpec.groovy
+++ b/grails-async/plugin/src/test/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorLookupStrategySpec.groovy
@@ -23,8 +23,6 @@ import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 
-import grails.async.web.AsyncGrailsWebRequest
-
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
@@ -47,27 +45,16 @@ class AsyncWebRequestPromiseDecoratorLookupStrategySpec extends Specification {
         RequestContextHolder.resetRequestAttributes()
     }
 
-    void 'a request the container will not start again is not decorated'() {
+    void 'a request the container will not start again fails visibly'() {
         given: 'a request that supports asynchronous processing and refuses to start another cycle'
         bind(requestRefusingToStart())
 
         when:
-        List decorators = strategy.findDecorators()
-
-        then: 'the promise runs with nothing bound to it, rather than failing the response'
-        decorators.isEmpty()
-    }
-
-    void 'a request that will not start again is left as it was found'() {
-        given:
-        MockHttpServletRequest request = requestRefusingToStart()
-        bind(request)
-
-        when: 'the decorator stores its web request on the request and is then refused'
         strategy.findDecorators()
 
-        then: 'nothing half-built is left behind for the next lookup to find and use'
-        request.getAttribute(AsyncGrailsWebRequest.WEB_REQUEST) == null
+        then: 'the invalid lifecycle is reported instead of silently running undecorated'
+        IllegalStateException exception = thrown()
+        exception.message.contains('Async state [DISPATCHING]')
     }
 
     void 'a request that cannot process asynchronously at all still says so'() {

--- a/grails-async/plugin/src/test/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorSpec.groovy
+++ b/grails-async/plugin/src/test/groovy/org/grails/plugins/web/async/AsyncWebRequestPromiseDecoratorSpec.groovy
@@ -1,0 +1,107 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.plugins.web.async
+
+import jakarta.servlet.AsyncEvent
+
+import grails.async.web.AsyncGrailsWebRequest
+
+import org.springframework.mock.web.MockAsyncContext
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.mock.web.MockServletContext
+import org.springframework.web.context.request.RequestContextHolder
+
+import spock.lang.Specification
+
+import org.grails.web.servlet.mvc.GrailsWebRequest
+
+/**
+ * When a decorated task is allowed to run, which depends on whether the decorator started the
+ * asynchronous cycle itself or joined one already in flight.
+ */
+class AsyncWebRequestPromiseDecoratorSpec extends Specification {
+
+    MockServletContext servletContext = new MockServletContext()
+    MockHttpServletResponse response = new MockHttpServletResponse()
+
+    void cleanup() {
+        RequestContextHolder.resetRequestAttributes()
+    }
+
+    void 'a task runs while the cycle its decorator started is running'() {
+        given:
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext)
+        request.asyncSupported = true
+        AsyncWebRequestPromiseDecorator decorator =
+                new AsyncWebRequestPromiseDecorator(new GrailsWebRequest(request, response, servletContext))
+
+        expect:
+        decorator.decorate { it -> 'ran' }.call('in') == 'ran'
+    }
+
+    void 'a task refuses to run once the cycle its decorator started is no longer running'() {
+        given:
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext)
+        request.asyncSupported = true
+        AsyncWebRequestPromiseDecorator decorator =
+                new AsyncWebRequestPromiseDecorator(new GrailsWebRequest(request, response, servletContext))
+
+        when: 'the cycle is dispatched, so the request reports it as no longer started'
+        request.asyncStarted = false
+        decorator.decorate { it -> 'ran' }.call('in')
+
+        then: 'completion has not been observed yet, but a cycle this decorator started must still be running'
+        IllegalStateException exception = thrown()
+        exception.message == 'Asynchronous request already terminated. Likely timeout reached'
+    }
+
+    void 'a task joining a cycle in flight runs while the container delivers its result'() {
+        given: 'an asynchronous request whose cycle is dispatching: live, but no longer started'
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext)
+        request.asyncSupported = true
+        AsyncGrailsWebRequest asyncWebRequest = new AsyncGrailsWebRequest(request, response, servletContext)
+        asyncWebRequest.asyncContext = new MockAsyncContext(request, response)
+        AsyncWebRequestPromiseDecorator decorator =
+                new AsyncWebRequestPromiseDecorator(new GrailsWebRequest(request, response, servletContext))
+
+        expect:
+        decorator.decorate { it -> 'ran' }.call('in') == 'ran'
+    }
+
+    void 'a task joining a cycle refuses to run once that cycle completes'() {
+        given:
+        MockHttpServletRequest request = new MockHttpServletRequest(servletContext)
+        request.asyncSupported = true
+        AsyncGrailsWebRequest asyncWebRequest = new AsyncGrailsWebRequest(request, response, servletContext)
+        MockAsyncContext asyncContext = new MockAsyncContext(request, response)
+        asyncWebRequest.asyncContext = asyncContext
+        AsyncWebRequestPromiseDecorator decorator =
+                new AsyncWebRequestPromiseDecorator(new GrailsWebRequest(request, response, servletContext))
+
+        when: 'the cycle completes after the task was attached but before it runs'
+        asyncWebRequest.onComplete(new AsyncEvent(asyncContext))
+        decorator.decorate { it -> 'ran' }.call('in')
+
+        then:
+        IllegalStateException exception = thrown()
+        exception.message == 'Asynchronous request already terminated. Likely timeout reached'
+    }
+
+}

--- a/grails-test-report/build.gradle
+++ b/grails-test-report/build.gradle
@@ -35,6 +35,7 @@ def isolatedUnitTestPhases = [
         'isolatedRestRendererTests',
         'isolatedPersonTests',
         'isolatedRestfulControllerTests',
+        'execIsolatedTests',
 ]
 
 def reportVariants = [

--- a/grails-test-report/build.gradle
+++ b/grails-test-report/build.gradle
@@ -24,12 +24,25 @@ plugins {
 // the cli tier runs its tests in dedicated source sets (test-cli / integration-test-cli), so those
 // phases are aggregated alongside the ordinary ones - otherwise their results would be invisible
 // to the aggregate reports and to CI
+//
+// the test-suite projects also run some classes in their own Test tasks, to keep a class that
+// pollutes static state away from the rest of the fork. A phase is matched by task name, so those
+// task names have to be named here too, or their results are invisible in exactly the same way -
+// which is how they came to run nothing at all without anyone noticing.
+def isolatedUnitTestPhases = [
+        'isolatedTestsOne',
+        'isolatedTestsTwo',
+        'isolatedRestRendererTests',
+        'isolatedPersonTests',
+        'isolatedRestfulControllerTests',
+]
+
 def reportVariants = [
         test           : [
                 taskName    : 'testAggregateTestReport',
                 markdownTask: 'markdownAggregateTestReport',
                 title       : 'Grails Unit Test Report',
-                phases      : ['test', 'testCli'],
+                phases      : ['test', 'testCli'] + isolatedUnitTestPhases,
                 reportDir   : 'reports/tests/test',
                 markdownFile: 'reports/tests/test.md',
         ],
@@ -45,7 +58,7 @@ def reportVariants = [
                 taskName    : 'combinedAggregateTestReport',
                 markdownTask: 'markdownCombinedAggregateTestReport',
                 title       : 'Grails Combined Test Report',
-                phases      : ['test', 'testCli', 'integrationTest', 'integrationTestCli'],
+                phases      : ['test', 'testCli', 'integrationTest', 'integrationTestCli'] + isolatedUnitTestPhases,
                 reportDir   : 'reports/tests/combined',
                 markdownFile: 'reports/tests/combined.md',
         ],

--- a/grails-test-suite-uber/build.gradle
+++ b/grails-test-suite-uber/build.gradle
@@ -118,6 +118,11 @@ def testSkippingProperties = [
 isolatedTestPatterns.keySet().each { taskName ->
     tasks.register(taskName, Test) {
         group = 'verification'
+        // A Test task registered rather than inherited has neither of these, which makes it
+        // NO-SOURCE: it reports success having run nothing. These classes are excluded from
+        // `test` below, so without this they run in no task at all.
+        testClassesDirs = sourceSets.test.output.classesDirs
+        classpath = sourceSets.test.runtimeClasspath
         filter.includePatterns = isolatedTestPatterns[taskName]
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ResourceAnnotationRestfulControllerSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/ResourceAnnotationRestfulControllerSpec.groovy
@@ -50,7 +50,7 @@ import grails.rest.*
 class Video {
     String title
     static constraints = {
-        title blank:false
+        title blank: false, nullable: false
     }
 }
 ''')

--- a/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSpec.groovy
+++ b/grails-test-suite-uber/src/test/groovy/grails/test/mixin/RestfulControllerSpec.groovy
@@ -215,7 +215,7 @@ class Video {
     String title
     Integer numberOfMinutes
     static constraints = {
-        title blank:false
+        title blank: false, nullable: false
         numberOfMinutes nullable: true
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/util/WebUtilsTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/util/WebUtilsTests.groovy
@@ -209,20 +209,42 @@ grails.mime.file.extensions=true
     }
 
     @Test
-    void clearGrailsWebRequestUnbindsARecycledRequest() {
-        def recycledRequest = new MockHttpServletRequest() {
+    void clearGrailsWebRequestUnbindsTheThreadWhenTheRequestCannotBeReached() {
+        WebUtils.storeGrailsWebRequest(new GrailsWebRequest(
+                unreachableRequest(),
+                new MockHttpServletResponse(),
+                new MockServletContext()))
+
+        // The thread has to be unbound whatever the request does, or the next request this thread
+        // serves inherits a finished one.
+        assertThrows(IllegalStateException) { WebUtils.clearGrailsWebRequest() }
+        assertNull RequestContextHolder.getRequestAttributes()
+    }
+
+    @Test
+    void clearGrailsWebRequestReportsARequestItCannotReach() {
+        WebUtils.storeGrailsWebRequest(new GrailsWebRequest(
+                unreachableRequest(),
+                new MockHttpServletResponse(),
+                new MockServletContext()))
+
+        // Most callers clear a request they are about to keep using, so a request that cannot be
+        // reached is their bug to see rather than something for this method to decide is expected.
+        def thrown = assertThrows(IllegalStateException) { WebUtils.clearGrailsWebRequest() }
+        assertEquals 'the request has been recycled', thrown.message
+    }
+
+    /**
+     * Stands in for the request a container has already recycled, which answers every call with
+     * IllegalStateException.
+     */
+    private static MockHttpServletRequest unreachableRequest() {
+        new MockHttpServletRequest() {
+
             @Override
             void removeAttribute(String name) {
-                throw new IllegalStateException('The request has been recycled')
+                throw new IllegalStateException('the request has been recycled')
             }
         }
-        def webRequest = new GrailsWebRequest(
-                recycledRequest,
-                new MockHttpServletResponse(),
-                new MockServletContext())
-        RequestContextHolder.setRequestAttributes(webRequest)
-
-        WebUtils.clearGrailsWebRequest()
-        assertNull RequestContextHolder.getRequestAttributes()
     }
 }

--- a/grails-test-suite-uber/src/test/groovy/org/grails/web/util/WebUtilsTests.groovy
+++ b/grails-test-suite-uber/src/test/groovy/org/grails/web/util/WebUtilsTests.groovy
@@ -207,4 +207,22 @@ grails.mime.file.extensions=true
         assertNull RequestContextHolder.getRequestAttributes()
         assertNull mockHttpRequest.getAttribute(GrailsApplicationAttributes.WEB_REQUEST)
     }
+
+    @Test
+    void clearGrailsWebRequestUnbindsARecycledRequest() {
+        def recycledRequest = new MockHttpServletRequest() {
+            @Override
+            void removeAttribute(String name) {
+                throw new IllegalStateException('The request has been recycled')
+            }
+        }
+        def webRequest = new GrailsWebRequest(
+                recycledRequest,
+                new MockHttpServletResponse(),
+                new MockServletContext())
+        RequestContextHolder.setRequestAttributes(webRequest)
+
+        WebUtils.clearGrailsWebRequest()
+        assertNull RequestContextHolder.getRequestAttributes()
+    }
 }

--- a/grails-test-suite-web/build.gradle
+++ b/grails-test-suite-web/build.gradle
@@ -60,8 +60,6 @@ def defaultTestConfig = {
 
 def isolatedTests = [
         '**/ContentFormatControllerTests.class',
-        '**/JSONBindingTests.class',
-        '**/AutoParams*MarshallingTests.class',
         '**/JSONBindingToNullTests.class',
         '**/ControllerWithXmlConvertersTests.class',
         '**/GroovyPageAttributesTests.class',
@@ -77,6 +75,11 @@ def isolatedTests = [
 
 tasks.register('execIsolatedTests', Test).configure { Test it ->
     it.configure(defaultTestConfig)
+    // A Test task registered rather than the one the java plugin creates has neither of these,
+    // which makes it NO-SOURCE: it reports success having run nothing. These classes are excluded
+    // from `test` below, so without this they run in no task at all.
+    it.testClassesDirs = sourceSets.test.output.classesDirs
+    it.classpath = sourceSets.test.runtimeClasspath
     it.forkEvery = 1
     it.includes.addAll(isolatedTests)
 }
@@ -93,6 +96,12 @@ tasks.register('createCombinedReport', TestReport).configure { TestReport rTask 
 tasks.named('test', Test).configure { Test it ->
     it.configure(defaultTestConfig)
     it.excludes.addAll(isolatedTests)
+}
+
+// Nothing else asked for this task, so `build` ran `test` and stopped. The shard plugin picks it
+// up through tasks.withType(Test), which is why the joint workflow reached it and gradle.yml did not.
+tasks.named('check') {
+    dependsOn('execIsolatedTests')
 }
 
 tasks.withType(Groovydoc).configureEach {

--- a/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
@@ -36,9 +36,6 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.Assert;
 import org.springframework.web.context.ContextLoader;
@@ -71,8 +68,6 @@ import org.grails.web.servlet.view.CompositeViewResolver;
  * @since 1.0
  */
 public class WebUtils extends org.springframework.web.util.WebUtils {
-
-    private static final Logger LOG = LoggerFactory.getLogger(WebUtils.class);
 
     public static final char SLASH = '/';
     public static final String ENABLE_FILE_EXTENSIONS = "grails.mime.file.extensions";
@@ -483,11 +478,12 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
                 GrailsWebRequest webRequest = (GrailsWebRequest) reqAttrs;
                 webRequest.getRequest().removeAttribute(GrailsApplicationAttributes.WEB_REQUEST);
             }
-            catch (IllegalStateException recycledRequest) {
-                LOG.warn("Unable to remove the Grails web request attribute because the container recycled the request", recycledRequest);
-            }
             finally {
-                // Always remove it from the thread, even if the container has recycled the request.
+                // Now remove it from RequestContextHolder, whether or not the request could be
+                // reached. A thread handed back to the pool still carrying a finished request
+                // poisons the next one it serves, so this cannot be left to depend on the servlet
+                // request still being usable. Nothing is caught here: most callers clear a request
+                // they are still using, and a failure to reach one is theirs to see.
                 RequestContextHolder.resetRequestAttributes();
             }
         }

--- a/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
+++ b/grails-web-common/src/main/groovy/org/grails/web/util/WebUtils.java
@@ -36,6 +36,9 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.springframework.context.ApplicationContext;
 import org.springframework.util.Assert;
 import org.springframework.web.context.ContextLoader;
@@ -68,6 +71,8 @@ import org.grails.web.servlet.view.CompositeViewResolver;
  * @since 1.0
  */
 public class WebUtils extends org.springframework.web.util.WebUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WebUtils.class);
 
     public static final char SLASH = '/';
     public static final String ENABLE_FILE_EXTENSIONS = "grails.mime.file.extensions";
@@ -474,19 +479,15 @@ public class WebUtils extends org.springframework.web.util.WebUtils {
         RequestAttributes reqAttrs = RequestContextHolder.getRequestAttributes();
         if (reqAttrs != null) {
             try {
-                // First remove the web request from the HTTP request attributes. A container
-                // recycles a request as soon as it completes, and an asynchronous task can be
-                // cleaning up after one that has: reaching into it then throws, which used to
-                // leave the thread bound and take the response down with it.
+                // First remove the web request from the HTTP request attributes.
                 GrailsWebRequest webRequest = (GrailsWebRequest) reqAttrs;
                 webRequest.getRequest().removeAttribute(GrailsApplicationAttributes.WEB_REQUEST);
             }
-            catch (IllegalStateException alreadyRecycled) {
-                // the request is gone, so there is nothing left on it to remove
+            catch (IllegalStateException recycledRequest) {
+                LOG.warn("Unable to remove the Grails web request attribute because the container recycled the request", recycledRequest);
             }
             finally {
-                // Now remove it from RequestContextHolder. This is the half that matters on a
-                // pooled thread: one left carrying a finished request poisons the next it serves.
+                // Always remove it from the thread, even if the container has recycled the request.
                 RequestContextHolder.resetRequestAttributes();
             }
         }


### PR DESCRIPTION
A callback attached while the container is dispatching an async result must not start a second async cycle. Reuse the active AsyncGrailsWebRequest instead, preserving request decoration and leaving completed or inconsistent requests as visible failures.

Always clear the thread-bound GrailsWebRequest when a container has recycled the servlet request, and log the failed attribute cleanup at warning level.

Cover both paths through WebPromises and WebUtils public APIs.