### PR TITLE
Register a late ConfigurationClassPostProcessor for resources.groovy/xml

### DIFF
--- a/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
+++ b/grails-core/src/main/groovy/grails/boot/config/GrailsApplicationPostProcessor.groovy
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor
 import org.springframework.context.annotation.AnnotationConfigUtils
+import org.springframework.context.annotation.ConfigurationClassPostProcessor
 import org.springframework.aot.AotDetector
 import org.springframework.beans.factory.support.RootBeanDefinition
 import org.springframework.beans.factory.config.BeanDefinition
@@ -81,6 +82,13 @@ import org.apache.grails.core.plugins.PluginDiscovery
 class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProcessor, ApplicationContextAware, ApplicationListener<ApplicationContextEvent> {
 
     static final boolean RELOADING_ENABLED = Environment.isReloadingAgentEnabled()
+
+    /**
+     * Name under which a second {@link ConfigurationClassPostProcessor} is registered to parse
+     * {@code @Configuration} classes contributed after Spring's own processor has already run.
+     * See {@link #registerLateConfigurationClassPostProcessor}.
+     */
+    private static final String LATE_CONFIGURATION_CLASS_POST_PROCESSOR_BEAN_NAME = 'grailsLateConfigurationClassPostProcessor'
 
     final GrailsApplication grailsApplication
     final GrailsApplicationLifeCycle lifeCycle
@@ -313,6 +321,35 @@ class GrailsApplicationPostProcessor implements BeanDefinitionRegistryPostProces
                         .register(registrar)
             }
         }
+
+        registerLateConfigurationClassPostProcessor(registry)
+    }
+
+    /**
+     * Registers a second {@link ConfigurationClassPostProcessor} so that {@code @Configuration}
+     * classes contributed by {@code resources.groovy}, {@code resources.xml}, or the application's
+     * own {@code doWithSpring}/{@code beanRegistrar()} -- all drained above -- get parsed.
+     *
+     * <p>This class is discovered as an ordinary registry bean (see
+     * {@link GrailsAutoConfiguration#grailsApplicationPostProcessor}), not added manually like
+     * {@link GrailsEarlyPluginRegistrationPostProcessor}, so Spring always invokes it after its own
+     * {@code ConfigurationClassPostProcessor} has already completed its one and only pass over the
+     * registry. Without a second pass, the {@code @Configuration} classes registered above are added
+     * as plain bean definitions but never expanded. Spring marks every bean definition a processor
+     * has already parsed with {@code CONFIGURATION_CLASS_ATTRIBUTE}, so this second pass skips
+     * everything the first one handled and only expands what arrived here.</p>
+     *
+     * <p>Skipped for an AOT-optimized context, matching {@link org.grails.plugins.CoreGrailsPlugin}:
+     * the configuration classes it would otherwise re-parse were already parsed at build time, and
+     * {@code loadExternalBeans} above skips {@code resources.groovy}/{@code resources.xml} entirely
+     * in that case.</p>
+     */
+    private static void registerLateConfigurationClassPostProcessor(BeanDefinitionRegistry registry) {
+        if (AotDetector.useGeneratedArtifacts()) {
+            return
+        }
+        registerInfrastructureBean(registry, LATE_CONFIGURATION_CLASS_POST_PROCESSOR_BEAN_NAME,
+                ConfigurationClassPostProcessor)
     }
 
     /**

--- a/grails-core/src/test/groovy/grails/boot/config/LateConfigurationClassPostProcessorSpec.groovy
+++ b/grails-core/src/test/groovy/grails/boot/config/LateConfigurationClassPostProcessorSpec.groovy
@@ -1,0 +1,100 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.boot.config
+
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+import grails.core.GrailsApplicationLifeCycleAdapter
+import grails.util.Environment
+import grails.util.Holders
+import org.apache.grails.core.plugins.DefaultPluginDiscovery
+import org.apache.grails.core.plugins.PluginDiscovery
+import spock.lang.Specification
+
+/**
+ * Reproduces apache/grails-core#16029: an {@code @Configuration} class contributed to the registry
+ * by {@code GrailsApplicationPostProcessor.postProcessBeanDefinitionRegistry} -- standing in for one
+ * declared in an application's {@code resources.groovy}, which drains through that same method --
+ * must still be parsed, even though it arrives strictly after Spring's own
+ * {@code ConfigurationClassPostProcessor} has already completed its one and only pass.
+ *
+ * <p>{@code GrailsApplicationPostProcessor} is wired here exactly as {@code GrailsAutoConfiguration}
+ * wires it in production (see {@code GrailsAutoConfiguration#grailsApplicationPostProcessor}): as an
+ * ordinary, non-{@code PriorityOrdered} {@code @Bean}, so Spring only discovers and invokes it after
+ * expanding the primary source's own configuration -- the same round in which Spring's processor
+ * finishes running.</p>
+ */
+class LateConfigurationClassPostProcessorSpec extends Specification {
+
+    void 'a @Configuration class registered after Boot auto-configuration is still parsed'() {
+        given: 'a context wiring GrailsApplicationPostProcessor the same way GrailsAutoConfiguration does'
+            def ctx = new AnnotationConfigApplicationContext()
+            def discovery = new DefaultPluginDiscovery([] as Class<?>[])
+            discovery.loadPluginsFromClasspath = false
+            discovery.init(ctx.environment)
+            ctx.beanFactory.registerSingleton(PluginDiscovery.BEAN_NAME, discovery)
+            ctx.register(LateConfigPostProcessorWiring)
+
+        when: 'the context refreshes'
+            ctx.refresh()
+
+        then: 'the @Bean method on the late @Configuration class was expanded into a real bean'
+            ctx.getBean('lateBean') instanceof LateConfigBean
+
+        cleanup:
+            ctx.close()
+            Holders.clear()
+            Environment.setInitializing(false)
+    }
+}
+
+@Configuration
+class LateConfigPostProcessorWiring {
+
+    @Bean
+    GrailsApplicationPostProcessor grailsApplicationPostProcessor(
+            ApplicationContext applicationContext, PluginDiscovery pluginDiscovery) {
+        new GrailsApplicationPostProcessor(new LateConfigLifeCycle(), applicationContext, pluginDiscovery)
+    }
+}
+
+class LateConfigLifeCycle extends GrailsApplicationLifeCycleAdapter {
+
+    @Override
+    Closure doWithSpring() {
+        { -> delegate.lateConfig(LateConfig) }
+    }
+}
+
+/** Stands in for an {@code @Configuration} class declared in an application's resources.groovy. */
+@Configuration
+class LateConfig {
+
+    @Bean
+    LateConfigBean lateBean() {
+        new LateConfigBean()
+    }
+}
+
+class LateConfigBean {
+
+}


### PR DESCRIPTION
## Summary
- Fixes #16029: `@Configuration` classes registered in an application's `resources.groovy` (and `resources.xml`, and the application's own `doWithSpring`/`beanRegistrar()`) were no longer processed by a `ConfigurationClassPostProcessor` in 8.0.0-M3.
- Root cause: `GrailsApplicationPostProcessor` (which drains those late-arriving beans) is discovered as an ordinary registry bean, so Spring always invokes it *after* its own `ConfigurationClassPostProcessor` has already completed its one and only pass over the registry. `CoreGrailsPlugin` used to unconditionally register a second processor that happened to catch this late content, but a later change made it stand down whenever Spring's own processor is already present — correct for the early plugin-registration phase, but wrong for this late phase, since Spring's processor has always already run there.
- Fix registers a second `ConfigurationClassPostProcessor` at the end of `GrailsApplicationPostProcessor.postProcessBeanDefinitionRegistry`, after all late-phase beans are drained. Spring marks every bean definition a processor has already parsed, so this second pass only expands what's genuinely new; it's skipped under AOT, matching `CoreGrailsPlugin`'s existing guard.

## Test plan
- [x] Added `LateConfigurationClassPostProcessorSpec`, which reproduces the exact bug shape and was confirmed to fail without the fix and pass with it.
- [x] Full `grails-core` test suite green (1102 suites, 0 failures/errors).
- [x] `./gradlew :grails-core:codeStyle` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)