### PR TITLE
Include groovydoc in the Groovy Snapshot Canary Build

### DIFF
--- a/.github/workflows/groovy-snapshot-canary.yml
+++ b/.github/workflows/groovy-snapshot-canary.yml
@@ -185,7 +185,6 @@ jobs:
           ./gradlew ${{ matrix.gradle_task }}
           --continue
           --stacktrace
-          -x groovydoc
           -PskipCodeStyle
           -PskipMicronautProjects
           -PmaxTestParallel=3


### PR DESCRIPTION
After discussion in the weekly, we decided to remove the exclusion of groovydoc from the Groovy Snapshot Canary Build, as we missed a regression with Groovy 5.1.1 particularly hitting groovydoc.