### PR TITLE
test(grails-datamapping-core): restore the transaction service specs lost in the 7.2.x merge

### DIFF
--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/services/DefaultTransactionServiceSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/services/DefaultTransactionServiceSpec.groovy
@@ -24,27 +24,174 @@ import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.TransactionSystemException
 
 import org.grails.datastore.mapping.core.Datastore
+import org.grails.datastore.mapping.transactions.CustomizableRollbackTransactionAttribute
+import org.grails.datastore.mapping.transactions.TransactionCapableDatastore
 import spock.lang.Specification
 
-/**
- * The diff only adds the explicit {@code datastore}/{@code getDatastore()}/{@code setDatastore()}
- * {@code Service} contract (previously implicit/inherited) - the rest of this class (the
- * {@code withTransaction}/{@code withRollback}/{@code withNewTransaction} overloads) predates this
- * PR and is already exercised via real {@code TransactionService} usage in the separate
- * {@code grails-datamapping-core-test} module (which doesn't count toward this module's own
- * coverage - see item 14's cross-module attribution note), so out of scope here.
- */
 class DefaultTransactionServiceSpec extends Specification {
 
-    void "getDatastore/setDatastore round-trip"() {
+    DefaultTransactionService transactionService = new DefaultTransactionService()
+
+    PlatformTransactionManager transactionManager = Mock(PlatformTransactionManager) {
+        getTransaction(_) >> Mock(TransactionStatus)
+    }
+
+    TransactionCapableDatastore transactionCapableDatastore = Mock(TransactionCapableDatastore) {
+        getTransactionManager() >> transactionManager
+    }
+
+    void 'getDatastore/setDatastore round-trip'() {
         given:
-        def service = new DefaultTransactionService()
-        def datastore = Mock(Datastore)
+        Datastore datastore = Mock(Datastore)
 
         when:
-        service.setDatastore(datastore)
+        transactionService.setDatastore(datastore)
 
         then:
-        service.getDatastore().is(datastore)
+        transactionService.getDatastore().is(datastore)
+    }
+
+    void 'withTransaction(Closure) executes the callable within a transaction'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+
+        when:
+        String result = transactionService.withTransaction { status -> 'done' }
+
+        then:
+        result == 'done'
+        1 * transactionManager.commit(_)
+    }
+
+    void 'withTransaction(Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+
+        when:
+        transactionService.withTransaction { status -> 'done' }
+
+        then:
+        TransactionSystemException e = thrown(TransactionSystemException)
+        e.message.contains('does not support transactions')
+    }
+
+    void 'withRollback(Closure) executes the callable and rolls back'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+
+        expect:
+        transactionService.withRollback { status -> 'done' } == 'done'
+    }
+
+    void 'withRollback(Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+
+        when:
+        transactionService.withRollback { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
+    }
+
+    void 'withNewTransaction(Closure) executes the callable with PROPAGATION_REQUIRES_NEW'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+
+        expect:
+        transactionService.withNewTransaction { status -> 'done' } == 'done'
+    }
+
+    void 'withNewTransaction(Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+
+        when:
+        transactionService.withNewTransaction { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
+    }
+
+    void 'withTransaction(TransactionDefinition, Closure) executes the callable with the given definition'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        expect:
+        transactionService.withTransaction(definition) { status -> 'done' } == 'done'
+    }
+
+    void 'withTransaction(TransactionDefinition, Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        when:
+        transactionService.withTransaction(definition) { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
+    }
+
+    void 'withTransaction(Map, Closure) builds a transaction definition from the map'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+
+        expect:
+        transactionService.withTransaction([readOnly: true]) { status -> 'done' } == 'done'
+    }
+
+    void 'withTransaction(Map, Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+
+        when:
+        transactionService.withTransaction([readOnly: true]) { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
+    }
+
+    void 'withRollback(TransactionDefinition, Closure) executes the callable and rolls back'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        expect:
+        transactionService.withRollback(definition) { status -> 'done' } == 'done'
+    }
+
+    void 'withRollback(TransactionDefinition, Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        when:
+        transactionService.withRollback(definition) { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
+    }
+
+    void 'withNewTransaction(TransactionDefinition, Closure) forces PROPAGATION_REQUIRES_NEW'() {
+        given:
+        transactionService.datastore = transactionCapableDatastore
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        expect:
+        transactionService.withNewTransaction(definition) { status -> 'done' } == 'done'
+    }
+
+    void 'withNewTransaction(TransactionDefinition, Closure) throws when the datastore does not support transactions'() {
+        given:
+        transactionService.datastore = Mock(Datastore)
+        TransactionDefinition definition = new CustomizableRollbackTransactionAttribute()
+
+        when:
+        transactionService.withNewTransaction(definition) { status -> 'done' }
+
+        then:
+        thrown(TransactionSystemException)
     }
 }


### PR DESCRIPTION
## Problem

The 7.2.x → 8.0.x merge hit an `add/add` conflict on `DefaultTransactionServiceSpec` — both branches had independently created the file. The resolution kept 8.0.x's version, which had **1** test, and dropped 7.2.x's **14**.

**The drop was accidental, not a scoping decision.** The resolution was half-applied: it took 7.2.x's four Spring transaction imports but not the test methods that use them, leaving `PlatformTransactionManager`, `TransactionDefinition`, `TransactionStatus` and `TransactionSystemException` imported and unused on `8.0.x`. Pre-merge `8.0.x` had neither the imports nor the tests, so they arrived together and only half survived.

## Changes

Restores 7.2.x's suite and keeps 8.0.x's accessor test — 15 tests:

- the full `withTransaction` / `withRollback` / `withNewTransaction` matrix across the `Closure`, `TransactionDefinition` and `Map` overloads, each with its "datastore does not support transactions" counterpart
- `getDatastore/setDatastore round-trip`, covering the explicit `datastore` field `8.0.x` added to `DefaultTransactionService`

Also drops the class-level comment claiming the overloads were out of scope — untrue once the suite is restored, and it referenced "this PR" and "item 14" of a plan that is not in the repository.

## Why the suite ports unchanged

`DefaultTransactionService` differs between the two branches *only* by that added field and its accessors. Every method the restored tests exercise is byte-identical between 7.2.x and 8.0.x, and 7.2.x's property-style `transactionService.datastore = ...` resolves to the new setter.

## Verification

```
./gradlew :grails-datamapping-core:test --tests "org.grails.datastore.gorm.services.DefaultTransactionServiceSpec"
```

All 15 pass. `:grails-datamapping-core:codeStyle` is clean and every import is used.

`DefaultTenantServiceSpec`, the other `add/add` in that merge, was resolved cleanly (only a `{ }` → `{}` whitespace change) and is left alone — its class genuinely diverged on 8.0.x with the `RESOLVING` reentrancy guard, so 8.0.x's version is the correct one there.