### PR TITLE
Canonicalize interceptor and security matcher request paths

### DIFF
--- a/gradle/spring-security-test-config.gradle
+++ b/gradle/spring-security-test-config.gradle
@@ -48,20 +48,22 @@ tasks.withType(Test).configureEach {
     ] as TestListener)
 }
 
-tasks.named('integrationTest', Test) {
-    systemProperty('geb.build.reportsDir', reporting.file("$projectDir/build/geb-reports"))
-    systemProperty('grails.geb.reporting.directory', reporting.file("$projectDir/build/geb-reports").canonicalFile.absolutePath)
-    // systemProperty('grails.geb.recording.mode', 'RECORD_ALL')
-    systemProperty('TESTCONFIG', System.getProperty('TESTCONFIG'))
+pluginManager.withPlugin('org.apache.grails.gradle.grails-integration-test') {
+    tasks.named('integrationTest', Test) {
+        systemProperty('geb.build.reportsDir', reporting.file("$projectDir/build/geb-reports"))
+        systemProperty('grails.geb.reporting.directory', reporting.file("$projectDir/build/geb-reports").canonicalFile.absolutePath)
+        // systemProperty('grails.geb.recording.mode', 'RECORD_ALL')
+        systemProperty('TESTCONFIG', System.getProperty('TESTCONFIG'))
 
-    // Waiting at-checks keep Geb tests resilient when a page is still loading after navigation.
-    systemProperty('grails.geb.atCheckWaiting.enabled', 'true')
-    systemProperty('grails.geb.timeouts.timeout', '30')
+        // Waiting at-checks keep Geb tests resilient when a page is still loading after navigation.
+        systemProperty('grails.geb.atCheckWaiting.enabled', 'true')
+        systemProperty('grails.geb.timeouts.timeout', '30')
 
-    doFirst {
-        logger.quiet(
-                '\n - Running tests for configuration: {}',
-                System.getProperty('TESTCONFIG', 'N/S')
-        )
+        doFirst {
+            logger.quiet(
+                    '\n - Running tests for configuration: {}',
+                    System.getProperty('TESTCONFIG', 'N/S')
+            )
+        }
     }
 }

--- a/grails-doc/src/en/guide/security/securityPlugins/springSecurity/core/ip.adoc
+++ b/grails-doc/src/en/guide/security/securityPlugins/springSecurity/core/ip.adoc
@@ -48,6 +48,8 @@ grails.plugin.springsecurity.ipRestrictions = [
 
 `pattern1` URLs can be accessed only from the external address 123.234.345.456, `pattern2` URLs can be accessed only from a 10.xxx.xxx.xxx intranet address, and `pattern3` URLs can be accessed only from 10.10.200.42 or 10.10.200.63. All other URL patterns are accessible from any IP address.
 
+Patterns are matched against the request path within the application, in the form the request is dispatched: the context path is not included, percent-encoded characters are decoded and matrix parameters (`;name=value`) are removed, so an encoded or matrix-parameter variant of a restricted URL is subject to the same restriction. For a forwarded request the path of the original request is checked.
+
 [WARNING]
 ====
 The format of `ipRestrictions` has changed from previous versions to avoid configuration parsing issues. In previous versions the property was a single Map, where the keys were the access patterns and the values were the IP addresses that are allowed. The old format is no longer supported and your configurations must be updated to the newer format.

--- a/grails-doc/src/en/guide/theWebLayer/interceptors/interceptorMatching.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/interceptors/interceptorMatching.adoc
@@ -82,4 +82,6 @@ class AdminInterceptor {
 }
 ----
 
+This is the canonical form defined by RFC 3986 and the Jakarta Servlet specification: path parameters are removed from each segment before percent-decoding, so an encoded semicolon (`%3B`) is a literal character rather than a parameter delimiter, and the path is decoded exactly once.
+
 A pattern that starts with the context path, such as `match(uri: '/app/admin/**')`, is also accepted for backwards compatibility. Requests dispatched through `<g:include>` are matched against the included path, which is the path the include is dispatched to.

--- a/grails-doc/src/en/guide/theWebLayer/interceptors/interceptorMatching.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/interceptors/interceptorMatching.adoc
@@ -64,4 +64,22 @@ All named arguments except for `uri` accept either a String or a Regex expressio
 * `controller` - The name of the controller
 * `action` - The name of the action
 * `method` - The HTTP method
-* `uri` - The URI of the request. If this argument is used then all other arguments will be ignored and only this will be used.
+* `uri` - The path of the request within the application. If this argument is used then all other arguments will be ignored and only this will be used.
+
+The `uri` argument is matched against the same path that URL mappings use to select the controller: percent-encoded characters are decoded, matrix parameters (`;name=value`) are removed, and the context path is not included. When an application is deployed under the context path `/app`, a request for `/app/%61dmin;x=1/users` is matched as `/admin/users`, so the following interceptor applies to it:
+
+[source,groovy]
+----
+class AdminInterceptor {
+  AdminInterceptor() {
+    match(uri: '/admin/**')
+    .excludes(uri: '/admin/health')
+  }
+
+  boolean before() {
+    ...
+  }
+}
+----
+
+A pattern that starts with the context path, such as `match(uri: '/app/admin/**')`, is also accepted for backwards compatibility. Requests dispatched through `<g:include>` are matched against the included path, which is the path the include is dispatched to.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -3108,11 +3108,14 @@ for `/admin/**`. Interceptors matched by controller, action or namespace are una
 
 Review interceptors that use `uri` matching for the following changes:
 
-* **Interceptors combining `match(uri:)` with `excludes(uri:)` now run under a context path.**
-In earlier versions such an interceptor never matched when the application was deployed under a non-root context path
-(for example `server.servlet.context-path=/app`), because the exclusion check also required the pattern to match the
-context-prefixed request URI. It now behaves as configured, so interceptors that were silently inactive start
-executing.
+* **Interceptors combining `match(uri:)` with an `excludes(...)` now run under a context path.**
+In earlier versions a matcher that paired a `uri` pattern with any exclusion (`excludes(uri:)`, `excludes(controller:)`,
+`excludes(action:)` or a closure) never matched when the application was deployed under a non-root context path (for
+example `server.servlet.context-path=/app`), because the exclusion check required the pattern to match both the
+context-prefixed and the context-relative request URI, which a pattern such as `/api/**` cannot do. Only that shape was
+affected: `matchAll()` with exclusions, `match(controller:)` and other name-based matchers, `match(uri:)` without an
+exclusion, and `uri` patterns that match both forms such as `/**` all ran as expected. The affected shape now behaves
+as configured, so an interceptor written that way starts executing under a context path.
 
 * **Patterns are matched against the path within the application only.**
 A pattern is no longer also compared with the context-prefixed request URI, so `+match(uri: '/*/*')+` no longer matches

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -3132,3 +3132,13 @@ context path; override it when a matcher needs the context-prefixed form.
 The Spring Security plugin applies the same canonicalization when matching `ipRestrictions` patterns and when the
 `AntPathRequestMatcher` compatibility class selects a filter chain, so an encoded or matrix-parameter variant of a
 restricted path is subject to the same restriction as the plain path.
+
+The canonical form follows the URI and Servlet specifications, with two deliberate exceptions. Path parameters are
+removed from each segment before percent-decoding, as Jakarta Servlet 6.0 section 3.5.2 requires of containers, so an
+encoded semicolon (`%3B`) is a literal character and not a parameter delimiter (RFC 3986 section 2.2). Percent-encoded
+unreserved characters such as `%61` are decoded (RFC 3986 section 2.3), and the path is decoded exactly once
+(RFC 3986 section 2.4). The exceptions are inherited from Spring's `UrlPathHelper`, which Grails URL mapping dispatch
+has used since Grails 3: the context path is compared case-insensitively although RFC 3986 section 6.2.2.1 and
+RFC 9110 section 4.2.3 define paths as case-sensitive, and during a `RequestDispatcher` include the included path is
+matched. Interceptors and the Spring Security matchers follow dispatch on both points because a matcher that
+disagrees with dispatch lets a request reach a controller without its interceptors or restrictions.

--- a/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
+++ b/grails-doc/src/en/guide/upgrading/upgrading80x.adoc
@@ -3097,3 +3097,38 @@ grails {
 imported whether or not they are present — a star import of an absent package contributes no classes and is
 not an error in Groovy, so the probe changed nothing it could observe. An application that relied on the
 import being *omitted* when the package was absent sees no difference in compiled output.
+
+==== 54. Interceptor URI Matching Uses the Dispatched Path
+
+Interceptors that match on `uri`, with `match(uri: ...)` or `excludes(uri: ...)`, now match the same path that URL
+mappings route on: percent escapes are decoded, matrix parameters (`;name=value`) are removed and the context path is
+stripped before the pattern is applied. Previously the raw request URI was matched, so an encoded (`/%61dmin/users`)
+or matrix-parameter (`/admin;x=1/users`) request could reach a controller without triggering an interceptor declared
+for `/admin/**`. Interceptors matched by controller, action or namespace are unaffected.
+
+Review interceptors that use `uri` matching for the following changes:
+
+* **Interceptors combining `match(uri:)` with `excludes(uri:)` now run under a context path.**
+In earlier versions such an interceptor never matched when the application was deployed under a non-root context path
+(for example `server.servlet.context-path=/app`), because the exclusion check also required the pattern to match the
+context-prefixed request URI. It now behaves as configured, so interceptors that were silently inactive start
+executing.
+
+* **Patterns are matched against the path within the application only.**
+A pattern is no longer also compared with the context-prefixed request URI, so `+match(uri: '/*/*')+` no longer matches
+`/app/save` under the context path `/app`. Patterns that begin with the context path, such as
+`match(uri: '/app/admin/**')`, are still accepted for backwards compatibility.
+
+* **Includes are matched against the included path.**
+During a `<g:include>` or `RequestDispatcher` include, `uri` matchers see the included path rather than the URI of the
+outer request. This is consistent with the controller selected for the include and with `match(controller:)`
+matchers, which already matched the included controller.
+
+* **Custom `grails.interceptors.Matcher` implementations receive the canonical path.**
+The `uri` argument passed to `doesMatch` is now the decoded, application-relative path without matrix parameters. A new
+`doesMatch(String uri, UrlMappingInfo info, String method, String contextPath)` default method also supplies the
+context path; override it when a matcher needs the context-prefixed form.
+
+The Spring Security plugin applies the same canonicalization when matching `ipRestrictions` patterns and when the
+`AntPathRequestMatcher` compatibility class selects a filter chain, so an encoded or matrix-parameter variant of a
+restricted path is subject to the same restriction as the plain path.

--- a/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -29,6 +29,7 @@ import jakarta.servlet.http.HttpServletResponse
 
 import org.springframework.core.Ordered
 import org.springframework.web.servlet.ModelAndView
+import org.springframework.web.util.UrlPathHelper
 
 import grails.artefact.controller.support.RequestForwarder
 import grails.artefact.controller.support.ResponseRedirector
@@ -89,25 +90,17 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
             allMatchers << matcher
         }
 
-        HttpServletRequest req = request
-        String ctxPath = req.contextPath
-        String uri = req.requestURI
-        String noCtxUri = uri - ctxPath
-        boolean checkNoCtxUri = ctxPath && uri.startsWith(ctxPath)
+        String uri = UrlPathHelper.defaultInstance.getPathWithinApplication(request)
 
         def matchedInfo = request.getAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST)
 
         UrlMappingInfo grailsMappingInfo = (UrlMappingInfo) matchedInfo
 
         for (Matcher matcher in allMatchers) {
-            boolean matchUri = matcher.doesMatch(uri, grailsMappingInfo, req.method)
-            boolean matchNoCtxUri = matcher.doesMatch(noCtxUri, grailsMappingInfo, req.method)
-
-            if (matcher.isExclude() && matchUri && matchNoCtxUri) {
-                // Exclude interceptors are special because with only one of the conditions being false the interceptor
-                // won't be applied to the request
-                return true
-            } else if (!matcher.isExclude() && (matchUri || (checkNoCtxUri && matchNoCtxUri))) {
+            boolean matches = matcher instanceof UrlMappingMatcher
+                    ? ((UrlMappingMatcher) matcher).doesMatch(uri, grailsMappingInfo, request.method, request.contextPath)
+                    : matcher.doesMatch(uri, grailsMappingInfo, request.method)
+            if (matches) {
                 return true
             }
         }

--- a/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -78,6 +78,15 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
         doesMatch(request)
     }
     /**
+     * Whether this interceptor matches the given request.
+     *
+     * <p>URI matchers see the same path that URL mappings route on: decoded, with matrix parameters removed and the
+     * context path stripped. During a {@code RequestDispatcher} include this is the included path, which is also
+     * the path the include is dispatched on. The path is canonicalized once per call and passed to every
+     * {@link Matcher}. A request whose URI contains a malformed percent escape is matched undecoded rather than
+     * failing.
+     *
+     * @param request The request to match
      * @return Whether the current interceptor does match
      */
     @Generated
@@ -90,17 +99,21 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
             allMatchers << matcher
         }
 
-        String uri = UrlPathHelper.defaultInstance.getPathWithinApplication(request)
-
-        def matchedInfo = request.getAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST)
-
-        UrlMappingInfo grailsMappingInfo = (UrlMappingInfo) matchedInfo
+        String uri
+        try {
+            uri = UrlPathHelper.defaultInstance.getPathWithinApplication(request)
+        } catch (IllegalArgumentException ignored) {
+            // the URI has a malformed percent escape and cannot be decoded: match it undecoded rather than fail
+            UrlPathHelper rawPathHelper = new UrlPathHelper()
+            rawPathHelper.urlDecode = false
+            uri = rawPathHelper.getPathWithinApplication(request)
+        }
+        String contextPath = request.contextPath
+        String method = request.method
+        UrlMappingInfo grailsMappingInfo = (UrlMappingInfo) request.getAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST)
 
         for (Matcher matcher in allMatchers) {
-            boolean matches = matcher instanceof UrlMappingMatcher
-                    ? ((UrlMappingMatcher) matcher).doesMatch(uri, grailsMappingInfo, request.method, request.contextPath)
-                    : matcher.doesMatch(uri, grailsMappingInfo, request.method)
-            if (matches) {
+            if (matcher.doesMatch(uri, grailsMappingInfo, method, contextPath)) {
                 return true
             }
         }

--- a/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
+++ b/grails-interceptors/src/main/groovy/grails/artefact/Interceptor.groovy
@@ -80,11 +80,19 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
     /**
      * Whether this interceptor matches the given request.
      *
-     * <p>URI matchers see the same path that URL mappings route on: decoded, with matrix parameters removed and the
-     * context path stripped. During a {@code RequestDispatcher} include this is the included path, which is also
-     * the path the include is dispatched on. The path is canonicalized once per call and passed to every
-     * {@link Matcher}. A request whose URI contains a malformed percent escape is matched undecoded rather than
-     * failing.
+     * <p>URI matchers see the same path that URL mappings route on, resolved with the same {@link UrlPathHelper}
+     * call: path parameters ({@code ;name=value}) are removed per segment before percent-decoding, as Jakarta
+     * Servlet 6.0 section 3.5.2 requires of containers, so an encoded semicolon ({@code %3B}) stays a literal
+     * character (RFC 3986 section 2.2); the path is decoded exactly once (RFC 3986 section 2.4); and the context
+     * path is stripped. Two points follow Spring, and therefore dispatch, rather than the URI specification: the
+     * context path is compared case-insensitively although RFC 3986 section 6.2.2.1 defines paths as case-sensitive,
+     * and during a {@code RequestDispatcher} include the included path is matched, which is also the path the
+     * include is dispatched on. A matcher that disagreed with dispatch on either point would let a request reach a
+     * controller without its interceptors, so dispatch wins.
+     *
+     * <p>The path is canonicalized once per call and passed to every {@link Matcher}. A request whose URI contains
+     * an illegal percent escape, which a Servlet 6.0 container rejects with 400 before dispatch, is matched
+     * undecoded rather than failing.
      *
      * @param request The request to match
      * @return Whether the current interceptor does match
@@ -103,7 +111,7 @@ trait Interceptor implements ResponseRenderer, ResponseRedirector, RequestForwar
         try {
             uri = UrlPathHelper.defaultInstance.getPathWithinApplication(request)
         } catch (IllegalArgumentException ignored) {
-            // the URI has a malformed percent escape and cannot be decoded: match it undecoded rather than fail
+            // illegal percent escape: match the undecoded path rather than fail
             UrlPathHelper rawPathHelper = new UrlPathHelper()
             rawPathHelper.urlDecode = false
             uri = rawPathHelper.getPathWithinApplication(request)

--- a/grails-interceptors/src/main/groovy/grails/interceptors/Matcher.groovy
+++ b/grails-interceptors/src/main/groovy/grails/interceptors/Matcher.groovy
@@ -51,6 +51,26 @@ interface Matcher {
     boolean doesMatch(String uri, UrlMappingInfo info, String method)
 
     /**
+     * Performs the match for a request deployed under a context path.
+     *
+     * <p>{@link grails.artefact.Interceptor#doesMatch(jakarta.servlet.http.HttpServletRequest)} canonicalizes the
+     * request path once and calls this method for every matcher. The default implementation delegates to
+     * {@link #doesMatch(String, UrlMappingInfo, String)} with the same path, so a custom matcher only needs to
+     * implement this method if it wants to take the context path into account.
+     *
+     * @param uri The path of the request within the application: decoded, with matrix parameters removed and the
+     * context path stripped, exactly as URL mappings route it
+     * @param info The {@link UrlMappingInfo} matched for the request, or {@code null} if none was matched
+     * @param method The HTTP method of the request
+     * @param contextPath The context path of the request, empty when the application is deployed at the root
+     * @return True if it does match
+     * @since 8.0
+     */
+    default boolean doesMatch(String uri, UrlMappingInfo info, String method, String contextPath) {
+        doesMatch(uri, info, method)
+    }
+
+    /**
      * Defines the match for the given arguments
      *
      * @param arguments A named argument map including one or more of the controller name, action name, namespace and method

--- a/grails-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
+++ b/grails-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
@@ -18,12 +18,15 @@
  */
 package org.grails.plugins.web.interceptors
 
+import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.util.HashCodeHelper
 
 import org.springframework.util.AntPathMatcher
+import org.springframework.web.util.UriUtils
+import org.springframework.web.util.UrlPathHelper
 
 import grails.artefact.Interceptor
 import grails.interceptors.Matcher
@@ -61,16 +64,20 @@ class UrlMappingMatcher implements Matcher {
     }
 
     boolean doesMatch(String uri, UrlMappingInfo info, String method) {
-        boolean hasUriPatterns = !uriPatterns.isEmpty()
+        doesMatch(uri, info, method, null)
+    }
 
-        boolean isExcluded = this.isExcluded(uri, info)
+    boolean doesMatch(String uri, UrlMappingInfo info, String method, String contextPath) {
+        boolean hasUriPatterns = !uriPatterns.isEmpty()
+        String path = canonicalizePath(uri)
+
+        boolean isExcluded = this.isExcluded(path, info, contextPath)
         if (matchAll && !isExcluded) return true
 
         if (!isExcluded) {
             if (hasUriPatterns) {
-                uri = uri.replace(';', '')
                 for (pattern in uriPatterns) {
-                    if (pathMatcher.match(pattern, uri)) {
+                    if (matchesPattern(pattern, path, contextPath)) {
                         return true
                     }
                 }
@@ -84,8 +91,12 @@ class UrlMappingMatcher implements Matcher {
     }
 
     protected boolean isExcluded(String uri, UrlMappingInfo info) {
+        isExcluded(uri, info, null)
+    }
+
+    protected boolean isExcluded(String uri, UrlMappingInfo info, String contextPath) {
         for (pattern in uriExcludePatterns) {
-            if (pathMatcher.match(pattern, uri)) {
+            if (matchesPattern(pattern, uri, contextPath)) {
                 return true
             }
         }
@@ -97,6 +108,30 @@ class UrlMappingMatcher implements Matcher {
             }
         }
         return false
+    }
+
+    private String canonicalizePath(String uri) {
+        if (uri == null || uri.isEmpty()) {
+            return '/'
+        }
+        String path = UrlPathHelper.defaultInstance.removeSemicolonContent(uri)
+        try {
+            path = UriUtils.decode(path, StandardCharsets.UTF_8)
+        } catch (IllegalArgumentException ignored) {
+            // keep the semicolon-stripped form when the URI is malformed
+        }
+        path = UrlPathHelper.defaultInstance.removeSemicolonContent(path)
+        path ?: '/'
+    }
+
+    private boolean matchesPattern(String pattern, String path, String contextPath) {
+        if (pathMatcher.match(pattern, path)) {
+            return true
+        }
+        if (contextPath && contextPath != '/' && (pattern == contextPath || pattern.startsWith(contextPath + '/'))) {
+            return pathMatcher.match(pattern.substring(contextPath.length()) ?: '/', path)
+        }
+        false
     }
 
     protected boolean doesMatchInternal(UrlMappingInfo info, String method) {

--- a/grails-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
+++ b/grails-interceptors/src/main/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcher.groovy
@@ -18,15 +18,12 @@
  */
 package org.grails.plugins.web.interceptors
 
-import java.nio.charset.StandardCharsets
 import java.util.regex.Pattern
 
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.util.HashCodeHelper
 
 import org.springframework.util.AntPathMatcher
-import org.springframework.web.util.UriUtils
-import org.springframework.web.util.UrlPathHelper
 
 import grails.artefact.Interceptor
 import grails.interceptors.Matcher
@@ -34,6 +31,12 @@ import grails.web.mapping.UrlMappingInfo
 
 /**
  * Used to match {@link UrlMappingInfo} instance by {@link grails.artefact.Interceptor} instances
+ *
+ * <p>URI patterns are matched against the path passed to {@link #doesMatch(String, UrlMappingInfo, String, String)}
+ * as-is. {@link grails.artefact.Interceptor#doesMatch(jakarta.servlet.http.HttpServletRequest)} passes the decoded,
+ * application-relative path that URL mappings route on, so this class must not decode or remove matrix parameters
+ * again: that would match a different path than the one dispatched ({@code /health%3Bx} is dispatched as
+ * {@code /health;x}, not as {@code /health}).
  *
  * @author Graeme Rocher
  * @since 3.0
@@ -67,17 +70,17 @@ class UrlMappingMatcher implements Matcher {
         doesMatch(uri, info, method, null)
     }
 
+    @Override
     boolean doesMatch(String uri, UrlMappingInfo info, String method, String contextPath) {
         boolean hasUriPatterns = !uriPatterns.isEmpty()
-        String path = canonicalizePath(uri)
 
-        boolean isExcluded = this.isExcluded(path, info, contextPath)
+        boolean isExcluded = this.isExcluded(uri, info, contextPath)
         if (matchAll && !isExcluded) return true
 
         if (!isExcluded) {
             if (hasUriPatterns) {
                 for (pattern in uriPatterns) {
-                    if (matchesPattern(pattern, path, contextPath)) {
+                    if (matchesPattern(pattern, uri, contextPath)) {
                         return true
                     }
                 }
@@ -110,20 +113,12 @@ class UrlMappingMatcher implements Matcher {
         return false
     }
 
-    private String canonicalizePath(String uri) {
-        if (uri == null || uri.isEmpty()) {
-            return '/'
-        }
-        String path = UrlPathHelper.defaultInstance.removeSemicolonContent(uri)
-        try {
-            path = UriUtils.decode(path, StandardCharsets.UTF_8)
-        } catch (IllegalArgumentException ignored) {
-            // keep the semicolon-stripped form when the URI is malformed
-        }
-        path = UrlPathHelper.defaultInstance.removeSemicolonContent(path)
-        path ?: '/'
-    }
-
+    /**
+     * Matches the pattern against the application-relative path. A pattern that begins with the context path is
+     * also accepted with the context path removed, so interceptors written against a context-prefixed URI
+     * (issue 10857) keep working. The path itself is never re-prefixed with the context path, so a pattern such as
+     * <code>/*&#47;*</code> only matches paths with two segments inside the application.
+     */
     private boolean matchesPattern(String pattern, String path, String contextPath) {
         if (pathMatcher.match(pattern, path)) {
             return true

--- a/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -267,6 +267,19 @@ class InterceptorSpec extends Specification {
         '/foo/bar' | true
     }
 
+    void "Test URI matching uses the canonical request path"() {
+        given:
+        def interceptor = new TestAdminUriInterceptor()
+        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), new MockHttpServletRequest('', requestUri), new MockHttpServletResponse())
+        webRequest.request.setAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST, new ForwardUrlMappingInfo(controllerName: 'admin', action: 'deleteUser'))
+
+        expect:
+        interceptor.doesMatch()
+
+        where:
+        requestUri << ['/admin;x=1/deleteUser', '/%61dmin/deleteUser']
+    }
+
     void "Test match with uri and context path"() {
         given: "A test interceptor"
         def i = new TestUriInterceptor()
@@ -444,6 +457,12 @@ class TestUriInterceptor implements Interceptor {
     }
 }
 
+class TestAdminUriInterceptor implements Interceptor {
+    TestAdminUriInterceptor() {
+        match(uri: '/admin/**')
+    }
+}
+
 class TestContextUriInterceptor implements Interceptor {
     TestContextUriInterceptor() {
         match(uri: '/grails/bar/**')
@@ -460,7 +479,7 @@ class TestExcludeUriWithoutContextPathInterceptor implements Interceptor {
 
 class TestExcludeUriWithContextPathInterceptor implements Interceptor {
     TestExcludeUriWithContextPathInterceptor() {
-        matchAll().excludes(uri: "/grails/mgmt/*")
+        matchAll().excludes(uri: '/grails/mgmt/*')
     }
 }
 

--- a/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -18,11 +18,14 @@
  */
 package grails.artefact
 
+import grails.interceptors.Matcher
 import grails.util.GrailsWebMockUtil
+import grails.web.mapping.UrlMappingInfo
 import groovy.transform.Generated
 import org.grails.plugins.web.interceptors.InterceptorArtefactHandler
 import org.grails.web.mapping.ForwardUrlMappingInfo
 import org.grails.web.mapping.mvc.UrlMappingsHandlerMapping
+import org.grails.web.util.WebUtils
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.mock.web.MockServletContext
@@ -267,17 +270,155 @@ class InterceptorSpec extends Specification {
         '/foo/bar' | true
     }
 
-    void "Test URI matching uses the canonical request path"() {
-        given:
+    @Unroll
+    void "Test URI matching uses the path that URL mappings route on: #requestUri"() {
+        given: "an interceptor matching /admin/**"
         def interceptor = new TestAdminUriInterceptor()
-        def webRequest = GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), new MockHttpServletRequest('', requestUri), new MockHttpServletResponse())
-        webRequest.request.setAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST, new ForwardUrlMappingInfo(controllerName: 'admin', action: 'deleteUser'))
+        bindRequest(requestUri)
+
+        expect: "the request is matched as URL mappings would dispatch it"
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        requestUri                | shouldMatch | reason
+        '/admin/deleteUser'       | true        | 'plain path'
+        '/admin;x=1/deleteUser'   | true        | 'matrix parameters are not part of the path'
+        '/%61dmin/deleteUser'     | true        | 'percent escapes are decoded'
+        '/admin%3Bx=1/deleteUser' | false       | 'an encoded semicolon is a literal character, so this is a different path'
+        '/%2561dmin/deleteUser'   | false       | 'decoded once, this is /%61dmin/deleteUser, not /admin/deleteUser'
+    }
+
+    void "Test a URI exclude only fires for the dispatched path"() {
+        given: "an interceptor for everything except /health"
+        def interceptor = new TestExcludeHealthUriInterceptor()
+        bindRequest('/health%3Bx')
+
+        expect: "the interceptor still runs because /health;x is dispatched to a different path than /health"
+        interceptor.doesMatch()
+    }
+
+    @Unroll
+    void "Test URI matching during an include matches the included path: #pattern"() {
+        given: "a request for /admin/dashboard that is including /stats/index"
+        def interceptor = new TestPatternUriInterceptor(pattern)
+        def request = bindRequest('/admin/dashboard')
+        request.setAttribute(WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE, '/stats/index')
+
+        expect: "the included path is matched, which is also the path the include is dispatched on"
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        pattern     | shouldMatch
+        '/admin/**' | false
+        '/stats/**' | true
+    }
+
+    @Unroll
+    void "Test a malformed percent escape is matched undecoded instead of failing: #requestUri"() {
+        given: "an interceptor matching /admin/**"
+        def interceptor = new TestAdminUriInterceptor()
+        bindRequest(requestUri)
+
+        expect:
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        requestUri    | shouldMatch
+        '/foo%'       | false
+        '/admin/foo%' | true
+        '/admin/%zz'  | true
+    }
+
+    @Unroll
+    void "Test URI decoding uses the request character encoding like URL mappings do: #characterEncoding"() {
+        given: "an interceptor matching the decoded UTF-8 form of the path"
+        def interceptor = new TestPatternUriInterceptor('/caf\u00e9')
+        def request = bindRequest('/caf%C3%A9')
+        request.characterEncoding = characterEncoding
+
+        expect:
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        characterEncoding | shouldMatch
+        'UTF-8'           | true
+        'ISO-8859-1'      | false
+    }
+
+    @Unroll
+    void "Test match with uri and excludes with uri under a context path: #requestUri"() {
+        given: "match(uri: '/api/**').excludes(uri: '/api/health') deployed under /app"
+        def interceptor = new TestApiExcludingHealthUriInterceptor()
+        bindRequest(requestUri, '/app')
+
+        expect:
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        requestUri        | shouldMatch
+        '/app/api/orders' | true
+        '/app/api/health' | false
+        '/app/other'      | false
+    }
+
+    @Unroll
+    void "Test URI patterns are matched against the path within the application only: #pattern"() {
+        given: "a request for /app/save deployed under /app"
+        def interceptor = new TestPatternUriInterceptor(pattern)
+        bindRequest('/app/save', '/app')
+
+        expect:
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        pattern     | shouldMatch | reason
+        '/save'     | true        | 'application-relative pattern'
+        '/*'        | true        | 'application-relative wildcard'
+        '/app/save' | true        | 'context-prefixed pattern accepted for backwards compatibility'
+        '/*/*'      | false       | 'the context path is not part of the matched path'
+        '/app/*/*'  | false       | 'nor is it re-added when the pattern carries it'
+    }
+
+    void "Test a custom Matcher receives the canonical path through the default context path method"() {
+        given: "an interceptor using a Matcher that only implements the three argument doesMatch"
+        def matcher = new RecordingMatcher()
+        def interceptor = new TestCustomMatcherInterceptor(matcher)
+        bindRequest('/app/%61dmin;x=1/users', '/app')
 
         expect:
         interceptor.doesMatch()
+        matcher.uri == '/admin/users'
+        matcher.method == 'GET'
+    }
 
-        where:
-        requestUri << ['/admin;x=1/deleteUser', '/%61dmin/deleteUser']
+    void "Test a custom Matcher can receive the context path"() {
+        given: "an interceptor using a Matcher that overrides the four argument doesMatch"
+        def matcher = new ContextPathRecordingMatcher()
+        def interceptor = new TestCustomMatcherInterceptor(matcher)
+        bindRequest('/app/admin/users', '/app')
+
+        expect:
+        interceptor.doesMatch()
+        matcher.uri == '/admin/users'
+        matcher.contextPath == '/app'
+    }
+
+    void "Test a custom Matcher that does not match is honoured"() {
+        given:
+        def matcher = new RecordingMatcher(result: false)
+        def interceptor = new TestCustomMatcherInterceptor(matcher)
+        bindRequest('/admin/users')
+
+        expect:
+        !interceptor.doesMatch()
+        matcher.uri == '/admin/users'
+    }
+
+    private MockHttpServletRequest bindRequest(String requestUri, String contextPath = '') {
+        def mockRequest = new MockHttpServletRequest('GET', requestUri)
+        mockRequest.contextPath = contextPath
+        GrailsWebMockUtil.bindMockWebRequest(new MockServletContext(), mockRequest, new MockHttpServletResponse())
+        mockRequest
     }
 
     void "Test match with uri and context path"() {
@@ -460,6 +601,76 @@ class TestUriInterceptor implements Interceptor {
 class TestAdminUriInterceptor implements Interceptor {
     TestAdminUriInterceptor() {
         match(uri: '/admin/**')
+    }
+}
+
+class TestPatternUriInterceptor implements Interceptor {
+    TestPatternUriInterceptor(String pattern) {
+        match(uri: pattern)
+    }
+}
+
+class TestExcludeHealthUriInterceptor implements Interceptor {
+    TestExcludeHealthUriInterceptor() {
+        matchAll().excludes(uri: '/health')
+    }
+}
+
+class TestApiExcludingHealthUriInterceptor implements Interceptor {
+    TestApiExcludingHealthUriInterceptor() {
+        match(uri: '/api/**').excludes(uri: '/api/health')
+    }
+}
+
+class TestCustomMatcherInterceptor implements Interceptor {
+    TestCustomMatcherInterceptor(Matcher matcher) {
+        matchers << matcher
+    }
+}
+
+class RecordingMatcher implements Matcher {
+    String uri
+    String method
+    boolean result = true
+
+    @Override
+    boolean doesMatch(String uri, UrlMappingInfo info) {
+        doesMatch(uri, info, null)
+    }
+
+    @Override
+    boolean doesMatch(String uri, UrlMappingInfo info, String method) {
+        this.uri = uri
+        this.method = method
+        result
+    }
+
+    @Override
+    Matcher matches(Map arguments) { this }
+
+    @Override
+    Matcher matchAll() { this }
+
+    @Override
+    Matcher excludes(Map arguments) { this }
+
+    @Override
+    Matcher except(Map arguments) { this }
+
+    @Override
+    Matcher excludes(Closure<Boolean> condition) { this }
+
+    @Override
+    boolean isExclude() { false }
+}
+
+class ContextPathRecordingMatcher extends RecordingMatcher {
+    String contextPath
+
+    @Override
+    boolean doesMatch(String uri, UrlMappingInfo info, String method, String contextPath) {
+        this.contextPath = contextPath
+        doesMatch(uri, info, method)
     }
 }
 

--- a/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
+++ b/grails-interceptors/src/test/groovy/grails/artefact/InterceptorSpec.groovy
@@ -362,6 +362,23 @@ class InterceptorSpec extends Specification {
     }
 
     @Unroll
+    void "Test match with uri and a controller exclude under a context path: #requestUri"() {
+        given: "match(uri: '/api/**').excludes(controller: 'health') deployed under /app"
+        def interceptor = new TestApiExcludingHealthControllerInterceptor()
+        def request = bindRequest(requestUri, '/app')
+        request.setAttribute(UrlMappingsHandlerMapping.MATCHED_REQUEST, new ForwardUrlMappingInfo(controllerName: controller))
+
+        expect:
+        interceptor.doesMatch() == shouldMatch
+
+        where:
+        requestUri        | controller | shouldMatch
+        '/app/api/orders' | 'orders'   | true
+        '/app/api/health' | 'health'   | false
+        '/app/other'      | 'other'    | false
+    }
+
+    @Unroll
     void "Test URI patterns are matched against the path within the application only: #pattern"() {
         given: "a request for /app/save deployed under /app"
         def interceptor = new TestPatternUriInterceptor(pattern)
@@ -619,6 +636,12 @@ class TestExcludeHealthUriInterceptor implements Interceptor {
 class TestApiExcludingHealthUriInterceptor implements Interceptor {
     TestApiExcludingHealthUriInterceptor() {
         match(uri: '/api/**').excludes(uri: '/api/health')
+    }
+}
+
+class TestApiExcludingHealthControllerInterceptor implements Interceptor {
+    TestApiExcludingHealthControllerInterceptor() {
+        match(uri: '/api/**').excludes(controller: 'health')
     }
 }
 

--- a/grails-interceptors/src/test/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcherSpec.groovy
+++ b/grails-interceptors/src/test/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcherSpec.groovy
@@ -64,4 +64,19 @@ class UrlMappingMatcherSpec extends Specification {
         then:
         !matcher.doesMatch(url, info)
     }
+
+    void "URI patterns and excludes ignore matrix parameters"() {
+        given:
+        def matcher = new UrlMappingMatcher(Mock(Interceptor))
+        matcher.matches(uri: '/admin/**').excludes(uri: '/admin/health')
+
+        expect:
+        matcher.doesMatch(uri, null) == matches
+
+        where:
+        uri                       | matches
+        '/admin;x=1/deleteUser'   | true
+        '/admin/health;x=1'       | false
+        '/%61dmin/deleteUser'     | true
+    }
 }

--- a/grails-interceptors/src/test/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcherSpec.groovy
+++ b/grails-interceptors/src/test/groovy/org/grails/plugins/web/interceptors/UrlMappingMatcherSpec.groovy
@@ -22,8 +22,9 @@ import grails.artefact.Interceptor
 import grails.util.Environment
 import grails.web.mapping.UrlMappingInfo
 import spock.lang.Issue
-import spock.util.environment.RestoreSystemProperties
 import spock.lang.Specification
+import spock.lang.Unroll
+import spock.util.environment.RestoreSystemProperties
 
 class UrlMappingMatcherSpec extends Specification {
 
@@ -65,18 +66,67 @@ class UrlMappingMatcherSpec extends Specification {
         !matcher.doesMatch(url, info)
     }
 
-    void "URI patterns and excludes ignore matrix parameters"() {
-        given:
+    @Unroll
+    void "the matcher matches the path it is given without decoding it again: #uri"() {
+        given: "match(uri: '/admin/**').excludes(uri: '/admin/health')"
         def matcher = new UrlMappingMatcher(Mock(Interceptor))
         matcher.matches(uri: '/admin/**').excludes(uri: '/admin/health')
 
-        expect:
+        expect: "Interceptor canonicalizes the request path once, so a literal semicolon or escape is a different path"
         matcher.doesMatch(uri, null) == matches
 
         where:
-        uri                       | matches
-        '/admin;x=1/deleteUser'   | true
-        '/admin/health;x=1'       | false
-        '/%61dmin/deleteUser'     | true
+        uri                   | matches
+        '/admin/deleteUser'   | true
+        '/admin/health'       | false
+        '/admin/health;x'     | true
+        '/%61dmin/deleteUser' | false
+    }
+
+    @Unroll
+    void "a pattern is matched against the path within the application under context path /app: #pattern"() {
+        given:
+        def matcher = new UrlMappingMatcher(Mock(Interceptor))
+        matcher.matches(uri: pattern)
+
+        expect:
+        matcher.doesMatch('/save', null, 'GET', '/app') == matches
+
+        where:
+        pattern             | matches
+        '/save'             | true
+        '/*'                | true
+        '/app/save'         | true
+        '/app'              | false
+        '/*/*'              | false
+        '/app/*/*'          | false
+        '/application/save' | false
+    }
+
+    @Unroll
+    void "a context-prefixed exclude pattern only strips the context path when one is given: #contextPath"() {
+        given: "matchAll().excludes(uri: '/app/mgmt/*')"
+        def matcher = new UrlMappingMatcher(Mock(Interceptor))
+        matcher.matchAll().excludes(uri: '/app/mgmt/*')
+
+        expect:
+        matcher.doesMatch('/mgmt/health', null, 'GET', contextPath) == matches
+
+        where:
+        contextPath | matches
+        '/app'      | false
+        '/'         | true
+        ''          | true
+        null        | true
+    }
+
+    void "the three argument doesMatch behaves as if no context path was given"() {
+        given:
+        def matcher = new UrlMappingMatcher(Mock(Interceptor))
+        matcher.matches(uri: '/app/save')
+
+        expect:
+        !matcher.doesMatch('/save', null, 'GET')
+        matcher.doesMatch('/app/save', null, 'GET')
     }
 }

--- a/grails-spring-security/compat/build.gradle
+++ b/grails-spring-security/compat/build.gradle
@@ -52,8 +52,15 @@ dependencies {
     compileOnly 'jakarta.servlet:jakarta.servlet-api'
     compileOnly 'org.apache.groovy:groovy'
     compileOnly 'org.slf4j:slf4j-api'
+
+    testImplementation 'jakarta.servlet:jakarta.servlet-api'
+    testImplementation 'org.springframework:spring-test'
+    testImplementation 'org.spockframework:spock-core'
+
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }
 
 apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
 }

--- a/grails-spring-security/compat/build.gradle
+++ b/grails-spring-security/compat/build.gradle
@@ -62,5 +62,5 @@ dependencies {
 
 apply {
     from rootProject.layout.projectDirectory.file('gradle/docs-config.gradle')
-    from rootProject.layout.projectDirectory.file('gradle/test-config.gradle')
+    from rootProject.layout.projectDirectory.file('gradle/spring-security-test-config.gradle')
 }

--- a/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
+++ b/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
@@ -23,6 +23,7 @@ import groovy.transform.CompileStatic
 import jakarta.servlet.http.HttpServletRequest
 
 import org.springframework.util.AntPathMatcher
+import org.springframework.web.util.UrlPathHelper
 
 @CompileStatic
 class AntPathRequestMatcher implements RequestMatcher {
@@ -47,11 +48,7 @@ class AntPathRequestMatcher implements RequestMatcher {
         if (httpMethod && !httpMethod.equalsIgnoreCase(request.method)) {
             return false
         }
-        def path = request.requestURI ?: '/'
-        def contextPath = request.contextPath
-        if (contextPath && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length())
-        }
+        def path = UrlPathHelper.defaultInstance.removeSemicolonContent(UrlPathHelper.defaultInstance.getPathWithinApplication(request)) ?: '/'
         def candidate = caseSensitive ? path : path.toLowerCase(Locale.ENGLISH)
         def matcherPattern = caseSensitive ? pattern : pattern.toLowerCase(Locale.ENGLISH)
         pathMatcher.match(matcherPattern, candidate)

--- a/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
+++ b/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
@@ -28,6 +28,8 @@ import org.springframework.web.util.UrlPathHelper
 @CompileStatic
 class AntPathRequestMatcher implements RequestMatcher {
 
+    private static final UrlPathHelper PATH_HELPER = UrlPathHelper.defaultInstance
+
     private final String pattern
     private final String httpMethod
     private final boolean caseSensitive
@@ -48,10 +50,35 @@ class AntPathRequestMatcher implements RequestMatcher {
         if (httpMethod && !httpMethod.equalsIgnoreCase(request.method)) {
             return false
         }
-        def path = UrlPathHelper.defaultInstance.removeSemicolonContent(UrlPathHelper.defaultInstance.getPathWithinApplication(request)) ?: '/'
-        def candidate = caseSensitive ? path : path.toLowerCase(Locale.ENGLISH)
-        def matcherPattern = caseSensitive ? pattern : pattern.toLowerCase(Locale.ENGLISH)
+        String path = getPathWithinApplication(request)
+        String candidate = caseSensitive ? path : path.toLowerCase(Locale.ENGLISH)
+        String matcherPattern = caseSensitive ? pattern : pattern.toLowerCase(Locale.ENGLISH)
         pathMatcher.match(matcherPattern, candidate)
+    }
+
+    /**
+     * The request URI canonicalized the way request dispatch sees it: matrix parameters removed, percent escapes
+     * decoded and the context path stripped, so an encoded or matrix-parameter variant of a path selects the same
+     * filter chain as the plain path. The request URI itself is used rather than an include attribute, because the
+     * chain is selected for the request being filtered. A URI with a malformed percent escape is matched undecoded
+     * rather than failing chain selection.
+     */
+    private static String getPathWithinApplication(HttpServletRequest request) {
+        String uri = request.requestURI
+        if (!uri) {
+            return '/'
+        }
+        String path = PATH_HELPER.removeSemicolonContent(uri)
+        try {
+            path = PATH_HELPER.decodeRequestString(request, path)
+        } catch (IllegalArgumentException ignored) {
+            // malformed percent escape: keep the undecoded path
+        }
+        String contextPath = request.contextPath
+        if (contextPath && contextPath != '/' && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length())
+        }
+        path ?: '/'
     }
 
     @Override

--- a/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
+++ b/grails-spring-security/compat/src/main/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcher.groovy
@@ -29,6 +29,7 @@ import org.springframework.web.util.UrlPathHelper
 class AntPathRequestMatcher implements RequestMatcher {
 
     private static final UrlPathHelper PATH_HELPER = UrlPathHelper.defaultInstance
+    private static final UrlPathHelper RAW_PATH_HELPER = rawPathHelper()
 
     private final String pattern
     private final String httpMethod
@@ -57,28 +58,27 @@ class AntPathRequestMatcher implements RequestMatcher {
     }
 
     /**
-     * The request URI canonicalized the way request dispatch sees it: matrix parameters removed, percent escapes
-     * decoded and the context path stripped, so an encoded or matrix-parameter variant of a path selects the same
-     * filter chain as the plain path. The request URI itself is used rather than an include attribute, because the
-     * chain is selected for the request being filtered. A URI with a malformed percent escape is matched undecoded
-     * rather than failing chain selection.
+     * The request path within the application, resolved with the same {@link UrlPathHelper} call that Grails URL
+     * mapping dispatch uses, so an encoded or matrix-parameter variant of a path selects the same filter chain as
+     * the path it is dispatched to. Path parameters are removed per segment before percent-decoding (Jakarta Servlet
+     * 6.0 section 3.5.2), so an encoded semicolon stays a literal character (RFC 3986 section 2.2), and the path is
+     * decoded exactly once (RFC 3986 section 2.4). Like dispatch, and unlike RFC 3986 section 6.2.2.1, the context
+     * path is compared case-insensitively, and during a {@code RequestDispatcher} include the included URI is
+     * matched. A URI with an illegal percent escape, which a Servlet 6.0 container rejects with 400 before the filter
+     * chain runs, is matched undecoded rather than failing chain selection.
      */
     private static String getPathWithinApplication(HttpServletRequest request) {
-        String uri = request.requestURI
-        if (!uri) {
-            return '/'
-        }
-        String path = PATH_HELPER.removeSemicolonContent(uri)
         try {
-            path = PATH_HELPER.decodeRequestString(request, path)
+            PATH_HELPER.getPathWithinApplication(request)
         } catch (IllegalArgumentException ignored) {
-            // malformed percent escape: keep the undecoded path
+            RAW_PATH_HELPER.getPathWithinApplication(request)
         }
-        String contextPath = request.contextPath
-        if (contextPath && contextPath != '/' && path.startsWith(contextPath)) {
-            path = path.substring(contextPath.length())
-        }
-        path ?: '/'
+    }
+
+    private static UrlPathHelper rawPathHelper() {
+        UrlPathHelper helper = new UrlPathHelper()
+        helper.urlDecode = false
+        helper
     }
 
     @Override

--- a/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
+++ b/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.springframework.security.web.util.matcher
+
+import org.springframework.mock.web.MockHttpServletRequest
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class AntPathRequestMatcherSpec extends Specification {
+
+    @Unroll
+    void 'matches canonical request path #requestUri'() {
+        given:
+        def request = new MockHttpServletRequest('GET', requestUri)
+        request.contextPath = '/app'
+
+        expect:
+        new AntPathRequestMatcher('/admin/**').matches(request)
+
+        where:
+        requestUri << ['/app/admin;x=1/deleteUser', '/app/admin%3Bx=1/deleteUser', '/app/%61dmin/deleteUser']
+    }
+}

--- a/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
+++ b/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
@@ -19,6 +19,7 @@
 package org.springframework.security.web.util.matcher
 
 import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.util.WebUtils
 
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -26,15 +27,95 @@ import spock.lang.Unroll
 class AntPathRequestMatcherSpec extends Specification {
 
     @Unroll
-    void 'matches canonical request path #requestUri'() {
+    void 'matches the canonical request path under context path /app: #requestUri'() {
         given:
         def request = new MockHttpServletRequest('GET', requestUri)
         request.contextPath = '/app'
 
         expect:
-        new AntPathRequestMatcher('/admin/**').matches(request)
+        new AntPathRequestMatcher('/admin/**').matches(request) == matches
 
         where:
-        requestUri << ['/app/admin;x=1/deleteUser', '/app/admin%3Bx=1/deleteUser', '/app/%61dmin/deleteUser']
+        requestUri                    | matches | reason
+        '/app/admin/deleteUser'       | true    | 'plain path'
+        '/app/admin;x=1/deleteUser'   | true    | 'matrix parameters are removed'
+        '/app/%61dmin/deleteUser'     | true    | 'percent escapes are decoded'
+        '/app/admin%3Bx=1/deleteUser' | false   | 'an encoded semicolon is a literal character, so this is a different path'
+        '/app/public'                 | false   | 'unrelated path'
+        '/APP/admin/deleteUser'       | false   | 'the context path is matched case-sensitively'
+    }
+
+    void 'matches the request path when deployed at the root'() {
+        expect:
+        new AntPathRequestMatcher('/admin/**').matches(new MockHttpServletRequest('GET', '/admin;x=1/deleteUser'))
+        !new AntPathRequestMatcher('/admin/**').matches(new MockHttpServletRequest('GET', '/public'))
+    }
+
+    @Unroll
+    void 'a malformed percent escape is matched undecoded instead of failing chain selection: #pattern'() {
+        given:
+        def request = new MockHttpServletRequest('GET', '/app/foo%')
+        request.contextPath = '/app'
+
+        expect:
+        new AntPathRequestMatcher(pattern).matches(request) == matches
+
+        where:
+        pattern     | matches
+        '/admin/**' | false
+        '/foo*'     | true
+    }
+
+    @Unroll
+    void 'the request URI is matched even when an include attribute is present: #pattern'() {
+        given:
+        def request = new MockHttpServletRequest('GET', '/app/public')
+        request.contextPath = '/app'
+        request.setAttribute(WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE, '/app/admin/x')
+
+        expect:
+        new AntPathRequestMatcher(pattern).matches(request) == matches
+
+        where:
+        pattern      | matches
+        '/admin/**'  | false
+        '/public/**' | true
+    }
+
+    void 'pattern matching is case-insensitive by default and case-sensitive on request'() {
+        given:
+        def request = new MockHttpServletRequest('GET', '/app/ADMIN/deleteUser')
+        request.contextPath = '/app'
+
+        expect:
+        new AntPathRequestMatcher('/admin/**').matches(request)
+        !new AntPathRequestMatcher('/admin/**', null, true).matches(request)
+    }
+
+    void 'the HTTP method must match when one is given'() {
+        given:
+        def request = new MockHttpServletRequest('POST', '/admin/deleteUser')
+
+        expect:
+        new AntPathRequestMatcher('/admin/**', 'POST', false).matches(request)
+        new AntPathRequestMatcher('/admin/**', 'post', false).matches(request)
+        !new AntPathRequestMatcher('/admin/**', 'GET', false).matches(request)
+    }
+
+    void 'an empty request URI is matched as the root path'() {
+        expect:
+        new AntPathRequestMatcher('/').matches(new MockHttpServletRequest('GET', ''))
+        !new AntPathRequestMatcher('/admin/**').matches(new MockHttpServletRequest('GET', ''))
+    }
+
+    void 'equality and description are based on the pattern, method and case sensitivity'() {
+        expect:
+        new AntPathRequestMatcher('/admin/**') == new AntPathRequestMatcher('/admin/**', null, false)
+        new AntPathRequestMatcher('/admin/**').hashCode() == new AntPathRequestMatcher('/admin/**', null, false).hashCode()
+        new AntPathRequestMatcher('/admin/**') != new AntPathRequestMatcher('/admin/**', 'GET', false)
+        new AntPathRequestMatcher('/admin/**') != new AntPathRequestMatcher('/admin/**', null, true)
+        new AntPathRequestMatcher('/admin/**') != new AntPathRequestMatcher('/other/**')
+        new AntPathRequestMatcher('/admin/**').toString() == "Ant [pattern='/admin/**']"
+        new AntPathRequestMatcher('/admin/**', 'GET', false).toString() == "Ant [pattern='/admin/**', GET]"
     }
 }

--- a/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
+++ b/grails-spring-security/compat/src/test/groovy/org/springframework/security/web/util/matcher/AntPathRequestMatcherSpec.groovy
@@ -42,7 +42,8 @@ class AntPathRequestMatcherSpec extends Specification {
         '/app/%61dmin/deleteUser'     | true    | 'percent escapes are decoded'
         '/app/admin%3Bx=1/deleteUser' | false   | 'an encoded semicolon is a literal character, so this is a different path'
         '/app/public'                 | false   | 'unrelated path'
-        '/APP/admin/deleteUser'       | false   | 'the context path is matched case-sensitively'
+        '/APP/admin/deleteUser'       | true    | 'the context path is compared case-insensitively, as dispatch does'
+        '/app/admin//deleteUser'      | true    | 'empty segments are collapsed, as dispatch does'
     }
 
     void 'matches the request path when deployed at the root'() {
@@ -67,7 +68,7 @@ class AntPathRequestMatcherSpec extends Specification {
     }
 
     @Unroll
-    void 'the request URI is matched even when an include attribute is present: #pattern'() {
+    void 'the included path is matched during an include, as dispatch does: #pattern'() {
         given:
         def request = new MockHttpServletRequest('GET', '/app/public')
         request.contextPath = '/app'
@@ -78,8 +79,8 @@ class AntPathRequestMatcherSpec extends Specification {
 
         where:
         pattern      | matches
-        '/admin/**'  | false
-        '/public/**' | true
+        '/admin/**'  | true
+        '/public/**' | false
     }
 
     void 'pattern matching is case-insensitive by default and case-sensitive on request'() {

--- a/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
+++ b/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
@@ -26,12 +26,14 @@ import jakarta.servlet.ServletException
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletRequestWrapper
 import jakarta.servlet.http.HttpServletResponse
 
 import org.springframework.security.access.ConfigAttribute
 import org.springframework.security.web.util.matcher.IpAddressMatcher
 import org.springframework.util.AntPathMatcher
 import org.springframework.web.filter.GenericFilterBean
+import org.springframework.web.util.UrlPathHelper
 
 import grails.plugin.springsecurity.InterceptedUrl
 import grails.plugin.springsecurity.ReflectionUtils
@@ -54,6 +56,7 @@ class IpAddressFilter extends GenericFilterBean {
     protected static final String IPV6_LOOPBACK = '0:0:0:0:0:0:0:1'
 
     protected final AntPathMatcher pathMatcher = new AntPathMatcher()
+    protected final UrlPathHelper urlPathHelper = UrlPathHelper.defaultInstance
 
     protected List<InterceptedUrl> restrictions
 
@@ -112,14 +115,7 @@ class IpAddressFilter extends GenericFilterBean {
             return true
         }
 
-        String uri = request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE)
-        if (!uri) {
-            uri = request.requestURI
-            String contextPath = request.contextPath
-            if (contextPath != '/' && uri.startsWith(contextPath)) {
-                uri = uri.substring(contextPath.length())
-            }
-        }
+        String uri = getPathWithinApplication(request)
 
         List<InterceptedUrl> matching = findMatchingRules(uri)
         if (!matching) {
@@ -136,6 +132,19 @@ class IpAddressFilter extends GenericFilterBean {
 
         log.warn 'disallowed request {} from {}', uri, ip
         false
+    }
+
+    protected String getPathWithinApplication(HttpServletRequest request) {
+        String forwardUri = request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE) as String
+        if (forwardUri) {
+            return urlPathHelper.removeSemicolonContent(urlPathHelper.getPathWithinApplication(new HttpServletRequestWrapper(request) {
+                @Override
+                String getRequestURI() {
+                    forwardUri
+                }
+            }))
+        }
+        urlPathHelper.removeSemicolonContent(urlPathHelper.getPathWithinApplication(request))
     }
 
     protected List<InterceptedUrl> findMatchingRules(String uri) {

--- a/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
+++ b/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
@@ -56,6 +56,7 @@ class IpAddressFilter extends GenericFilterBean {
 
     protected final AntPathMatcher pathMatcher = new AntPathMatcher()
     protected final UrlPathHelper urlPathHelper = UrlPathHelper.defaultInstance
+    protected final UrlPathHelper rawUrlPathHelper = rawUrlPathHelper()
 
     protected List<InterceptedUrl> restrictions
 
@@ -134,28 +135,41 @@ class IpAddressFilter extends GenericFilterBean {
     }
 
     /**
-     * Resolves the path that restriction patterns are matched against: the original request URI when the request
-     * was forwarded, otherwise the request URI, canonicalized the way request dispatch sees it. Matrix parameters
-     * are removed and percent escapes decoded before the context path is stripped, so an encoded or matrix-parameter
-     * variant of a restricted path cannot sidestep its restriction. A URI with a malformed percent escape is matched
-     * undecoded rather than aborting the filter chain.
+     * Resolves the path that restriction patterns are matched against, in the form Grails URL mapping dispatch
+     * resolves it: path parameters removed per segment before percent-decoding (Jakarta Servlet 6.0 section 3.5.2),
+     * decoded exactly once (RFC 3986 section 2.4) and relative to the context path, so an encoded or matrix-parameter
+     * variant of a restricted path is subject to the same restriction. For a forwarded request the original request
+     * URI is checked, canonicalized the same way. Like dispatch, and unlike RFC 3986 section 6.2.2.1, the context
+     * path is compared case-insensitively. A URI with an illegal percent escape, which a Servlet 6.0 container
+     * rejects with 400 before the filter chain runs, is matched undecoded rather than aborting the chain.
      */
     protected String getPathWithinApplication(HttpServletRequest request) {
-        String uri = (request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE) as String) ?: request.requestURI
-        if (!uri) {
-            return '/'
+        String forwardUri = request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE) as String
+        if (!forwardUri) {
+            try {
+                return urlPathHelper.getPathWithinApplication(request)
+            } catch (IllegalArgumentException ignored) {
+                return rawUrlPathHelper.getPathWithinApplication(request)
+            }
         }
-        String path = urlPathHelper.removeSemicolonContent(uri)
+        String path = urlPathHelper.removeSemicolonContent(forwardUri)
+        String contextPath = (request.getAttribute(WebUtils.FORWARD_CONTEXT_PATH_ATTRIBUTE) as String) ?: request.contextPath
         try {
             path = urlPathHelper.decodeRequestString(request, path)
+            contextPath = urlPathHelper.decodeRequestString(request, contextPath)
         } catch (IllegalArgumentException ignored) {
-            // malformed percent escape: keep the undecoded path
+            // illegal percent escape: match the undecoded path
         }
-        String contextPath = request.contextPath
-        if (contextPath && contextPath != '/' && path.startsWith(contextPath)) {
+        if (contextPath && contextPath != '/' && path.regionMatches(true, 0, contextPath, 0, contextPath.length())) {
             path = path.substring(contextPath.length())
         }
         path ?: '/'
+    }
+
+    private static UrlPathHelper rawUrlPathHelper() {
+        UrlPathHelper helper = new UrlPathHelper()
+        helper.urlDecode = false
+        helper
     }
 
     protected List<InterceptedUrl> findMatchingRules(String uri) {

--- a/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
+++ b/grails-spring-security/plugin/src/main/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilter.groovy
@@ -26,7 +26,6 @@ import jakarta.servlet.ServletException
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletRequestWrapper
 import jakarta.servlet.http.HttpServletResponse
 
 import org.springframework.security.access.ConfigAttribute
@@ -134,17 +133,29 @@ class IpAddressFilter extends GenericFilterBean {
         false
     }
 
+    /**
+     * Resolves the path that restriction patterns are matched against: the original request URI when the request
+     * was forwarded, otherwise the request URI, canonicalized the way request dispatch sees it. Matrix parameters
+     * are removed and percent escapes decoded before the context path is stripped, so an encoded or matrix-parameter
+     * variant of a restricted path cannot sidestep its restriction. A URI with a malformed percent escape is matched
+     * undecoded rather than aborting the filter chain.
+     */
     protected String getPathWithinApplication(HttpServletRequest request) {
-        String forwardUri = request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE) as String
-        if (forwardUri) {
-            return urlPathHelper.removeSemicolonContent(urlPathHelper.getPathWithinApplication(new HttpServletRequestWrapper(request) {
-                @Override
-                String getRequestURI() {
-                    forwardUri
-                }
-            }))
+        String uri = (request.getAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE) as String) ?: request.requestURI
+        if (!uri) {
+            return '/'
         }
-        urlPathHelper.removeSemicolonContent(urlPathHelper.getPathWithinApplication(request))
+        String path = urlPathHelper.removeSemicolonContent(uri)
+        try {
+            path = urlPathHelper.decodeRequestString(request, path)
+        } catch (IllegalArgumentException ignored) {
+            // malformed percent escape: keep the undecoded path
+        }
+        String contextPath = request.contextPath
+        if (contextPath && contextPath != '/' && path.startsWith(contextPath)) {
+            path = path.substring(contextPath.length())
+        }
+        path ?: '/'
     }
 
     protected List<InterceptedUrl> findMatchingRules(String uri) {

--- a/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
+++ b/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
@@ -21,6 +21,7 @@ package grails.plugin.springsecurity.web.filter
 import jakarta.servlet.FilterChain
 
 import grails.plugin.springsecurity.AbstractUnitSpec
+import org.grails.web.util.WebUtils
 
 /**
  * Unit tests for <code>IpAddressFilter</code>.
@@ -188,5 +189,43 @@ class IpAddressFilterSpec extends AbstractUnitSpec {
         404 == response.status
 
         0 == chainCount
+    }
+
+    void 'doFilter canonicalizes restricted paths'() {
+        given:
+        filter.allowLocalhost = false
+        filter.ipRestrictions = [[pattern: '/admin/**', access: '10.0.0.0/8']]
+        int chainCount = 0
+        def chain = [doFilter: { req, res -> chainCount++ }] as FilterChain
+        request.remoteAddr = '192.168.1.123'
+
+        when:
+        request.requestURI = requestUri
+        response.reset()
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        chainCount == 0
+
+        where:
+        requestUri << ['/admin;x=1/deleteUser', '/admin%3Bx=1/deleteUser', '/%61dmin/deleteUser']
+    }
+
+    void 'doFilter canonicalizes forwarded restricted paths'() {
+        given:
+        filter.allowLocalhost = false
+        filter.ipRestrictions = [[pattern: '/admin/**', access: '10.0.0.0/8']]
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.requestURI = '/public'
+        request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, '/admin;x=1/deleteUser')
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        0 * chain.doFilter(_, _)
     }
 }

--- a/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
+++ b/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
@@ -254,9 +254,26 @@ class IpAddressFilterSpec extends AbstractUnitSpec {
         (denied ? 0 : 1) * chain.doFilter(_, _)
 
         where:
-        requestUri              | denied
-        '/app/admin/deleteUser' | true
-        '/app/public'           | false
+        requestUri              | denied | reason
+        '/app/admin/deleteUser' | true   | 'context-prefixed restricted path'
+        '/APP/admin/deleteUser' | true   | 'the context path is compared case-insensitively, as dispatch does'
+        '/app/public'           | false  | 'unrestricted path'
+    }
+
+    void 'doFilter restricts the included path during an include, as dispatch does'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.requestURI = '/public'
+        request.setAttribute(WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE, '/admin/deleteUser')
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        0 * chain.doFilter(_, _)
     }
 
     void 'doFilter canonicalizes forwarded restricted paths'() {
@@ -290,6 +307,28 @@ class IpAddressFilterSpec extends AbstractUnitSpec {
         then:
         response.status == 404
         0 * chain.doFilter(_, _)
+    }
+
+    @Unroll
+    void 'doFilter strips the forwarded context path case-insensitively: #forwardUri'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.contextPath = '/app'
+        request.requestURI = '/app/public'
+        request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, forwardUri)
+        request.setAttribute(WebUtils.FORWARD_CONTEXT_PATH_ATTRIBUTE, '/app')
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        0 * chain.doFilter(_, _)
+
+        where:
+        forwardUri << ['/app/admin/deleteUser', '/APP/admin/deleteUser']
     }
 
     void 'doFilter restricts the forwarded path even when an include attribute is present'() {

--- a/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
+++ b/grails-spring-security/plugin/src/test/groovy/grails/plugin/springsecurity/web/filter/IpAddressFilterSpec.groovy
@@ -22,6 +22,7 @@ import jakarta.servlet.FilterChain
 
 import grails.plugin.springsecurity.AbstractUnitSpec
 import org.grails.web.util.WebUtils
+import spock.lang.Unroll
 
 /**
  * Unit tests for <code>IpAddressFilter</code>.
@@ -191,31 +192,76 @@ class IpAddressFilterSpec extends AbstractUnitSpec {
         0 == chainCount
     }
 
-    void 'doFilter canonicalizes restricted paths'() {
+    @Unroll
+    void 'doFilter matches restrictions against the path as dispatch sees it: #requestUri'() {
         given:
-        filter.allowLocalhost = false
-        filter.ipRestrictions = [[pattern: '/admin/**', access: '10.0.0.0/8']]
-        int chainCount = 0
-        def chain = [doFilter: { req, res -> chainCount++ }] as FilterChain
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
         request.remoteAddr = '192.168.1.123'
+        request.requestURI = requestUri
 
         when:
-        request.requestURI = requestUri
-        response.reset()
         filter.doFilter(request, response, chain)
 
         then:
-        response.status == 404
-        chainCount == 0
+        (response.status == 404) == denied
+        (denied ? 0 : 1) * chain.doFilter(_, _)
 
         where:
-        requestUri << ['/admin;x=1/deleteUser', '/admin%3Bx=1/deleteUser', '/%61dmin/deleteUser']
+        requestUri                | denied | reason
+        '/admin/deleteUser'       | true   | 'plain path'
+        '/admin;x=1/deleteUser'   | true   | 'matrix parameters are removed'
+        '/%61dmin/deleteUser'     | true   | 'percent escapes are decoded'
+        '/admin%3Bx=1/deleteUser' | false  | 'an encoded semicolon is a literal character, so this is not an /admin/** path'
+        '/public'                 | false  | 'unrestricted path'
+    }
+
+    @Unroll
+    void 'doFilter matches a malformed percent escape undecoded instead of throwing: #requestUri'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.requestURI = requestUri
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        (response.status == 404) == denied
+        (denied ? 0 : 1) * chain.doFilter(_, _)
+
+        where:
+        requestUri    | denied
+        '/foo%'       | false
+        '/admin/foo%' | true
+    }
+
+    @Unroll
+    void 'doFilter strips the context path before matching: #requestUri'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.contextPath = '/app'
+        request.requestURI = requestUri
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        (response.status == 404) == denied
+        (denied ? 0 : 1) * chain.doFilter(_, _)
+
+        where:
+        requestUri              | denied
+        '/app/admin/deleteUser' | true
+        '/app/public'           | false
     }
 
     void 'doFilter canonicalizes forwarded restricted paths'() {
         given:
-        filter.allowLocalhost = false
-        filter.ipRestrictions = [[pattern: '/admin/**', access: '10.0.0.0/8']]
+        restrictAdminToIntranet()
         def chain = Mock(FilterChain)
         request.remoteAddr = '192.168.1.123'
         request.requestURI = '/public'
@@ -227,5 +273,59 @@ class IpAddressFilterSpec extends AbstractUnitSpec {
         then:
         response.status == 404
         0 * chain.doFilter(_, _)
+    }
+
+    void 'doFilter strips the context path from a forwarded path'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.contextPath = '/app'
+        request.requestURI = '/app/public'
+        request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, '/app/%61dmin/deleteUser')
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        0 * chain.doFilter(_, _)
+    }
+
+    void 'doFilter restricts the forwarded path even when an include attribute is present'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '192.168.1.123'
+        request.requestURI = '/public'
+        request.setAttribute(WebUtils.FORWARD_REQUEST_URI_ATTRIBUTE, '/admin/deleteUser')
+        request.setAttribute(WebUtils.INCLUDE_REQUEST_URI_ATTRIBUTE, '/public')
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 404
+        0 * chain.doFilter(_, _)
+    }
+
+    void 'doFilter allows a restricted path from an address in the allowed range'() {
+        given:
+        restrictAdminToIntranet()
+        def chain = Mock(FilterChain)
+        request.remoteAddr = '10.20.30.40'
+        request.requestURI = '/%61dmin;x=1/deleteUser'
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.status == 200
+        1 * chain.doFilter(_, _)
+    }
+
+    private void restrictAdminToIntranet() {
+        filter.allowLocalhost = false
+        filter.ipRestrictions = [[pattern: '/admin/**', access: '10.0.0.0/8']]
     }
 }


### PR DESCRIPTION
## Summary

ASF security review finding **f003**, with sibling matchers **f017** and **f020**.

Interceptor URI matching used the raw servlet `requestURI` (not decoded). `UrlMappingMatcher` only stripped `;` then ran `AntPathMatcher`. Grails dispatch uses Spring `UrlPathHelper.getPathWithinApplication`, which decodes and strips matrix parameters. Encoded segments (`/%61dmin/deleteUser`) or matrix parameters (`/admin;x=1/deleteUser`) could therefore reach a controller while `match(uri: '/admin/**')` did not fire.

The same requestURI/dispatch desync existed in:

- Spring Security compat `AntPathRequestMatcher` (f017)
- `IpAddressFilter` (f020), including forwarded URIs

This is a real matcher/dispatch inconsistency. It is **not** a framework-wide unauthenticated auth bypass: the shipped auth example matches controller/action from `UrlMappingInfo`, application-level auth is out of scope (threat model §3), and URI-pattern interceptors are a documented optional matcher. Treat as a bug / ASF MODERATE at most, not a 9.8 CVE.

## Changes

- Interceptor matching uses `UrlPathHelper.getPathWithinApplication`.
- `UrlMappingMatcher` canonicalizes the path (decode + strip matrix parameters) and still accepts context-prefixed patterns from issue 10857.
- Compat `AntPathRequestMatcher` and `IpAddressFilter` match the same canonical application path.

## Testing

- `:grails-interceptors:test`
- `:grails-spring-security-compat:test`
- `:grails-spring-security:test`
- codeStyle on those modules
