### PR TITLE
Resolve the DevTools restart loader through the parent chain

### DIFF
--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
@@ -118,18 +118,22 @@ public class HibernateMappingContextConfiguration extends Configuration implemen
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
         resourcePatternResolver = ResourcePatternUtils.getResourcePatternResolver(applicationContext);
-        String dsName = ConnectionSource.DEFAULT.equals(dataSourceName) ? "dataSource" : "dataSource_" + dataSourceName;
+        String dsName = ConnectionSource.DEFAULT.equals(dataSourceName) ?
+                Settings.SETTING_DATASOURCE :
+                Settings.SETTING_DATASOURCE + "_" + dataSourceName;
         Properties properties = getProperties();
 
-        if (applicationContext.containsBean(dsName)) {
+        // A DataSource already configured (by setDataSourceConnectionSource) is the one the
+        // datastore's connection source and transaction manager use, so it stays authoritative.
+        if (!properties.containsKey(Environment.DATASOURCE) && applicationContext.containsBean(dsName)) {
             properties.put(Environment.DATASOURCE, applicationContext.getBean(dsName));
         }
         properties.put(Environment.CURRENT_SESSION_CONTEXT_CLASS, currentSessionContext.getName());
         ClassLoader applicationClassLoader = applicationContext.getClassLoader();
-        // Keep CLASSLOADERS absent when the context loader is null and DevTools is not
+        // Keep CLASSLOADERS absent when the context loader is null and DevTools restart is not
         // active so buildSessionFactory can fall back to this class's loader.
         if (applicationClassLoader != null ||
-                DevToolsClassLoaders.isRestartClassLoader(Thread.currentThread().getContextClassLoader())) {
+                DevToolsClassLoaders.isRestartClassLoaderOrDescendant(Thread.currentThread().getContextClassLoader())) {
             properties.put(AvailableSettings.CLASSLOADERS,
                     DevToolsClassLoaders.preferRestartClassLoader(applicationClassLoader));
         }
@@ -338,9 +342,9 @@ public class HibernateMappingContextConfiguration extends Configuration implemen
         Object classLoaderObject = getProperties().get(AvailableSettings.CLASSLOADERS);
         ClassLoader storedClassLoader = classLoaderObject instanceof ClassLoader ?
                 (ClassLoader) classLoaderObject : getClass().getClassLoader();
-        // Re-check TCCL: addProperties() / a custom configClass can overwrite CLASSLOADERS
-        // after the setters. GrailsDomainBinder.bindClass only setClassName(entityName);
-        // Hibernate then re-resolves Class via ReflectHelper.classForName (TCCL).
+        // addProperties() or a custom configClass may have replaced CLASSLOADERS after the
+        // setters ran. GrailsDomainBinder binds entities by class name and Hibernate resolves
+        // them through this loader, so it has to see the restarted application classes.
         return DevToolsClassLoaders.preferRestartClassLoader(storedClassLoader);
     }
 

--- a/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactory.java
+++ b/grails-data-hibernate5/core/src/main/groovy/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactory.java
@@ -52,7 +52,6 @@ import org.grails.orm.hibernate.HibernateEventListeners;
 import org.grails.orm.hibernate.cfg.GrailsDomainBinder;
 import org.grails.orm.hibernate.cfg.HibernateMappingContext;
 import org.grails.orm.hibernate.cfg.HibernateMappingContextConfiguration;
-import org.grails.orm.hibernate.cfg.Settings;
 import org.grails.orm.hibernate.support.AbstractClosureEventTriggeringInterceptor;
 import org.grails.orm.hibernate.support.ClosureEventTriggeringInterceptor;
 
@@ -140,18 +139,14 @@ public class HibernateConnectionSourceFactory extends AbstractHibernateConnectio
             configuration.getProperties().put("jakarta.persistence.validation.factory", registry);
         }
 
-        // setApplicationContext looks up dataSource / dataSource_<name> from this field.
         configuration.setDataSourceName(name);
-
-        String dsName = dataSourceConnectionSource.getName();
-        String beanName = ConnectionSource.DEFAULT.equals(dsName) ?
-                Settings.SETTING_DATASOURCE :
-                Settings.SETTING_DATASOURCE + "_" + dsName;
-        if (applicationContext != null && applicationContext.containsBean(beanName)) {
-            configuration.setApplicationContext(this.applicationContext);
-        }
-        else {
-            configuration.setDataSourceConnectionSource(dataSourceConnectionSource);
+        // The connection source is the DataSource of record: the datastore's connection source
+        // and transaction manager use it, so Hibernate must open sessions against the same instance.
+        configuration.setDataSourceConnectionSource(dataSourceConnectionSource);
+        if (applicationContext != null) {
+            // Resolves resources and class loading through the context, whose loader is the one
+            // the application classes were loaded with, also under a DevTools restart.
+            configuration.setApplicationContext(applicationContext);
         }
 
         Resource[] configLocations = hibernateSettings.getConfigLocations();

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationSpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationSpec.groovy
@@ -23,6 +23,7 @@ import javax.sql.DataSource
 import org.grails.datastore.gorm.jdbc.connections.DataSourceSettings
 import org.grails.datastore.mapping.core.connections.ConnectionSource
 import org.hibernate.cfg.AvailableSettings
+import org.hibernate.cfg.Environment
 import org.springframework.context.ApplicationContext
 import spock.lang.Specification
 
@@ -41,14 +42,10 @@ class HibernateMappingContextConfigurationSpec extends Specification {
     void "setApplicationContext uses the context class loader when DevTools is not active"() {
         given:
         def config = new HibernateMappingContextConfiguration()
-        ClassLoader cl = new URLClassLoader([] as URL[], originalContextClassLoader)
-        ApplicationContext appCtx = Stub(ApplicationContext) {
-            containsBean("dataSource") >> false
-            getClassLoader() >> cl
-        }
+        ClassLoader cl = loaderUnder(originalContextClassLoader)
 
         when:
-        config.setApplicationContext(appCtx)
+        config.setApplicationContext(applicationContext(cl))
 
         then:
         config.getProperties().get(AvailableSettings.CLASSLOADERS).is(cl)
@@ -57,13 +54,9 @@ class HibernateMappingContextConfigurationSpec extends Specification {
     void "setApplicationContext leaves CLASSLOADERS unset when the context class loader is null"() {
         given:
         def config = new HibernateMappingContextConfiguration()
-        ApplicationContext appCtx = Stub(ApplicationContext) {
-            containsBean("dataSource") >> false
-            getClassLoader() >> null
-        }
 
         when:
-        config.setApplicationContext(appCtx)
+        config.setApplicationContext(applicationContext(null))
 
         then:
         !config.getProperties().containsKey(AvailableSettings.CLASSLOADERS)
@@ -72,51 +65,143 @@ class HibernateMappingContextConfigurationSpec extends Specification {
     void "setApplicationContext prefers RestartClassLoader thread context class loader over the context class loader"() {
         given:
         def config = new HibernateMappingContextConfiguration()
-        ClassLoader contextLoader = new URLClassLoader([] as URL[], originalContextClassLoader)
-        ApplicationContext appCtx = Stub(ApplicationContext) {
-            containsBean("dataSource") >> false
-            getClassLoader() >> contextLoader
-        }
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
+        ClassLoader restartLoader = restartClassLoader()
 
         when:
         Thread.currentThread().contextClassLoader = restartLoader
-        config.setApplicationContext(appCtx)
+        config.setApplicationContext(applicationContext(loaderUnder(originalContextClassLoader)))
 
         then:
         config.getProperties().get(AvailableSettings.CLASSLOADERS).is(restartLoader)
+    }
+
+    void "setApplicationContext prefers a thread context class loader that delegates to the RestartClassLoader"() {
+        given: "a servlet container has swapped its web application loader in during context start"
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setApplicationContext(applicationContext(loaderUnder(originalContextClassLoader)))
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+    }
+
+    void "setApplicationContext keeps a context class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader restartLoader = restartClassLoader()
+        ClassLoader contextLoader = loaderUnder(restartLoader)
+
+        when:
+        Thread.currentThread().contextClassLoader = restartLoader
+        config.setApplicationContext(applicationContext(contextLoader))
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(contextLoader)
+    }
+
+    void "setApplicationContext with a null context class loader uses a thread context class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setApplicationContext(applicationContext(null))
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+    }
+
+    void "setApplicationContext resolves the dataSource bean when no DataSource is configured"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        DataSource beanDataSource = Stub(DataSource)
+        ApplicationContext appCtx = Stub(ApplicationContext) {
+            containsBean("dataSource") >> true
+            getBean("dataSource") >> beanDataSource
+            getClassLoader() >> originalContextClassLoader
+        }
+
+        when:
+        config.setApplicationContext(appCtx)
+
+        then:
+        config.getProperties().get(Environment.DATASOURCE).is(beanDataSource)
+    }
+
+    void "setApplicationContext resolves the named dataSource bean for a named connection source"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        config.setDataSourceName("secondary")
+        DataSource beanDataSource = Stub(DataSource)
+        ApplicationContext appCtx = Stub(ApplicationContext) {
+            containsBean("dataSource_secondary") >> true
+            getBean("dataSource_secondary") >> beanDataSource
+            getClassLoader() >> originalContextClassLoader
+        }
+
+        when:
+        config.setApplicationContext(appCtx)
+
+        then:
+        config.getProperties().get(Environment.DATASOURCE).is(beanDataSource)
+    }
+
+    void "setApplicationContext keeps the DataSource configured by setDataSourceConnectionSource"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        DataSource connectionSourceDataSource = Stub(DataSource)
+        DataSource beanDataSource = Stub(DataSource)
+        ApplicationContext appCtx = Stub(ApplicationContext) {
+            containsBean("dataSource") >> true
+            getBean("dataSource") >> beanDataSource
+            getClassLoader() >> originalContextClassLoader
+        }
+
+        when:
+        config.setDataSourceConnectionSource(connectionSource(ConnectionSource.DEFAULT, connectionSourceDataSource))
+        config.setApplicationContext(appCtx)
+
+        then:
+        config.getProperties().get(Environment.DATASOURCE).is(connectionSourceDataSource)
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(originalContextClassLoader)
     }
 
     void "setDataSourceConnectionSource uses RestartClassLoader thread context class loader"() {
         given:
         def config = new HibernateMappingContextConfiguration()
         DataSource ds = Stub(DataSource)
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
+        ClassLoader restartLoader = restartClassLoader()
 
         when:
         Thread.currentThread().contextClassLoader = restartLoader
-        config.setDataSourceConnectionSource(Stub(ConnectionSource) {
-            getSource() >> ds
-            getName() >> "default"
-        })
+        config.setDataSourceConnectionSource(connectionSource(ConnectionSource.DEFAULT, ds))
 
         then:
         config.getProperties().get(AvailableSettings.CLASSLOADERS).is(restartLoader)
-        config.getProperties().get(org.hibernate.cfg.Environment.DATASOURCE).is(ds)
+        config.getProperties().get(Environment.DATASOURCE).is(ds)
+    }
+
+    void "setDataSourceConnectionSource uses a thread context class loader that delegates to the RestartClassLoader"() {
+        given: "a servlet container has swapped its web application loader in during context start"
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setDataSourceConnectionSource(connectionSource(ConnectionSource.DEFAULT, Stub(DataSource)))
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
     }
 
     void "setDataSourceConnectionSource uses the connection source class loader when DevTools is not active"() {
         given:
         def config = new HibernateMappingContextConfiguration()
-        DataSource ds = Stub(DataSource)
-        ConnectionSource<DataSource, DataSourceSettings> connSrc = Stub(ConnectionSource) {
-            getName() >> "secondary"
-            getSource() >> ds
-        }
+        ConnectionSource<DataSource, DataSourceSettings> connSrc = connectionSource("secondary", Stub(DataSource))
 
         when:
         config.setDataSourceConnectionSource(connSrc)
@@ -129,16 +214,50 @@ class HibernateMappingContextConfigurationSpec extends Specification {
     void "resolveSessionFactoryClassLoader prefers RestartClassLoader thread context class loader over configured class loader"() {
         given:
         def config = new HibernateMappingContextConfiguration()
-        ClassLoader configuredLoader = new URLClassLoader([] as URL[], originalContextClassLoader)
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
-        config.getProperties().put(AvailableSettings.CLASSLOADERS, configuredLoader)
+        ClassLoader restartLoader = restartClassLoader()
+        config.getProperties().put(AvailableSettings.CLASSLOADERS, loaderUnder(originalContextClassLoader))
 
         when:
         Thread.currentThread().contextClassLoader = restartLoader
 
         then:
         config.resolveSessionFactoryClassLoader().is(restartLoader)
+    }
+
+    void "resolveSessionFactoryClassLoader keeps a configured class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader configuredLoader = loaderUnder(restartClassLoader())
+        config.getProperties().put(AvailableSettings.CLASSLOADERS, configuredLoader)
+
+        when:
+        Thread.currentThread().contextClassLoader = loaderUnder(originalContextClassLoader)
+
+        then:
+        config.resolveSessionFactoryClassLoader().is(configuredLoader)
+    }
+
+    private ApplicationContext applicationContext(ClassLoader classLoader) {
+        Stub(ApplicationContext) {
+            containsBean(_) >> false
+            getClassLoader() >> classLoader
+        }
+    }
+
+    private ConnectionSource<DataSource, DataSourceSettings> connectionSource(String name, DataSource dataSource) {
+        Stub(ConnectionSource) {
+            getName() >> name
+            getSource() >> dataSource
+        } as ConnectionSource<DataSource, DataSourceSettings>
+    }
+
+    private static ClassLoader restartClassLoader() {
+        new GroovyClassLoader().parseClass(
+                'class RestartClassLoader extends ClassLoader {}'
+        ).getDeclaredConstructor().newInstance() as ClassLoader
+    }
+
+    private static ClassLoader loaderUnder(ClassLoader parent) {
+        new URLClassLoader([] as URL[], parent)
     }
 }

--- a/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactorySpec.groovy
+++ b/grails-data-hibernate5/core/src/test/groovy/org/grails/orm/hibernate/connections/HibernateConnectionSourceFactorySpec.groovy
@@ -26,6 +26,7 @@ import org.grails.datastore.mapping.core.DatastoreUtils
 import org.grails.datastore.mapping.core.connections.ConnectionSource
 import org.grails.orm.hibernate.cfg.HibernateMappingContext
 import org.hibernate.cfg.AvailableSettings
+import org.hibernate.cfg.Environment
 import org.hibernate.SessionFactory
 import org.hibernate.dialect.H2Dialect
 import org.hibernate.dialect.Oracle8iDialect
@@ -36,6 +37,16 @@ import spock.lang.Specification
  * Created by graemerocher on 06/07/2016.
  */
 class HibernateConnectionSourceFactorySpec extends Specification {
+
+    ClassLoader originalContextClassLoader
+
+    def setup() {
+        originalContextClassLoader = Thread.currentThread().contextClassLoader
+    }
+
+    def cleanup() {
+        Thread.currentThread().contextClassLoader = originalContextClassLoader
+    }
 
     void "Test hibernate connection factory"() {
         when:"A factory is used to create a session factory"
@@ -64,73 +75,61 @@ class HibernateConnectionSourceFactorySpec extends Specification {
         connectionSource.source.isClosed()
     }
 
-    void "buildConfiguration uses setApplicationContext when the dataSource bean exists even if the connection source is named default"() {
+    void "buildConfiguration uses the connection source DataSource and the application context class loader"() {
         given:
-        ClassLoader applicationClassLoader = new URLClassLoader([] as URL[], getClass().classLoader)
+        ClassLoader applicationClassLoader = loaderUnder(getClass().classLoader)
+        DataSource connectionSourceDataSource = Stub(DataSource)
         ApplicationContext applicationContext = Stub(ApplicationContext) {
             containsBean("dataSource") >> true
-            containsBean("default") >> false
             getBean("dataSource") >> Stub(DataSource)
             getClassLoader() >> applicationClassLoader
         }
         HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
         factory.setApplicationContext(applicationContext)
-        ConnectionSource<DataSource, DataSourceSettings> dataSourceConnectionSource = Stub(ConnectionSource) {
-            getName() >> ConnectionSource.DEFAULT
-            getSource() >> Stub(DataSource)
-            getSettings() >> new DataSourceSettings()
-        }
 
         when:
-        def configuration = factory.buildConfiguration(
-                ConnectionSource.DEFAULT, dataSourceConnectionSource, new HibernateConnectionSourceSettings())
+        def configuration = factory.buildConfiguration(ConnectionSource.DEFAULT,
+                connectionSource(ConnectionSource.DEFAULT, connectionSourceDataSource), new HibernateConnectionSourceSettings())
 
         then:
         configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(applicationClassLoader)
+        configuration.getProperties().get(Environment.DATASOURCE).is(connectionSourceDataSource)
     }
 
-    void "buildConfiguration injects the named dataSource bean instead of the default dataSource"() {
+    void "buildConfiguration keeps the connection source DataSource for a named connection source"() {
         given:
-        ClassLoader applicationClassLoader = new URLClassLoader([] as URL[], getClass().classLoader)
-        DataSource defaultDataSource = Stub(DataSource)
-        DataSource secondaryDataSource = Stub(DataSource)
+        ClassLoader applicationClassLoader = loaderUnder(getClass().classLoader)
+        DataSource connectionSourceDataSource = Stub(DataSource)
         ApplicationContext applicationContext = Stub(ApplicationContext) {
             containsBean("dataSource") >> true
             containsBean("dataSource_secondary") >> true
-            getBean("dataSource") >> defaultDataSource
-            getBean("dataSource_secondary") >> secondaryDataSource
+            getBean("dataSource") >> Stub(DataSource)
+            getBean("dataSource_secondary") >> Stub(DataSource)
             getClassLoader() >> applicationClassLoader
         }
         HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
         factory.setApplicationContext(applicationContext)
-        ConnectionSource<DataSource, DataSourceSettings> dataSourceConnectionSource = Stub(ConnectionSource) {
-            getName() >> "secondary"
-            getSource() >> Stub(DataSource)
-            getSettings() >> new DataSourceSettings()
-        }
 
         when:
-        def configuration = factory.buildConfiguration(
-                "secondary", dataSourceConnectionSource, new HibernateConnectionSourceSettings())
+        def configuration = factory.buildConfiguration("secondary",
+                connectionSource("secondary", connectionSourceDataSource), new HibernateConnectionSourceSettings())
 
         then:
         configuration.dataSourceName == "secondary"
         configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(applicationClassLoader)
-        configuration.getProperties().get(org.hibernate.cfg.Environment.DATASOURCE).is(secondaryDataSource)
+        configuration.getProperties().get(Environment.DATASOURCE).is(connectionSourceDataSource)
     }
 
-    void "buildConfiguration uses the connection source class loader when the dataSource bean does not exist"() {
+    void "buildConfiguration uses the connection source class loader when the application context has no class loader"() {
         given:
         ApplicationContext applicationContext = Stub(ApplicationContext) {
-            containsBean("dataSource") >> false
+            containsBean(_) >> false
+            getClassLoader() >> null
         }
         HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
         factory.setApplicationContext(applicationContext)
-        ConnectionSource<DataSource, DataSourceSettings> dataSourceConnectionSource = Stub(ConnectionSource) {
-            getName() >> ConnectionSource.DEFAULT
-            getSource() >> Stub(DataSource)
-            getSettings() >> new DataSourceSettings()
-        }
+        ConnectionSource<DataSource, DataSourceSettings> dataSourceConnectionSource =
+                connectionSource(ConnectionSource.DEFAULT, Stub(DataSource))
 
         when:
         def configuration = factory.buildConfiguration(
@@ -138,6 +137,71 @@ class HibernateConnectionSourceFactorySpec extends Specification {
 
         then:
         configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(dataSourceConnectionSource.getClass().getClassLoader())
+    }
+
+    void "buildConfiguration uses the connection source class loader without an application context"() {
+        given:
+        HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
+        ConnectionSource<DataSource, DataSourceSettings> dataSourceConnectionSource =
+                connectionSource(ConnectionSource.DEFAULT, Stub(DataSource))
+
+        when:
+        def configuration = factory.buildConfiguration(
+                ConnectionSource.DEFAULT, dataSourceConnectionSource, new HibernateConnectionSourceSettings())
+
+        then:
+        configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(dataSourceConnectionSource.getClass().getClassLoader())
+    }
+
+    void "buildConfiguration uses the context class loader that delegates to the RestartClassLoader during servlet container start"() {
+        given: "the container's web application loader is the thread context class loader and the context reports it"
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+        ApplicationContext applicationContext = Stub(ApplicationContext) {
+            containsBean(_) >> false
+            getClassLoader() >> containerLoader
+        }
+        HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
+        factory.setApplicationContext(applicationContext)
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        def configuration = factory.buildConfiguration(ConnectionSource.DEFAULT,
+                connectionSource(ConnectionSource.DEFAULT, Stub(DataSource)), new HibernateConnectionSourceSettings())
+
+        then:
+        configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+    }
+
+    void "buildConfiguration uses a thread context class loader that delegates to the RestartClassLoader without an application context"() {
+        given:
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+        HibernateConnectionSourceFactory factory = new HibernateConnectionSourceFactory()
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        def configuration = factory.buildConfiguration(ConnectionSource.DEFAULT,
+                connectionSource(ConnectionSource.DEFAULT, Stub(DataSource)), new HibernateConnectionSourceSettings())
+
+        then:
+        configuration.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+    }
+
+    private ConnectionSource<DataSource, DataSourceSettings> connectionSource(String name, DataSource dataSource) {
+        Stub(ConnectionSource) {
+            getName() >> name
+            getSource() >> dataSource
+            getSettings() >> new DataSourceSettings()
+        } as ConnectionSource<DataSource, DataSourceSettings>
+    }
+
+    private static ClassLoader restartClassLoader() {
+        new GroovyClassLoader().parseClass(
+                'class RestartClassLoader extends ClassLoader {}'
+        ).getDeclaredConstructor().newInstance() as ClassLoader
+    }
+
+    private static ClassLoader loaderUnder(ClassLoader parent) {
+        new URLClassLoader([] as URL[], parent)
     }
 }
 

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
@@ -155,10 +155,10 @@ public class HibernateMappingContextConfiguration extends Configuration
             properties.put("hibernate.enhancer.enableDirtyTracking", FALSE_LITERAL);
             properties.put("hibernate.enhancer.enableAssociationManagement", FALSE_LITERAL);
             ClassLoader applicationClassLoader = applicationContext.getClassLoader();
-            // Keep CLASSLOADERS absent when the context loader is null and DevTools is not
+            // Keep CLASSLOADERS absent when the context loader is null and DevTools restart is not
             // active so buildSessionFactory can fall back to this class's loader.
             if (applicationClassLoader != null ||
-                    DevToolsClassLoaders.isRestartClassLoader(Thread.currentThread().getContextClassLoader())) {
+                    DevToolsClassLoaders.isRestartClassLoaderOrDescendant(Thread.currentThread().getContextClassLoader())) {
                 properties.put(AvailableSettings.CLASSLOADERS,
                         DevToolsClassLoaders.preferRestartClassLoader(applicationClassLoader));
             }
@@ -374,9 +374,9 @@ public class HibernateMappingContextConfiguration extends Configuration
         Object classLoaderObject = getProperties().get(AvailableSettings.CLASSLOADERS);
         ClassLoader storedClassLoader = classLoaderObject instanceof ClassLoader ?
                 (ClassLoader) classLoaderObject : getClass().getClassLoader();
-        // Re-check TCCL: addProperties() / a custom configClass can overwrite CLASSLOADERS
-        // after the setters. GrailsDomainBinder.bindClass only setClassName(entityName);
-        // Hibernate then re-resolves Class via ReflectHelper.classForName (TCCL).
+        // addProperties() or a custom configClass may have replaced CLASSLOADERS after the
+        // setters ran. GrailsDomainBinder binds entities by class name and Hibernate resolves
+        // them through this loader, so it has to see the restarted application classes.
         return DevToolsClassLoaders.preferRestartClassLoader(storedClassLoader);
     }
 

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationSpec.groovy
@@ -332,6 +332,89 @@ class HibernateMappingContextConfigurationSpec extends Specification {
         Thread.currentThread().contextClassLoader = originalCl
     }
 
+    def "setApplicationContext prefers a thread context class loader that delegates to the RestartClassLoader over the context class loader"() {
+        given: "a servlet container has swapped its web application loader in during context start"
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader contextLoader = new URLClassLoader([] as URL[], Thread.currentThread().contextClassLoader)
+        ApplicationContext appCtx = Stub(ApplicationContext) {
+            containsBean("dataSource") >> false
+            getClassLoader() >> contextLoader
+        }
+        ClassLoader containerLoader = new URLClassLoader([] as URL[], restartClassLoader())
+        def originalCl = Thread.currentThread().contextClassLoader
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setApplicationContext(appCtx)
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = originalCl
+    }
+
+    def "setApplicationContext with a null context class loader uses a thread context class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        ApplicationContext appCtx = Stub(ApplicationContext) {
+            containsBean("dataSource") >> false
+            getClassLoader() >> null
+        }
+        ClassLoader containerLoader = new URLClassLoader([] as URL[], restartClassLoader())
+        def originalCl = Thread.currentThread().contextClassLoader
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setApplicationContext(appCtx)
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = originalCl
+    }
+
+    def "setDataSourceConnectionSource uses a thread context class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        DataSource ds = Stub(DataSource)
+        ConnectionSource<DataSource, DataSourceSettings> connSrc = Stub(ConnectionSource) {
+            getName() >> ConnectionSource.DEFAULT
+            getSource() >> ds
+        }
+        ClassLoader containerLoader = new URLClassLoader([] as URL[], restartClassLoader())
+        def originalCl = Thread.currentThread().contextClassLoader
+
+        when:
+        Thread.currentThread().contextClassLoader = containerLoader
+        config.setDataSourceConnectionSource(connSrc)
+
+        then:
+        config.getProperties().get(AvailableSettings.CLASSLOADERS).is(containerLoader)
+        config.getProperties().get(JdbcSettings.JAKARTA_NON_JTA_DATASOURCE).is(ds)
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = originalCl
+    }
+
+    def "resolveSessionFactoryClassLoader keeps a configured class loader that delegates to the RestartClassLoader"() {
+        given:
+        def config = new HibernateMappingContextConfiguration()
+        ClassLoader configuredLoader = new URLClassLoader([] as URL[], restartClassLoader())
+        config.getProperties().put(AvailableSettings.CLASSLOADERS, configuredLoader)
+        def originalCl = Thread.currentThread().contextClassLoader
+
+        when:
+        Thread.currentThread().contextClassLoader = new URLClassLoader([] as URL[], originalCl)
+
+        then:
+        config.resolveSessionFactoryClassLoader().is(configuredLoader)
+
+        cleanup:
+        Thread.currentThread().contextClassLoader = originalCl
+    }
+
     def "setApplicationContext when datasource property already set does not overwrite it"() {
         given:
         def config = new HibernateMappingContextConfiguration()
@@ -513,6 +596,12 @@ class HibernateMappingContextConfigurationSpec extends Specification {
         
         expect:
         config.getProperties().get(AvailableSettings.CLASSLOADERS).is(cl)
+    }
+
+    private static ClassLoader restartClassLoader() {
+        new GroovyClassLoader().parseClass(
+                'class RestartClassLoader extends ClassLoader {}'
+        ).getDeclaredConstructor().newInstance() as ClassLoader
     }
 }
 

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/DevToolsClassLoaders.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/DevToolsClassLoaders.java
@@ -20,14 +20,20 @@ package org.grails.datastore.mapping.reflect;
 
 /**
  * Resolves the class loader GORM and Hibernate should use when Spring Boot DevTools
- * is on the classpath.
+ * restart is active.
  *
- * <p>DevTools splits the classpath across a base loader (third-party jars) and a
- * {@code RestartClassLoader} (application classes). Hibernate's JPA metamodel and
- * GORM's entity registry key entities by {@link Class} identity, so domain classes
- * loaded by the restart loader are "not an entity" if Hibernate resolved them
- * through the base loader. Preferring the restart loader — typically the thread
- * context class loader on {@code restartedMain} — keeps those identities aligned.</p>
+ * <p>DevTools splits the classpath across a base loader (third-party jars, including
+ * GORM and Hibernate) and a {@code RestartClassLoader} (application classes). Hibernate's
+ * JPA metamodel and GORM's entity registry key entities by {@link Class} identity, so a
+ * domain class Hibernate resolved through the base loader is "not an entity" to code
+ * holding the restart loader's copy. Hibernate resolves entities by name through the
+ * loader it is bootstrapped with, so that loader must see the restarted classes.</p>
+ *
+ * <p>The thread context class loader is not always the {@code RestartClassLoader} itself
+ * while the application starts. A servlet container swaps in its own web application
+ * loader during context start (Tomcat's {@code TomcatEmbeddedWebappClassLoader}), and
+ * that loader delegates to the {@code RestartClassLoader} as its parent. Every check here
+ * therefore walks the parent chain rather than matching only the loader's own type.</p>
  *
  * @since 8.0
  */
@@ -43,7 +49,7 @@ public final class DevToolsClassLoaders {
     /**
      * @param classLoader the loader to inspect, possibly {@code null}
      * @return {@code true} when {@code classLoader} is Spring Boot DevTools'
-     * {@code RestartClassLoader}
+     * {@code RestartClassLoader} itself
      */
     public static boolean isRestartClassLoader(ClassLoader classLoader) {
         if (classLoader == null) {
@@ -61,46 +67,41 @@ public final class DevToolsClassLoaders {
     }
 
     /**
-     * Prefer the thread context class loader when it is DevTools'
-     * {@code RestartClassLoader}, unless {@code fallback} is that loader or a
-     * descendant of it (the child can see everything the restart loader sees
-     * plus its own classes). Otherwise return {@code fallback}, or this class's
-     * loader when {@code fallback} is {@code null}.
+     * @param classLoader the loader to inspect, possibly {@code null}
+     * @return {@code true} when {@code classLoader} is the {@code RestartClassLoader} or
+     * delegates to one through its parent chain, and so sees the restarted application classes
+     */
+    public static boolean isRestartClassLoaderOrDescendant(ClassLoader classLoader) {
+        for (ClassLoader current = classLoader; current != null; current = current.getParent()) {
+            if (isRestartClassLoader(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns a loader that sees the restarted application classes when DevTools restart is
+     * active. {@code fallback} is kept when it already does; otherwise the thread context class
+     * loader is used when it does. When neither does, DevTools restart is not active on this
+     * thread and {@code fallback} is returned, or this class's loader when {@code fallback} is
+     * {@code null}.
      *
-     * @param fallback the loader to use when DevTools is not active
+     * @param fallback the loader to use when DevTools restart is not active
      * @return a non-null class loader
      */
-    @SuppressWarnings("PMD.UseProperClassLoader") // last-resort fallback; TCCL is checked first when it is a RestartClassLoader
+    @SuppressWarnings("PMD.UseProperClassLoader") // last-resort fallback once neither candidate sees the restart loader
     public static ClassLoader preferRestartClassLoader(ClassLoader fallback) {
+        if (isRestartClassLoaderOrDescendant(fallback)) {
+            return fallback;
+        }
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        if (isRestartClassLoader(contextClassLoader)) {
-            if (isLoaderOrDescendant(fallback, contextClassLoader)) {
-                return fallback;
-            }
+        if (isRestartClassLoaderOrDescendant(contextClassLoader)) {
             return contextClassLoader;
         }
         if (fallback != null) {
             return fallback;
         }
         return DevToolsClassLoaders.class.getClassLoader();
-    }
-
-    /**
-     * @deprecated use {@link #preferRestartClassLoader(ClassLoader)}
-     */
-    @Deprecated
-    public static ClassLoader resolve(ClassLoader fallback) {
-        return preferRestartClassLoader(fallback);
-    }
-
-    private static boolean isLoaderOrDescendant(ClassLoader candidate, ClassLoader ancestor) {
-        ClassLoader current = candidate;
-        while (current != null) {
-            if (current == ancestor) {
-                return true;
-            }
-            current = current.getParent();
-        }
-        return false;
     }
 }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/DevToolsClassLoadersSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/DevToolsClassLoadersSpec.groovy
@@ -39,13 +39,8 @@ class DevToolsClassLoadersSpec extends Specification {
     }
 
     void "isRestartClassLoader matches the RestartClassLoader simple name"() {
-        given:
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
-
         expect:
-        DevToolsClassLoaders.isRestartClassLoader(restartLoader)
+        DevToolsClassLoaders.isRestartClassLoader(restartClassLoader())
     }
 
     void "isRestartClassLoader does not match RestartClassLoader ignoring case"() {
@@ -68,21 +63,52 @@ class DevToolsClassLoadersSpec extends Specification {
         DevToolsClassLoaders.isRestartClassLoader(restartLoader)
     }
 
+    void "isRestartClassLoader does not match a loader that only delegates to the RestartClassLoader"() {
+        expect:
+        !DevToolsClassLoaders.isRestartClassLoader(loaderUnder(restartClassLoader()))
+    }
+
+    void "isRestartClassLoaderOrDescendant is false for null and ordinary loaders"() {
+        expect:
+        !DevToolsClassLoaders.isRestartClassLoaderOrDescendant(null)
+        !DevToolsClassLoaders.isRestartClassLoaderOrDescendant(DevToolsClassLoaders.classLoader)
+        !DevToolsClassLoaders.isRestartClassLoaderOrDescendant(loaderUnder(DevToolsClassLoaders.classLoader))
+    }
+
+    void "isRestartClassLoaderOrDescendant matches the RestartClassLoader and loaders delegating to it"() {
+        given:
+        ClassLoader restartLoader = restartClassLoader()
+        ClassLoader child = loaderUnder(restartLoader)
+
+        expect:
+        DevToolsClassLoaders.isRestartClassLoaderOrDescendant(restartLoader)
+        DevToolsClassLoaders.isRestartClassLoaderOrDescendant(child)
+        DevToolsClassLoaders.isRestartClassLoaderOrDescendant(loaderUnder(child))
+    }
+
     void "preferRestartClassLoader prefers a RestartClassLoader thread context class loader"() {
         given:
-        ClassLoader fallback = new URLClassLoader([] as URL[], DevToolsClassLoaders.classLoader)
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
+        ClassLoader fallback = loaderUnder(DevToolsClassLoaders.classLoader)
+        ClassLoader restartLoader = restartClassLoader()
         Thread.currentThread().contextClassLoader = restartLoader
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(fallback).is(restartLoader)
     }
 
+    void "preferRestartClassLoader prefers a thread context class loader that delegates to the RestartClassLoader"() {
+        given: "a servlet container has swapped its web application loader in as the context class loader"
+        ClassLoader fallback = loaderUnder(DevToolsClassLoaders.classLoader)
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+        Thread.currentThread().contextClassLoader = containerLoader
+
+        expect:
+        DevToolsClassLoaders.preferRestartClassLoader(fallback).is(containerLoader)
+    }
+
     void "preferRestartClassLoader returns the fallback when DevTools is not active"() {
         given:
-        ClassLoader fallback = new URLClassLoader([] as URL[], DevToolsClassLoaders.classLoader)
+        ClassLoader fallback = loaderUnder(DevToolsClassLoaders.classLoader)
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(fallback).is(fallback)
@@ -90,9 +116,8 @@ class DevToolsClassLoadersSpec extends Specification {
 
     void "preferRestartClassLoader ignores a non-restart thread context class loader"() {
         given:
-        ClassLoader fallback = new URLClassLoader([] as URL[], DevToolsClassLoaders.classLoader)
-        ClassLoader otherLoader = new URLClassLoader([] as URL[], DevToolsClassLoaders.classLoader)
-        Thread.currentThread().contextClassLoader = otherLoader
+        ClassLoader fallback = loaderUnder(DevToolsClassLoaders.classLoader)
+        Thread.currentThread().contextClassLoader = loaderUnder(DevToolsClassLoaders.classLoader)
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(fallback).is(fallback)
@@ -100,13 +125,20 @@ class DevToolsClassLoadersSpec extends Specification {
 
     void "preferRestartClassLoader prefers a RestartClassLoader even when fallback is null"() {
         given:
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
+        ClassLoader restartLoader = restartClassLoader()
         Thread.currentThread().contextClassLoader = restartLoader
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(null).is(restartLoader)
+    }
+
+    void "preferRestartClassLoader prefers a delegating thread context class loader even when fallback is null"() {
+        given:
+        ClassLoader containerLoader = loaderUnder(restartClassLoader())
+        Thread.currentThread().contextClassLoader = containerLoader
+
+        expect:
+        DevToolsClassLoaders.preferRestartClassLoader(null).is(containerLoader)
     }
 
     void "preferRestartClassLoader falls back to this class's loader when fallback is null"() {
@@ -116,11 +148,18 @@ class DevToolsClassLoadersSpec extends Specification {
 
     void "preferRestartClassLoader returns a descendant fallback of the RestartClassLoader"() {
         given:
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
-        ClassLoader fallback = new URLClassLoader([] as URL[], restartLoader)
+        ClassLoader restartLoader = restartClassLoader()
+        ClassLoader fallback = loaderUnder(restartLoader)
         Thread.currentThread().contextClassLoader = restartLoader
+
+        expect:
+        DevToolsClassLoaders.preferRestartClassLoader(fallback).is(fallback)
+    }
+
+    void "preferRestartClassLoader keeps a fallback that delegates to the RestartClassLoader when the thread context class loader is unrelated"() {
+        given:
+        ClassLoader fallback = loaderUnder(restartClassLoader())
+        Thread.currentThread().contextClassLoader = loaderUnder(DevToolsClassLoaders.classLoader)
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(fallback).is(fallback)
@@ -128,17 +167,20 @@ class DevToolsClassLoadersSpec extends Specification {
 
     void "preferRestartClassLoader returns the RestartClassLoader fallback"() {
         given:
-        ClassLoader restartLoader = new GroovyClassLoader().parseClass(
-                'class RestartClassLoader extends ClassLoader {}'
-        ).getDeclaredConstructor().newInstance() as ClassLoader
+        ClassLoader restartLoader = restartClassLoader()
         Thread.currentThread().contextClassLoader = restartLoader
 
         expect:
         DevToolsClassLoaders.preferRestartClassLoader(restartLoader).is(restartLoader)
     }
 
-    void "resolve delegates to preferRestartClassLoader"() {
-        expect:
-        DevToolsClassLoaders.resolve(null).is(DevToolsClassLoaders.preferRestartClassLoader(null))
+    private static ClassLoader restartClassLoader() {
+        new GroovyClassLoader().parseClass(
+                'class RestartClassLoader extends ClassLoader {}'
+        ).getDeclaredConstructor().newInstance() as ClassLoader
+    }
+
+    private static ClassLoader loaderUnder(ClassLoader parent) {
+        new URLClassLoader([] as URL[], parent)
     }
 }

--- a/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
+++ b/grails-doc/src/en/guide/gettingStarted/developmentReloading.adoc
@@ -25,8 +25,6 @@ Spring Boot Developer Tools is a feature of Spring Boot that provides automatic 
 
 For larger applications, you may need to adjust the default settings for optimal performance.  This works well until your application becomes very large, at which point restarts may take longer or fail.
 
-When Spring Boot Developer Tools restart is active, Grails bootstraps Hibernate with the restart class loader. That keeps domain class identity consistent with Hibernate's metamodel without moving GORM or Grails jars onto the restart loader.
-
 Please see the Spring Boot documentation for more details: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#using-boot-devtools[Spring Boot Developer Tools].
 
 NOTE: You can use Spring Developer Tools in combination with a browser extension to get automatic browser


### PR DESCRIPTION
Follow-up to #16299 addressing review feedback.

Under a DevTools restart the thread context class loader is not always the RestartClassLoader. Tomcat swaps
in TomcatEmbeddedWebappClassLoader during context start, which delegates to the RestartClassLoader as its
parent. A check that matched only the loader's own type fell back to the base loader in that window, which
is how the Hibernate 5 SessionFactory on 8.0.0-M5 ended up with base-loader entity classes (#16287).
Current 8.0.x only avoids it because the datastore is now constructed before Tomcat starts.

- Walk the loader parent chain in DevToolsClassLoaders; keep a fallback that already sees the restart loader.
- Hibernate 5 mirrors Hibernate 7: connection source is the DataSource of record, the context supplies the
  class loader. Removes the duplicated bean-name derivation.
- Drop the unreleased resolve() alias and the guide paragraph.
- Specs cover the container-loader condition, which the previous specs did not exercise.