### PR TITLE
Fix JsonScanner number parsing for bare exponents and -Infinity

### DIFF
--- a/grails-data-mongodb/bson/src/main/groovy/org/grails/datastore/bson/json/JsonScanner.java
+++ b/grails-data-mongodb/bson/src/main/groovy/org/grails/datastore/bson/json/JsonScanner.java
@@ -361,6 +361,7 @@ class JsonScanner {
                         case JsonToken.CLOSE_BRACE:
                         case JsonToken.CLOSE_BRACKET:
                         case JsonToken.CLOSE_PARENS:
+                        case -1:
                             state = JsonScanner.NumberState.DONE;
                             break;
                         default:
@@ -384,7 +385,9 @@ class JsonScanner {
                             break;
                         }
                         c = readCharacter();
-                        numberBuilder.append((char) c);
+                        if (i < NFINITY.length - 1) {
+                            numberBuilder.append((char) c);
+                        }
                     }
                     if (sawMinusInfinity) {
                         type = JsonTokenType.DOUBLE;

--- a/grails-data-mongodb/bson/src/test/groovy/org/grails/datastore/bson/json/JsonReaderSpec.groovy
+++ b/grails-data-mongodb/bson/src/test/groovy/org/grails/datastore/bson/json/JsonReaderSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.datastore.bson.json
+
+import org.bson.BsonType
+import spock.lang.Specification
+
+/**
+ * Regression coverage for two JsonScanner number-parsing bugs:
+ *
+ * <p>SAW_EXPONENT_DIGITS was the only numeric scanner state whose terminator switch omitted an
+ * explicit end-of-input case (every sibling state treats EOF the same as a closing delimiter), so
+ * a bare exponent-notation number with nothing following it (e.g. a top-level "1e2") threw
+ * JsonParseException instead of parsing.
+ *
+ * <p>SAW_MINUS_I appended the character it read on every iteration of its "-Infinity" match loop,
+ * including the terminator character read immediately after matching the literal's final 'y' - so
+ * the buffer handed to Double.parseDouble always carried one extra trailing character, and
+ * "-Infinity" failed to parse in every context (end-of-input, before a comma, before a closing
+ * bracket).
+ */
+class JsonReaderSpec extends Specification {
+
+    void "reads a bare exponent-notation number with nothing following it"() {
+        given:
+        JsonReader reader = new JsonReader('1e2')
+
+        expect:
+        reader.readBsonType() == BsonType.DOUBLE
+        reader.readDouble() == 100.0d
+    }
+
+    void "reads -Infinity as negative infinity, at end-of-input and followed by a delimiter"() {
+        expect:
+        new JsonReader('-Infinity').readBsonType() == BsonType.DOUBLE
+
+        when:
+        JsonReader reader = new JsonReader('[-Infinity]')
+        reader.readBsonType()
+        reader.readStartArray()
+
+        then:
+        reader.readBsonType() == BsonType.DOUBLE
+        reader.readDouble() == Double.NEGATIVE_INFINITY
+    }
+}


### PR DESCRIPTION
## Summary
- `SAW_EXPONENT_DIGITS` was the only numeric scanner state whose terminator switch omitted an explicit end-of-input case, so a bare exponent-notation number with nothing following it (e.g. a top-level `1e2`) threw `JsonParseException` instead of parsing.
- `SAW_MINUS_I` appended the character it read on every iteration of its `-Infinity` match loop, including the terminator character read immediately after matching the literal's final `y` - so the buffer handed to `Double.parseDouble` always carried one extra trailing character, and `-Infinity` failed to parse in every context (end-of-input, before a comma, before a closing bracket).
- Found while adding broader `JsonReader`/`JsonWriter` test coverage on `8.1.x`; `JsonScanner` is unchanged since `7.0.x`, so the fix applies cleanly here. This branch had no prior `JsonReader` test coverage, so a minimal `JsonReaderSpec` is added with just the two regression tests.

## Test plan
- [x] `./gradlew :grails-data-mongodb-bson:test` - full module suite green, including the two new regression tests
- [x] `./gradlew :grails-data-mongodb-bson:codeStyle` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAjfckcY4EJsxranv1RyGV