### PR TITLE
Fix params and attrs map access broken by Groovy 5 dispatch

### DIFF
--- a/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
+++ b/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
@@ -44,6 +44,8 @@ import org.apache.grails.core.internal.util.TypeConverters;
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public abstract class AbstractTypeConvertingMap extends GroovyObjectSupport implements Map, Cloneable {
+    private static final String METACLASS_PROPERTY = "metaClass";
+
     protected Map wrappedMap;
 
     public AbstractTypeConvertingMap() {
@@ -347,6 +349,72 @@ public abstract class AbstractTypeConvertingMap extends GroovyObjectSupport impl
 
     public Set entrySet() {
         return wrappedMap.entrySet();
+    }
+
+    /**
+     * Subscript access ({@code map['name']}) always addresses a map entry, never a JavaBean
+     * property of this class.
+     *
+     * <p>Groovy 5 changed runtime method selection for classes implementing {@link Map}: for a
+     * {@code String} key it prefers {@code DefaultGroovyMethods.getAt(Object, String)}, which
+     * reads a bean property, over {@code DefaultGroovyMethods.getAt(Map, Object)}, which reads a
+     * map entry. Declaring the {@code String} overload here keeps map semantics, so an entry that
+     * happens to share its name with a getter on this class remains reachable.
+     *
+     * @param key the map key
+     * @return the value stored under the key, or {@code null}
+     * @since 8.0.0
+     */
+    public Object getAt(String key) {
+        return get(key);
+    }
+
+    /**
+     * Subscript assignment ({@code map['name'] = value}) always writes a map entry, never a
+     * JavaBean property of this class. See {@link #getAt(String)} for why the overload is needed.
+     *
+     * @param key the map key
+     * @param value the value to store
+     * @return the previous value stored under the key, or {@code null}
+     * @since 8.0.0
+     */
+    public Object putAt(String key, Object value) {
+        return put(key, value);
+    }
+
+    /**
+     * Property access ({@code map.name}) reads a map entry rather than a JavaBean property, so
+     * that entries whose names collide with a getter on this class remain reachable. Getters such
+     * as {@code getRequest()} are still callable as methods. The {@code metaClass} property is
+     * excluded because Groovy relies on it.
+     *
+     * @param name the map key
+     * @return the value stored under the key, or {@code null}
+     * @since 8.0.0
+     */
+    @Override
+    public Object getProperty(String name) {
+        if (METACLASS_PROPERTY.equals(name)) {
+            return super.getProperty(name);
+        }
+        return get(name);
+    }
+
+    /**
+     * Property assignment ({@code map.name = value}) writes a map entry rather than a JavaBean
+     * property of this class. See {@link #getProperty(String)}.
+     *
+     * @param name the map key
+     * @param value the value to store
+     * @since 8.0.0
+     */
+    @Override
+    public void setProperty(String name, Object value) {
+        if (METACLASS_PROPERTY.equals(name)) {
+            super.setProperty(name, value);
+            return;
+        }
+        put(name, value);
     }
 
     @Override

--- a/grails-core/src/test/groovy/org/grails/util/TypeConvertingMapTests.groovy
+++ b/grails-core/src/test/groovy/org/grails/util/TypeConvertingMapTests.groovy
@@ -156,6 +156,67 @@ class TypeConvertingMapTests {
         assert toTypeConverting(a: 1, b: 2).hashCode() != ["b": 2, a: 1].hashCode()
     }
 
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testSubscriptAccessForKeysCollidingWithInheritedProperties() {
+        def map = toTypeConverting([:])
+
+        map['empty'] = 'e1'
+        map['class'] = 'c1'
+
+        assert map['empty'] == 'e1'
+        assert map['class'] == 'c1'
+        assert map.empty == 'e1'
+        assert map.class == 'c1'
+        assert !map.isEmpty()
+        assert map.getClass() == TypeConvertingMap
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testSubscriptAccessForKeysCollidingWithASubclassGetter() {
+        def map = new IdentifiedTypeConvertingMap(id: 'abc')
+
+        map['identifier'] = 'other'
+
+        assert map.getIdentifier() == 'abc'
+        assert map['identifier'] == 'other'
+        assert map.identifier == 'other'
+        assert map['id'] == 'abc'
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testPropertyAssignmentWritesToTheMap() {
+        def map = new IdentifiedTypeConvertingMap([:])
+
+        map.identifier = 'other'
+
+        assert map['identifier'] == 'other'
+        assert map.getIdentifier() == null
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testMetaClassPropertyIsNotShadowedByTheMap() {
+        def map = toTypeConverting([:])
+
+        map['metaClass'] = 'mc'
+
+        assert map['metaClass'] == 'mc'
+        assert map.metaClass instanceof MetaClass
+    }
+
+    static class IdentifiedTypeConvertingMap extends TypeConvertingMap {
+        IdentifiedTypeConvertingMap(Map map) {
+            super(map)
+        }
+
+        Object getIdentifier() {
+            get('id')
+        }
+    }
+
     protected toTypeConverting(map) {
         new TypeConvertingMap(map)
     }

--- a/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
@@ -64,8 +64,7 @@ Both forms always address a request parameter, even when the parameter name happ
 method on `params` itself. `params.request` and `params['request']` read the request parameter
 named `request`, not the `HttpServletRequest`; use `params.getRequest()` when you want the
 request object. `params.getIdentifier()` always reads the conventional `id` parameter, so a form
-field named `identifier` cannot divert the domain object a command object resolves to. The same
-rule applies to tag library attributes: `attrs.foo` and `attrs['foo']` always read the attribute named `foo`.
+field named `identifier` cannot divert the domain object a command object resolves to.
 
 
 ==== Using Flash Scope

--- a/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
@@ -60,6 +60,13 @@ class BookController {
 
 This is one of the ways that Grails unifies access to the different scopes.
 
+Both forms always address a request parameter, even when the parameter name happens to match a
+method on `params` itself. `params.request` and `params['request']` read the request parameter
+named `request`, not the `HttpServletRequest`; use `params.getRequest()` when you want the
+request object. `params.getIdentifier()` returns the `identifier` parameter when one was
+submitted, and otherwise falls back to the conventional `id` parameter. The same rule applies to
+tag library attributes: `attrs.foo` and `attrs['foo']` always read the attribute named `foo`.
+
 
 ==== Using Flash Scope
 

--- a/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
@@ -69,8 +69,9 @@ field named `identifier` cannot divert the domain object a command object resolv
 This holds for dynamically compiled Groovy. Under `@CompileStatic` or `@GrailsCompileStatic` the
 compiler binds property syntax to the declared accessor, so `params.identifier` and
 `params.request` call `getIdentifier()` and `getRequest()` rather than reading the parameter, and
-assigning to them does not compile. In statically compiled code read those two names with
-`params['identifier']` and `params['request']`, and write them with `params.put(name, value)`.
+assigning to them does not compile. The same applies to a tag library attribute named after an
+accessor. In statically compiled code use the subscript form to read such a name, and
+`params.put(name, value)` to write it.
 
 
 ==== Using Flash Scope

--- a/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
@@ -63,9 +63,9 @@ This is one of the ways that Grails unifies access to the different scopes.
 Both forms always address a request parameter, even when the parameter name happens to match a
 method on `params` itself. `params.request` and `params['request']` read the request parameter
 named `request`, not the `HttpServletRequest`; use `params.getRequest()` when you want the
-request object. `params.getIdentifier()` returns the `identifier` parameter when one was
-submitted, and otherwise falls back to the conventional `id` parameter. The same rule applies to
-tag library attributes: `attrs.foo` and `attrs['foo']` always read the attribute named `foo`.
+request object. `params.getIdentifier()` always reads the conventional `id` parameter, so a form
+field named `identifier` cannot divert the domain object a command object resolves to. The same
+rule applies to tag library attributes: `attrs.foo` and `attrs['foo']` always read the attribute named `foo`.
 
 
 ==== Using Flash Scope

--- a/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/controllers/controllersAndScopes.adoc
@@ -66,6 +66,12 @@ named `request`, not the `HttpServletRequest`; use `params.getRequest()` when yo
 request object. `params.getIdentifier()` always reads the conventional `id` parameter, so a form
 field named `identifier` cannot divert the domain object a command object resolves to.
 
+This holds for dynamically compiled Groovy. Under `@CompileStatic` or `@GrailsCompileStatic` the
+compiler binds property syntax to the declared accessor, so `params.identifier` and
+`params.request` call `getIdentifier()` and `getRequest()` rather than reading the parameter, and
+assigning to them does not compile. In statically compiled code read those two names with
+`params['identifier']` and `params['request']`, and write them with `params.put(name, value)`.
+
 
 ==== Using Flash Scope
 

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1504,10 +1504,10 @@ params.request         // the same parameter
 params.getRequest()    // the HttpServletRequest
 ----
 
-Two behaviors differ from Grails 7:
+`params.getIdentifier()` is unchanged and still reads the conventional `id` parameter; a parameter named `identifier` is an ordinary map entry and does not divert it.
 
-* `params.getIdentifier()` returns a parameter literally named `identifier` when one was submitted, and otherwise falls back to the conventional `id` parameter as before.
-* `params.metaClass` always returns the Groovy `MetaClass`. In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.
+One behavior differs from Grails 7: `params.metaClass` always returns the Groovy `MetaClass`.
+In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.
 
 ==== 29. MIME Types Are Now Framework Defaults
 

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1507,10 +1507,13 @@ params.getRequest()    // the HttpServletRequest
 [NOTE]
 ====
 This applies to dynamically compiled Groovy.
-Under `@CompileStatic` or `@GrailsCompileStatic` the compiler binds property syntax to the declared accessor rather than routing through `getProperty`, so for the two names that collide with an accessor on `params`, `params.identifier` calls `getIdentifier()` and `params.request` calls `getRequest()` instead of reading the map entry.
-Writing them that way does not compile: `params.identifier = value` fails with `Cannot set read-only property: identifier`, and `params['request'] = value` fails with `Cannot assign value of type java.lang.String to variable of type jakarta.servlet.http.HttpServletRequest`.
+Under `@CompileStatic` or `@GrailsCompileStatic` the compiler binds property syntax to the declared accessor rather than routing through `getProperty`, so a name that collides with an accessor is reached through that accessor instead of the map.
 
-In statically compiled code, read these two parameters with `params['identifier']` and `params['request']`, and write them with `params.put('identifier', value)` and `params.put('request', value)`:
+On `params` the two colliding names are `identifier` and `request`: `params.identifier` calls `getIdentifier()` and `params.request` calls `getRequest()`, and writing them does not compile — `params.identifier = value` fails with `Cannot set read-only property: identifier`, and `params['request'] = value` fails with `Cannot assign value of type java.lang.String to variable of type jakarta.servlet.http.HttpServletRequest`.
+
+On `attrs` the colliding name is `gspTagSyntaxCall`, and there the failure is silent rather than loud: that property has a real setter, so `attrs.gspTagSyntaxCall = value` compiles and drives the tag-output flag while leaving the map untouched.
+
+The subscript form is the portable one for an accessor-colliding name on either map, and reads identically under both compilation modes:
 
 [source,groovy]
 ----
@@ -1523,11 +1526,18 @@ class BookController {
 }
 ----
 
-Every other parameter name is unaffected, and the subscript form behaves the same under both compilation modes.
+Every other name on either map is unaffected.
 ====
 
-One behavior differs from Grails 7: `params.metaClass` always returns the Groovy `MetaClass`.
+Two behaviors differ from Grails 7.
+
+`params.metaClass` always returns the Groovy `MetaClass`.
 In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.
+Assigning to the dotted form throws — `params.metaClass = 'mc'` raises a `GroovyCastException` — while `params['metaClass'] = 'mc'` stores an ordinary map entry.
+
+Assigning to a name backed by a real setter writes a map entry instead of invoking that setter.
+This affects `attrs`, where Grails 7 routed both `attrs.gspTagSyntaxCall = false` and `attrs['gspTagSyntaxCall'] = false` to `setGspTagSyntaxCall()`; both now write a map entry and leave the flag at its default, so an attribute of that name reaches the tag as an attribute.
+Nothing in the framework depends on the old routing — it drives the flag through the two-argument constructor and the explicit accessors — but a tag library that relied on the assignment form must call `setGspTagSyntaxCall()` directly.
 
 ==== 29. MIME Types Are Now Framework Defaults
 

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1495,7 +1495,7 @@ For a `String` subscript key, and for dotted property access, Groovy now prefers
 On `params` (`GrailsParameterMap`) and on tag library `attrs` (`GroovyPageAttributes`) that made an entry named after an accessor unreachable: `params['request']` returned the `HttpServletRequest` instead of the submitted parameter, and `params['identifier'] = value` threw a `ReadOnlyPropertyException`.
 
 Grails 8 restores the Grails 7 rule.
-`params['name']`, `params.name`, `attrs['name']` and `attrs.name` always address a map entry; call the accessor method when you want the framework object:
+In dynamically compiled Groovy, `params['name']`, `params.name`, `attrs['name']` and `attrs.name` all address a map entry; call the accessor method when you want the framework object:
 
 [source,groovy]
 ----
@@ -1503,6 +1503,28 @@ params['request']      // the request parameter named "request", or null when no
 params.request         // the same parameter
 params.getRequest()    // the HttpServletRequest
 ----
+
+[NOTE]
+====
+This applies to dynamically compiled Groovy.
+Under `@CompileStatic` or `@GrailsCompileStatic` the compiler binds property syntax to the declared accessor rather than routing through `getProperty`, so for the two names that collide with an accessor on `params`, `params.identifier` calls `getIdentifier()` and `params.request` calls `getRequest()` instead of reading the map entry.
+Writing them that way does not compile: `params.identifier = value` fails with `Cannot set read-only property: identifier`, and `params['request'] = value` fails with `Cannot assign value of type java.lang.String to variable of type jakarta.servlet.http.HttpServletRequest`.
+
+In statically compiled code, read these two parameters with `params['identifier']` and `params['request']`, and write them with `params.put('identifier', value)` and `params.put('request', value)`:
+
+[source,groovy]
+----
+@GrailsCompileStatic
+class BookController {
+    def save() {
+        params.put('request', 'submitted value')   // params['request'] = ... does not compile
+        def submitted = params['request']          // the parameter; params.request is the HttpServletRequest
+    }
+}
+----
+
+Every other parameter name is unaffected, and the subscript form behaves the same under both compilation modes.
+====
 
 One behavior differs from Grails 7: `params.metaClass` always returns the Groovy `MetaClass`.
 In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1504,8 +1504,6 @@ params.request         // the same parameter
 params.getRequest()    // the HttpServletRequest
 ----
 
-`params.getIdentifier()` is unchanged and still reads the conventional `id` parameter; a parameter named `identifier` is an ordinary map entry and does not divert it.
-
 One behavior differs from Grails 7: `params.metaClass` always returns the Groovy `MetaClass`.
 In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.
 

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1488,6 +1488,27 @@ def value = configObject.containsKey(key) ? configObject.get(key) : null
 
 Grails applies this guard internally when resolving Spring profile activation keys; you only need it in application code that navigates a raw `ConfigObject` by subscript.
 
+===== 28.3 `params` and `attrs` entries that share a name with an accessor
+
+Groovy 5 changed runtime method selection for classes that implement `Map`.
+For a `String` subscript key, and for dotted property access, Groovy now prefers a JavaBean property of the class over a map entry.
+On `params` (`GrailsParameterMap`) and on tag library `attrs` (`GroovyPageAttributes`) that made an entry named after an accessor unreachable: `params['request']` returned the `HttpServletRequest` instead of the submitted parameter, and `params['identifier'] = value` threw a `ReadOnlyPropertyException`.
+
+Grails 8 restores the Grails 7 rule.
+`params['name']`, `params.name`, `attrs['name']` and `attrs.name` always address a map entry; call the accessor method when you want the framework object:
+
+[source,groovy]
+----
+params['request']      // the request parameter named "request", or null when none was submitted
+params.request         // the same parameter
+params.getRequest()    // the HttpServletRequest
+----
+
+Two behaviors differ from Grails 7:
+
+* `params.getIdentifier()` returns a parameter literally named `identifier` when one was submitted, and otherwise falls back to the conventional `id` parameter as before.
+* `params.metaClass` always returns the Groovy `MetaClass`. In Grails 7 a request parameter named `metaClass` shadowed it; read such a parameter with `params['metaClass']`.
+
 ==== 29. MIME Types Are Now Framework Defaults
 
 Grails 8 ships the full set of supported MIME types as built-in framework defaults.

--- a/grails-gsp/grails-taglib/build.gradle
+++ b/grails-gsp/grails-taglib/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine' // Required to discover the JUnit 5 tests in this module
 }
 
 apply {

--- a/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
+++ b/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
@@ -19,6 +19,7 @@
 package org.grails.taglib
 
 
+import groovy.transform.CompileStatic
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.*
@@ -124,6 +125,61 @@ class GroovyPageAttributesTests {
         assertEquals 'container', attrs.class
         assertFalse attrs.isEmpty()
         assertEquals GroovyPageAttributes, attrs.getClass()
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testWritingAnAttributeNamedAfterASetterNoLongerInvokesThatSetter() {
+        def attrs = toGroovyPageAttributes([:])
+
+        // Grails 7 routed both of these to setGspTagSyntaxCall(); they now write a map entry and
+        // leave the flag alone, so an attribute of that name reaches the tag as an attribute
+        attrs.gspTagSyntaxCall = false
+        assertEquals false, attrs['gspTagSyntaxCall']
+        assertTrue attrs.isGspTagSyntaxCall()
+
+        def other = toGroovyPageAttributes([:])
+        other['gspTagSyntaxCall'] = false
+        assertEquals false, other['gspTagSyntaxCall']
+        assertTrue other.isGspTagSyntaxCall()
+
+        // the flag is still driven by its own accessors
+        other.setGspTagSyntaxCall(false)
+        assertFalse other.isGspTagSyntaxCall()
+        assertEquals false, other['gspTagSyntaxCall']
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testStaticCompilationWritesTheFieldRatherThanTheMap() {
+        // Documented limitation: @CompileStatic binds property syntax to the declared setter, so
+        // unlike params — where the equivalent assignment fails to compile — this one compiles
+        // and silently drives the flag instead of the map. Use the subscript form in statically
+        // compiled taglibs.
+        def viaProperty = toGroovyPageAttributes([:])
+        StaticallyCompiledAccess.write(viaProperty)
+
+        assertFalse viaProperty.isGspTagSyntaxCall()             // the flag was written
+        assertFalse viaProperty.containsKey('gspTagSyntaxCall')  // the map was not
+
+        // the subscript form addresses the map under static compilation, as it does dynamically
+        def viaSubscript = toGroovyPageAttributes([:])
+        StaticallyCompiledAccess.writeViaSubscript(viaSubscript)
+
+        assertEquals false, viaSubscript['gspTagSyntaxCall']      // the map was written
+        assertTrue viaSubscript.isGspTagSyntaxCall()              // the flag was not
+    }
+
+    @CompileStatic
+    static class StaticallyCompiledAccess {
+
+        static void write(GroovyPageAttributes attrs) {
+            attrs.gspTagSyntaxCall = false
+        }
+
+        static void writeViaSubscript(GroovyPageAttributes attrs) {
+            attrs['gspTagSyntaxCall'] = false
+        }
     }
 
     protected toGroovyPageAttributes(map) {

--- a/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
+++ b/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
@@ -94,6 +94,38 @@ class GroovyPageAttributesTests {
         assert '[one:foo]' == attrs.toString()
     }
 
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testGspTagSyntaxCallAttributeIsAMapEntry() {
+        def attrs = toGroovyPageAttributes([:])
+
+        attrs['gspTagSyntaxCall'] = 'value'
+
+        assertEquals 'value', attrs['gspTagSyntaxCall']
+        assertEquals 'value', attrs.gspTagSyntaxCall
+        assertTrue attrs.isGspTagSyntaxCall()
+
+        attrs.setGspTagSyntaxCall(false)
+
+        assertFalse attrs.isGspTagSyntaxCall()
+        assertEquals 'value', attrs['gspTagSyntaxCall']
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testAttributeNamesCollidingWithInheritedProperties() {
+        def attrs = toGroovyPageAttributes([:])
+
+        attrs['empty'] = 'e1'
+        attrs['class'] = 'container'
+
+        assertEquals 'e1', attrs['empty']
+        assertEquals 'container', attrs['class']
+        assertEquals 'container', attrs.class
+        assertFalse attrs.isEmpty()
+        assertEquals GroovyPageAttributes, attrs.getClass()
+    }
+
     protected toGroovyPageAttributes(map) {
         new GroovyPageAttributes(map)
     }

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
@@ -128,7 +128,30 @@ class CommandObjectInstantiationSpec extends Specification implements Controller
     }
 
     @Issue('https://github.com/apache/grails-core/issues/16280')
-    void 'Test a parameter named identifier does not divert domain command object resolution'() {
+    void 'Test a parameter named identifier cannot resolve a domain command object'() {
+        given: 'a persisted domain object whose id is submitted only as an "identifier" parameter'
+        def decoy = new DomainClassCommandObject(name: 'Decoy').save()
+
+        expect:
+        decoy.id != null
+
+        when: '''no id is submitted, so Controller.initializeCommandObject falls back to params.getIdentifier()'''
+        request.method = 'GET'
+        params.identifier = decoy.id
+        controller.domainCommandObject()
+
+        then: 'the fallback reads the absent "id" parameter and resolves nothing'
+        response.status == HttpServletResponse.SC_OK
+        model.commandObject == null
+
+        and: 'the identifier parameter is still readable as an ordinary map entry'
+        params['identifier'] == decoy.id
+        params.identifier == decoy.id
+        params.getIdentifier() == null
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/16280')
+    void 'Test the id parameter resolves the command object when an identifier parameter is also present'() {
         given:
         def target = new DomainClassCommandObject(name: 'Target').save()
         def decoy = new DomainClassCommandObject(name: 'Decoy').save()
@@ -144,13 +167,13 @@ class CommandObjectInstantiationSpec extends Specification implements Controller
         params.identifier = decoy.id
         controller.domainCommandObject()
 
-        then: 'the command object is resolved from id, not from the identifier field'
+        then: 'the command object is resolved from id'
         response.status == HttpServletResponse.SC_OK
         model.commandObject.id == target.id
         model.commandObject.name == 'Target'
 
-        and: 'the identifier parameter is still readable as an ordinary map entry'
-        params.identifier == decoy.id
+        and: 'both parameters remain readable as ordinary map entries'
+        params['id'] == target.id
         params['identifier'] == decoy.id
         params.getIdentifier() == target.id
     }

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
@@ -126,6 +126,34 @@ class CommandObjectInstantiationSpec extends Specification implements Controller
         where:
         requestMethod << ['POST', 'PUT', 'GET', 'DELETE']
     }
+
+    @Issue('https://github.com/apache/grails-core/issues/16280')
+    void 'Test a parameter named identifier does not divert domain command object resolution'() {
+        given:
+        def target = new DomainClassCommandObject(name: 'Target').save()
+        def decoy = new DomainClassCommandObject(name: 'Decoy').save()
+
+        expect:
+        target.id != null
+        decoy.id != null
+        target.id != decoy.id
+
+        when: 'a request carries both an id and a form field named identifier'
+        request.method = 'POST'
+        params.id = target.id
+        params.identifier = decoy.id
+        controller.domainCommandObject()
+
+        then: 'the command object is resolved from id, not from the identifier field'
+        response.status == HttpServletResponse.SC_OK
+        model.commandObject.id == target.id
+        model.commandObject.name == 'Target'
+
+        and: 'the identifier parameter is still readable as an ordinary map entry'
+        params.identifier == decoy.id
+        params['identifier'] == decoy.id
+        params.getIdentifier() == target.id
+    }
 }
 
 @Artefact('Controller')

--- a/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
+++ b/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
@@ -73,8 +73,6 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
 
     public static final Object[] EMPTY_ARGS = new Object[0];
 
-    private static final String IDENTIFIER = "identifier";
-
     /**
      * Does not populate the GrailsParameterMap from the request but instead uses the supplied values.
      *
@@ -238,17 +236,16 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
     /**
      * Returns the identifier in the request.
      *
-     * <p>A request parameter literally named {@code identifier} takes precedence, so that a form
-     * field of that name stays reachable through this accessor as well as through
-     * {@code params['identifier']}. Otherwise the conventional {@code id} parameter is returned,
-     * which is the long-standing behaviour of this method.
+     * <p>This always reads the conventional {@code id} parameter. It deliberately ignores a
+     * parameter named {@code identifier}: the value is used by
+     * {@code Controller.initializeCommandObject()} to load a domain command object, so letting a
+     * submitted field named {@code identifier} take precedence would let a request address a
+     * different domain object than its {@code id} parameter names. Read such a parameter with
+     * {@code params['identifier']}.
      *
-     * @return the {@code identifier} parameter when one is present, otherwise the {@code id} parameter
+     * @return The identifier in the request
      */
     public Object getIdentifier() {
-        if (containsKey(IDENTIFIER)) {
-            return get(IDENTIFIER);
-        }
         return get(GormProperties.IDENTITY);
     }
 

--- a/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
+++ b/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
@@ -73,6 +73,8 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
 
     public static final Object[] EMPTY_ARGS = new Object[0];
 
+    private static final String IDENTIFIER = "identifier";
+
     /**
      * Does not populate the GrailsParameterMap from the request but instead uses the supplied values.
      *
@@ -234,9 +236,19 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
     }
 
     /**
-     * @return The identifier in the request
+     * Returns the identifier in the request.
+     *
+     * <p>A request parameter literally named {@code identifier} takes precedence, so that a form
+     * field of that name stays reachable through this accessor as well as through
+     * {@code params['identifier']}. Otherwise the conventional {@code id} parameter is returned,
+     * which is the long-standing behaviour of this method.
+     *
+     * @return the {@code identifier} parameter when one is present, otherwise the {@code id} parameter
      */
     public Object getIdentifier() {
+        if (containsKey(IDENTIFIER)) {
+            return get(IDENTIFIER);
+        }
         return get(GormProperties.IDENTITY);
     }
 

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -395,6 +395,190 @@ class GrailsParameterMapTests {
     }
 
     @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testAddingIdentifierParam() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap['identifier'] = 'id1'
+
+        assertEquals 'id1', theMap['identifier']
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testSubscriptAccessForNamesThatCollideWithGetters() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        ['identifier', 'request', 'empty', 'class', 'metaClass', 'plain'].each { String name ->
+            theMap[name] = "value of $name".toString()
+        }
+
+        ['identifier', 'request', 'empty', 'class', 'metaClass', 'plain'].each { String name ->
+            assertEquals "value of $name".toString(), theMap[name], "subscript access for [$name] should read the parameter"
+            assertTrue theMap.containsKey(name), "[$name] should be a key of the map"
+        }
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testPropertyAccessForNamesThatCollideWithGetters() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap.identifier = 'id1'
+        theMap.request = 'r1'
+        theMap.empty = 'e1'
+
+        assertEquals 'id1', theMap.identifier
+        assertEquals 'r1', theMap.request
+        assertEquals 'e1', theMap.empty
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'r1', theMap['request']
+        assertEquals 'e1', theMap['empty']
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testGetIdentifierStillReturnsTheIdParameter() {
+        mockRequest.addParameter("id", "abc")
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertEquals 'abc', theMap.getIdentifier()
+
+        // a parameter literally named "identifier" takes precedence over the "id" convention
+        theMap['identifier'] = 'other'
+
+        assertEquals 'other', theMap.getIdentifier()
+        assertEquals 'other', theMap['identifier']
+        assertEquals 'other', theMap.identifier
+        assertEquals 'abc', theMap['id']
+
+        // removing it falls back to the "id" parameter again
+        theMap.remove('identifier')
+
+        assertEquals 'abc', theMap.getIdentifier()
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testGetIdentifierReturnsNullWhenNeitherParameterIsPresent() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertNull theMap.getIdentifier()
+
+        theMap['identifier'] = null
+
+        assertNull theMap.getIdentifier()
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testGetRequestStillReturnsTheRequest() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap['request'] = 'r1'
+
+        assertSame mockRequest, theMap.getRequest()
+        assertEquals 'r1', theMap['request']
+        assertEquals 'r1', theMap.request
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testCollidingNamesAreNullWhenNoSuchParameterWasSubmitted() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        // "request" and "identifier" name parameters, so with no such parameter submitted they
+        // read as null rather than falling back to getRequest()/getIdentifier()
+        assertNull theMap['request']
+        assertNull theMap.request
+        assertNull theMap['identifier']
+        assertNull theMap.identifier
+        assertNull theMap.nonexistent
+
+        // the accessors themselves are unaffected
+        assertSame mockRequest, theMap.getRequest()
+        assertNull theMap.getIdentifier()
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testCollidingParameterNamesArrivingFromTheRequest() {
+        mockRequest.addParameter("identifier", "id1")
+        mockRequest.addParameter("request", "r1")
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'r1', theMap['request']
+        assertEquals 'id1', theMap.identifier
+        assertEquals 'r1', theMap.request
+        assertSame mockRequest, theMap.getRequest()
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testMetaClassPropertyIsNotShadowedByTheMap() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap['metaClass'] = 'mc'
+
+        assertEquals 'mc', theMap['metaClass']
+        assertNotNull theMap.metaClass
+        assertNotEquals 'mc', theMap.metaClass
+        assertEquals GrailsParameterMap, theMap.getClass()
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testSubscriptKeyTypePermutations() {
+        theMap = new GrailsParameterMap(mockRequest)
+        def prefix = 'ident'
+
+        theMap["${prefix}ifier"] = 'gstring'
+        theMap[42] = 'answer'
+        theMap['nil'] = null
+
+        assertEquals 'gstring', theMap["${prefix}ifier"]
+        assertEquals 'gstring', theMap['identifier']
+        assertEquals 'answer', theMap[42]
+        assertNull theMap['nil']
+        assertTrue theMap.containsKey('nil')
+
+        theMap.remove('identifier')
+        assertFalse theMap.containsKey('identifier')
+        assertNull theMap['identifier']
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testCollidingParameterNamesSurviveCloningAndQueryString() {
+        mockRequest.addParameter("identifier", "id1")
+        mockRequest.addParameter("request", "r1")
+        theMap = new GrailsParameterMap(mockRequest)
+
+        GrailsParameterMap theClone = theMap.clone()
+        assertEquals 'id1', theClone['identifier']
+        assertEquals 'r1', theClone['request']
+
+        def queryString = theMap.toQueryString()[1..-1].split('&')
+        assert queryString.find { it == 'identifier=id1' }
+        assert queryString.find { it == 'request=r1' }
+    }
+
+    @Test
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testCollidingParameterNamesInNestedMaps() {
+        mockRequest.addParameter("book.identifier", "id1")
+        mockRequest.addParameter("book.request", "r1")
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assert theMap['book'] instanceof GrailsParameterMap
+        assertEquals 'id1', theMap['book']['identifier']
+        assertEquals 'r1', theMap['book']['request']
+        assertEquals 'id1', theMap.book.identifier
+        assertEquals 'r1', theMap.book.request
+    }
+
+    @Test
     void testToQueryStringWithMultiD() {
         mockRequest.addParameter("name", "Dierk Koenig")
         mockRequest.addParameter("dob", "01/01/1970")

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -438,34 +438,30 @@ class GrailsParameterMapTests {
 
     @Test
     @Issue("https://github.com/apache/grails-core/issues/16280")
-    void testGetIdentifierStillReturnsTheIdParameter() {
+    void testGetIdentifierAlwaysReadsTheIdParameter() {
         mockRequest.addParameter("id", "abc")
         theMap = new GrailsParameterMap(mockRequest)
 
         assertEquals 'abc', theMap.getIdentifier()
 
-        // a parameter literally named "identifier" takes precedence over the "id" convention
+        // a parameter named "identifier" is an ordinary map entry and must not divert
+        // getIdentifier(), which Controller.initializeCommandObject() uses to load a domain object
         theMap['identifier'] = 'other'
 
-        assertEquals 'other', theMap.getIdentifier()
+        assertEquals 'abc', theMap.getIdentifier()
         assertEquals 'other', theMap['identifier']
         assertEquals 'other', theMap.identifier
         assertEquals 'abc', theMap['id']
-
-        // removing it falls back to the "id" parameter again
-        theMap.remove('identifier')
-
-        assertEquals 'abc', theMap.getIdentifier()
     }
 
     @Test
     @Issue("https://github.com/apache/grails-core/issues/16280")
-    void testGetIdentifierReturnsNullWhenNeitherParameterIsPresent() {
+    void testGetIdentifierIsNullWhenNoIdParameterWasSubmitted() {
         theMap = new GrailsParameterMap(mockRequest)
 
         assertNull theMap.getIdentifier()
 
-        theMap['identifier'] = null
+        theMap['identifier'] = 'other'
 
         assertNull theMap.getIdentifier()
     }
@@ -497,7 +493,7 @@ class GrailsParameterMapTests {
 
         // the accessors themselves are unaffected
         assertSame mockRequest, theMap.getRequest()
-        assertNull theMap.getIdentifier()
+        assertNull theMap.getIdentifier()   // no "id" parameter was submitted
     }
 
     @Test

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -21,6 +21,7 @@ package grails.web.servlet.mvc
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 
+import groovy.transform.CompileStatic
 import org.junit.jupiter.api.Test
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.mock.web.MockHttpServletRequest
@@ -476,6 +477,32 @@ class GrailsParameterMapTests {
         assertSame mockRequest, theMap.getRequest()
         assertEquals 'r1', theMap['request']
         assertEquals 'r1', theMap.request
+    }
+
+    @Test
+    @CompileStatic
+    @Issue("https://github.com/apache/grails-core/issues/16280")
+    void testStaticCompilationBindsPropertySyntaxToTheAccessor() {
+        GrailsParameterMap params = new GrailsParameterMap(mockRequest)
+
+        // subscript access addresses the map under @CompileStatic as well, because getAt(String)
+        // and putAt(String, Object) are declared methods the static compiler resolves directly
+        params['identifier'] = 'id1'
+        assertEquals 'id1', params['identifier']
+        assertNull params['request']
+
+        // put() is the portable way to write a parameter whose name collides with an accessor;
+        // params['request'] = 'r1' does not compile, because the static compiler binds it to the
+        // HttpServletRequest-typed "request" property
+        params.put('request', 'r1')
+        assertEquals 'r1', params['request']
+
+        // property syntax binds to the declared accessor at compile time and bypasses
+        // getProperty, so it does NOT read the map entry under static compilation.
+        // Writing it does not compile at all: "params.identifier = value" fails with
+        // "Cannot set read-only property: identifier".
+        assertNull params.identifier            // getIdentifier() reads the absent "id" parameter
+        assertSame mockRequest, params.request  // getRequest()
     }
 
     @Test

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -22,6 +22,8 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 
 import groovy.transform.CompileStatic
+import org.codehaus.groovy.runtime.typehandling.GroovyCastException
+import org.junit.jupiter.api.function.Executable
 import org.junit.jupiter.api.Test
 import org.springframework.context.support.StaticMessageSource
 import org.springframework.mock.web.MockHttpServletRequest
@@ -545,9 +547,12 @@ class GrailsParameterMapTests {
         theMap['metaClass'] = 'mc'
 
         assertEquals 'mc', theMap['metaClass']
-        assertNotNull theMap.metaClass
-        assertNotEquals 'mc', theMap.metaClass
+        assertTrue theMap.metaClass instanceof MetaClass
         assertEquals GrailsParameterMap, theMap.getClass()
+
+        // the dotted form is reserved for Groovy's own machinery, so assigning to it throws
+        // rather than storing a parameter
+        assertThrows(GroovyCastException, { theMap.metaClass = 'mc' } as Executable)
     }
 
     @Test


### PR DESCRIPTION
Fixes #16280

## Problem

Groovy 5 changed runtime method selection for classes that implement `Map`. For a `String` subscript key, `DefaultGroovyMethods.putAt(Object, String, Object)` (→ `setProperty`) now wins over `putAt(Map, K, V)` (→ `put`), and `getAt(Object, String)` (→ `getProperty`) over `getAt(Map, Object)`. Because `GrailsParameterMap` declares `getIdentifier()` and `getRequest()` with no setters, those names became read-only *properties* rather than ordinary map keys:

```
groovy.lang.ReadOnlyPropertyException: Cannot set read-only property: identifier
	at groovy.lang.MetaClassImpl.setProperty(MetaClassImpl.java:2837)
	at org.codehaus.groovy.runtime.InvokerHelper.setProperty(InvokerHelper.java:187)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.putAt(DefaultGroovyMethods.java:12191)
```

| Expression | Groovy 4.0.30 (Grails 7) | Groovy 5.x before this PR |
|---|---|---|
| `params['identifier'] = 'x'` | map put | throws `ReadOnlyPropertyException` |
| `params['request'] = 'x'` | map put | throws `ReadOnlyPropertyException` |
| `params['identifier']` | map value | `getIdentifier()` → `params.id` |
| `params['request']` | map value | the `HttpServletRequest` |
| `params.identifier` / `params.request` | map value | getter result |

`GroovyPageAttributes` is affected the same way: `attrs['gspTagSyntaxCall'] = x` silently wrote the boolean field instead of the map.

## Fix

`AbstractTypeConvertingMap` — the shared base of `GrailsParameterMap` and `GroovyPageAttributes` — declares `getAt(String)` / `putAt(String, Object)` and map-first `getProperty` / `setProperty`, so subscript and property access always address a map entry. This restores the Grails 7 rule.

Declaring `getAt(Object)` / `putAt(Object, Object)` does **not** work; DGM's `String` overload remains the closer match. The `String` overloads are what fix it, verified against both Groovy 4.0.30 and Groovy 5.0.6.

`metaClass` is exempt from the property override so Groovy's own machinery keeps working. It is still readable as a map entry through `params['metaClass']`.

`getIdentifier()` and `getRequest()` are unchanged. `getIdentifier()` still reads only the `id` parameter — an earlier revision of this PR let a parameter named `identifier` take precedence, which `0093ab2` reverted after review, because `Controller.initializeCommandObject()` feeds that value to `Type.get()` when resolving a domain command object. `getRequest()` keeps its `HttpServletRequest` return type; widening it to `Object` would break every caller and would let a submitted form field flow into framework code expecting a servlet request.

Both names remain reachable as ordinary map entries through `params['identifier']` and `params['request']`, which is what the issue asked for.

## Also in this PR

`grails-taglib` had no `junit-jupiter-engine` on its test runtime classpath, so `GroovyPageAttributesTests` — the module's only JUnit 5 test — was never discovered. Added the engine; all tests in that module now run and pass.

## Documentation

- `upgrading80x.adoc` §28.3, alongside the existing Groovy 5 behavior-change notes: the restored rule, a NOTE covering the static-compilation limitation on both `params` and `attrs`, and the two deltas from Grails 7 (`params.metaClass`, and assignment to a setter-backed name writing a map entry instead of invoking the setter).
- `controllersAndScopes.adoc` — the everyday rule for `params` and `attrs` access.

## Testing

- `GrailsParameterMapTests`: collision names via subscript and dot syntax; collisions arriving from the HTTP request; `getIdentifier()` reading only `id`; `getRequest()` unaffected; absent keys reading as `null`; `metaClass` neither shadowed nor assignable; statically compiled access; `GString` / `Integer` / `null` keys and values; `remove` / `containsKey`; cloning; `toQueryString`; nested maps.
- `TypeConvertingMapTests`: 4 new tests at the level where the fix lives.
- `GroovyPageAttributesTests`: 2 new tests.

Verified green: `grails-core`, `grails-web-common`, `grails-controllers`, `grails-web-mvc`, `grails-url-mappings`, `grails-gsp`, `grails-web-taglib`, `grails-taglib`, `grails-shell-cli`.

`aggregateViolations` reports no Checkstyle, CodeNarc, PMD or SpotBugs issues.

Opened as a draft to confirm CI is green before requesting review.

