### PR TITLE
Remove dead xml-apis dependency exclusions

### DIFF
--- a/grails-data-hibernate5/core/build.gradle
+++ b/grails-data-hibernate5/core/build.gradle
@@ -57,7 +57,6 @@ dependencies {
         exclude group:'org.slf4j', module:'jcl-over-slf4j'
         exclude group:'org.slf4j', module:'slf4j-api'
         exclude group:'org.slf4j', module:'slf4j-log4j12'
-        exclude group:'xml-apis', module:'xml-apis'
     }
     api 'org.hibernate.validator:hibernate-validator', {
         exclude group:'commons-logging', module:'commons-logging'

--- a/grails-data-hibernate7/core/build.gradle
+++ b/grails-data-hibernate7/core/build.gradle
@@ -57,7 +57,6 @@ dependencies {
         exclude group:'org.slf4j', module:'jcl-over-slf4j'
         exclude group:'org.slf4j', module:'slf4j-api'
         exclude group:'org.slf4j', module:'slf4j-log4j12'
-        exclude group:'xml-apis', module:'xml-apis'
     }
     api "org.hibernate.models:hibernate-models"
     api 'org.hibernate.validator:hibernate-validator', {
@@ -85,7 +84,6 @@ dependencies {
         exclude group:'org.slf4j', module:'jcl-over-slf4j'
         exclude group:'org.slf4j', module:'slf4j-api'
         exclude group:'org.slf4j', module:'slf4j-log4j12'
-        exclude group:'xml-apis', module:'xml-apis'
     }
 
     testImplementation 'org.testcontainers:testcontainers'

--- a/grails-datamapping-validation/build.gradle
+++ b/grails-datamapping-validation/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     }
 
     api "commons-validator:commons-validator:$commonsValidatorVersion", { // Candidate for grails-bom?
-        exclude group: 'xml-apis', module:'xml-apis'
         exclude group: 'commons-digester', module:'commons-digester'
         exclude group: 'commons-logging', module:'commons-logging'
         exclude group: 'commons-beanutils', module:'commons-beanutils'


### PR DESCRIPTION
`xml-apis:xml-apis` has not been reachable from any of these dependencies for several major versions, so the four exclusions are no-ops:

- **`hibernate-core` 7.4.1.Final** and **`hibernate-core-jakarta` 5.6.15.Final** never declare `xml-apis`. Hibernate's own POM already excludes it from every one of its dependencies, and mapping XML has been bound with JAXB (`jakarta.xml.bind-api` + `jaxb-runtime`) since Hibernate 6 dropped dom4j.
- **`commons-validator` 1.9.0** no longer pulls `commons-digester`/`xml-apis`.

### Verification

With the exclusions removed, `dependencyInsight --dependency xml-apis` finds no match on `compileClasspath`, `runtimeClasspath`, or `testRuntimeClasspath` for any of the three modules, and the full resolved dependency graphs are byte-identical to before.

The only publication change is the removal of three dead `<exclusion>` entries from the generated POMs (the fourth is on a `compileOnly` dependency, which is not published).

`:grails-datamapping-validation:test`, `:grails-data-hibernate7-core:test` and `:grails-data-hibernate5-core:test` pass (3066 tests, 0 failures), and `aggregateStyleViolations` reports no Checkstyle or CodeNarc violations.