### PR TITLE
Fix params and attrs entries shadowed by bean accessors on Groovy 5

### DIFF
--- a/grails-controllers/src/main/groovy/grails/artefact/Controller.groovy
+++ b/grails-controllers/src/main/groovy/grails/artefact/Controller.groovy
@@ -374,7 +374,7 @@ trait Controller implements ResponseRenderer, ResponseRedirector, RequestForward
                 if (entityIdentifierValue == null) {
                     final GrailsWebRequest webRequest = GrailsWebRequest
                             .lookup(request)
-                    entityIdentifierValue = webRequest?.getParams().getIdentifier()
+                    entityIdentifierValue = webRequest?.getParams()?.get(GormProperties.IDENTITY)
                 }
             }
             if (entityIdentifierValue instanceof String) {

--- a/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
+++ b/grails-core/src/main/groovy/grails/util/AbstractTypeConvertingMap.java
@@ -38,6 +38,23 @@ import org.apache.grails.core.internal.util.TypeConverters;
  * Type converting maps have no inherent ordering. Two maps with identical entries
  * but arranged in a different order internally are considered equal.
  *
+ * <h2>Subclasses must not declare JavaBean accessors</h2>
+ *
+ * A subclass must not declare a no-argument {@code getX()} or {@code isX()} method, because this
+ * class implements {@link Map} and Groovy resolves a JavaBean accessor ahead of the map entry of
+ * the same name. Such an accessor makes the entry {@code x} unreadable through
+ * {@code map.x} and {@code map['x']}, and makes assignment to it fail with
+ * {@code ReadOnlyPropertyException}. It applies to statically compiled callers too: the static
+ * compiler binds to the declared accessor and never reaches {@code getProperty}/{@code setProperty},
+ * so the collision cannot be worked around at runtime.
+ *
+ * Expose such a value under a name that is not a JavaBean accessor - for example
+ * {@code GrailsParameterMap.request()} - or under a method that takes an argument.
+ *
+ * A setter is a weaker case and is allowed: it leaves reads addressing the map, but assignment to
+ * that one name invokes the setter instead of storing an entry, so such an entry must be written
+ * with {@link Map#put}. {@code GroovyPageAttributes.setGspTagSyntaxCall(boolean)} is the only one.
+ *
  * @author Graeme Rocher
  * @author Lari Hotari
  * @since 1.2

--- a/grails-core/src/test/groovy/org/grails/util/TypeConvertingMapTests.groovy
+++ b/grails-core/src/test/groovy/org/grails/util/TypeConvertingMapTests.groovy
@@ -156,6 +156,21 @@ class TypeConvertingMapTests {
         assert toTypeConverting(a: 1, b: 2).hashCode() != ["b": 2, a: 1].hashCode()
     }
 
+    // https://github.com/apache/grails-core/issues/16280
+    // The base class declares no no-argument getX()/isX() accessor, so no key name is shadowed.
+    // Keys named after methods that do exist on the hierarchy are ordinary entries.
+    @Test
+    void testKeysNamedAfterMethodsOnTheHierarchyAreOrdinaryEntries() {
+        def map = toTypeConverting([:])
+
+        ['identifier', 'request', 'gspTagSyntaxCall', 'byte', 'int', 'wrappedMap'].each { String key ->
+            map[key] = "value of $key".toString()
+            assert map[key] == "value of $key".toString()
+            assert map.get(key) == "value of $key".toString()
+            assert map.containsKey(key)
+        }
+    }
+
     protected toTypeConverting(map) {
         new TypeConvertingMap(map)
     }

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -1488,6 +1488,39 @@ def value = configObject.containsKey(key) ? configObject.get(key) : null
 
 Grails applies this guard internally when resolving Spring profile activation keys; you only need it in application code that navigates a raw `ConfigObject` by subscript.
 
+===== 28.3 A getter on a map no longer hides behind a map entry
+
+In Groovy 4, reading or writing a property on a class that implements `Map` always addressed a map entry.
+In Groovy 5 a public JavaBean accessor declared on such a class is resolved first, so an entry whose name matches an accessor becomes unreadable, and assigning to it throws `groovy.lang.ReadOnlyPropertyException`.
+This affected `params`, where `getRequest()` and `getIdentifier()` made request parameters named `request` and `identifier` unreachable.
+
+Grails 8 removes those accessors, so `params` behaves as it did in Grails 7 - every parameter name is an ordinary map entry, in dotted and subscript form, and under static compilation:
+
+[source,groovy]
+----
+params.identifier = 'id1'       // the request parameter, not a property
+params['request'] = 'req1'      // the request parameter, not the HttpServletRequest
+----
+
+Two methods changed as a result:
+
+[cols="1,1", options="header"]
+|===
+| Grails 7
+| Grails 8
+
+| `params.getRequest()`
+| `params.request()`
+
+| `params.getIdentifier()`
+| `params.id` -- it only ever read the `id` parameter
+|===
+
+The same change applies to the `attrs` map passed to a GSP tag, whose internal implementation renames `isGspTagSyntaxCall()` to `gspTagSyntaxCall()`.
+Its setter is retained, so assigning `attrs.gspTagSyntaxCall` still invokes that setter rather than storing an attribute - as in Grails 7. Store an attribute of that name with `attrs.put('gspTagSyntaxCall', value)`.
+
+NOTE: When adding a class that extends `grails.util.TypeConvertingMap`, do not declare a no-argument `getX()` or `isX()` method on it, or the entry `x` becomes unreachable for the same reason. Statically compiled callers bind directly to the accessor, so the collision cannot be corrected at runtime.
+
 ==== 29. MIME Types Are Now Framework Defaults
 
 Grails 8 ships the full set of supported MIME types as built-in framework defaults.

--- a/grails-gsp/grails-taglib/build.gradle
+++ b/grails-gsp/grails-taglib/build.gradle
@@ -84,6 +84,9 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.slf4j:slf4j-nop' // Get rid of warning about missing slf4j implementation during compilation and tests
     testImplementation 'org.spockframework:spock-core'
+    // spock-core supplies the Spock engine, so the specs in this module run without it, but the
+    // plain JUnit 5 tests need the Jupiter engine or they are silently never discovered.
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 apply {

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/GroovyPageAttributes.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/GroovyPageAttributes.java
@@ -47,7 +47,18 @@ public class GroovyPageAttributes extends TypeConvertingMap implements Cloneable
         this.gspTagSyntaxCall = gspTagSyntaxCall;
     }
 
-    public boolean isGspTagSyntaxCall() {
+    /**
+     * Whether the tag was invoked with GSP tag syntax rather than as a method call.
+     *
+     * <p>Deliberately not named {@code isGspTagSyntaxCall()}. This class implements {@link Map},
+     * and a JavaBean accessor on a map shadows the map entry of the same name, which made an
+     * attribute named {@code gspTagSyntaxCall} unreadable. See
+     * {@link grails.util.AbstractTypeConvertingMap} for the rule.
+     *
+     * @return {@code true} when invoked with GSP tag syntax
+     * @since 8.0
+     */
+    public boolean gspTagSyntaxCall() {
         return gspTagSyntaxCall;
     }
 

--- a/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
+++ b/grails-gsp/grails-taglib/src/main/groovy/org/grails/taglib/TagOutput.java
@@ -54,7 +54,7 @@ public class TagOutput {
             throw new GrailsTagException("Tag [" + tagName + "] does not exist. No corresponding tag library found.");
         }
 
-        boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall();
+        boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).gspTagSyntaxCall();
         if (!(attrs instanceof GroovyPageAttributes)) {
             attrs = new GroovyPageAttributes(attrs, false);
         }

--- a/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
+++ b/grails-gsp/grails-taglib/src/test/groovy/org/grails/taglib/GroovyPageAttributesTests.groovy
@@ -18,7 +18,7 @@
  */
 package org.grails.taglib
 
-
+import groovy.transform.CompileStatic
 import org.junit.jupiter.api.Test
 
 import static org.junit.jupiter.api.Assertions.*
@@ -94,7 +94,75 @@ class GroovyPageAttributesTests {
         assert '[one:foo]' == attrs.toString()
     }
 
+    // https://github.com/apache/grails-core/issues/16280
+    // Reading an attribute named after an accessor on this class addresses the map, not the accessor.
+    @Test
+    void testReadingAnAttributeNamedAfterAnAccessorAddressesTheMap() {
+        def attrs = toGroovyPageAttributes([:])
+        attrs.put('gspTagSyntaxCall', 'an attribute value')
+
+        assertEquals 'an attribute value', attrs['gspTagSyntaxCall']
+        assertEquals 'an attribute value', attrs.gspTagSyntaxCall
+        assertTrue attrs.gspTagSyntaxCall()
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testStaticallyCompiledAttributeReadAddressesTheMap() {
+        def attrs = toGroovyPageAttributes([:])
+        StaticallyCompiledAccess.write(attrs, 'an attribute value')
+
+        assertEquals 'an attribute value', attrs['gspTagSyntaxCall']
+        assertEquals 'an attribute value', StaticallyCompiledAccess.readSubscript(attrs)
+        assertEquals 'an attribute value', StaticallyCompiledAccess.readProperty(attrs)
+        assertTrue attrs.gspTagSyntaxCall()
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    // gspTagSyntaxCall keeps a real setter, so assigning that one name invokes the setter rather
+    // than storing an entry - both in dotted and subscript form. That is the Grails 7 behaviour,
+    // and TagOutput and GroovyPage rely on it. Use put() to store an attribute of that name.
+    @Test
+    void testAssigningGspTagSyntaxCallInvokesTheSetter() {
+        def dotted = toGroovyPageAttributes([:])
+        dotted.gspTagSyntaxCall = false
+        assertFalse dotted.gspTagSyntaxCall()
+        assertFalse dotted.containsKey('gspTagSyntaxCall')
+
+        def subscript = toGroovyPageAttributes([:])
+        subscript['gspTagSyntaxCall'] = false
+        assertFalse subscript.gspTagSyntaxCall()
+        assertFalse subscript.containsKey('gspTagSyntaxCall')
+    }
+
+    @Test
+    void testGspTagSyntaxCallDefaultsToTrueAndIsSettable() {
+        def attrs = toGroovyPageAttributes([:])
+        assertTrue attrs.gspTagSyntaxCall()
+
+        attrs.setGspTagSyntaxCall(false)
+        assertFalse attrs.gspTagSyntaxCall()
+
+        assertFalse new GroovyPageAttributes([:], false).gspTagSyntaxCall()
+    }
+
     protected toGroovyPageAttributes(map) {
         new GroovyPageAttributes(map)
+    }
+
+    @CompileStatic
+    static class StaticallyCompiledAccess {
+
+        static void write(GroovyPageAttributes attrs, Object value) {
+            attrs.put('gspTagSyntaxCall', value)
+        }
+
+        static Object readSubscript(GroovyPageAttributes attrs) {
+            attrs['gspTagSyntaxCall']
+        }
+
+        static Object readProperty(GroovyPageAttributes attrs) {
+            attrs.gspTagSyntaxCall
+        }
     }
 }

--- a/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
+++ b/grails-gsp/grails-web-taglib/src/main/groovy/grails/artefact/TagLibrary.groovy
@@ -171,7 +171,7 @@ trait TagLibrary implements WebAttributes, ServletAttributes, TagLibraryInvoker 
                         final String currentNamespace = resolvedNamespace
                         result = { Map attrs = [:], Closure body = null ->
                             Object output = TagOutput.captureTagOutput(gspTagLibraryLookup, currentNamespace, name, attrs, body, OutputContextLookupHelper.lookupOutputContext())
-                            boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).isGspTagSyntaxCall()
+                            boolean gspTagSyntaxCall = attrs instanceof GroovyPageAttributes && ((GroovyPageAttributes) attrs).gspTagSyntaxCall()
                             boolean returnsObject = gspTagLibraryLookup.doesTagReturnObject(currentNamespace, name)
                             if (gspTagSyntaxCall && !returnsObject && output != null) {
                                 OutputEncodingStack.currentStack().taglibWriter.print(output)

--- a/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
+++ b/grails-gsp/plugin/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
@@ -103,7 +103,7 @@ class ValidationTagLib implements TagLibrary {
             messageSource.getMessage("${valueMessagePrefix}.${field}", null, null, request.locale) :
             null
 
-        def tagSyntaxCall = (attrs instanceof GroovyPageAttributes) ? attrs.isGspTagSyntaxCall() : false
+        def tagSyntaxCall = (attrs instanceof GroovyPageAttributes) ? attrs.gspTagSyntaxCall() : false
 
         def rejectedValue = null
         if (valueMessage) {
@@ -298,7 +298,7 @@ class ValidationTagLib implements TagLibrary {
     @CompileStatic
     private def messageImpl(Map attrs) {
         Locale locale = FormatTagLib.resolveLocale(attrs.locale)
-        def tagSyntaxCall = (attrs instanceof GroovyPageAttributes) ? attrs.isGspTagSyntaxCall() : false
+        def tagSyntaxCall = (attrs instanceof GroovyPageAttributes) ? attrs.gspTagSyntaxCall() : false
 
         def text
         Object error = attrs.error ?: attrs.message

--- a/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
+++ b/grails-test-suite-web/src/test/groovy/org/grails/web/commandobjects/CommandObjectInstantiationSpec.groovy
@@ -126,6 +126,56 @@ class CommandObjectInstantiationSpec extends Specification implements Controller
         where:
         requestMethod << ['POST', 'PUT', 'GET', 'DELETE']
     }
+
+    @Issue('https://github.com/apache/grails-core/issues/16280')
+    void 'Test a parameter named identifier does not resolve a domain command object'() {
+        given: 'a saved domain object a request could try to address'
+        def decoy = new DomainClassCommandObject(name: 'Decoy')
+        decoy.save(flush: true)
+
+        expect:
+        decoy.id != null
+
+        when: 'a GET submits only identifier, so the binding source has no id and the id fallback runs'
+        request.method = 'GET'
+        params.identifier = decoy.id
+        controller.domainCommandObject()
+
+        then: 'the identifier parameter is not treated as the entity id'
+        response.status == HttpServletResponse.SC_OK
+        model.commandObject == null
+
+        and: 'and it is still readable as an ordinary request parameter'
+        params['identifier'] == decoy.id
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/16280')
+    void 'Test id wins over a parameter named identifier when resolving a domain command object'() {
+        given:
+        def target = new DomainClassCommandObject(name: 'Target')
+        def decoy = new DomainClassCommandObject(name: 'Decoy')
+        target.save()
+        decoy.save(flush: true)
+
+        expect:
+        target.id != null
+        decoy.id != null
+        target.id != decoy.id
+
+        when:
+        request.method = 'GET'
+        params.id = target.id
+        params.identifier = decoy.id
+        controller.domainCommandObject()
+
+        then:
+        response.status == HttpServletResponse.SC_OK
+        model.commandObject.id == target.id
+        model.commandObject.name == 'Target'
+
+        and:
+        params['identifier'] == decoy.id
+    }
 }
 
 @Artefact('Controller')

--- a/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
+++ b/grails-web-common/src/main/groovy/grails/web/servlet/mvc/GrailsParameterMap.java
@@ -41,7 +41,6 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 
 import grails.databinding.DataBinder;
 import grails.util.TypeConvertingMap;
-import org.grails.datastore.mapping.model.config.GormProperties;
 import org.grails.web.binding.StructuredDateEditor;
 import org.grails.web.servlet.mvc.GrailsWebRequest;
 import org.grails.web.servlet.mvc.exceptions.ControllerExecutionException;
@@ -132,9 +131,17 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
     }
 
     /**
-     * @return Returns the request.
+     * Returns the request this map was populated from.
+     *
+     * <p>Deliberately not named {@code getRequest()}. This class implements {@link Map}, and a
+     * JavaBean accessor on a map shadows the map entry of the same name, which made a request
+     * parameter named {@code request} unreadable and unwritable. See
+     * {@link grails.util.AbstractTypeConvertingMap} for the rule.
+     *
+     * @return the request, never {@code null} for a map created from a request
+     * @since 8.0
      */
-    public HttpServletRequest getRequest() {
+    public HttpServletRequest request() {
         return request;
     }
 
@@ -231,13 +238,6 @@ public class GrailsParameterMap extends TypeConvertingMap implements Cloneable {
             throw new ControllerExecutionException("Unable to convert parameter map [" + this +
                  "] to a query string: " + e.getMessage(), e);
         }
-    }
-
-    /**
-     * @return The identifier in the request
-     */
-    public Object getIdentifier() {
-        return get(GormProperties.IDENTITY);
     }
 
     private String lookupFormat(String name) {

--- a/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
+++ b/grails-web-common/src/test/groovy/grails/web/servlet/mvc/GrailsParameterMapTests.groovy
@@ -18,6 +18,7 @@
  */
 package grails.web.servlet.mvc
 
+import groovy.transform.CompileStatic
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 
@@ -483,5 +484,127 @@ class GrailsParameterMapTests {
         def params = new GrailsParameterMap(request)
         assert '[a.b.c.d:1, a:[b.c.d:1, b:[c.d:1, c:[d:1], e:2], b.e:2], a.b.e:2]' == params.toString()
         assert params != null
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testAddingParametersNamedAfterAnAccessor() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap['identifier'] = 'id1'
+        theMap['request'] = 'req1'
+
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'req1', theMap['request']
+        assertEquals 'id1', theMap.get('identifier')
+        assertEquals 'req1', theMap.get('request')
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testPropertySyntaxForParametersNamedAfterAnAccessor() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        theMap.identifier = 'id1'
+        theMap.request = 'req1'
+
+        assertEquals 'id1', theMap.identifier
+        assertEquals 'req1', theMap.request
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'req1', theMap['request']
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testParametersNamedAfterAnAccessorArrivingFromTheRequest() {
+        mockRequest.addParameter('identifier', 'id1')
+        mockRequest.addParameter('request', 'req1')
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'req1', theMap['request']
+        assertEquals 'id1', theMap.identifier
+        assertEquals 'req1', theMap.request
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testParametersNamedAfterAnAccessorAreAbsentWhenNotSubmitted() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertNull theMap['identifier']
+        assertNull theMap['request']
+        assertNull theMap.identifier
+        assertNull theMap.request
+        assertFalse theMap.containsKey('identifier')
+        assertFalse theMap.containsKey('request')
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    // getProperty/setProperty are runtime hooks the static compiler never reaches, so a colliding
+    // accessor could not be worked around at runtime. This pins that statically compiled access
+    // reaches the map in every form.
+    @Test
+    void testStaticallyCompiledAccessAddressesTheMap() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        StaticallyCompiledAccess.writeSubscript(theMap, 'id1')
+        assertEquals 'id1', theMap['identifier']
+        assertEquals 'id1', StaticallyCompiledAccess.readSubscript(theMap)
+        assertEquals 'id1', StaticallyCompiledAccess.readProperty(theMap)
+
+        StaticallyCompiledAccess.writeProperty(theMap, 'id2')
+        assertEquals 'id2', theMap['identifier']
+        assertEquals 'id2', StaticallyCompiledAccess.readProperty(theMap)
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testTheUnderlyingRequestIsStillReachable() {
+        theMap = new GrailsParameterMap(mockRequest)
+
+        assertSame mockRequest, theMap.request()
+        assertSame mockRequest, StaticallyCompiledAccess.readRequest(theMap)
+
+        theMap['request'] = 'req1'
+        assertSame mockRequest, theMap.request()
+    }
+
+    // https://github.com/apache/grails-core/issues/16280
+    @Test
+    void testRemovingAndCloningParametersNamedAfterAnAccessor() {
+        mockRequest.addParameter('identifier', 'id1')
+        theMap = new GrailsParameterMap(mockRequest)
+
+        def cloned = theMap.clone()
+        assertEquals 'id1', cloned['identifier']
+
+        assertEquals 'id1', theMap.remove('identifier')
+        assertFalse theMap.containsKey('identifier')
+        assertEquals 'id1', cloned['identifier']
+    }
+
+    @CompileStatic
+    static class StaticallyCompiledAccess {
+
+        static void writeSubscript(GrailsParameterMap params, Object value) {
+            params['identifier'] = value
+        }
+
+        static void writeProperty(GrailsParameterMap params, Object value) {
+            params.identifier = value
+        }
+
+        static Object readSubscript(GrailsParameterMap params) {
+            params['identifier']
+        }
+
+        static Object readProperty(GrailsParameterMap params) {
+            params.identifier
+        }
+
+        static HttpServletRequest readRequest(GrailsParameterMap params) {
+            params.request()
+        }
     }
 }

--- a/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/AbstractRequestBodyDataBindingSourceCreator.groovy
+++ b/grails-web-databinding/src/main/groovy/org/grails/web/databinding/bindingsource/AbstractRequestBodyDataBindingSourceCreator.groovy
@@ -74,7 +74,7 @@ abstract class AbstractRequestBodyDataBindingSourceCreator extends DefaultDataBi
     CollectionDataBindingSource createCollectionDataBindingSource(MimeType mimeType, Class bindingTargetType, Object bindingSource) throws DataBindingSourceCreationException {
         try {
             if (bindingSource instanceof GrailsParameterMap) {
-                def req = bindingSource.getRequest()
+                def req = bindingSource.request()
                 def is = req.getInputStream()
                 return createCollectionBindingSource(is, req.getCharacterEncoding())
             }

--- a/grails-web-databinding/src/test/groovy/org/grails/web/databinding/bindingsource/AbstractRequestBodyDataBindingSourceCreatorSpec.groovy
+++ b/grails-web-databinding/src/test/groovy/org/grails/web/databinding/bindingsource/AbstractRequestBodyDataBindingSourceCreatorSpec.groovy
@@ -22,8 +22,8 @@ package org.grails.web.databinding.bindingsource
 import grails.databinding.CollectionDataBindingSource
 import grails.databinding.DataBindingSource
 import grails.databinding.SimpleMapDataBindingSource
-import grails.web.http.HttpHeaders
 import grails.web.mime.MimeType
+import grails.web.servlet.mvc.GrailsParameterMap
 import org.grails.web.servlet.mvc.GrailsWebRequest
 import org.grails.web.util.GrailsApplicationAttributes
 import org.springframework.http.HttpMethod
@@ -32,6 +32,7 @@ import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -59,7 +60,8 @@ class AbstractRequestBodyDataBindingSourceCreatorSpec extends Specification {
 
             @Override
             protected CollectionDataBindingSource createCollectionBindingSource(Reader reader) {
-                return null
+                String body = reader.text
+                return { -> [new SimpleMapDataBindingSource([id: body])] } as CollectionDataBindingSource
             }
         }
     }
@@ -100,6 +102,20 @@ class AbstractRequestBodyDataBindingSourceCreatorSpec extends Specification {
         "request"      | build("PUT", null)
         "url"          | build("PUT", "")
         "request"      | build("PUT", "x")
+    }
+
+    @Issue('https://github.com/apache/grails-core/issues/16280')
+    void "test a collection binding source built from a GrailsParameterMap reads the request body"() {
+        given: 'a parameter map over a request whose body carries the binding source'
+        MockHttpServletRequest request = build('POST', 'from the body')
+        GrailsParameterMap params = new GrailsParameterMap(request)
+
+        when: 'the creator resolves the underlying request through request()'
+        CollectionDataBindingSource source = bindingSourceCreator
+                .createCollectionDataBindingSource(MimeType.ALL, Object, params)
+
+        then:
+        source.dataBindingSources*.identifierValue == ['from the body']
     }
 }
 


### PR DESCRIPTION
Fixes #16280
Supersedes #16281

## Root cause

The issue and #16281 both attributed this to a change in `DefaultGroovyMethods` overload selection. That is not what happened — the `getAt`/`putAt` signatures are byte-identical in Groovy 4.0.33 and 5.1.0, and selection among them did not change.

The change is inside `MetaClassImpl`, for classes that implement `Map`:

| | Groovy 4.0.33 | Groovy 5.1.0 |
|---|---|---|
| `getProperty` | `if (isMap && !isStatic) return ((Map) object).get(name);` — unconditionally, before any getter lookup | getter lookup runs first; the map `get` is only reached when there is no visible public getter |
| `setProperty` | setter if one exists, **else** `((Map) object).put(name, newValue)` | the map-`put` branch is guarded by `(mp == null \|\| !mp.isPublic() \|\| isSpecialProperty(name))`, so a public getter-only bean property falls through to `throw new ReadOnlyPropertyException` |

So the trigger is simply: **a public JavaBean accessor on a `Map` implementation now shadows the map entry of the same name.** The subscript form reaches the same code via `DefaultGroovyMethods.putAt(Object, String, Object)` → `InvokerHelper.setProperty`.

`GrailsParameterMap` declared `getRequest()` and `getIdentifier()`, which is why request parameters named `request` and `identifier` became unreadable and threw on assignment.

## Fix

Remove the colliding accessors. With no bean accessor of that name, Groovy 5 reaches the map on every path:

- dynamic — `getProperty` → `method == null` → `isMap` → `Map.get`; `setProperty` → `mp == null` → `Map.put`
- `@CompileStatic` — `StaticTypeCheckingVisitor.getTypeForMapPropertyExpression` types it as a map entry and `StaticTypesCallSiteWriter` emits `Map.get` / `Map.put`
- subscript, both modes — DGM `getAt`/`putAt` land on the same `get`/`put`

The whole production change is two methods renamed, one deleted, and five call sites. No `getProperty`, `setProperty`, `getAt` or `putAt` override.

### Why not the metaclass overrides in #16281

#16281 kept the accessors and overrode `getProperty`/`setProperty`/`getAt`/`putAt` on `AbstractTypeConvertingMap`. That cannot reach statically compiled call sites. In `StaticTypesCallSiteWriter`, `makeGetPropertyWithGetter(...)` is tried **before** `writeMapDotProperty(...)`, and the mutator loop runs before the `Map.put` branch — so `@CompileStatic` binds to the declared accessor and never consults the metaclass hooks. #16281 had to document that as a limitation. It also regressed `attrs.gspTagSyntaxCall = false` from "invoke the setter" (Grails 7) to "write a map entry".

The same reasoning rules out an annotation plus AST transform: a local transform on the map class can only generate those same runtime hooks, and the static compiler at the *call site* still binds to the declared getter. It would add public API without fixing the static half.

Thanks to @jdaugherty, whose review on #16281 established both of those points and redirected this to restoring the behaviour rather than documenting around it.

## API changes

| Grails 7 | Grails 8 |
|---|---|
| `params.getRequest()` | `params.request()` |
| `params.getIdentifier()` | `params.id` — it only ever read the `id` parameter |
| `GroovyPageAttributes.isGspTagSyntaxCall()` | `gspTagSyntaxCall()` (internal class) |

`getRequest()` gained a non-bean replacement rather than being deleted, because there is a real caller: `AbstractRequestBodyDataBindingSourceCreator` reads the request body from a `GrailsParameterMap` binding source. `getIdentifier()` had exactly one caller in the monorepo (`Controller.groovy`), now reading `GormProperties.IDENTITY` directly, so the `id`-only semantics are unchanged.

`setGspTagSyntaxCall(boolean)` is deliberately retained. A write-only property reproduces Grails 7 exactly — the read addresses the map, the assignment invokes the setter — which avoids the regression #16281 introduced. `TagOutput` and `GroovyPage` rely on that setter.

`AbstractTypeConvertingMap` gains a javadoc statement of the invariant so this does not recur: a subclass must not declare a no-argument `getX()`/`isX()`, because such an accessor cannot be worked around at runtime.

## Tests

- `GrailsParameterMapTests` — 7 new cases: `identifier` and `request` via subscript and dotted syntax, values arriving from the request, absent keys reading `null`, `remove`/`clone`, `request()` still reachable, and a `@CompileStatic` helper pinning statically compiled read *and* write in both forms.
- `GroovyPageAttributesTests` — 4 new cases covering the `attrs` side, including the static read and the setter-parity case.
- `TypeConvertingMapTests` — one case at the base-class level.
- `CommandObjectInstantiationSpec` — a request submitting **only** `identifier` (no `id`), so `SimpleMapDataBindingSource.getIdentifierValue()` returns null and the `Controller` fallback actually runs. This is the shape @jdaugherty asked for; the earlier version passed regardless of `getIdentifier()`.
- `AbstractRequestBodyDataBindingSourceCreatorSpec` — covers the `GrailsParameterMap` branch that now calls `request()`.

Every new test was mutation-checked. Reinstating the accessors makes `GrailsParameterMapTests` fail to **compile** with `Cannot set read-only property: identifier` — the exact static error #16281 documented — and with that one case removed so the file compiles, all 7 dynamic cases fail. Reinstating `isGspTagSyntaxCall()` fails the two `attrs` read cases. Pointing the `Controller` fallback at `identifier` fails the command-object spec on `model.commandObject == null`, the resolution itself.

### Build fix

`grails-taglib` had no `junit-jupiter-engine` on its test runtime classpath. Its Spock specs ran (spock-core brings its own engine), but `GroovyPageAttributesTests` — the module's only plain JUnit 5 class — was never discovered. Added, module-local; the convention-level fix is tracked in #16289.

## Documentation

`upgrading80x.adoc` §28.3 — the Groovy 5 change, the restored rule, and the two method renames. No caveat section is needed any more, because `params` is uniformly a map again in both compilation modes.
