### PR TITLE
Fix marshalling of non-public classes and Serializable beans

### DIFF
--- a/grails-common/src/main/groovy/org/apache/grails/common/reflect/ReflectionUtils.java
+++ b/grails-common/src/main/groovy/org/apache/grails/common/reflect/ReflectionUtils.java
@@ -78,20 +78,20 @@ public final class ReflectionUtils {
     /**
      * Resolves a read method that can actually be invoked on {@code target}.
      *
-     * <p>Where the property is declared by an interface, the interface method is returned: it is
-     * declared by an accessible type, and virtual dispatch still reaches the implementation. Where
-     * it is not -- a non-public class with no interface declaring the getter -- a private copy of
-     * the method is widened, so that the accessibility flag cannot leak into a {@code Method}
-     * instance shared through a descriptor cache.
+     * <p>Where an equivalent method is declared by a public type anywhere in the hierarchy -- an
+     * interface or a superclass -- that one is returned: it is declared by an accessible type, and
+     * virtual dispatch still reaches the override. Only where there is no such type does the method
+     * need help, and then a private copy is widened, so that the accessibility flag cannot leak
+     * into a {@code Method} instance shared through a descriptor cache.
      *
      * @param readMethod  the property's read method, typically from a {@code PropertyDescriptor}
-     * @param targetClass the class being read, used to resolve the interface method
+     * @param targetClass the class being read, used to resolve the publicly accessible method
      * @param target      the instance being read, or {@code null} for a static read method
      * @return a method that may be invoked on {@code target}
      */
     public static Method resolveInvokableReadMethod(Method readMethod, Class<?> targetClass, @Nullable Object target)
             throws NoSuchMethodException {
-        Method invokable = ClassUtils.getInterfaceMethodIfPossible(readMethod, targetClass);
+        Method invokable = ClassUtils.getPubliclyAccessibleMethodIfPossible(readMethod, targetClass);
         if (canAccess(invokable, target)) {
             return invokable;
         }
@@ -151,10 +151,10 @@ public final class ReflectionUtils {
             return false;
         }
         if (LOG.isWarnEnabled()) {
-            LOG.warn("Class [{}] is not public, so its properties can only be read by widening access reflectively. " +
-                            "Declare the class public - as a named class rather than an anonymous one where " +
-                            "necessary - so that it reads as a standard JavaBean. This handling may be withdrawn in " +
-                            "a future major release. To silence this, set the log level of [{}] above WARN. " +
+            LOG.warn("Class [{}] is not public. Grails reads its properties through compatibility handling that may " +
+                            "be withdrawn in a future major release. Declare it as a named public class so that it " +
+                            "reads as a standard JavaBean, or register an ObjectMarshaller for it if the class is " +
+                            "not yours. To silence this, set the log level of [{}] above WARN. " +
                             "(warned once per class)",
                     clazz.getName(), LOG.getName());
         }

--- a/grails-common/src/main/groovy/org/apache/grails/common/reflect/ReflectionUtils.java
+++ b/grails-common/src/main/groovy/org/apache/grails/common/reflect/ReflectionUtils.java
@@ -1,0 +1,196 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InaccessibleObjectException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * Reads the properties of a bean whose class is not {@code public}.
+ *
+ * <p>A class that is not public -- anonymous, local, or package-private -- cannot have its read
+ * methods invoked from another package even when the methods themselves are public, so reflection
+ * over such a bean needs help. Groovy 4 stamped {@code ACC_PUBLIC} on anonymous inner classes and
+ * Groovy 5 does not, which is why beans of that shape reach the framework at all.
+ *
+ * <p>This compatibility handling is deliberately visible: {@link #warnOnNonPublicClass} reports the
+ * class once so an application can be corrected, and so the handling can be withdrawn if the
+ * compiler stops producing non-public classes for this shape.
+ *
+ * @since 8.0.0
+ */
+public final class ReflectionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReflectionUtils.class);
+
+    /** Best-effort upper bound, so that generated class names cannot grow the set without limit. */
+    private static final int MAX_WARNED_CLASSES = 1024;
+
+    /**
+     * Keyed by class name rather than by {@link Class}, so that reporting a class never retains its
+     * class loader. A reload therefore does not report the same class again, which is intended: a
+     * reload loop would otherwise repeat every warning.
+     */
+    private static final Set<String> WARNED_NON_PUBLIC_CLASSES = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Packages whose classes an application cannot declare public itself, so reporting them would
+     * only be noise. {@code java.util.KeyValueHolder}, handed out by {@code Map.entry}, is the one
+     * that turns up in practice.
+     *
+     * <p>The {@code grails} packages are deliberately absent: a framework class reaching this code
+     * is worth seeing, and the tests declare their fixtures under {@code org.grails}.
+     */
+    private static final String[] NON_APPLICATION_PACKAGES = {
+        "java.", "javax.", "jakarta.", "groovy.", "org.apache.groovy.", "org.codehaus.groovy.",
+        "org.springframework."
+    };
+
+    private ReflectionUtils() {
+    }
+
+    /**
+     * Resolves a read method that can actually be invoked on {@code target}.
+     *
+     * <p>Where the property is declared by an interface, the interface method is returned: it is
+     * declared by an accessible type, and virtual dispatch still reaches the implementation. Where
+     * it is not -- a non-public class with no interface declaring the getter -- a private copy of
+     * the method is widened, so that the accessibility flag cannot leak into a {@code Method}
+     * instance shared through a descriptor cache.
+     *
+     * @param readMethod  the property's read method, typically from a {@code PropertyDescriptor}
+     * @param targetClass the class being read, used to resolve the interface method
+     * @param target      the instance being read, or {@code null} for a static read method
+     * @return a method that may be invoked on {@code target}
+     */
+    public static Method resolveInvokableReadMethod(Method readMethod, Class<?> targetClass, @Nullable Object target)
+            throws NoSuchMethodException {
+        Method invokable = ClassUtils.getInterfaceMethodIfPossible(readMethod, targetClass);
+        if (canAccess(invokable, target)) {
+            return invokable;
+        }
+        // getDeclaredMethod cannot fail here: invokable was resolved from this very class's methods.
+        Method widened = invokable.getDeclaringClass()
+                .getDeclaredMethod(invokable.getName(), invokable.getParameterTypes());
+        widened.setAccessible(true);
+        return widened;
+    }
+
+    /**
+     * Makes an instance field readable, widening it only when it is not readable already.
+     *
+     * <p>The field is expected to have come from {@link Class#getDeclaredFields}, which hands out a
+     * fresh copy on every call, so widening it is confined to the caller's own copy.
+     *
+     * @param field an instance field
+     * @param target the instance being read
+     * @return {@code false} when the field cannot be read, in which case the caller should skip it
+     *         rather than fail the whole read
+     */
+    public static boolean tryMakeReadable(Field field, @Nullable Object target) {
+        if (canAccess(field, target)) {
+            return true;
+        }
+        try {
+            field.setAccessible(true);
+            return true;
+        }
+        catch (InaccessibleObjectException | SecurityException e) {
+            // The declaring class is in a named module that does not open its package to us
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Cannot read field [{}] of [{}]: {}",
+                        field.getName(), field.getDeclaringClass().getName(), e.getMessage());
+            }
+            return false;
+        }
+    }
+
+    /**
+     * Reports {@code clazz} if it is not public, at most once per class.
+     *
+     * <p>Synthetic classes and classes from the JDK, Groovy and Spring are not reported: they are
+     * not written by the application whose log this is, so nobody reading it can act on them.
+     *
+     * <p>The bookkeeping deliberately runs before the log level is consulted, so that "once" does
+     * not depend on how logging happens to be configured.
+     *
+     * @return whether this call was the one that reported the class
+     */
+    public static boolean warnOnNonPublicClass(@Nullable Class<?> clazz) {
+        if (clazz == null || Modifier.isPublic(clazz.getModifiers()) || !isApplicationClass(clazz)) {
+            return false;
+        }
+        if (WARNED_NON_PUBLIC_CLASSES.size() >= MAX_WARNED_CLASSES ||
+                !WARNED_NON_PUBLIC_CLASSES.add(clazz.getName())) {
+            return false;
+        }
+        if (LOG.isWarnEnabled()) {
+            LOG.warn("Class [{}] is not public, so its properties can only be read by widening access reflectively. " +
+                            "Declare the class public - as a named class rather than an anonymous one where " +
+                            "necessary - so that it reads as a standard JavaBean. This handling may be withdrawn in " +
+                            "a future major release. To silence this, set the log level of [{}] above WARN. " +
+                            "(warned once per class)",
+                    clazz.getName(), LOG.getName());
+        }
+        return true;
+    }
+
+    /**
+     * Forgets which classes have been reported. Intended for tests, which would otherwise depend on
+     * whether another test in the same JVM reported the same class first.
+     */
+    public static void resetWarnedClasses() {
+        WARNED_NON_PUBLIC_CLASSES.clear();
+    }
+
+    /**
+     * {@code canAccess} rejects a non-null instance for a static member, which a caller iterating
+     * property descriptors or declared fields should not have to know.
+     */
+    private static boolean canAccess(Method method, @Nullable Object target) {
+        return method.canAccess(Modifier.isStatic(method.getModifiers()) ? null : target);
+    }
+
+    private static boolean canAccess(Field field, @Nullable Object target) {
+        return field.canAccess(Modifier.isStatic(field.getModifiers()) ? null : target);
+    }
+
+    private static boolean isApplicationClass(Class<?> clazz) {
+        if (clazz.isSynthetic()) {
+            return false;
+        }
+        String name = clazz.getName();
+        for (String prefix : NON_APPLICATION_PACKAGES) {
+            if (name.startsWith(prefix)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/ReflectionUtilsSpec.groovy
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/ReflectionUtilsSpec.groovy
@@ -1,0 +1,137 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect
+
+import java.beans.Introspector
+import java.beans.PropertyDescriptor
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+
+import org.apache.grails.common.reflect.beans.PublicFieldBean
+import org.apache.grails.common.reflect.beans.PublicThing
+import org.apache.grails.common.reflect.beans.ThingFactory
+
+import spock.lang.Specification
+
+/**
+ * Covers reading a bean whose class is not public. The fixtures deliberately live in another
+ * package: in this one the JVM access check passes and nothing would need widening.
+ */
+class ReflectionUtilsSpec extends Specification {
+
+    void setup() {
+        ReflectionUtils.resetWarnedClasses()
+    }
+
+    void cleanup() {
+        ReflectionUtils.resetWarnedClasses()
+    }
+
+    private static Method readMethodOf(Object bean, String property) {
+        PropertyDescriptor descriptor = Introspector.getBeanInfo(bean.getClass()).propertyDescriptors
+                .find { it.name == property }
+        descriptor.readMethod
+    }
+
+    void 'a read method declared by a public interface needs no widening'() {
+        given:
+        def thing = ThingFactory.anonymousThing('thing')
+        Method readMethod = readMethodOf(thing, 'name')
+
+        when:
+        Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
+
+        then: 'the interface declares it, so it is invokable as it stands'
+            invokable.declaringClass == PublicThing
+            invokable.invoke(thing) == 'thing'
+    }
+
+    void 'a read method with no accessible declaring type is widened on a copy'() {
+        given: 'a package-private class implementing nothing, so there is nowhere to resolve to'
+        def thing = ThingFactory.standaloneThing('thing')
+        Method readMethod = readMethodOf(thing, 'name')
+
+        expect: 'it cannot be invoked from this package to begin with'
+            !readMethod.canAccess(thing)
+
+        when:
+        Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
+
+        then:
+            invokable.invoke(thing) == 'thing'
+
+        and: 'the method handed in was left alone, so a shared descriptor cache keeps its own flag'
+            !invokable.is(readMethod)
+            !readMethod.canAccess(thing)
+    }
+
+    void 'a covariant read method resolves to the override rather than the bridge'() {
+        given:
+        def thing = ThingFactory.covariantThing('value')
+        Method readMethod = readMethodOf(thing, 'value')
+
+        when:
+        Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
+
+        then:
+            invokable.invoke(thing) == 'value'
+            !invokable.bridge
+    }
+
+    void 'a field that is already readable is not widened'() {
+        given:
+        def bean = new PublicFieldBean('label')
+        Field field = PublicFieldBean.getDeclaredField('label')
+
+        expect:
+            field.canAccess(bean)
+            ReflectionUtils.tryMakeReadable(field, bean)
+            field.get(bean) == 'label'
+    }
+
+    void 'a class that is not public is reported exactly once'() {
+        given:
+        Class<?> beanClass = ThingFactory.standaloneThing('thing').getClass()
+
+        expect: 'the first call reports it and the second finds it already reported'
+            ReflectionUtils.warnOnNonPublicClass(beanClass)
+            !ReflectionUtils.warnOnNonPublicClass(beanClass)
+
+        when:
+        ReflectionUtils.resetWarnedClasses()
+
+        then: 'the reset is what tests rely on to be independent of each other'
+            ReflectionUtils.warnOnNonPublicClass(beanClass)
+    }
+
+    void 'a public class is not reported'() {
+        expect:
+            !ReflectionUtils.warnOnNonPublicClass(PublicFieldBean)
+    }
+
+    void 'a class the application could not have declared public is not reported'() {
+        expect: 'java.util.KeyValueHolder is not public, but nobody reading the log can act on it'
+            !Modifier.isPublic(Map.entry('a', 'b').getClass().modifiers)
+            !ReflectionUtils.warnOnNonPublicClass(Map.entry('a', 'b').getClass())
+
+        and:
+            !ReflectionUtils.warnOnNonPublicClass(null)
+    }
+}

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/ReflectionUtilsSpec.groovy
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/ReflectionUtilsSpec.groovy
@@ -18,12 +18,14 @@
  */
 package org.apache.grails.common.reflect
 
-import java.beans.Introspector
 import java.beans.PropertyDescriptor
 import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
+import org.springframework.beans.BeanUtils
+
+import org.apache.grails.common.reflect.beans.PublicCovariantBase
 import org.apache.grails.common.reflect.beans.PublicFieldBean
 import org.apache.grails.common.reflect.beans.PublicThing
 import org.apache.grails.common.reflect.beans.ThingFactory
@@ -44,8 +46,13 @@ class ReflectionUtilsSpec extends Specification {
         ReflectionUtils.resetWarnedClasses()
     }
 
+    /**
+     * Takes the read method the way the marshallers do. {@code java.beans.Introspector} pre-resolves
+     * a getter to its publicly accessible declaration, which would leave these features asserting
+     * nothing, so this asks Spring for the declaring-class method instead.
+     */
     private static Method readMethodOf(Object bean, String property) {
-        PropertyDescriptor descriptor = Introspector.getBeanInfo(bean.getClass()).propertyDescriptors
+        PropertyDescriptor descriptor = BeanUtils.getPropertyDescriptors(bean.getClass())
                 .find { it.name == property }
         descriptor.readMethod
     }
@@ -55,11 +62,15 @@ class ReflectionUtilsSpec extends Specification {
         def thing = ThingFactory.anonymousThing('thing')
         Method readMethod = readMethodOf(thing, 'name')
 
+        expect: 'the method as declared by the anonymous class cannot be invoked from here'
+            !readMethod.canAccess(thing)
+
         when:
         Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
 
-        then: 'the interface declares it, so it is invokable as it stands'
+        then: 'the interface declares it, so nothing has to be widened'
             invokable.declaringClass == PublicThing
+            invokable.canAccess(thing)
             invokable.invoke(thing) == 'thing'
     }
 
@@ -82,17 +93,43 @@ class ReflectionUtilsSpec extends Specification {
             !readMethod.canAccess(thing)
     }
 
-    void 'a covariant read method resolves to the override rather than the bridge'() {
-        given:
+    void 'a read method declared by a public superclass needs no widening either'() {
+        given: 'a package-private class covariantly overriding a public superclass method'
         def thing = ThingFactory.covariantThing('value')
         Method readMethod = readMethodOf(thing, 'value')
+
+        expect:
+            !readMethod.canAccess(thing)
+
+        when:
+        Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
+
+        then: 'the superclass declaration is accessible, and dispatch still reaches the override'
+            invokable.declaringClass == PublicCovariantBase
+            invokable.canAccess(thing)
+            invokable.invoke(thing) == 'value'
+
+        and: 'so the method handed in was left alone'
+            !readMethod.canAccess(thing)
+    }
+
+    void 'a covariant read method with no public declaring type resolves to the override, not the bridge'() {
+        given: 'nothing public anywhere in the hierarchy, so the copy has to be widened'
+        def thing = ThingFactory.hiddenCovariantThing('tag')
+        Method readMethod = readMethodOf(thing, 'tag')
+
+        expect:
+            !readMethod.canAccess(thing)
 
         when:
         Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, thing.getClass(), thing)
 
         then:
-            invokable.invoke(thing) == 'value'
+            invokable.invoke(thing) == 'tag'
             !invokable.bridge
+
+        and:
+            !readMethod.canAccess(thing)
     }
 
     void 'a field that is already readable is not widened'() {

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicCovariantBase.java
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicCovariantBase.java
@@ -1,0 +1,25 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect.beans;
+
+/** Declares the property as {@code Object}, so a covariant override generates a bridge method. */
+public abstract class PublicCovariantBase {
+
+    public abstract Object getValue();
+}

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicFieldBean.java
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicFieldBean.java
@@ -1,0 +1,31 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect.beans;
+
+/** A public class with a public field, which needs no widening to be read. */
+public class PublicFieldBean {
+
+    public static final String KIND = "bean";
+
+    public final String label;
+
+    public PublicFieldBean(String label) {
+        this.label = label;
+    }
+}

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicThing.java
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/PublicThing.java
@@ -1,0 +1,25 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect.beans;
+
+/** A public interface, so that an implementation's read method has an accessible declaring type. */
+public interface PublicThing {
+
+    String getName();
+}

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/ThingFactory.java
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/ThingFactory.java
@@ -48,6 +48,15 @@ public final class ThingFactory {
     public static Object covariantThing(String value) {
         return new CovariantThing(value);
     }
+
+    /**
+     * @return a covariant override with no public type anywhere in its hierarchy, so the read method
+     *         cannot be resolved to an accessible declaration and has to be widened. This is the
+     *         only shape that reaches the override-versus-bridge choice.
+     */
+    public static Object hiddenCovariantThing(String tag) {
+        return new HiddenCovariantThing(tag);
+    }
 }
 
 class StandaloneThing {
@@ -74,5 +83,24 @@ class CovariantThing extends PublicCovariantBase {
     @Override
     public String getValue() {
         return value;
+    }
+}
+
+abstract class HiddenCovariantBase {
+
+    public abstract Object getTag();
+}
+
+class HiddenCovariantThing extends HiddenCovariantBase {
+
+    private final String tag;
+
+    HiddenCovariantThing(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public String getTag() {
+        return tag;
     }
 }

--- a/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/ThingFactory.java
+++ b/grails-common/src/test/groovy/org/apache/grails/common/reflect/beans/ThingFactory.java
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.grails.common.reflect.beans;
+
+/**
+ * Hands out beans whose classes are not public. They live in a different package from
+ * {@code ReflectionUtils} on purpose: in the same package the JVM access check passes and none of
+ * these shapes would need widening at all.
+ */
+public final class ThingFactory {
+
+    private ThingFactory() {
+    }
+
+    /** An anonymous implementation of a public interface. */
+    public static PublicThing anonymousThing(final String name) {
+        return new PublicThing() {
+
+            @Override
+            public String getName() {
+                return name;
+            }
+        };
+    }
+
+    /** A package-private class that implements nothing, so a read has nowhere to resolve to. */
+    public static Object standaloneThing(String name) {
+        return new StandaloneThing(name);
+    }
+
+    /** A package-private class overriding a public method covariantly, so javac emits a bridge. */
+    public static Object covariantThing(String value) {
+        return new CovariantThing(value);
+    }
+}
+
+class StandaloneThing {
+
+    private final String name;
+
+    StandaloneThing(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}
+
+class CovariantThing extends PublicCovariantBase {
+
+    private final String value;
+
+    CovariantThing(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
@@ -25,6 +25,8 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import grails.converters.JSON;
 import grails.persistence.PersistenceMethod;
@@ -64,14 +66,17 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Object value = readMethod.invoke(o, (Object[]) null);
+                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
+                    ReflectionUtils.makeAccessible(invokableMethod);
+                    Object value = invokableMethod.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);
                 }
             }
             for (Field field : o.getClass().getDeclaredFields()) {
                 int modifiers = field.getModifiers();
-                if (field.canAccess(o) && Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers))) {
+                if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) &&
+                        !field.isSynthetic() && field.canAccess(o)) {
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
                     writer.key(field.getName());

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import grails.converters.JSON;
 import grails.persistence.PersistenceMethod;
@@ -67,7 +66,11 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    ReflectionUtils.makeAccessible(invokableMethod);
+                    if (!invokableMethod.canAccess(o)) {
+                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
+                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
+                        invokableMethod.setAccessible(true);
+                    }
                     Object value = invokableMethod.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GenericJavaBeanMarshaller.java
@@ -25,11 +25,11 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.util.ClassUtils;
 
 import grails.converters.JSON;
 import grails.persistence.PersistenceMethod;
 import grails.web.controllers.ControllerMethod;
+import org.apache.grails.common.reflect.ReflectionUtils;
 import org.grails.core.util.IncludeExcludeSupport;
 import org.grails.web.converters.exceptions.ConverterException;
 import org.grails.web.converters.marshaller.IncludeExcludePropertyMarshaller;
@@ -52,6 +52,7 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
         List<String> excludes = json.getExcludes(clazz);
         List<String> includes = json.getIncludes(clazz);
         IncludeExcludeSupport<String> includeExcludeSupport = new IncludeExcludeSupport<>();
+        ReflectionUtils.warnOnNonPublicClass(clazz);
 
         try {
             writer.object();
@@ -65,13 +66,8 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    if (!invokableMethod.canAccess(o)) {
-                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
-                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
-                        invokableMethod.setAccessible(true);
-                    }
-                    Object value = invokableMethod.invoke(o, (Object[]) null);
+                    Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, clazz, o);
+                    Object value = invokable.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);
                 }
@@ -79,9 +75,10 @@ public class GenericJavaBeanMarshaller extends IncludeExcludePropertyMarshaller<
             for (Field field : o.getClass().getDeclaredFields()) {
                 int modifiers = field.getModifiers();
                 if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) &&
-                        !field.isSynthetic() && field.canAccess(o)) {
+                        !field.isSynthetic()) {
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
+                    if (!ReflectionUtils.tryMakeReadable(field, o)) continue;
                     writer.key(field.getName());
                     json.convertAnother(field.get(o));
                 }

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
@@ -27,6 +27,8 @@ import java.util.List;
 import groovy.lang.GroovyObject;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import grails.converters.JSON;
 import grails.persistence.PersistenceMethod;
@@ -66,16 +68,19 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Object value = readMethod.invoke(o, (Object[]) null);
+                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
+                    ReflectionUtils.makeAccessible(invokableMethod);
+                    Object value = invokableMethod.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);
                 }
             }
             for (Field field : clazz.getDeclaredFields()) {
                 int modifiers = field.getModifiers();
-                if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers))) {
+                if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) && !field.isSynthetic()) {
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
+                    ReflectionUtils.makeAccessible(field);
                     writer.key(name);
                     json.convertAnother(field.get(o));
                 }

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
@@ -27,12 +27,11 @@ import java.util.List;
 import groovy.lang.GroovyObject;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import grails.converters.JSON;
 import grails.persistence.PersistenceMethod;
 import grails.web.controllers.ControllerMethod;
+import org.apache.grails.common.reflect.ReflectionUtils;
 import org.grails.core.util.IncludeExcludeSupport;
 import org.grails.web.converters.exceptions.ConverterException;
 import org.grails.web.converters.marshaller.IncludeExcludePropertyMarshaller;
@@ -55,6 +54,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
         List<String> excludes = json.getExcludes(clazz);
         List<String> includes = json.getIncludes(clazz);
         IncludeExcludeSupport<String> includeExcludeSupport = new IncludeExcludeSupport<>();
+        ReflectionUtils.warnOnNonPublicClass(clazz);
         try {
             writer.object();
             for (PropertyDescriptor property : BeanUtils.getPropertyDescriptors(clazz)) {
@@ -68,13 +68,8 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    if (!invokableMethod.canAccess(o)) {
-                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
-                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
-                        invokableMethod.setAccessible(true);
-                    }
-                    Object value = invokableMethod.invoke(o, (Object[]) null);
+                    Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, clazz, o);
+                    Object value = invokable.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);
                 }
@@ -84,7 +79,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
                 if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) && !field.isSynthetic()) {
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
-                    ReflectionUtils.makeAccessible(field);
+                    if (!ReflectionUtils.tryMakeReadable(field, o)) continue;
                     writer.key(name);
                     json.convertAnother(field.get(o));
                 }

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/json/GroovyBeanMarshaller.java
@@ -69,7 +69,11 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<JSON>
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    ReflectionUtils.makeAccessible(invokableMethod);
+                    if (!invokableMethod.canAccess(o)) {
+                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
+                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
+                        invokableMethod.setAccessible(true);
+                    }
                     Object value = invokableMethod.invoke(o, (Object[]) null);
                     writer.key(name);
                     json.convertAnother(value);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import grails.converters.XML;
 import org.grails.web.converters.exceptions.ConverterException;
@@ -46,7 +48,9 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null) {
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
-                    Object value = readMethod.invoke(o, (Object[]) null);
+                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, o.getClass());
+                    ReflectionUtils.makeAccessible(invokableMethod);
+                    Object value = invokableMethod.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);
                     xml.end();
@@ -54,8 +58,9 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
             }
             for (Field field : o.getClass().getDeclaredFields()) {
                 int modifiers = field.getModifiers();
-                if (field.canAccess(o) && Modifier.isPublic(modifiers) &&
-                        !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers))) {
+                if (Modifier.isPublic(modifiers) &&
+                        !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) &&
+                        !field.isSynthetic() && field.canAccess(o)) {
                     xml.startNode(field.getName());
                     xml.convertAnother(field.get(o));
                     xml.end();

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Modifier;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import grails.converters.XML;
 import org.grails.web.converters.exceptions.ConverterException;
@@ -49,7 +48,11 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
                 if (readMethod != null) {
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, o.getClass());
-                    ReflectionUtils.makeAccessible(invokableMethod);
+                    if (!invokableMethod.canAccess(o)) {
+                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
+                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
+                        invokableMethod.setAccessible(true);
+                    }
                     Object value = invokableMethod.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GenericJavaBeanMarshaller.java
@@ -24,9 +24,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.util.ClassUtils;
 
 import grails.converters.XML;
+import org.apache.grails.common.reflect.ReflectionUtils;
 import org.grails.web.converters.exceptions.ConverterException;
 import org.grails.web.converters.marshaller.ObjectMarshaller;
 
@@ -42,18 +42,14 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
 
     public void marshalObject(Object o, XML xml) throws ConverterException {
         try {
+            ReflectionUtils.warnOnNonPublicClass(o.getClass());
             for (PropertyDescriptor property : BeanUtils.getPropertyDescriptors(o.getClass())) {
                 String name = property.getName();
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null) {
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
-                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, o.getClass());
-                    if (!invokableMethod.canAccess(o)) {
-                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
-                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
-                        invokableMethod.setAccessible(true);
-                    }
-                    Object value = invokableMethod.invoke(o, (Object[]) null);
+                    Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, o.getClass(), o);
+                    Object value = invokable.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);
                     xml.end();
@@ -63,7 +59,8 @@ public class GenericJavaBeanMarshaller implements ObjectMarshaller<XML> {
                 int modifiers = field.getModifiers();
                 if (Modifier.isPublic(modifiers) &&
                         !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) &&
-                        !field.isSynthetic() && field.canAccess(o)) {
+                        !field.isSynthetic()) {
+                    if (!ReflectionUtils.tryMakeReadable(field, o)) continue;
                     xml.startNode(field.getName());
                     xml.convertAnother(field.get(o));
                     xml.end();

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
@@ -27,6 +27,8 @@ import java.util.List;
 import groovy.lang.GroovyObject;
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import grails.converters.XML;
 import grails.persistence.Entity;
@@ -66,7 +68,9 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Object value = readMethod.invoke(o, (Object[]) null);
+                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
+                    ReflectionUtils.makeAccessible(invokableMethod);
+                    Object value = invokableMethod.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);
                     xml.end();
@@ -74,10 +78,11 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
             }
             for (Field field : o.getClass().getDeclaredFields()) {
                 int modifiers = field.getModifiers();
-                if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers))) {
+                if (Modifier.isPublic(modifiers) && !(Modifier.isStatic(modifiers) || Modifier.isTransient(modifiers)) && !field.isSynthetic()) {
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
                     if (isEntity && (name.equals(GormProperties.ATTACHED) || name.equals(GormProperties.ERRORS))) continue;
+                    ReflectionUtils.makeAccessible(field);
                     xml.startNode(name);
                     xml.convertAnother(field.get(o));
                     xml.end();

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
@@ -27,13 +27,12 @@ import java.util.List;
 import groovy.lang.GroovyObject;
 
 import org.springframework.beans.BeanUtils;
-import org.springframework.util.ClassUtils;
-import org.springframework.util.ReflectionUtils;
 
 import grails.converters.XML;
 import grails.persistence.Entity;
 import grails.persistence.PersistenceMethod;
 import grails.web.controllers.ControllerMethod;
+import org.apache.grails.common.reflect.ReflectionUtils;
 import org.grails.core.util.IncludeExcludeSupport;
 import org.grails.datastore.mapping.model.config.GormProperties;
 import org.grails.web.converters.exceptions.ConverterException;
@@ -52,6 +51,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
     public void marshalObject(Object o, XML xml) throws ConverterException {
         try {
             Class<? extends Object> clazz = o.getClass();
+            ReflectionUtils.warnOnNonPublicClass(clazz);
             List<String> excludes = xml.getExcludes(clazz);
             List<String> includes = xml.getIncludes(clazz);
             IncludeExcludeSupport<String> includeExcludeSupport = new IncludeExcludeSupport<>();
@@ -68,13 +68,8 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
                     if (Modifier.isStatic(readMethod.getModifiers())) continue;
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
-                    Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    if (!invokableMethod.canAccess(o)) {
-                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
-                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
-                        invokableMethod.setAccessible(true);
-                    }
-                    Object value = invokableMethod.invoke(o, (Object[]) null);
+                    Method invokable = ReflectionUtils.resolveInvokableReadMethod(readMethod, clazz, o);
+                    Object value = invokable.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);
                     xml.end();
@@ -86,7 +81,7 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
                     String name = field.getName();
                     if (!shouldInclude(includeExcludeSupport, includes, excludes, o, name)) continue;
                     if (isEntity && (name.equals(GormProperties.ATTACHED) || name.equals(GormProperties.ERRORS))) continue;
-                    ReflectionUtils.makeAccessible(field);
+                    if (!ReflectionUtils.tryMakeReadable(field, o)) continue;
                     xml.startNode(name);
                     xml.convertAnother(field.get(o));
                     xml.end();

--- a/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
+++ b/grails-converters/src/main/groovy/org/grails/web/converters/marshaller/xml/GroovyBeanMarshaller.java
@@ -69,7 +69,11 @@ public class GroovyBeanMarshaller extends IncludeExcludePropertyMarshaller<XML> 
                     if (readMethod.getAnnotation(PersistenceMethod.class) != null) continue;
                     if (readMethod.getAnnotation(ControllerMethod.class) != null) continue;
                     Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
-                    ReflectionUtils.makeAccessible(invokableMethod);
+                    if (!invokableMethod.canAccess(o)) {
+                        // Widen a private copy, so the flag never leaks into the shared descriptor cache
+                        invokableMethod = invokableMethod.getDeclaringClass().getDeclaredMethod(invokableMethod.getName());
+                        invokableMethod.setAccessible(true);
+                    }
                     Object value = invokableMethod.invoke(o, (Object[]) null);
                     xml.startNode(name);
                     xml.convertAnother(value);

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/DynamicGroovyPersonFactory.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/DynamicGroovyPersonFactory.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans
+
+/**
+ * The same shapes as {@link GroovyPersonFactory}, but compiled dynamically rather than statically,
+ * so that the marshallers are exercised against both Groovy compilation modes.
+ */
+class DynamicGroovyPersonFactory {
+
+    static PublicPerson anonymousPerson(String name, int age) {
+        new PublicPerson() {
+
+            @Override
+            String getName() {
+                name
+            }
+
+            @Override
+            int getAge() {
+                age
+            }
+        }
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/GroovyPersonFactory.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/GroovyPersonFactory.groovy
@@ -1,0 +1,81 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans
+
+import groovy.transform.CompileStatic
+
+/**
+ * Hands out instances of Groovy classes that are not public, but whose read methods are. This is the
+ * shape produced by an anonymous implementation of a public interface inside a Grails controller.
+ */
+@CompileStatic
+class GroovyPersonFactory {
+
+    /**
+     * @return an anonymous implementation of a public interface
+     */
+    static PublicPerson anonymousPerson(String name, int age) {
+        new PublicPerson() {
+
+            @Override
+            String getName() {
+                name
+            }
+
+            @Override
+            int getAge() {
+                age
+            }
+        }
+    }
+
+    /**
+     * @return an anonymous implementation that also exposes a public field
+     */
+    static PublicPerson anonymousPersonWithPublicField(String name, int age, String nick) {
+        new PublicPerson() {
+
+            public String nickname = nick
+
+            @Override
+            String getName() {
+                name
+            }
+
+            @Override
+            int getAge() {
+                age
+            }
+        }
+    }
+
+    /**
+     * @return an instance of a package-private class implementing a public interface
+     */
+    static PublicPerson packagePrivatePerson(String name, int age) {
+        new PackagePrivateGroovyPerson(name, age)
+    }
+
+    /**
+     * @return an instance of a package-private class that implements no interface at all
+     */
+    static Object standalonePerson(String name) {
+        new PackagePrivateStandaloneGroovyBean(name)
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/HiddenCovariantBase.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/HiddenCovariantBase.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * Declares the property as {@code Object} so a covariant override generates a bridge method, and is
+ * itself not public so there is no accessible declaration anywhere in the hierarchy.
+ */
+abstract class HiddenCovariantBase {
+
+    public abstract Object getTag();
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/HiddenCovariantJavaBean.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/HiddenCovariantJavaBean.java
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * Overrides the read method covariantly, so the class carries both the {@code String} override and
+ * the compiler's {@code Object} bridge. With no public type in the hierarchy the read method has to
+ * be widened, which is the only path that chooses between the two.
+ */
+class HiddenCovariantJavaBean extends HiddenCovariantBase {
+
+    private final String tag;
+
+    HiddenCovariantJavaBean(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public String getTag() {
+        return tag;
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
@@ -1,0 +1,61 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * Hands out instances of Java classes that are not public, but whose read methods are.
+ */
+public final class JavaPersonFactory {
+
+    private JavaPersonFactory() {
+    }
+
+    /**
+     * @return an anonymous implementation of a public interface
+     */
+    public static PublicPerson anonymousPerson(final String name, final int age) {
+        return new PublicPerson() {
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public int getAge() {
+                return age;
+            }
+        };
+    }
+
+    /**
+     * @return an instance of a package-private class implementing a public interface
+     */
+    public static PublicPerson packagePrivatePerson(String name, int age) {
+        return new PackagePrivateJavaPerson(name, age);
+    }
+
+    /**
+     * @return an instance of a package-private class that implements no interface at all, so the
+     *         read method cannot be resolved to a public declaring type
+     */
+    public static Object standalonePerson(String name) {
+        return new PackagePrivateStandaloneJavaBean(name);
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
@@ -80,4 +80,13 @@ public final class JavaPersonFactory {
     public static Object standalonePerson(String name) {
         return new PackagePrivateStandaloneJavaBean(name);
     }
+
+    /**
+     * @return an instance of a class carrying both a covariant read method and the compiler's
+     *         bridge for it, with no public type in its hierarchy, so reading it has to choose
+     *         between the two
+     */
+    public static Object covariantBean(String tag) {
+        return new HiddenCovariantJavaBean(tag);
+    }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/JavaPersonFactory.java
@@ -45,6 +45,28 @@ public final class JavaPersonFactory {
     }
 
     /**
+     * @return an anonymous implementation that also exposes a public field. Because the declaring
+     *         class is not public, the field is not readable from another package until access is
+     *         widened, which is why it used to be dropped from the output
+     */
+    public static PublicPerson anonymousPersonWithPublicField(final String name, final int age, String nick) {
+        return new PublicPerson() {
+
+            public final String nickname = nick;
+
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public int getAge() {
+                return age;
+            }
+        };
+    }
+
+    /**
      * @return an instance of a package-private class implementing a public interface
      */
     public static PublicPerson packagePrivatePerson(String name, int age) {

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateGroovyPerson.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateGroovyPerson.groovy
@@ -1,0 +1,49 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans
+
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+
+/**
+ * Package-private Groovy class with public read methods inherited from a public interface.
+ */
+@PackageScope
+@CompileStatic
+class PackagePrivateGroovyPerson implements PublicPerson {
+
+    private final String name
+
+    private final int age
+
+    PackagePrivateGroovyPerson(String name, int age) {
+        this.name = name
+        this.age = age
+    }
+
+    @Override
+    String getName() {
+        name
+    }
+
+    @Override
+    int getAge() {
+        age
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateJavaPerson.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateJavaPerson.java
@@ -1,0 +1,44 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * Package-private class with public read methods inherited from a public interface.
+ */
+class PackagePrivateJavaPerson implements PublicPerson {
+
+    private final String name;
+
+    private final int age;
+
+    PackagePrivateJavaPerson(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public int getAge() {
+        return age;
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateStandaloneGroovyBean.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateStandaloneGroovyBean.groovy
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans
+
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+
+/**
+ * Package-private Groovy class whose only read method is declared on the class itself, so there is
+ * no publicly accessible interface method to fall back on.
+ */
+@PackageScope
+@CompileStatic
+class PackagePrivateStandaloneGroovyBean {
+
+    private final String name
+
+    PackagePrivateStandaloneGroovyBean(String name) {
+        this.name = name
+    }
+
+    String getName() {
+        name
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateStandaloneJavaBean.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/PackagePrivateStandaloneJavaBean.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * Package-private class with a public read method that is declared on the class itself, so there is
+ * no publicly accessible interface method to fall back on.
+ */
+class PackagePrivateStandaloneJavaBean {
+
+    private final String name;
+
+    PackagePrivateStandaloneJavaBean(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/PublicPerson.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/PublicPerson.java
@@ -1,0 +1,35 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+/**
+ * A public interface with both abstract and default read methods, mirroring the shape of
+ * interfaces such as Spring Security's {@code UserDetails}. Implementations live in non-public
+ * classes so that the converters have to resolve the interface method to be able to invoke it.
+ */
+public interface PublicPerson {
+
+    String getName();
+
+    int getAge();
+
+    default boolean isActive() {
+        return true;
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/SerializableGroovyBean.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/SerializableGroovyBean.groovy
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans
+
+import groovy.transform.CompileStatic
+
+/**
+ * The Groovy twin of {@link SerializableJavaBean}: a serializable bean carrying the {@code private
+ * static final serialVersionUID} that virtually every serializable bean declares, plus a static
+ * constant and a public instance field.
+ */
+@CompileStatic
+class SerializableGroovyBean implements Serializable {
+
+    private static final long serialVersionUID = 1L
+
+    static final String KIND = 'authority'
+
+    public final String label
+
+    private final String authority
+
+    SerializableGroovyBean(String authority, String label) {
+        this.authority = authority
+        this.label = label
+    }
+
+    String getAuthority() {
+        authority
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/beans/SerializableJavaBean.java
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/beans/SerializableJavaBean.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.beans;
+
+import java.io.Serializable;
+
+/**
+ * An ordinary {@code Serializable} Java bean, carrying the {@code private static final
+ * serialVersionUID} that virtually every serializable bean declares, plus a public constant and a
+ * public instance field.
+ */
+public class SerializableJavaBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String KIND = "authority";
+
+    public final String label;
+
+    private final String authority;
+
+    public SerializableJavaBean(String authority, String label) {
+        this.authority = authority;
+        this.label = label;
+    }
+
+    public String getAuthority() {
+        return authority;
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
@@ -1,0 +1,197 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.marshaller.json
+
+import java.lang.reflect.Modifier
+
+import spock.lang.Specification
+
+import org.springframework.context.ApplicationContext
+
+import grails.converters.JSON
+import grails.core.DefaultGrailsApplication
+import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.web.converters.beans.GroovyPersonFactory
+import org.grails.web.converters.beans.JavaPersonFactory
+import org.grails.web.converters.beans.SerializableJavaBean
+import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
+
+/**
+ * Marshalling objects whose class is not public (anonymous, inner or package-private) and ordinary
+ * {@code Serializable} beans.
+ *
+ * @see <a href="https://github.com/apache/grails-core/issues/16294">GitHub issue 16294</a>
+ * @see <a href="https://github.com/apache/grails-core/issues/16295">GitHub issue 16295</a>
+ */
+class NonPublicClassMarshallingSpec extends Specification {
+
+    void setup() {
+        def initializer = new ConvertersConfigurationInitializer()
+        def grailsApplication = new DefaultGrailsApplication()
+        grailsApplication.initialise()
+        def mappingContext = new KeyValueMappingContext('json')
+        grailsApplication.setApplicationContext(Stub(ApplicationContext) {
+            getBean('grailsDomainClassMappingContext', MappingContext) >> mappingContext
+        })
+        grailsApplication.setMappingContext(mappingContext)
+        initializer.grailsApplication = grailsApplication
+        initializer.initialize()
+    }
+
+    void 'an anonymous Groovy class implementing a public interface is marshalled'() {
+        given: 'an anonymous implementation, as handed out by Spring Security style factories'
+        def person = GroovyPersonFactory.anonymousPerson('user', 42)
+
+        expect: 'the class itself is not public, only its read methods are'
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then: 'the overridden read methods are invoked, not just the interface default method'
+        json == [active: true, age: 42, name: 'user']
+    }
+
+    void 'a public field of an anonymous Groovy class is marshalled'() {
+        given:
+        def person = GroovyPersonFactory.anonymousPersonWithPublicField('user', 42, 'nick')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user', nickname: 'nick']
+    }
+
+    void 'a package-private Groovy class implementing a public interface is marshalled'() {
+        given:
+        def person = GroovyPersonFactory.packagePrivatePerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user']
+    }
+
+    void 'a package-private Groovy class without any interface is marshalled'() {
+        given: 'a read method whose only declaring type is the non-public class itself'
+        def person = GroovyPersonFactory.standalonePerson('user')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [name: 'user']
+    }
+
+    void 'an anonymous Java class implementing a public interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.anonymousPerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user']
+    }
+
+    void 'a package-private Java class implementing a public interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.packagePrivatePerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user']
+    }
+
+    void 'a package-private Java class without any interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.standalonePerson('user')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [name: 'user']
+    }
+
+    void 'a Serializable Java bean is marshalled without tripping over its static fields'() {
+        given: 'a bean declaring private static final serialVersionUID, as most Java beans do'
+        def bean = new SerializableJavaBean('ROLE_ADMIN', 'Administrator')
+
+        when:
+        Map json = parse(new JSON(bean).toString())
+
+        then: 'the read method and the public instance field are marshalled'
+        json == [authority: 'ROLE_ADMIN', label: 'Administrator']
+
+        and: 'the static fields are not'
+        !json.containsKey('serialVersionUID')
+        !json.containsKey('KIND')
+    }
+
+    void 'a map of non-public beans and Serializable beans is marshalled as a whole'() {
+        given: 'the object graph of the reported reproducer'
+        def person = GroovyPersonFactory.anonymousPerson('user', 42)
+        def authorities = [new SerializableJavaBean('ROLE_ADMIN', 'Administrator')]
+
+        when:
+        Map json = parse(new JSON([user: person, authorities: authorities]).toString())
+
+        then:
+        json.user == [active: true, age: 42, name: 'user']
+        json.authorities == [[authority: 'ROLE_ADMIN', label: 'Administrator']]
+    }
+
+    private static Map parse(String json) {
+        normalise(JSON.parse(json)) as Map
+    }
+
+    private static Object normalise(Object value) {
+        if (value instanceof Map) {
+            return value.collectEntries { key, item -> [(key.toString()): normalise(item)] }
+        }
+        if (value instanceof List) {
+            return value.collect { normalise(it) }
+        }
+        value
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
@@ -28,6 +28,7 @@ import grails.converters.JSON
 import grails.core.DefaultGrailsApplication
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
+import org.grails.web.converters.beans.DynamicGroovyPersonFactory
 import org.grails.web.converters.beans.GroovyPersonFactory
 import org.grails.web.converters.beans.JavaPersonFactory
 import org.grails.web.converters.beans.SerializableJavaBean
@@ -179,6 +180,20 @@ class NonPublicClassMarshallingSpec extends Specification {
         then:
         json.user == [active: true, age: 42, name: 'user']
         json.authorities == [[authority: 'ROLE_ADMIN', label: 'Administrator']]
+    }
+
+    void 'a dynamically compiled anonymous Groovy class is marshalled'() {
+        given:
+        def person = DynamicGroovyPersonFactory.anonymousPerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user']
     }
 
     private static Map parse(String json) {

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
@@ -28,11 +28,13 @@ import org.springframework.context.ApplicationContext
 
 import grails.converters.JSON
 import grails.core.DefaultGrailsApplication
+import org.apache.grails.common.reflect.ReflectionUtils
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.web.converters.beans.DynamicGroovyPersonFactory
 import org.grails.web.converters.beans.GroovyPersonFactory
 import org.grails.web.converters.beans.JavaPersonFactory
+import org.grails.web.converters.beans.SerializableGroovyBean
 import org.grails.web.converters.beans.SerializableJavaBean
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
 
@@ -46,6 +48,7 @@ import org.grails.web.converters.configuration.ConvertersConfigurationInitialize
 class NonPublicClassMarshallingSpec extends Specification {
 
     void setup() {
+        ReflectionUtils.resetWarnedClasses()
         def initializer = new ConvertersConfigurationInitializer()
         def grailsApplication = new DefaultGrailsApplication()
         grailsApplication.initialise()
@@ -228,5 +231,70 @@ class NonPublicClassMarshallingSpec extends Specification {
 
     private static Method readMethodOf(Object bean) {
         BeanUtils.getPropertyDescriptors(bean.getClass()).find { it.name == 'name' }.readMethod
+    }
+
+    void 'a public field of an anonymous Java class is marshalled'() {
+        given:
+        def person = JavaPersonFactory.anonymousPersonWithPublicField('user', 42, 'nick')
+
+        expect: 'the field is public, but unreadable from here until access is widened'
+        !Modifier.isPublic(person.getClass().modifiers)
+        !person.getClass().getDeclaredField('nickname').canAccess(person)
+
+        when:
+        Map json = parse(new JSON(person).toString())
+
+        then:
+        json == [active: true, age: 42, name: 'user', nickname: 'nick']
+    }
+
+    void 'a Serializable Groovy bean is marshalled without tripping over its static fields'() {
+        given:
+        def bean = new SerializableGroovyBean('ROLE_ADMIN', 'Administrator')
+
+        when:
+        Map json = parse(new JSON(bean).toString())
+
+        then:
+        json == [authority: 'ROLE_ADMIN', label: 'Administrator']
+
+        and:
+        !json.containsKey('serialVersionUID')
+        !json.containsKey('KIND')
+    }
+
+    void 'marshalling a Groovy bean does not widen access on the shared property descriptor cache'() {
+        given: 'a package-private Groovy class with no interface, the only shape needing widening'
+        def person = GroovyPersonFactory.standalonePerson('user')
+
+        expect:
+        !readMethodOf(person).canAccess(person)
+
+        when:
+        new JSON(person).toString()
+
+        then:
+        !readMethodOf(person).canAccess(person)
+    }
+
+    void 'a bean class that is not public is reported once'() {
+        given:
+        def person = GroovyPersonFactory.packagePrivatePerson('user', 42)
+
+        when:
+        new JSON(person).toString()
+
+        then: 'marshalling reported the class, so a further report finds it already done'
+        !ReflectionUtils.warnOnNonPublicClass(person.getClass())
+
+        when: 'another instance of the same class is marshalled'
+        new JSON(GroovyPersonFactory.packagePrivatePerson('other', 43)).toString()
+
+        then: 'it is still reported only the once'
+        !ReflectionUtils.warnOnNonPublicClass(person.getClass())
+    }
+
+    void cleanup() {
+        ReflectionUtils.resetWarnedClasses()
     }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
@@ -18,10 +18,12 @@
  */
 package org.grails.web.converters.marshaller.json
 
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 import spock.lang.Specification
 
+import org.springframework.beans.BeanUtils
 import org.springframework.context.ApplicationContext
 
 import grails.converters.JSON
@@ -208,5 +210,23 @@ class NonPublicClassMarshallingSpec extends Specification {
             return value.collect { normalise(it) }
         }
         value
+    }
+
+    void 'marshalling does not widen access on the shared property descriptor cache'() {
+        given: 'a package-private class with no interface, the only shape that needs widening'
+        def person = JavaPersonFactory.standalonePerson('user')
+
+        expect: 'its cached read method is not invokable from another package to begin with'
+        !readMethodOf(person).canAccess(person)
+
+        when:
+        new JSON(person).toString()
+
+        then: 'marshalling left the flag on the cached instance alone'
+        !readMethodOf(person).canAccess(person)
+    }
+
+    private static Method readMethodOf(Object bean) {
+        BeanUtils.getPropertyDescriptors(bean.getClass()).find { it.name == 'name' }.readMethod
     }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/json/NonPublicClassMarshallingSpec.groovy
@@ -294,6 +294,20 @@ class NonPublicClassMarshallingSpec extends Specification {
         !ReflectionUtils.warnOnNonPublicClass(person.getClass())
     }
 
+    void 'a covariant read method with no public declaring type is marshalled from the override'() {
+        given: 'the class carries both a String override and the compiler\'s Object bridge'
+        def bean = JavaPersonFactory.covariantBean('tag')
+
+        expect:
+        !Modifier.isPublic(bean.getClass().modifiers)
+
+        when:
+        Map json = parse(new JSON(bean).toString())
+
+        then: 'the override was read, once'
+        json == [tag: 'tag']
+    }
+
     void cleanup() {
         ReflectionUtils.resetWarnedClasses()
     }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
@@ -28,6 +28,7 @@ import grails.converters.XML
 import grails.core.DefaultGrailsApplication
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
+import org.grails.web.converters.beans.DynamicGroovyPersonFactory
 import org.grails.web.converters.beans.GroovyPersonFactory
 import org.grails.web.converters.beans.JavaPersonFactory
 import org.grails.web.converters.beans.SerializableJavaBean
@@ -195,5 +196,22 @@ class NonPublicClassMarshallingSpec extends Specification {
         then:
         xml.contains('<name>user</name>')
         xml.contains('<authority>ROLE_ADMIN</authority>')
+    }
+
+    void 'a dynamically compiled anonymous Groovy class is marshalled'() {
+        given:
+        def person = DynamicGroovyPersonFactory.anonymousPerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML([user: person]).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<age>42</age>')
+        xml.contains('<active>true</active>')
+        xml.count('<name>') == 1
     }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
@@ -1,0 +1,199 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.grails.web.converters.marshaller.xml
+
+import java.lang.reflect.Modifier
+
+import spock.lang.Specification
+
+import org.springframework.context.ApplicationContext
+
+import grails.converters.XML
+import grails.core.DefaultGrailsApplication
+import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
+import org.grails.datastore.mapping.model.MappingContext
+import org.grails.web.converters.beans.GroovyPersonFactory
+import org.grails.web.converters.beans.JavaPersonFactory
+import org.grails.web.converters.beans.SerializableJavaBean
+import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
+
+/**
+ * Marshalling objects whose class is not public (anonymous, inner or package-private) and ordinary
+ * {@code Serializable} beans.
+ *
+ * @see <a href="https://github.com/apache/grails-core/issues/16294">GitHub issue 16294</a>
+ * @see <a href="https://github.com/apache/grails-core/issues/16295">GitHub issue 16295</a>
+ */
+class NonPublicClassMarshallingSpec extends Specification {
+
+    void setup() {
+        def initializer = new ConvertersConfigurationInitializer()
+        def grailsApplication = new DefaultGrailsApplication()
+        grailsApplication.initialise()
+        def mappingContext = new KeyValueMappingContext('xml')
+        grailsApplication.setApplicationContext(Stub(ApplicationContext) {
+            getBean('grailsDomainClassMappingContext', MappingContext) >> mappingContext
+        })
+        grailsApplication.setMappingContext(mappingContext)
+        initializer.grailsApplication = grailsApplication
+        initializer.initialize()
+    }
+
+    void 'an anonymous Groovy class implementing a public interface is marshalled'() {
+        given: 'an anonymous implementation, wrapped in a map so the element name is well defined'
+        def person = GroovyPersonFactory.anonymousPerson('user', 42)
+
+        expect: 'the class itself is not public, only its read methods are'
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML([user: person]).toString()
+
+        then: 'the overridden read methods are invoked, not just the interface default method'
+        xml.contains('<name>user</name>')
+        xml.contains('<age>42</age>')
+        xml.contains('<active>true</active>')
+
+        and: 'the synthetic fields capturing the enclosing variables are not marshalled'
+        xml.count('<name>') == 1
+        xml.count('<age>') == 1
+    }
+
+    void 'a public field of an anonymous Groovy class is marshalled'() {
+        given:
+        def person = GroovyPersonFactory.anonymousPersonWithPublicField('user', 42, 'nick')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML([user: person]).toString()
+
+        then: 'the declared public field is marshalled, the synthetic capture fields are not'
+        xml.contains('<name>user</name>')
+        xml.contains('<nickname>nick</nickname>')
+        xml.count('<name>') == 1
+        !xml.contains('<nick>')
+    }
+
+    void 'a package-private Groovy class implementing a public interface is marshalled'() {
+        given:
+        def person = GroovyPersonFactory.packagePrivatePerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML(person).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<age>42</age>')
+        xml.contains('<active>true</active>')
+    }
+
+    void 'a package-private Groovy class without any interface is marshalled'() {
+        given: 'a read method whose only declaring type is the non-public class itself'
+        def person = GroovyPersonFactory.standalonePerson('user')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML(person).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+    }
+
+    void 'an anonymous Java class implementing a public interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.anonymousPerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML([user: person]).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<age>42</age>')
+        xml.contains('<active>true</active>')
+    }
+
+    void 'a package-private Java class implementing a public interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.packagePrivatePerson('user', 42)
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML(person).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<age>42</age>')
+        xml.contains('<active>true</active>')
+    }
+
+    void 'a package-private Java class without any interface is marshalled'() {
+        given:
+        def person = JavaPersonFactory.standalonePerson('user')
+
+        expect:
+        !Modifier.isPublic(person.getClass().modifiers)
+
+        when:
+        String xml = new XML(person).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+    }
+
+    void 'a Serializable Java bean is marshalled without tripping over its static fields'() {
+        given: 'a bean declaring private static final serialVersionUID, as most Java beans do'
+        def bean = new SerializableJavaBean('ROLE_ADMIN', 'Administrator')
+
+        when:
+        String xml = new XML(bean).toString()
+
+        then: 'the read method and the public instance field are marshalled'
+        xml.contains('<authority>ROLE_ADMIN</authority>')
+        xml.contains('<label>Administrator</label>')
+
+        and: 'the static fields are not'
+        !xml.contains('serialVersionUID')
+        !xml.contains('KIND')
+    }
+
+    void 'a map of non-public beans and Serializable beans is marshalled as a whole'() {
+        given: 'the object graph of the reported reproducer'
+        def person = GroovyPersonFactory.anonymousPerson('user', 42)
+        def authorities = [new SerializableJavaBean('ROLE_ADMIN', 'Administrator')]
+
+        when:
+        String xml = new XML([user: person, authorities: authorities]).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<authority>ROLE_ADMIN</authority>')
+    }
+}

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
@@ -18,10 +18,12 @@
  */
 package org.grails.web.converters.marshaller.xml
 
+import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 import spock.lang.Specification
 
+import org.springframework.beans.BeanUtils
 import org.springframework.context.ApplicationContext
 
 import grails.converters.XML
@@ -213,5 +215,23 @@ class NonPublicClassMarshallingSpec extends Specification {
         xml.contains('<age>42</age>')
         xml.contains('<active>true</active>')
         xml.count('<name>') == 1
+    }
+
+    void 'marshalling does not widen access on the shared property descriptor cache'() {
+        given: 'a package-private class with no interface, the only shape that needs widening'
+        def person = JavaPersonFactory.standalonePerson('user')
+
+        expect: 'its cached read method is not invokable from another package to begin with'
+        !readMethodOf(person).canAccess(person)
+
+        when:
+        new XML(person).toString()
+
+        then: 'marshalling left the flag on the cached instance alone'
+        !readMethodOf(person).canAccess(person)
+    }
+
+    private static Method readMethodOf(Object bean) {
+        BeanUtils.getPropertyDescriptors(bean.getClass()).find { it.name == 'name' }.readMethod
     }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
@@ -28,11 +28,13 @@ import org.springframework.context.ApplicationContext
 
 import grails.converters.XML
 import grails.core.DefaultGrailsApplication
+import org.apache.grails.common.reflect.ReflectionUtils
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.model.MappingContext
 import org.grails.web.converters.beans.DynamicGroovyPersonFactory
 import org.grails.web.converters.beans.GroovyPersonFactory
 import org.grails.web.converters.beans.JavaPersonFactory
+import org.grails.web.converters.beans.SerializableGroovyBean
 import org.grails.web.converters.beans.SerializableJavaBean
 import org.grails.web.converters.configuration.ConvertersConfigurationInitializer
 
@@ -46,6 +48,7 @@ import org.grails.web.converters.configuration.ConvertersConfigurationInitialize
 class NonPublicClassMarshallingSpec extends Specification {
 
     void setup() {
+        ReflectionUtils.resetWarnedClasses()
         def initializer = new ConvertersConfigurationInitializer()
         def grailsApplication = new DefaultGrailsApplication()
         grailsApplication.initialise()
@@ -231,7 +234,74 @@ class NonPublicClassMarshallingSpec extends Specification {
         !readMethodOf(person).canAccess(person)
     }
 
+    void 'a public field of an anonymous Java class is marshalled'() {
+        given:
+        def person = JavaPersonFactory.anonymousPersonWithPublicField('user', 42, 'nick')
+
+        expect: 'the field is public, but unreadable from here until access is widened'
+        !Modifier.isPublic(person.getClass().modifiers)
+        !person.getClass().getDeclaredField('nickname').canAccess(person)
+
+        when:
+        String xml = new XML([user: person]).toString()
+
+        then:
+        xml.contains('<name>user</name>')
+        xml.contains('<nickname>nick</nickname>')
+    }
+
+    void 'a Serializable Groovy bean is marshalled without tripping over its static fields'() {
+        given:
+        def bean = new SerializableGroovyBean('ROLE_ADMIN', 'Administrator')
+
+        when:
+        String xml = new XML(bean).toString()
+
+        then:
+        xml.contains('<authority>ROLE_ADMIN</authority>')
+        xml.contains('<label>Administrator</label>')
+
+        and:
+        !xml.contains('serialVersionUID')
+        !xml.contains('KIND')
+    }
+
+    void 'marshalling a Groovy bean does not widen access on the shared property descriptor cache'() {
+        given: 'a package-private Groovy class with no interface, the only shape needing widening'
+        def person = GroovyPersonFactory.standalonePerson('user')
+
+        expect:
+        !readMethodOf(person).canAccess(person)
+
+        when:
+        new XML(person).toString()
+
+        then:
+        !readMethodOf(person).canAccess(person)
+    }
+
+    void 'a bean class that is not public is reported once'() {
+        given:
+        def person = GroovyPersonFactory.packagePrivatePerson('user', 42)
+
+        when:
+        new XML(person).toString()
+
+        then: 'marshalling reported the class, so a further report finds it already done'
+        !ReflectionUtils.warnOnNonPublicClass(person.getClass())
+
+        when: 'another instance of the same class is marshalled'
+        new XML(GroovyPersonFactory.packagePrivatePerson('other', 43)).toString()
+
+        then: 'it is still reported only the once'
+        !ReflectionUtils.warnOnNonPublicClass(person.getClass())
+    }
+
     private static Method readMethodOf(Object bean) {
         BeanUtils.getPropertyDescriptors(bean.getClass()).find { it.name == 'name' }.readMethod
+    }
+
+    void cleanup() {
+        ReflectionUtils.resetWarnedClasses()
     }
 }

--- a/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
+++ b/grails-converters/src/test/groovy/org/grails/web/converters/marshaller/xml/NonPublicClassMarshallingSpec.groovy
@@ -301,6 +301,21 @@ class NonPublicClassMarshallingSpec extends Specification {
         BeanUtils.getPropertyDescriptors(bean.getClass()).find { it.name == 'name' }.readMethod
     }
 
+    void 'a covariant read method with no public declaring type is marshalled from the override'() {
+        given: 'the class carries both a String override and the compiler\'s Object bridge'
+        def bean = JavaPersonFactory.covariantBean('tag')
+
+        expect:
+        !Modifier.isPublic(bean.getClass().modifiers)
+
+        when:
+        String xml = new XML(bean).toString()
+
+        then: 'the override was read, and the bridge did not add a second node'
+        xml.contains('<tag>tag</tag>')
+        xml.count('<tag>') == 1
+    }
+
     void cleanup() {
         ReflectionUtils.resetWarnedClasses()
     }

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -3097,3 +3097,70 @@ grails {
 imported whether or not they are present — a star import of an absent package contributes no classes and is
 not an error in Groovy, so the probe changed nothing it could observe. An application that relied on the
 import being *omitted* when the package was absent sees no difference in compiled output.
+
+==== 54. Non-Public Bean Classes Are Marshalled, and Reported Once
+
+`someObject as JSON` (and `as XML`) previously failed when the object's class was not `public` — an
+anonymous, local, or package-private class — even though its property getters were public. The request
+failed with `ConverterException` wrapping `IllegalAccessException`. The same conversion also failed for any
+`Serializable` bean, because the marshaller asked whether a `private static final long serialVersionUID`
+field was accessible before checking that it was static, which the JDK rejects.
+
+Both now work. The most common shape is an anonymous implementation of a public interface, which Groovy 4
+compiled to a `public` class and Groovy 5 does not:
+
+[source,groovy]
+----
+def show() {
+    def user = new UserDetails() {
+        @Override Collection<? extends GrantedAuthority> getAuthorities() { [new SimpleGrantedAuthority('ROLE_ADMIN')] }
+        @Override String getPassword() { null }
+        @Override String getUsername() { 'user' }
+    }
+    render([user: user] as JSON)
+}
+----
+
+===== 54.1 Public Fields of Non-Public Classes Are Now Included
+
+Java and Groovy beans are now treated alike. A `public` instance field declared on a class that is not
+public was silently omitted from the JSON or XML body when the bean was a plain Java object; it is now
+included, as it always was for a Groovy bean. If a field was being dropped by accident and should stay out
+of the payload, exclude it explicitly or register an `ObjectMarshaller` for the class:
+
+[source,groovy]
+----
+def json = someObject as JSON
+json.excludes = ['nickname']
+render json
+----
+
+Fields of a class in a named module that does not open its package are skipped rather than failing the
+whole conversion.
+
+===== 54.2 The Warning
+
+Reading a non-public class requires widening access reflectively, which is compatibility handling rather
+than a supported contract. Each such class is therefore reported once:
+
+[source,text]
+----
+Class [com.example.DemoController$1] is not public, so its properties can only be read by widening access
+reflectively. Declare the class public - as a named class rather than an anonymous one where necessary - so
+that it reads as a standard JavaBean. This handling may be withdrawn in a future major release. To silence
+this, set the log level of [org.apache.grails.common.reflect.ReflectionUtils] above WARN. (warned once per class)
+----
+
+The fix is to declare the class `public` — as a named class where it is currently anonymous — or to register
+an `ObjectMarshaller` for it. Classes from the JDK, Groovy, and Spring are never reported, since an
+application cannot declare them public.
+
+To silence the warning instead:
+
+[source,yaml]
+.application.yml
+----
+logging:
+    level:
+        org.apache.grails.common.reflect.ReflectionUtils: ERROR
+----

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -3100,14 +3100,20 @@ import being *omitted* when the package was absent sees no difference in compile
 
 ==== 54. Non-Public Bean Classes Are Marshalled, and Reported Once
 
-`someObject as JSON` (and `as XML`) previously failed when the object's class was not `public` — an
-anonymous, local, or package-private class — even though its property getters were public. The request
-failed with `ConverterException` wrapping `IllegalAccessException`. The same conversion also failed for any
-`Serializable` bean, because the marshaller asked whether a `private static final long serialVersionUID`
-field was accessible before checking that it was static, which the JDK rejects.
+Groovy 4 stamped `ACC_PUBLIC` on anonymous inner classes; Groovy 5, which Grails 8 builds on, does not.
+Reflection cannot invoke a method on a class that is not `public` from another package, even when the method
+itself is public, so code that marshalled an anonymous class perfectly well under Grails 7 started failing on
+Grails 8 with `ConverterException` wrapping `IllegalAccessException`. Nothing in the application changed —
+only the class modifier the compiler emits.
 
-Both now work. The most common shape is an anonymous implementation of a public interface, which Groovy 4
-compiled to a `public` class and Groovy 5 does not:
+A second failure in the same code path is fixed alongside it: converting any `Serializable` bean threw
+`IllegalArgumentException`, because the marshaller asked whether a `private static final long
+serialVersionUID` field was accessible before checking that it was static, which the JDK rejects. Practically
+every serializable bean declares that field, so this affected a large share of objects passed to `as JSON`.
+
+Grails 8 adds compatibility handling for the non-public case, and reports each such class once so that the
+code can be corrected — see 54.2 below. The shape that hits it is an anonymous implementation of a public
+interface:
 
 [source,groovy]
 ----
@@ -3120,6 +3126,10 @@ def show() {
     render([user: user] as JSON)
 }
 ----
+
+NOTE: Ordinary Groovy code is unaffected. Property access and method calls through the metaclass still work
+on such an object from any package, as does the JDK's `Introspector`; only raw reflection against the method
+as the non-public class declares it fails. That is what bean marshalling was doing.
 
 ===== 54.1 Public Fields of Non-Public Classes Are Now Included
 
@@ -3135,25 +3145,26 @@ json.excludes = ['nickname']
 render json
 ----
 
-Fields of a class in a named module that does not open its package are skipped rather than failing the
-whole conversion.
+A `public` *field* that cannot be read at all — because its class is in a named module that does not open
+its package — is skipped, and the rest of the object still converts. A *getter* in that same situation is
+not skipped: the conversion fails, as it did before Grails 8.
 
 ===== 54.2 The Warning
 
-Reading a non-public class requires widening access reflectively, which is compatibility handling rather
-than a supported contract. Each such class is therefore reported once:
+Reading a bean whose class is not public is compatibility handling rather than a supported contract, so each
+such class is reported once:
 
 [source,text]
 ----
-Class [com.example.DemoController$1] is not public, so its properties can only be read by widening access
-reflectively. Declare the class public - as a named class rather than an anonymous one where necessary - so
-that it reads as a standard JavaBean. This handling may be withdrawn in a future major release. To silence
+Class [com.example.DemoController$1] is not public. Grails reads its properties through compatibility
+handling that may be withdrawn in a future major release. Declare it as a named public class so that it
+reads as a standard JavaBean, or register an ObjectMarshaller for it if the class is not yours. To silence
 this, set the log level of [org.apache.grails.common.reflect.ReflectionUtils] above WARN. (warned once per class)
 ----
 
-The fix is to declare the class `public` — as a named class where it is currently anonymous — or to register
-an `ObjectMarshaller` for it. Classes from the JDK, Groovy, and Spring are never reported, since an
-application cannot declare them public.
+The fix is to declare the class `public` — as a named class where it is currently anonymous — or, for a class
+you do not own, to register an `ObjectMarshaller` for it. Classes from the JDK, Groovy, and Spring are never
+reported, since an application cannot declare those public.
 
 To silence the warning instead:
 


### PR DESCRIPTION
Fixes #16294
Fixes #16295

`someObject as JSON` (and `as XML`) failed for two very common shapes of object. Both are fixed here, since fixing the first one only exposes the second.

## #16294 — `IllegalAccessException` on a non-public class

A class that is not public — anonymous, local or package-private — cannot have its read methods invoked reflectively from another package, even though the methods themselves carry the `public` modifier. All four bean marshallers called `readMethod.invoke(...)` with no accessibility handling, so handing `as JSON` an anonymous implementation of a public interface (the usual shape of a Spring Security `UserDetails`) failed with:

```
java.lang.IllegalAccessException: class org.grails.web.converters.marshaller.json.GroovyBeanMarshaller
    cannot access a member of class com.example.DemoController$1 with modifiers "public"
```

The read method is now resolved to the interface method where one exists, and made accessible otherwise:

```java
Method invokableMethod = ClassUtils.getInterfaceMethodIfPossible(readMethod, clazz);
ReflectionUtils.makeAccessible(invokableMethod);
Object value = invokableMethod.invoke(o, (Object[]) null);
```

Resolving to the interface is not sufficient on its own — a package-private class with a public getter and no interface has nowhere to resolve to — so `makeAccessible` carries that case.

The public *field* loops of both `GroovyBeanMarshaller`s failed identically on `field.get(o)` and are now made accessible too.

## #16295 — `IllegalArgumentException` on any `Serializable` bean

`GenericJavaBeanMarshaller` evaluated `field.canAccess(o)` before the static check, and per its javadoc `canAccess` throws for a static member when the object is non-null. Any bean declaring `private static final long serialVersionUID` — nearly every `Serializable` bean — therefore failed:

```
java.lang.IllegalArgumentException: non-null object for
    private static final long org.springframework.security.core.authority.SimpleGrantedAuthority.serialVersionUID
```

The modifier checks now run first so they short-circuit before `canAccess`. This is a regression in the 8.x line from `9e60b8a4de`, which mechanically swapped the non-throwing `isAccessible()` for `canAccess(o)`.

## One change beyond the two issues

Groovy compiles the variables captured by an anonymous class into `ACC_PUBLIC | ACC_SYNTHETIC` `groovy.lang.Reference` fields. Once the field loops could actually read them, they were emitted as duplicate keys with empty-object values (`{"name":{},"age":{}}`) — the new tests caught exactly that. Synthetic fields are compiler artifacts and never part of a bean's state, so they are now skipped in all four marshallers.

## Files changed

- `grails-converters/.../marshaller/json/GroovyBeanMarshaller.java`
- `grails-converters/.../marshaller/json/GenericJavaBeanMarshaller.java`
- `grails-converters/.../marshaller/xml/GroovyBeanMarshaller.java`
- `grails-converters/.../marshaller/xml/GenericJavaBeanMarshaller.java`

## Tests

New fixtures under `org.grails.web.converters.beans`, deliberately in a different package from the marshallers — in the same package the JVM access check passes and neither bug reproduces. They cover a public interface with both abstract and `default` read methods (mirroring `UserDetails`), Groovy and Java anonymous / package-private / no-interface implementations, an anonymous class with a declared public field, and a `Serializable` bean carrying `private static final long serialVersionUID` alongside a public constant and a public instance field.

Two new specs of 9 features each, driven through the public `new JSON(x)` / `new XML(x)` API: `json.NonPublicClassMarshallingSpec` and `xml.NonPublicClassMarshallingSpec`. Every non-public case first asserts `!Modifier.isPublic(person.getClass().modifiers)`, so the tests fail loudly rather than silently passing if a future compiler stops producing a non-public class.

With the production change reverted, **18 of 18 fail** with the two reported exceptions verbatim; with it, 18/18 pass. Also green locally: full `:grails-converters:test`, `:grails-rest-transforms:test`, `:grails-test-suite-web:test`, `:grails-test-suite-uber:test`, `:grails-web-common:test` and `:grails-converters:codeStyle`.

No documentation change: this restores the documented behaviour of `as JSON` / `as XML` and adds no public API.