### PR TITLE
Document the PATCH mapping generated by resources and single

### DIFF
--- a/grails-doc/src/en/guide/REST/restfulControllers/extendingRestfulController.adoc
+++ b/grails-doc/src/en/guide/REST/restfulControllers/extendingRestfulController.adoc
@@ -41,6 +41,7 @@ POST,/books,save
 GET,/books/${id},show
 GET,/books/${id}/edit,edit
 PUT,/books/${id},update
+PATCH,/books/${id},patch
 DELETE,/books/${id},delete
 |===
 

--- a/grails-doc/src/en/guide/REST/restfulControllers/restControllersStepByStep.adoc
+++ b/grails-doc/src/en/guide/REST/restfulControllers/restControllersStepByStep.adoc
@@ -50,6 +50,7 @@ GET,/books/create,create
 GET,/books/${id}/edit,edit
 POST,/books,save
 PUT,/books/${id},update
+PATCH,/books/${id},patch
 DELETE,/books/${id},delete
 |===
 

--- a/grails-doc/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
@@ -37,6 +37,7 @@ POST,/books,save
 GET,/books/${id},show
 GET,/books/${id}/edit,edit
 PUT,/books/${id},update
+PATCH,/books/${id},patch
 DELETE,/books/${id},delete
 |===
 
@@ -74,6 +75,7 @@ post "/books"(controller:"book", action:"save")
 get "/books/$id"(controller:"book", action:"show")
 get "/books/$id/edit"(controller:"book", action:"edit")
 put "/books/$id"(controller:"book", action:"update")
+patch "/books/$id"(controller:"book", action:"patch")
 delete "/books/$id"(controller:"book", action:"delete")
 ----
 
@@ -101,6 +103,7 @@ POST,/book,save
 GET,/book,show
 GET,/book/edit,edit
 PUT,/book,update
+PATCH,/book,patch
 DELETE,/book,delete
 |===
 
@@ -129,8 +132,9 @@ GET,/books/${bookId}/authors,index
 GET,/books/${bookId}/authors/create,create
 POST,/books/${bookId}/authors,save
 GET,/books/${bookId}/authors/${id},show
-GET,/books/${bookId}/authors/edit/${id},edit
+GET,/books/${bookId}/authors/${id}/edit,edit
 PUT,/books/${bookId}/authors/${id},update
+PATCH,/books/${bookId}/authors/${id},patch
 DELETE,/books/${bookId}/authors/${id},delete
 |===
 


### PR DESCRIPTION
The guide documents seven mappings for `resources` and six for `single`. Both generate one more — `PATCH` has been generated since the action was added and was never documented, including in the "Explicit REST Mappings" equivalence list.

```groovy
"/books"(resources: 'book')
```

is equivalent to eight mappings, not seven:

```groovy
get    "/books"(controller: "book", action: "index")
get    "/books/create"(controller: "book", action: "create")
post   "/books"(controller: "book", action: "save")
get    "/books/$id"(controller: "book", action: "show")
get    "/books/$id/edit"(controller: "book", action: "edit")
put    "/books/$id"(controller: "book", action: "update")
patch  "/books/$id"(controller: "book", action: "patch")   // undocumented
delete "/books/$id"(controller: "book", action: "delete")
```

Adds the missing row to the `resources`, `single` and nested-resources tables in the URL mappings guide, and to the two action-convention tables in the REST section.

Also corrects the nested-resources table, which gave the edit URI as `/books/${bookId}/authors/edit/${id}`. The generated mapping appends `/edit` after the id, as asserted by `RestfulResourceMappingSpec`.