### PR TITLE
fix: apply Shadow so Forge AWS packaging works on Micronaut 4

### DIFF
--- a/grails-forge/grails-forge-web-netty/build.gradle
+++ b/grails-forge/grails-forge-web-netty/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id 'org.apache.grails.buildsrc.properties'
     id 'org.apache.grails.buildsrc.dependency-validator'
     id 'io.micronaut.application' version "$micronautApplicationPluginVersion"
+    id 'com.gradleup.shadow'
 }
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
@@ -144,11 +145,6 @@ TaskProvider<Zip> awsElasticBeanstalk = tasks.register('awsElasticBeanstalk', Zi
     }
     from(layout.projectDirectory.dir('aws')) {
         includeEmptyDirs = false
-        filesMatching('start.sh') {
-            filePermissions {
-                unix(0755)
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Fix Forge AWS packaging on Micronaut 4 (`8.0.x`). Apply `com.gradleup.shadow` without a version so `shadowJar` exists for `awsElasticBeanstalk`. GitHub Actions was failing with `Task with name 'shadowJar' not found`.
