### PR TITLE
Pin that the compiler config generator stays off the runtime classpath

### DIFF
--- a/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsGroovyCompilerConfigSpec.groovy
+++ b/grails-gradle/plugins/src/test/groovy/org/grails/gradle/plugin/core/GrailsGroovyCompilerConfigSpec.groovy
@@ -59,6 +59,29 @@ class GrailsGroovyCompilerConfigSpec extends GradleSpecification {
         result.output.contains('GENERATOR_HAS_CONTENT_INPUT=true')
     }
 
+    def "a task that adds to the runtime classpath after compiling does not cycle through the generator"() {
+        given: 'an application whose runtime classpath carries the output of a task that runs after classes'
+        setupTestResourceProject('compiler-config-runtime-classpath-producer')
+
+        when: 'the wiring is inspected'
+        def result = executeTask('inspectRuntimeProducer')
+
+        then: 'the producer is on the runtime classpath, and the generator does not depend on it'
+        result.output.contains('RUNTIME_CLASSPATH_BUILT_BY_PRODUCER=true')
+        result.output.contains('GENERATOR_DEPENDS_ON_RUNTIME_PRODUCER=false')
+        result.output.contains('COMBINED_CONTAINS_GRAILS_IMPORT=true')
+
+        when: 'the compile task and that producer are scheduled together'
+        def graph = executeTask('compileGroovy', ['packageRuntimeExtra', '--dry-run'])
+
+        then: 'the graph builds without a cycle, the generator ahead of the compile and the producer after'
+        def order = graph.output.readLines().findAll { it.startsWith(':') }
+        order.findIndexOf { it.startsWith(':generateCompileGroovyGrailsCompilerConfig') } <
+                order.findIndexOf { it.startsWith(':compileGroovy') }
+        order.findIndexOf { it.startsWith(':compileGroovy') } <
+                order.findIndexOf { it.startsWith(':packageRuntimeExtra') }
+    }
+
     def "a configurationScript assigned from a later callback is folded in, not clobbered"() {
         given: 'a user assigning configurationScript from projectsEvaluated'
         setupTestResourceProject('compiler-config-late-assignment')

--- a/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/build.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/build.gradle
@@ -1,0 +1,40 @@
+plugins {
+    id 'org.apache.grails.gradle.grails-app'
+}
+
+grails {
+    starImports = ['com.example.custom']
+}
+
+// A task that runs after the classes are compiled and puts its output on the runtime
+// classpath: the shape of asset-pipeline, the exploded plugin directory, or any other
+// post-compile packaging step. Its output reaches compileGroovy only through the
+// runtime classpath, which the compile classpath does not include.
+def packageRuntimeExtra = tasks.register('packageRuntimeExtra') {
+    dependsOn 'classes'
+    def out = layout.buildDirectory.dir('runtime-extra')
+    outputs.dir(out)
+    doLast {
+        def dir = out.get().asFile
+        dir.mkdirs()
+        new File(dir, 'extra.properties').text = 'generated=true'
+    }
+}
+
+dependencies {
+    runtimeOnly files(packageRuntimeExtra)
+}
+
+tasks.register('inspectRuntimeProducer') {
+    dependsOn 'generateCompileGroovyGrailsCompilerConfig'
+    doLast {
+        def gen = tasks.named('generateCompileGroovyGrailsCompilerConfig').get()
+        def deps = gen.taskDependencies.getDependencies(gen)*.path
+        println "GENERATOR_DEPENDENCIES=${deps}"
+        println "GENERATOR_DEPENDS_ON_RUNTIME_PRODUCER=${deps.any { it == ':packageRuntimeExtra' }}"
+        def runtimeProducers = configurations.runtimeClasspath.buildDependencies.getDependencies(null)*.path
+        println "RUNTIME_CLASSPATH_BUILT_BY_PRODUCER=${runtimeProducers.any { it == ':packageRuntimeExtra' }}"
+        def combined = file('build/grailsGroovyCompilerConfig-compileGroovy.groovy')
+        println "COMBINED_CONTAINS_GRAILS_IMPORT=${combined.exists() && combined.text.contains(/star 'com.example.custom'/)}"
+    }
+}

--- a/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/gradle.properties
+++ b/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/gradle.properties
@@ -1,0 +1,1 @@
+grailsVersion=__PROJECT_VERSION__

--- a/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/settings.gradle
+++ b/grails-gradle/plugins/src/test/resources/test-projects/compiler-config-runtime-classpath-producer/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'compiler-config-runtime-classpath-producer'


### PR DESCRIPTION
The task-based wiring that 9a529d1996 replaced with a doFirst declared runtimeClasspath as an input of the generator task, so any task whose output reached the runtime classpath became a transitive dependency of compileGroovy. A post-compile step that feeds the runtime classpath, such as asset-pipeline output or the exploded plugin directory, then closed a cycle. That is the concern raised on #16114.

The generator introduced there takes its script from grails { } state and declares no classpath input, so that edge no longer exists. This test recreates the scenario: a task that runs after classes and puts its output on the runtime classpath via runtimeOnly files(task). It asserts the generator does not depend on that task, and that compileGroovy and the producer schedule together without a cycle.
