### PR TITLE
M6 FIX: Require a username and password on the spring-boot-starter-security User

### DIFF
--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/SecurityFeature.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/SecurityFeature.java
@@ -76,7 +76,8 @@ public abstract class SecurityFeature implements Feature {
     protected void applyClassicDomainModel(GeneratorContext generatorContext) {
         final Project project = generatorContext.getProject();
         generatorContext.addTemplate("securityUser",
-                new RockerTemplate("grails-app/domain/{packagePath}/User.groovy", userClassic.template(project)));
+                new RockerTemplate("grails-app/domain/{packagePath}/User.groovy",
+                        userClassic.template(project, generatorContext.getFeatures())));
         generatorContext.addTemplate("securityRole",
                 new RockerTemplate("grails-app/domain/{packagePath}/Role.groovy", role.template(project)));
         generatorContext.addTemplate("securityUserRole",

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/SpringBootStarterSecurity.java
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/SpringBootStarterSecurity.java
@@ -76,7 +76,8 @@ public class SpringBootStarterSecurity extends SecurityFeature implements Primar
 
         final Project project = generatorContext.getProject();
         generatorContext.addTemplate("securityUser",
-                new RockerTemplate("grails-app/domain/{packagePath}/User.groovy", user.template(project)));
+                new RockerTemplate("grails-app/domain/{packagePath}/User.groovy",
+                        user.template(project, generatorContext.getFeatures())));
         generatorContext.addTemplate("securityUserController",
                 new RockerTemplate("grails-app/controllers/{packagePath}/UserController.groovy", userController.template(project)));
         generatorContext.addTemplate("securityUserService",

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/user.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/user.rocker.raw
@@ -18,8 +18,9 @@ under the License.
 *@
 
 @import org.grails.forge.application.Project
+@import org.grails.forge.feature.Features
 
-@args (Project project)
+@args (Project project, Features features)
 
 package @project.getPackageName()
 
@@ -38,9 +39,17 @@ class User implements UserDetails {
 
     static hasMany = [roles: String]
 
+@if (features.contains("gorm-mongodb")) {
+    static mapping = {
+        collection 'users'
+    }
+
+} else if (features.contains("gorm-hibernate5") || features.contains("gorm-hibernate7")) {
     static mapping = {
         table 'users'
     }
+
+}
 
     static constraints = {
         username nullable: false, blank: false, unique: true

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/user.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/user.rocker.raw
@@ -43,8 +43,8 @@ class User implements UserDetails {
     }
 
     static constraints = {
-        username blank: false, unique: true
-        password blank: false, password: true
+        username nullable: false, blank: false, unique: true
+        password nullable: false, blank: false, password: true
     }
 
     @@Override

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/userClassic.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/userClassic.rocker.raw
@@ -18,8 +18,9 @@ under the License.
 *@
 
 @import org.grails.forge.application.Project
+@import org.grails.forge.feature.Features
 
-@args (Project project)
+@args (Project project, Features features)
 
 package @project.getPackageName()
 
@@ -52,9 +53,17 @@ class User implements Serializable {
         UserRole.findAllByUser(this)*.role
     }
 
+@if (features.contains("gorm-mongodb")) {
+    static mapping = {
+        collection 'user'
+    }
+
+} else if (features.contains("gorm-hibernate5") || features.contains("gorm-hibernate7")) {
     static mapping = {
         table name: '`user`'
     }
+
+}
 
     static constraints = {
         email nullable: true, email: true, unique: true

--- a/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/userSpec.rocker.raw
+++ b/grails-forge/grails-forge-core/src/main/java/org/grails/forge/feature/security/template/userSpec.rocker.raw
@@ -28,13 +28,42 @@ import spock.lang.Specification
 
 class UserSpec extends Specification implements DomainUnitTest<User> {
 
-    void 'username and password are required'() {
+    void 'a user without a username and a password is rejected'() {
+        given:
+        User user = new User()
+
         expect:
-        !new User(username: '', password: '').validate()
+        !user.validate()
+
+        and:
+        with(user.errors) {
+            getFieldError('username').code == 'nullable'
+            getFieldError('password').code == 'nullable'
+        }
+    }
+
+    void 'a user whose username and password are blank is rejected'() {
+        given: 'the values are assigned directly, since the map constructor binds an empty string to null'
+        User user = new User()
+        user.username = ''
+        user.password = ''
+
+        expect:
+        !user.validate()
+
+        and:
+        with(user.errors) {
+            getFieldError('username').code == 'blank'
+            getFieldError('password').code == 'blank'
+        }
+    }
+
+    void 'a user with a username and a password is accepted'() {
+        expect:
         new User(username: 'admin', password: 'secret', roles: ['ROLE_ADMIN']).validate()
     }
 
-    void 'authorities derive from the roles'() {
+    void 'the authorities derive from the roles'() {
         expect:
         new User(username: 'admin', password: 'secret', roles: ['ROLE_ADMIN']).authorities*.authority == ['ROLE_ADMIN']
     }

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/GrailsSpringSecuritySpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/GrailsSpringSecuritySpec.groovy
@@ -24,7 +24,10 @@ import org.grails.forge.application.ApplicationType
 import org.grails.forge.feature.Category
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.DevelopmentReloading
+import org.grails.forge.options.GormImpl
+import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
+import org.grails.forge.options.ServletImpl
 import spock.lang.Unroll
 
 class GrailsSpringSecuritySpec extends ApplicationContextSpec implements CommandOutputFixture {
@@ -74,6 +77,40 @@ class GrailsSpringSecuritySpec extends ApplicationContextSpec implements Command
 
         and: 'a data spec covers the classic model'
         output['src/test/groovy/example/grails/UserSpec.groovy'].contains('[User, Role, UserRole]')
+    }
+
+    @Unroll
+    void 'the classic User domain maps through the #gorm mapping directive'() {
+        when:
+        def options = new Options(DevelopmentReloading.DEVTOOLS, gorm, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+        def user = generate(ApplicationType.WEB, options, ['grails-spring-security'])['grails-app/domain/example/grails/User.groovy']
+
+        then: 'the directive matches the data implementation'
+        user.contains(directive)
+
+        and: 'no directive from another data implementation leaks in'
+        !user.contains(foreign)
+
+        where:
+        gorm                | directive              | foreign
+        GormImpl.HIBERNATE5 | "table name: '`user`'" | "collection 'user'"
+        GormImpl.HIBERNATE7 | "table name: '`user`'" | "collection 'user'"
+        GormImpl.MONGODB    | "collection 'user'"    | "table name: '`user`'"
+    }
+
+    void 'the classic User domain carries no mapping block when neither Hibernate nor MongoDB is used'() {
+        when:
+        def options = new Options(DevelopmentReloading.DEVTOOLS, GormImpl.NEO4J, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+        def user = generate(ApplicationType.WEB, options, ['grails-spring-security'])['grails-app/domain/example/grails/User.groovy']
+
+        then: 'no persistence-unit directive is emitted for a store that uses neither'
+        !user.contains('static mapping')
+        !user.contains("table name: '`user`'")
+        !user.contains("collection 'user'")
+
+        and: 'the rest of the domain is still generated'
+        user.contains('class User implements Serializable')
+        user.contains('username unique: true, nullable: false')
     }
 
     void 'the feature shares the Spring Security category and advertises the plugin'() {

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/SpringBootStarterSecuritySpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/SpringBootStarterSecuritySpec.groovy
@@ -24,7 +24,10 @@ import org.grails.forge.application.ApplicationType
 import org.grails.forge.feature.Category
 import org.grails.forge.fixture.CommandOutputFixture
 import org.grails.forge.options.DevelopmentReloading
+import org.grails.forge.options.GormImpl
+import org.grails.forge.options.JdkVersion
 import org.grails.forge.options.Options
+import org.grails.forge.options.ServletImpl
 import spock.lang.Unroll
 
 class SpringBootStarterSecuritySpec extends ApplicationContextSpec implements CommandOutputFixture {
@@ -45,6 +48,11 @@ class SpringBootStarterSecuritySpec extends ApplicationContextSpec implements Co
 
         and: 'the credentials are required, so an account cannot be saved without them'
         user.contains('username nullable: false, blank: false, unique: true')
+
+        and: 'the default Hibernate app maps to a table, since user is a reserved word in several databases'
+        user.contains('''    static mapping = {
+        table 'users'
+    }''')
 
         and: 'the password field is marked as a password so scaffolding masks it'
         user.contains('password nullable: false, blank: false, password: true')
@@ -98,6 +106,40 @@ class SpringBootStarterSecuritySpec extends ApplicationContextSpec implements Co
         userSpec.contains("getFieldError('username').code == 'blank'")
         userSpec.contains("getFieldError('password').code == 'nullable'")
         userSpec.contains("getFieldError('password').code == 'blank'")
+    }
+
+    @Unroll
+    void 'the User domain maps through the #gorm mapping directive'() {
+        when:
+        def options = new Options(DevelopmentReloading.DEVTOOLS, gorm, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+        def user = generate(ApplicationType.WEB, options, ['spring-boot-starter-security'])['grails-app/domain/example/grails/User.groovy']
+
+        then: 'the directive matches the data implementation'
+        user.contains(directive)
+
+        and: 'no directive from another data implementation leaks in'
+        !user.contains(foreign)
+
+        where:
+        gorm                | directive             | foreign
+        GormImpl.HIBERNATE5 | "table 'users'"       | "collection 'users'"
+        GormImpl.HIBERNATE7 | "table 'users'"       | "collection 'users'"
+        GormImpl.MONGODB    | "collection 'users'"  | "table 'users'"
+    }
+
+    void 'the User domain carries no mapping block when neither Hibernate nor MongoDB is used'() {
+        when:
+        def options = new Options(DevelopmentReloading.DEVTOOLS, GormImpl.NEO4J, ServletImpl.DEFAULT_OPTION, JdkVersion.DEFAULT_OPTION)
+        def user = generate(ApplicationType.WEB, options, ['spring-boot-starter-security'])['grails-app/domain/example/grails/User.groovy']
+
+        then: 'no persistence-unit directive is emitted for a store that uses neither'
+        !user.contains('static mapping')
+        !user.contains("table 'users'")
+        !user.contains("collection 'users'")
+
+        and: 'the rest of the domain is still generated'
+        user.contains('class User implements UserDetails')
+        user.contains('username nullable: false, blank: false, unique: true')
     }
 
     void 'the feature appears in its own Spring Security category with the agreed title'() {

--- a/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/SpringBootStarterSecuritySpec.groovy
+++ b/grails-forge/grails-forge-core/src/test/groovy/org/grails/forge/feature/security/SpringBootStarterSecuritySpec.groovy
@@ -43,8 +43,11 @@ class SpringBootStarterSecuritySpec extends ApplicationContextSpec implements Co
         user.contains('static hasMany = [roles: String]')
         user.contains('new SimpleGrantedAuthority(it)')
 
+        and: 'the credentials are required, so an account cannot be saved without them'
+        user.contains('username nullable: false, blank: false, unique: true')
+
         and: 'the password field is marked as a password so scaffolding masks it'
-        user.contains('password blank: false, password: true')
+        user.contains('password nullable: false, blank: false, password: true')
 
         and: 'the scaffolded controller and UserDetailsService-backed service are generated'
         output['grails-app/controllers/example/grails/UserController.groovy'].contains('@Scaffold(RestfulServiceController<User>)')
@@ -89,6 +92,12 @@ class SpringBootStarterSecuritySpec extends ApplicationContextSpec implements Co
         def userSpec = output['src/test/groovy/example/grails/UserSpec.groovy']
         userSpec.contains('DomainUnitTest<User>')
         userSpec.contains("authorities*.authority == ['ROLE_ADMIN']")
+
+        and: 'that spec asserts the nullable and blank constraints separately'
+        userSpec.contains("getFieldError('username').code == 'nullable'")
+        userSpec.contains("getFieldError('username').code == 'blank'")
+        userSpec.contains("getFieldError('password').code == 'nullable'")
+        userSpec.contains("getFieldError('password').code == 'blank'")
     }
 
     void 'the feature appears in its own Spring Security category with the agreed title'() {


### PR DESCRIPTION
Two defects in the `spring-boot-starter-security` `User` template, both of which only show up once you generate an app and run it.

## 1. The credentials were not actually required

Grails 8 makes an unconstrained persistent property nullable by default (documented in `upgrading80x.adoc`, "GORM Properties Are Nullable by Default"). The template was never updated for that flip, so its `blank: false` constraints no longer make the credentials required — a `User` with a null username and a null password validates clean, and the scaffolded user admin will save one.

Every other domain template in the forge already declares `nullable: false`, which is what makes this look like a miss rather than a choice:

| Template | Constraint |
|---|---|
| `role.rocker.raw` | `authority unique: true, nullable: false` |
| `userClassic.rocker.raw` | `username unique: true, nullable: false` / `password nullable: false` |
| `userRole.rocker.raw` | `user nullable: false` / `role nullable: false, unique: 'user'` |
| `user.rocker.raw` | `username blank: false, unique: true` ← missing |

```groovy
static constraints = {
    username nullable: false, blank: false, unique: true
    password nullable: false, blank: false, password: true
}
```

### The generated spec failed out of the box

Creating an app with this feature produced a red build on the very first `./gradlew test`:

```
UserSpec > username and password are required FAILED
    Condition not satisfied:
    !new User(username: '', password: '').validate()
    ||                                    |
    |example.User : (unsaved)             true
    false
```

The assertion exercised neither constraint it appeared to test. The domain map constructor binds through data binding with `convertEmptyStringsToNull`, so `username: ''` arrives as `null` — the `blank` constraint never sees an empty string — and nullable-by-default then let the nulls through.

The spec now covers the two constraints as separate features, assigning the blank values directly since that is the only way a blank string actually reaches the property:

```groovy
void 'a user whose username and password are blank is rejected'() {
    given: 'the values are assigned directly, since the map constructor binds an empty string to null'
    User user = new User()
    user.username = ''
    user.password = ''

    expect:
    !user.validate()

    and:
    with(user.errors) {
        getFieldError('username').code == 'blank'
        getFieldError('password').code == 'blank'
    }
}
```

## 2. The mapping directive did not match the data store

The template emitted `table 'users'` for every data implementation, but `table` is a Hibernate directive. On MongoDB it is silently ignored, so the reason it is there — don't name the persistence unit `user`, a reserved word in PostgreSQL, H2 and SQL Server — was lost exactly where nothing warns about it. Reading the embedded MongoDB of a generated app, before and after:

| Directive | Collections created | docs in `users` | docs in `user` |
|---|---|---|---|
| `table 'users'` | `["user.next_id", "user"]` | 0 | 2 |
| `collection 'users'` | `["users.next_id", "users"]` | 2 | 0 |

The directive is now chosen from the selected features, the way `GrailsBase` and `DatabaseMigrationPlugin` already do, rather than from the gorm option — so it holds whether the implementation was picked with `--data` or by naming the feature:

```
@if (features.contains("gorm-mongodb")) {
    static mapping = {
        collection 'users'
    }

} else if (features.contains("gorm-hibernate5") || features.contains("gorm-hibernate7")) {
    static mapping = {
        table 'users'
    }

}
```

Hibernate 5 and 7 keep `table 'users'`, so the default app is unchanged. Neo4j gets no mapping block rather than a directive it does not understand.

## Verification

Generated a real app (`create-app --data mongodb --features spring-boot-starter-security --jdk 25`) and ran it, rather than only asserting on template text:

- `:grails-forge-core:test` — 347 tests, 0 failures
- `grails-forge` `codeStyle` — clean
- Generated app's `UserSpec` — 4/4 pass
- Reverting `nullable: false` and re-running makes the nullable feature fail, so the new spec is not vacuous. The blank feature passes either way — `blank: false` was always correct; the nullable gap was the whole defect.
- Each rendered variant is parsed to `Phases.CONVERSION` to confirm it is valid Groovy; that check caught a swallowed blank line before `static constraints` that the `contains` assertions did not.
- New tests unroll across HIBERNATE5 / HIBERNATE7 / MONGODB, asserting both the expected directive and that the other one does not leak in, plus a Neo4j case asserting no mapping block.

The app was also exercised end to end on embedded MongoDB: `/` anonymous 200, `/user` anonymous redirects to login, form login succeeds, `/user` as `ROLE_ADMIN` 200, `/user` as `ROLE_USER` 403.
