### PR TITLE
Fix fields template lookup leak from accessor-keyed memoization

### DIFF
--- a/grails-fields/src/main/groovy/grails/plugin/formfields/FormFieldsTemplateService.groovy
+++ b/grails-fields/src/main/groovy/grails/plugin/formfields/FormFieldsTemplateService.groovy
@@ -65,9 +65,11 @@ class FormFieldsTemplateService {
     }
 
     Map findTemplate(BeanPropertyAccessor propertyAccessor, String templateName, String templatesFolder, String theme = null) {
-        shouldCache ?
-                findTemplateCached(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, theme) :
-                findTemplateNotCached(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, theme)
+        // Build candidate paths before caching so memoization keys on lookup-relevant
+        // strings rather than request-scoped BeanPropertyAccessor instances, which retain
+        // root beans and property values and would otherwise leak per request.
+        List<String> candidatePaths = resolveCandidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, theme)
+        shouldCache ? findTemplateCached(candidatePaths) : findTemplateNotCached(candidatePaths)
     }
 
     static String toPropertyNameFormat(Class type) {
@@ -185,22 +187,22 @@ class FormFieldsTemplateService {
         grailsApplication?.config?.getProperty("grails.plugin.fields.$templateProperty", templateProperty) ?: templateProperty
     }
 
-    @Memoized
-    private Map<String, String> findTemplateCached(BeanPropertyAccessor propertyAccessor, String controllerNamespace, String controllerName, String actionName, String templateName, String templatesFolder, String themeName) {
-        findTemplateNotCached(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, themeName)
+    private List<String> resolveCandidateTemplatePaths(BeanPropertyAccessor propertyAccessor, String controllerNamespace, String controllerName, String actionName, String templateName, String templatesFolder, String themeName) {
+        if (themeName) {
+            // if theme is specified, first resolve all theme paths and then all the default paths
+            String themeFolder = THEMES_FOLDER + '/' + themeName
+            return candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, themeFolder) +
+                    candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, null)
+        }
+        return candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, null)
     }
 
-    private Map<String, String> findTemplateNotCached(BeanPropertyAccessor propertyAccessor, String controllerNamespace, String controllerName, String actionName, String templateName, String templatesFolder, String themeName) {
-        List<String> candidatePaths
-        if (themeName) {
-            //if theme is specified, first resolve all theme paths and then all the default paths
-            String themeFolder = THEMES_FOLDER + '/' + themeName
-            candidatePaths = candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, themeFolder)
-            candidatePaths = candidatePaths + candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, null)
-        } else {
-            candidatePaths = candidateTemplatePaths(propertyAccessor, controllerNamespace, controllerName, actionName, templateName, templatesFolder, null)
-        }
+    @Memoized
+    private Map<String, String> findTemplateCached(List<String> candidatePaths) {
+        findTemplateNotCached(candidatePaths)
+    }
 
+    private Map<String, String> findTemplateNotCached(List<String> candidatePaths) {
         candidatePaths.findResult { String path ->
             log.debug('looking for template with path {}', path)
             def source = groovyPageLocator.findTemplateByPath(path)

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/TemplateLookupCachingSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/TemplateLookupCachingSpec.groovy
@@ -125,11 +125,11 @@ class TemplateLookupCachingSpec extends BuildsAccessorFactory implements Service
 	@Issue('https://github.com/apache/grails-core/issues/16162')
 	void 'distinct accessors for the same property shape share the cache'() {
 		given:
-		def templateResource = new GroovyPageResourceScriptSource('/_fields/testBean/stringProperty/_widget.gsp', new ByteArrayResource('BEAN PROPERTY TEMPLATE'.getBytes('UTF-8')))
+		def templateResource = new GroovyPageResourceScriptSource('/_fields/templateLookupCachingCommand/stringProperty/_widget.gsp', new ByteArrayResource('BEAN PROPERTY TEMPLATE'.getBytes('UTF-8')))
 
 		and:
-		def bean1 = new TestBean(stringProperty: 'Bart Simpson')
-		def bean2 = new TestBean(stringProperty: 'Lisa Simpson')
+		def bean1 = new TemplateLookupCachingCommand(stringProperty: 'Bart Simpson')
+		def bean2 = new TemplateLookupCachingCommand(stringProperty: 'Lisa Simpson')
 		def property1 = beanPropertyAccessorFactory.accessorFor(bean1, 'stringProperty')
 		def property2 = beanPropertyAccessorFactory.accessorFor(bean2, 'stringProperty')
 
@@ -141,7 +141,7 @@ class TemplateLookupCachingSpec extends BuildsAccessorFactory implements Service
 		def template = service.findTemplate(property1, 'input', null, null)
 
 		then: 'the template path is correct'
-		template.path == '/_fields/testBean/stringProperty/input'
+		template.path == '/_fields/templateLookupCachingCommand/stringProperty/input'
 
 		and: 'the template was found by the service'
 		1 * mockGroovyPageLocator.findTemplateByPath(_) >> templateResource
@@ -150,10 +150,14 @@ class TemplateLookupCachingSpec extends BuildsAccessorFactory implements Service
 		template = service.findTemplate(property2, 'input', null, null)
 
 		then: 'the template path is still correct'
-		template.path == '/_fields/testBean/stringProperty/input'
+		template.path == '/_fields/templateLookupCachingCommand/stringProperty/input'
 
 		and: 'the locator is only called for the first accessor'
 		0 * mockGroovyPageLocator.findTemplateByPath(_)
 	}
 
+}
+
+class TemplateLookupCachingCommand {
+	String stringProperty
 }

--- a/grails-fields/src/test/groovy/grails/plugin/formfields/TemplateLookupCachingSpec.groovy
+++ b/grails-fields/src/test/groovy/grails/plugin/formfields/TemplateLookupCachingSpec.groovy
@@ -122,4 +122,38 @@ class TemplateLookupCachingSpec extends BuildsAccessorFactory implements Service
 		1 * mockGroovyPageLocator.findTemplateByPath(_) >> templateResource
 	}
 
+	@Issue('https://github.com/apache/grails-core/issues/16162')
+	void 'distinct accessors for the same property shape share the cache'() {
+		given:
+		def templateResource = new GroovyPageResourceScriptSource('/_fields/testBean/stringProperty/_widget.gsp', new ByteArrayResource('BEAN PROPERTY TEMPLATE'.getBytes('UTF-8')))
+
+		and:
+		def bean1 = new TestBean(stringProperty: 'Bart Simpson')
+		def bean2 = new TestBean(stringProperty: 'Lisa Simpson')
+		def property1 = beanPropertyAccessorFactory.accessorFor(bean1, 'stringProperty')
+		def property2 = beanPropertyAccessorFactory.accessorFor(bean2, 'stringProperty')
+
+		and: 'accessors retain distinct request beans, so accessor-keyed memoization would miss'
+		assert !property1.is(property2)
+		assert property1 != property2
+
+		when: 'calling it the first time'
+		def template = service.findTemplate(property1, 'input', null, null)
+
+		then: 'the template path is correct'
+		template.path == '/_fields/testBean/stringProperty/input'
+
+		and: 'the template was found by the service'
+		1 * mockGroovyPageLocator.findTemplateByPath(_) >> templateResource
+
+		when: 'calling it with a different accessor for the same lookup shape'
+		template = service.findTemplate(property2, 'input', null, null)
+
+		then: 'the template path is still correct'
+		template.path == '/_fields/testBean/stringProperty/input'
+
+		and: 'the locator is only called for the first accessor'
+		0 * mockGroovyPageLocator.findTemplateByPath(_)
+	}
+
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/apache/grails-core/issues/16162.

This is a real memory leak, not user error. `FormFieldsTemplateService` is a singleton, and template lookup caching is on by default. `findTemplateCached` was `@Memoized` with a `BeanPropertyAccessor` argument. `BeanPropertyAccessorImpl` is `@Canonical` and includes `rootBean` and `value`, so each request creates a unique unbounded cache key. Those accessors (and their beans) cannot be collected while the service lives, which grows into heap exhaustion on command objects and other non-domain forms.

`findTemplate` now builds the candidate template path list first and memoizes only that list of strings. Distinct accessors for the same property shape share one cache entry, and request beans are no longer retained. Theme-first then default fallback order is unchanged.

## Contributor Checklist

Please review the following checklist before submitting your pull request. Pull requests that do not meet these requirements may be closed without review.

### Issue and Scope

- [x] This PR is linked to an existing issue that has been **acknowledged or approved** by the project team. If no approved issue exists, please give background on why this change is necessary.  Tickets are preferred for release change log history.
- [x] This PR addresses the **complete scope** of the linked issue. Partial implementations or unfinished work should not be submitted for review.
- [x] This PR contains a **single, focused change**. Unrelated changes should be submitted as separate pull requests.
- [x] This PR targets the **correct branch** for the type of change:
    - **Patch release branches** (e.g., `7.0.x`): Bug fixes only. No new features or API changes.
    - **Minor release branches** (e.g., `7.1.x`): New features are welcome, but breaking existing APIs must be avoided.
    - **Major release branches** (e.g., `8.0.x`): Reserved for major changes. Breaking API changes are permitted.

### Code Quality

- [x] I have **added or updated tests** that cover the changes introduced in this PR. All code contributions are expected to include appropriate test coverage.
- [ ] I have verified that all existing tests pass by running `./gradlew build --rerun-tasks`.
- [x] My code follows the project's **code style** guidelines. I have run `./gradlew codeStyle` and resolved any violations. See [Code Style](../CONTRIBUTING.md#code-style) for details.
- [x] This PR does **not** include mass reformatting, style-only changes, or large-scale refactoring unless it was **explicitly approved** in the linked issue. Unsolicited reformatting will not be accepted.
- [x] If generative AI tooling was used in preparing this contribution, a quality model was used to ensure contributions are **consistent with the project's quality standards**.

### Licensing and Attribution

- [x] All contributed code is provided under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), and new source files include the appropriate **Apache license header**.
- [x] I have the necessary rights to submit this contribution and confirm it is my own original work (see [Legal Notice](../CONTRIBUTING.md#i-want-to-contribute)).
- [x] If generative AI tooling was used in preparing this contribution, I have followed the [Apache Software Foundation's policy on generative tooling](https://www.apache.org/legal/generative-tooling.html) and have properly attributed its use.

### Documentation

- [ ] If this PR introduces user-facing changes, I have included or updated the relevant documentation.
- [ ] If this PR adds a new feature, I have updated the **What's New** section of the Grails Guide.
- [ ] If this PR introduces breaking changes or changes that require user action during an upgrade, I have updated the **Upgrade Notes** for the corresponding version in the Grails Guide.
- [x] The PR description clearly explains **what** was changed and **why**.

## Generative AI attribution

Generative AI tooling (Cursor Grok 4.6 with GPT review) was used to draft the implementation and tests. The change was reviewed, tested in `grails-fields` (`./gradlew :grails-fields:test` and `:grails-fields:codeStyle`), and edited before submission.
