### PR TITLE
fix: grant Forge AWS deploy role Auto Scaling describe

### DIFF
--- a/grails-forge/infrastructure/shared.yaml
+++ b/grails-forge/infrastructure/shared.yaml
@@ -296,6 +296,15 @@ Resources:
                   - cloudformation:GetTemplate
                 Effect: Allow
                 Resource: '*'
+              - Action:
+                  - autoscaling:DescribeAutoScalingGroups
+                  - autoscaling:DescribeAutoScalingInstances
+                  - autoscaling:DescribeScalingActivities
+                  - autoscaling:DescribeLaunchConfigurations
+                  - ec2:DescribeInstances
+                  - ec2:DescribeInstanceStatus
+                Effect: Allow
+                Resource: '*'
             Version: '2012-10-17'
           PolicyName: DeployGrailsForgeApplicationVersions
 


### PR DESCRIPTION
## Description

GitHub Actions Elastic Beanstalk deploy failed with `autoscaling:DescribeAutoScalingGroups`. Grant Auto Scaling and EC2 describe on the deploy role.
