### PR TITLE
fix: Elastic Beanstalk managed policies for GitHub deploys

### DIFF
--- a/.github/workflows/forge-deploy-aws.yml
+++ b/.github/workflows/forge-deploy-aws.yml
@@ -163,9 +163,18 @@ jobs:
           wait_for_ready_green() {
             local operation="$1"
             local expected_version="$2"
-            local status health current_version attempt
+            local status health current_version attempt event
+            local start_iso
+            start_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             for attempt in {1..90}; do
+              event="$(aws elasticbeanstalk describe-events --environment-name "${ENVIRONMENT_NAME}" --start-time "${start_iso}" --query 'Events[?Severity==`ERROR`].Message' --output text)"
+              if [[ -n "${event}" && "${event}" != 'None' ]]; then
+                echo "${event}" >&2
+                echo "${operation} failed according to Elastic Beanstalk events." >&2
+                return 1
+              fi
               read -r status health current_version < <(aws elasticbeanstalk describe-environments --environment-names "${ENVIRONMENT_NAME}" --query 'Environments[0].[Status,Health,VersionLabel]' --output text)
+              echo "${operation} attempt=${attempt} Status=${status} Health=${health} VersionLabel=${current_version}"
               if [[ "${status}" == 'Ready' && "${health}" == 'Green' && "${current_version}" == "${expected_version}" ]]; then
                 return 0
               fi
@@ -193,26 +202,7 @@ jobs:
           aws elasticbeanstalk create-application-version \
             --application-name "${APPLICATION_NAME}" \
             --version-label "${VERSION_LABEL}" \
-            --source-bundle "S3Bucket=${ARTIFACT_BUCKET},S3Key=${S3_KEY}" \
-            --process >/dev/null
-
-          application_version_status=''
-          for attempt in {1..30}; do
-            application_version_status="$(aws elasticbeanstalk describe-application-versions --application-name "${APPLICATION_NAME}" --version-labels "${VERSION_LABEL}" --query 'ApplicationVersions[0].Status' --output text)"
-            application_version_status="${application_version_status^^}"
-            case "${application_version_status}" in
-              PROCESSED) break ;;
-              FAILED)
-                echo "Elastic Beanstalk application version processing failed." >&2
-                exit 1
-                ;;
-              *) sleep 10 ;;
-            esac
-          done
-          if [[ "${application_version_status}" != 'PROCESSED' ]]; then
-            echo "Elastic Beanstalk application version processing did not complete within the polling limit." >&2
-            exit 1
-          fi
+            --source-bundle "S3Bucket=${ARTIFACT_BUCKET},S3Key=${S3_KEY}" >/dev/null
 
           aws elasticbeanstalk update-environment \
             --environment-name "${ENVIRONMENT_NAME}" \

--- a/grails-forge/infrastructure/shared.yaml
+++ b/grails-forge/infrastructure/shared.yaml
@@ -225,6 +225,10 @@ Resources:
   GitHubDeployRole:
     Type: AWS::IAM::Role
     Properties:
+      ManagedPolicyArns:
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess-AWSElasticBeanstalk
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AWSElasticBeanstalkWebTier
+        - Fn::Sub: arn:${AWS::Partition}:iam::aws:policy/AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy
       AssumeRolePolicyDocument:
         Statement:
           - Action: sts:AssumeRoleWithWebIdentity


### PR DESCRIPTION
## Description

GitHub Actions cannot keep adding one IAM action at a time. Elastic Beanstalk `UpdateEnvironment` uses the caller identity for EC2, Auto Scaling, S3, and CloudFormation.

[einaregilsson/beanstalk-deploy](https://github.com/einaregilsson/beanstalk-deploy) is not on the ASF allowlist, so this replicates it with AWS CLI:

- Attach `AWSElasticBeanstalkWebTier` and `AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy` as that README specifies, plus `AdministratorAccess-AWSElasticBeanstalk` for environment updates.
- Upload the zip to our artifact bucket and `CreateApplicationVersion` **without** `--process` (no copy into the EB account bucket).
- Poll Elastic Beanstalk events and fail immediately on ERROR instead of waiting 15 minutes.
