### PR TITLE
Share SAX feature identifiers and make DOCTYPE rejection configurable

### DIFF
--- a/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/usingJSPTagLibraries.adoc
+++ b/grails-doc/src/en/guide/theWebLayer/gsp/taglibs/usingJSPTagLibraries.adoc
@@ -51,6 +51,18 @@ grails:
         tldScanPattern: 'classpath*:/META-INF/*.tld,/WEB-INF/tld/*.tld'
 ----
 
+Tag library descriptors are parsed with the framework's XML settings, which reject `DOCTYPE` declarations by default.  Many descriptors declare one -- `jakarta.servlet.jsp.jstl` ships several, among them `c-1_0-rt.tld`, which the default scan pattern includes -- so scanning them requires permitting declarations:
+
+[source,yaml]
+.grails-app/conf/application.yml
+----
+grails:
+    xml:
+        allowDocTypeDeclaration: true
+----
+
+Without it, resolving a JSP tag library fails with a `SAXParseException` reporting that `DOCTYPE is disallowed`.  Enabling the setting does not reopen the XXE vector; external entities and external DTDs stay refused.  See <<upgrading>> for the full description.
+
 JSTL standard library is no longer added as a dependency by default. In case you are using JSTL, you should also add these dependencies to `build.gradle`:
 [source,groovy]
 .build.gradle

--- a/grails-doc/src/en/guide/upgrading.adoc
+++ b/grails-doc/src/en/guide/upgrading.adoc
@@ -30,3 +30,22 @@ In compatibility mode, a `bindData` call that supplies only `exclude` continues 
 Values of typed `Map` properties are converted to the declared value type.  Conversion failures are added to the binding errors and data binding listeners receive the corresponding events.
 
 The values `true`, `false`, `'true'`, and `'false'` are accepted for `grails.databinding.denyByDefault`, ignoring case and surrounding whitespace for strings.  An unrecognised value logs a warning and enables secure deny-by-default binding.
+
+=== XML Parsing Defaults
+
+XML read by Grails is parsed with external entity expansion and external DTD loading disabled.  This closes the XXE vector: an entity that points at a file on disk contributes nothing to the parsed document.
+
+Grails 8 additionally rejects `DOCTYPE` declarations outright.  A request body, or any other document parsed through the framework, that carries a `DOCTYPE` is refused with a `SAXParseException` rather than parsed.
+
+This is stricter than blocking external entities, because it also refuses documents whose `DOCTYPE` is entirely internal and harmless.  Applications that must accept such documents can opt back in:
+
+[source,yaml]
+----
+grails:
+    xml:
+        allowDocTypeDeclaration: true
+----
+
+The setting is also accepted as the `grails.xml.allowDocTypeDeclaration` system property.  Opting in relaxes only whether a declaration is permitted; external general entities, external parameter entities and external DTDs stay refused either way, so it does not reopen the XXE vector.
+
+Descriptors read from the classpath are parsed by the same mechanism, and some carry a `DOCTYPE`.  JSP tag library descriptors are the common case: `jakarta.servlet.jsp.jstl` ships several, among them `c-1_0-rt.tld`, which the default `grails.gsp.tldScanPattern` scans.  An application that uses JSP tag libraries from a GSP needs this setting enabled.

--- a/grails-gradle/common/src/main/groovy/org/apache/grails/gradle/common/XmlParserFeature.java
+++ b/grails-gradle/common/src/main/groovy/org/apache/grails/gradle/common/XmlParserFeature.java
@@ -1,0 +1,93 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.grails.gradle.common;
+
+/**
+ * Registered SAX and Xerces parser feature identifiers used to harden XML parsing.
+ *
+ * <p><strong>These values are opaque identifiers, not addresses.</strong> Nothing is ever fetched
+ * from them. A parser matches them by exact string comparison against the prefixes it registers
+ * internally, {@code http://xml.org/sax/features/} and {@code http://apache.org/xml/features/}.
+ *
+ * <p><strong>Do not rewrite the {@code http} scheme to {@code https}.</strong> No parser
+ * recognizes the {@code https} spelling; {@code setFeature} answers it with
+ * {@code SAXNotRecognizedException}. Because callers wrap {@code setFeature} in a catch that
+ * tolerates parsers lacking a feature, an unrecognised name is swallowed and the hardening is
+ * silently disabled rather than failing loudly. A blanket "prefer https" sweep over the codebase
+ * therefore turns XML hardening off without leaving a trace, which is exactly what happened
+ * before these values were collected here.
+ *
+ * <p>Consumers must assert parser <em>behaviour</em> rather than reading these names back, so that
+ * the guarding tests hold no copy of the identifiers and cannot be rewritten by the same sweep.
+ *
+ * @since 8.0.0
+ */
+public enum XmlParserFeature {
+
+    /**
+     * Rejects any document carrying a {@code DOCTYPE} declaration.
+     *
+     * <p>Enabling this is stricter than blocking external entities: it refuses documents whose
+     * DOCTYPE is entirely internal and harmless. Descriptors read from the classpath — JSP tag
+     * library definitions, {@code web.xml}, {@code plugin.xml} — routinely carry a DOCTYPE, so a
+     * parser shared with those callers must leave this disabled.
+     */
+    DISALLOW_DOCTYPE_DECL("http://apache.org/xml/features/disallow-doctype-decl"),
+
+    /**
+     * Blocks resolution of external general entities, the primary XXE vector.
+     */
+    EXTERNAL_GENERAL_ENTITIES("http://xml.org/sax/features/external-general-entities"),
+
+    /**
+     * Blocks resolution of external parameter entities.
+     */
+    EXTERNAL_PARAMETER_ENTITIES("http://xml.org/sax/features/external-parameter-entities"),
+
+    /**
+     * Stops the parser building a grammar from a DTD.
+     */
+    LOAD_DTD_GRAMMAR("http://apache.org/xml/features/nonvalidating/load-dtd-grammar"),
+
+    /**
+     * Skips external DTD subsets instead of retrieving them.
+     *
+     * <p>This differs from the JAXP {@code XMLConstants.ACCESS_EXTERNAL_DTD} property, which
+     * raises an error when a document references an external DTD. Skipping is what allows a
+     * descriptor that names a DTD, such as a JSP 1.2 tag library, to parse without retrieving it.
+     */
+    LOAD_EXTERNAL_DTD("http://apache.org/xml/features/nonvalidating/load-external-dtd");
+
+    private final String featureName;
+
+    XmlParserFeature(String featureName) {
+        this.featureName = featureName;
+    }
+
+    /**
+     * @return the registered identifier to pass to {@code setFeature}
+     */
+    public String getFeatureName() {
+        return featureName;
+    }
+
+    @Override
+    public String toString() {
+        return featureName;
+    }
+
+}

--- a/grails-gradle/common/src/test/groovy/org/apache/grails/gradle/common/XmlParserFeatureSpec.groovy
+++ b/grails-gradle/common/src/test/groovy/org/apache/grails/gradle/common/XmlParserFeatureSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.grails.gradle.common
+
+import javax.xml.parsers.SAXParserFactory
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class XmlParserFeatureSpec extends Specification {
+
+    /**
+     * Every identifier must be one the parser actually registers.
+     *
+     * <p>Callers set these inside a catch that tolerates a parser lacking a feature, so an
+     * unrecognised identifier disables hardening silently instead of failing. Rewriting the
+     * {@code http} scheme to {@code https} is the way that happens in practice. This spec derives
+     * the identifiers from {@link XmlParserFeature#values()} rather than restating them, so the
+     * same rewrite cannot pass by changing the expectation to match.
+     */
+    @Unroll
+    void 'feature #feature is recognised by the parser'() {
+        given:
+        SAXParserFactory factory = SAXParserFactory.newInstance()
+
+        when:
+        factory.setFeature(feature.featureName, false)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        feature << XmlParserFeature.values()
+    }
+
+    void 'every feature is distinct'() {
+        expect:
+        XmlParserFeature.values()*.featureName.toUnique().size() == XmlParserFeature.values().length
+    }
+}

--- a/grails-gradle/model/build.gradle
+++ b/grails-gradle/model/build.gradle
@@ -42,6 +42,8 @@ ext {
 dependencies {
     implementation platform(project(':grails-gradle-bom'))
 
+    implementation project(':grails-gradle-common') // XmlParserFeature
+
     // compile grails-gradle-model with the Groovy version provided by Gradle
     // Groovy 4+ uses org.apache.groovy coordinates
     // when used by grails-gradle-plugin

--- a/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
+++ b/grails-gradle/model/src/main/groovy/org/grails/io/support/SpringIOUtils.java
@@ -49,6 +49,9 @@ import groovy.xml.XmlSlurper;
 
 import org.xml.sax.SAXException;
 
+import grails.util.Metadata;
+import org.apache.grails.gradle.common.XmlParserFeature;
+
 /**
  * Simple utility methods for file and stream copying.
  * All copy methods use a block size of 4096 bytes,
@@ -416,50 +419,86 @@ public class SpringIOUtils {
         return factory.newSAXParser();
     }
 
-    private static SAXParserFactory saxParserFactory = null;
+    /**
+     * Configuration key permitting {@code DOCTYPE} declarations in documents parsed by this class.
+     *
+     * <p>Parsers handed out here reject a {@code DOCTYPE} by default. Set
+     * {@code grails.xml.allowDocTypeDeclaration} to {@code true} in {@code application.yml}, or as
+     * a system property, to accept one.
+     *
+     * <p>Opting in does not reopen the XXE vector. External general entities, external parameter
+     * entities and external DTDs stay refused whichever way this is set, so an entity pointing at
+     * a file on disk still contributes nothing. What opting in changes is only whether a document
+     * carrying a declaration is refused outright.
+     *
+     * <p>It exists because these parsers also read trusted descriptors from the classpath, and
+     * some of those carry a {@code DOCTYPE}. JSP tag library descriptors are the common case:
+     * {@code jakarta.servlet.jsp.jstl} ships several, among them {@code c-1_0-rt.tld}, which the
+     * default {@code grails.gsp.tldScanPattern} scans.
+     */
+    public static final String ALLOW_DOCTYPE_DECLARATION = "grails.xml.allowDocTypeDeclaration";
+
+    /**
+     * Parser features switched off for every parser this class hands out.
+     *
+     * <p>{@link XmlParserFeature#DISALLOW_DOCTYPE_DECL} is handled separately because it is the
+     * one feature an application may turn off; see {@link #ALLOW_DOCTYPE_DECLARATION}.
+     */
+    private static final XmlParserFeature[] DISABLED_PARSER_FEATURES = {
+        XmlParserFeature.EXTERNAL_GENERAL_ENTITIES,
+        XmlParserFeature.EXTERNAL_PARAMETER_ENTITIES,
+        XmlParserFeature.LOAD_DTD_GRAMMAR,
+        XmlParserFeature.LOAD_EXTERNAL_DTD
+    };
+
+    private static SAXParserFactory strictParserFactory = null;
+
+    private static SAXParserFactory docTypeParserFactory = null;
 
     private static SAXParserFactory createParserFactory() throws ParserConfigurationException {
-        if (saxParserFactory == null) {
-            saxParserFactory = FactorySupport.createSaxParserFactory();
-            saxParserFactory.setNamespaceAware(true);
-            saxParserFactory.setValidating(false);
-            try {
-                saxParserFactory.setXIncludeAware(false);
-            } catch (UnsupportedOperationException e) {
-                // ignore, parser doesn't support
+        if (isDocTypeDeclarationAllowed()) {
+            if (docTypeParserFactory == null) {
+                docTypeParserFactory = buildParserFactory(true);
             }
+            return docTypeParserFactory;
+        }
+        if (strictParserFactory == null) {
+            strictParserFactory = buildParserFactory(false);
+        }
+        return strictParserFactory;
+    }
 
+    private static boolean isDocTypeDeclarationAllowed() {
+        return Boolean.TRUE.equals(
+                Metadata.getCurrent().getProperty(ALLOW_DOCTYPE_DECLARATION, Boolean.class, Boolean.FALSE));
+    }
+
+    private static SAXParserFactory buildParserFactory(boolean allowDocTypeDeclaration) throws ParserConfigurationException {
+        SAXParserFactory factory = FactorySupport.createSaxParserFactory();
+        factory.setNamespaceAware(true);
+        factory.setValidating(false);
+        try {
+            factory.setXIncludeAware(false);
+        } catch (UnsupportedOperationException e) {
+            // ignore, parser doesn't support
+        }
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (Exception e) {
+            // ignore, parser doesn't support
+        }
+        try {
+            factory.setFeature(XmlParserFeature.DISALLOW_DOCTYPE_DECL.getFeatureName(), !allowDocTypeDeclaration);
+        } catch (Exception e) {
+            // ignore, parser doesn't support
+        }
+        for (XmlParserFeature feature : DISABLED_PARSER_FEATURES) {
             try {
-                saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            } catch (Exception pce) {
-                // ignore, parser doesn't support
-            }
-            try {
-                saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            } catch (Exception pce) {
-                // ignore, parser doesn't support
-            }
-            try {
-                saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            } catch (Exception pce) {
-                // ignore, parser doesn't support
-            }
-            try {
-                saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            } catch (Exception e) {
-                // ignore, parser doesn't support
-            }
-            try {
-                saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", false);
-            } catch (Exception e) {
-                // ignore, parser doesn't support
-            }
-            try {
-                saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+                factory.setFeature(feature.getFeatureName(), false);
             } catch (Exception e) {
                 // ignore, parser doesn't support
             }
         }
-        return saxParserFactory;
+        return factory;
     }
 }

--- a/grails-gradle/model/src/test/groovy/org/grails/io/support/SpringIOUtilsSpec.groovy
+++ b/grails-gradle/model/src/test/groovy/org/grails/io/support/SpringIOUtilsSpec.groovy
@@ -18,12 +18,50 @@
  */
 package org.grails.io.support
 
-import org.xml.sax.SAXParseException
-import spock.lang.Specification
+import java.nio.file.Files
+import java.nio.file.Path
 
+import grails.util.Metadata
+
+import org.xml.sax.SAXParseException
+
+import spock.lang.Specification
+import spock.lang.TempDir
+
+/**
+ * Asserts the parser hardening applied by {@link SpringIOUtils} through observable parsing
+ * behaviour rather than by reading feature flags back off the factory.
+ *
+ * <p>This is deliberate. Reading the flags back would require this spec to hold its own copy of
+ * the feature identifiers, so a search-and-replace over those identifiers would rewrite the
+ * production code and this spec together and the suite would still pass. Driving real documents
+ * through the parser keeps the assertions independent of how the hardening is spelled.
+ */
 class SpringIOUtilsSpec extends Specification {
 
-    void 'createXmlSlurper parses documents without a doctype'() {
+    /** Shape of a JSP 1.2 tag library descriptor, as shipped inside jakarta jstl. */
+    private static final String TLD = '''<!DOCTYPE taglib
+  PUBLIC "-//Sun Microsystems, Inc.//DTD JSP Tag Library 1.2//EN"
+  "http://java.sun.com/dtd/web-jsptaglibrary_1_2.dtd">
+<taglib>
+  <uri>jakarta.tags.core</uri>
+  <tag><name>out</name><tag-class>org.example.OutTag</tag-class></tag>
+</taglib>'''
+
+    @TempDir
+    Path tempDir
+
+    void cleanup() {
+        System.clearProperty(SpringIOUtils.ALLOW_DOCTYPE_DECLARATION)
+        Metadata.reset()
+    }
+
+    private static void allowDocTypeDeclarations() {
+        System.setProperty(SpringIOUtils.ALLOW_DOCTYPE_DECLARATION, 'true')
+        Metadata.reset()
+    }
+
+    void 'createXmlSlurper parses a document without a doctype'() {
         when:
         def xml = SpringIOUtils.createXmlSlurper().parseText('<root><child>ok</child></root>')
 
@@ -31,18 +69,15 @@ class SpringIOUtilsSpec extends Specification {
         xml.child.text() == 'ok'
     }
 
-    void 'createXmlSlurper rejects doctype declarations with external entities'() {
+    void 'createXmlSlurper rejects a doctype declaration by default'() {
         when:
-        SpringIOUtils.createXmlSlurper().parseText('''<!DOCTYPE root [
-<!ENTITY ext SYSTEM "file:///not-resolved">
-]>
-<root>&ext;</root>''')
+        SpringIOUtils.createXmlSlurper().parseText(TLD)
 
         then:
         thrown(SAXParseException)
     }
 
-    void 'createXmlSlurper rejects doctype declarations with internal entities'() {
+    void 'createXmlSlurper rejects an internal doctype subset by default'() {
         when:
         SpringIOUtils.createXmlSlurper().parseText('''<!DOCTYPE root [
 <!ENTITY msg "safe">
@@ -51,5 +86,71 @@ class SpringIOUtilsSpec extends Specification {
 
         then:
         thrown(SAXParseException)
+    }
+
+    void 'the doctype configuration key lets an application parse descriptors that declare one'() {
+        given: 'an application.yml opting in, as an application would configure it'
+        Metadata.getInstance(new ByteArrayInputStream('''grails:
+    xml:
+        allowDocTypeDeclaration: true
+'''.getBytes('UTF-8')))
+
+        when:
+        def parsed = SpringIOUtils.createXmlSlurper().parseText(TLD)
+
+        then: 'the descriptor is readable'
+        parsed.uri.text() == 'jakarta.tags.core'
+        parsed.tag.name.text() == 'out'
+    }
+
+    void 'external entities stay blocked when doctype declarations are permitted'() {
+        given: 'a document whose entity points at a readable file on disk'
+        allowDocTypeDeclarations()
+        Path secret = tempDir.resolve('secret.txt')
+        Files.writeString(secret, 'top-secret-token')
+        String xml = """<!DOCTYPE root [
+<!ENTITY ext SYSTEM '${secret.toUri().toASCIIString()}'>
+]>
+<root>&ext;</root>"""
+
+        when:
+        def parsed = SpringIOUtils.createXmlSlurper().parseText(xml)
+
+        then: 'relaxing the doctype rule does not reopen the XXE vector'
+        !parsed.text().contains('top-secret-token')
+    }
+
+    void 'external dtds are skipped rather than retrieved when doctype declarations are permitted'() {
+        given:
+        allowDocTypeDeclarations()
+        String xml = """<!DOCTYPE root SYSTEM '${tempDir.resolve('missing.dtd').toUri().toASCIIString()}'>
+<root>ok</root>"""
+
+        expect:
+        SpringIOUtils.createXmlSlurper().parseText(xml).text() == 'ok'
+    }
+
+    void 'newSAXParser applies the same hardening as createXmlSlurper'() {
+        given:
+        allowDocTypeDeclarations()
+        Path secret = tempDir.resolve('secret.txt')
+        Files.writeString(secret, 'top-secret-token')
+        String xml = """<!DOCTYPE root [
+<!ENTITY ext SYSTEM '${secret.toUri().toASCIIString()}'>
+]>
+<root>&ext;</root>"""
+        StringBuilder text = new StringBuilder()
+
+        when:
+        SpringIOUtils.newSAXParser().parse(new ByteArrayInputStream(xml.getBytes('UTF-8')),
+                new org.xml.sax.helpers.DefaultHandler() {
+                    @Override
+                    void characters(char[] chars, int start, int length) {
+                        text.append(chars, start, length)
+                    }
+                })
+
+        then:
+        !text.toString().contains('top-secret-token')
     }
 }

--- a/grails-testing-support-http-client/build.gradle
+++ b/grails-testing-support-http-client/build.gradle
@@ -44,6 +44,7 @@ dependencies {
 
     implementation platform(project(':grails-bom'))
     implementation project(':grails-testing-support-core')
+    implementation 'org.apache.grails.gradle:grails-gradle-common' // XmlParserFeature
     implementation 'org.apache.groovy:groovy'
     implementation 'org.apache.groovy:groovy-json'
     implementation 'org.apache.groovy:groovy-xml'

--- a/grails-testing-support-http-client/src/main/groovy/org/apache/grails/testing/http/client/utils/XmlUtils.groovy
+++ b/grails-testing-support-http-client/src/main/groovy/org/apache/grails/testing/http/client/utils/XmlUtils.groovy
@@ -37,6 +37,8 @@ import groovy.xml.XmlSlurper
 
 import org.xml.sax.SAXException
 
+import org.apache.grails.gradle.common.XmlParserFeature
+
 /**
  * Utility methods for handling XML.
  *
@@ -45,13 +47,6 @@ import org.xml.sax.SAXException
 @CompileStatic
 class XmlUtils {
 
-    private static final String DISALLOW_DOCTYPE_DECL = 'http://apache.org/xml/features/disallow-doctype-decl'
-    private static final String EXTERNAL_GENERAL_ENTITIES = 'http://xml.org/sax/features/external-general-entities'
-    private static final String EXTERNAL_PARAMETER_ENTITIES = 'http://xml.org/sax/features/external-parameter-entities'
-    private static final String FEATURE_SECURE_PROCESSING = XMLConstants.FEATURE_SECURE_PROCESSING
-    private static final String LOAD_DTD_GRAMMAR = 'http://apache.org/xml/features/nonvalidating/load-dtd-grammar'
-    private static final String LOAD_EXTERNAL_DTD = 'http://apache.org/xml/features/nonvalidating/load-external-dtd'
-
     private static final Pattern SPACE_AND_EMPTY_ELEMENT_CLOSE = ~/ \/>/
     private static final String EMPTY_ELEMENT_CLOSE = '/>'
 
@@ -59,12 +54,12 @@ class XmlUtils {
     private static final Pattern XML_DECLARATION = ~/^\s*(<\?xml\b.*?\?>)/
 
     private static final Map<String, Boolean> SECURE_XML_SLURPER_FEATURES = [
-            (DISALLOW_DOCTYPE_DECL): true,
-            (EXTERNAL_GENERAL_ENTITIES): false,
-            (EXTERNAL_PARAMETER_ENTITIES): false,
-            (FEATURE_SECURE_PROCESSING): true,
-            (LOAD_DTD_GRAMMAR): false,
-            (LOAD_EXTERNAL_DTD): false
+            (XMLConstants.FEATURE_SECURE_PROCESSING): true,
+            (XmlParserFeature.DISALLOW_DOCTYPE_DECL.featureName): true,
+            (XmlParserFeature.EXTERNAL_GENERAL_ENTITIES.featureName): false,
+            (XmlParserFeature.EXTERNAL_PARAMETER_ENTITIES.featureName): false,
+            (XmlParserFeature.LOAD_DTD_GRAMMAR.featureName): false,
+            (XmlParserFeature.LOAD_EXTERNAL_DTD.featureName): false
     ].asImmutable()
 
     /**


### PR DESCRIPTION
> Relocated from [jamesfredley/grails-core#4](https://github.com/jamesfredley/grails-core/pull/4). That follow-up was opened on an archive fork by mistake; Grails PRs belong on `apache/grails-core`. Parent: apache/grails-core#16310.

Suggested follow-up to #16310. Keeps the feature-URI correction and the strict DOCTYPE default from that PR, and addresses three things found while reviewing it.

## Why the identifiers got rewritten

`eed8df3594` ("chore: update url to HTTPS", #13478) rewrote them across 79 files in April 2024:

```diff
-saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+saxParserFactory.setFeature("https://apache.org/xml/features/disallow-doctype-decl", false);
```

These are registered identifiers matched by exact string comparison, not addresses — nothing is fetched from them. No parser recognises the `https` spelling, so `setFeature` answers with `SAXNotRecognizedException`, and because each call is wrapped in a catch that tolerates parsers lacking a feature, the hardening switched off silently and stayed off for two years.

## Changes

**Collect the identifiers once.** They were declared twice, in `SpringIOUtils` and in the HTTP test client's `XmlUtils`, as bare literals in both — which is how one rewrite became two. `XmlParserFeature` in `grails-gradle-common` holds them, and carries the reason the scheme cannot be changed. That module is in the `grails-gradle` build alongside `SpringIOUtils`, and `grails-common` already re-exposes it (`api 'org.apache.grails.gradle:grails-gradle-common'`), so the root build and the test client both see it.

**Make DOCTYPE rejection configurable, still off by default.** `SpringIOUtils.createParserFactory()` returns one cached factory shared with readers of trusted classpath descriptors — `TldReader`, `WebXmlTagLibraryReader`, `PluginUtils` — and TLDs routinely carry a DOCTYPE. `jakarta.servlet.jsp.jstl:3.0.1` ships eight, including `c-1_0-rt.tld`, which the default `grails.gsp.tldScanPattern` in `GspAutoConfiguration` scans. `TagLibraryResolverImpl.initialize()` does not catch, so rejecting DOCTYPE stops JSP tag library resolution from the first `resolveTagLibrary(uri)` call.

The default stays strict. Applications that need declarations opt in:

```yaml
grails:
    xml:
        allowDocTypeDeclaration: true
```

Read through `Metadata`, so it works from `application.yml` or as a system property. Opting in relaxes only whether a declaration is permitted — external general entities, external parameter entities and external DTDs stay refused either way, which the tests assert. Documented in the upgrade notes and on the JSP tag library page.

**Test the hardening by behaviour, not by reading flags back.** A test that asserts `getFeature(...)` has to restate the identifiers, so the same sweep rewrites the test and the production code together; it fails, but at the test, with a name-lookup error whose tempting fix is to make the test tolerate it. Driving real documents through the parser keeps the assertions free of any identifier. `XmlParserFeatureSpec` additionally derives the list from `values()` and asserts each is one a parser actually registers, so an unrecognised name fails by name instead of silently.

Verified both failure modes: re-enabling DOCTYPE rejection without the opt-in fails 5 of 7 `SpringIOUtilsSpec` cases including the descriptor test, and rewriting the enum to `https` fails 4 of 7 plus all 5 `XmlParserFeatureSpec` cases.

## On adopting nohttp

Not enabled here, but worth calling out, because it is directly connected and could break this again.

The sweep in #13478 was preparatory work toward adopting `io.spring.nohttp`. The tool itself has never run over these modules, and would not have flagged these values: running its matcher with the default allowlist reports all five as allowed, because that allowlist carries `^http://xml\.org/.*` and `^http://apache\.org/xml/features/.*`. Spring hit the same problem and allowlisted it upstream.

So the tool is not the hazard — the manual preparation for it was. Adopting nohttp needs no exception for these five, and its allowlist is a useful reference for which `http://` strings in the codebase are identifiers rather than links. But if we make another run at adopting it, the same well-meant rewrite can land again, and the empty catches around `setFeature` will hide it again exactly as they did for the last two years.

That is what the comment on `XmlParserFeature` and the behavioural tests are for: the comment tells the next person why the scheme is fixed, and the tests fail loudly if it changes anyway rather than leaving the hardening quietly off.

## Testing

- `:grails-gradle-model:test`, `:grails-gradle-common:test`, `:grails-testing-support-http-client:test`
- Downstream consumers of `SpringIOUtils`: `:grails-web-databinding:test`, `:grails-converters:test`, `:grails-test-core:test`, `:grails-core:test`, `:grails-web-jsp:test`, `:grails-gsp:test`
- `codeStyle` on each changed module

