### PR TITLE
Review follow-up: keep alias sorting working, validate fetch keys, share the path check

### DIFF
--- a/grails-data-hibernate5/docs/src/docs/asciidoc/querying/finders.adoc
+++ b/grails-data-hibernate5/docs/src/docs/asciidoc/querying/finders.adoc
@@ -146,3 +146,5 @@ The same pagination and sorting parameters available on the link:../api/org/grai
 def books = Book.findAllByTitleLike("Harry Pot%",
                [max: 3, offset: 2, sort: "title", order: "desc"])
 ----
+
+The `sort` value must be a property path made up of identifiers separated by dots, such as `"title"` or `"author.name"`, that resolves through the domain class mapping. Anything else, for example a value carrying a second expression or a function call, is rejected with an `IllegalArgumentException` before the query is built, so request parameters can be passed through safely. A key whose first segment is not a property of the domain class is left for the query implementation to resolve, so aliases created with `createAlias` or declared in a <<whereQueries,where query>> can still be sorted on.

--- a/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/HqlListQueryBuilder.java
+++ b/grails-data-hibernate7/core/src/main/groovy/org/grails/orm/hibernate/query/HqlListQueryBuilder.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 
+import org.grails.datastore.mapping.reflect.NameUtils;
 import org.grails.orm.hibernate.cfg.HibernateMappingContext;
 import org.grails.orm.hibernate.cfg.Mapping;
 import org.grails.orm.hibernate.cfg.SortConfig;
@@ -39,7 +39,8 @@ import org.grails.orm.hibernate.cfg.domainbinding.hibernate.HibernatePersistentP
  */
 public class HqlListQueryBuilder {
 
-    private static final Pattern PROPERTY_PATH = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*");
+    private static final String ASC = HibernateQueryArgument.ORDER_ASC.value();
+    private static final String DESC = HibernateQueryArgument.ORDER_DESC.value();
 
     private final GrailsHibernatePersistentEntity entity;
     private final Map<String, Object> params;
@@ -58,6 +59,7 @@ public class HqlListQueryBuilder {
             Map<String, Object> fetchMap = (Map<String, Object>) fetchObj;
             fetchMap.forEach((prop, type) -> {
                 if (HibernateQueryArgument.JOIN.value().equals(type) || HibernateQueryArgument.EAGER.value().equals(type)) {
+                    requireMappedProperty(prop, HibernateQueryArgument.FETCH.value());
                     hql.append(" join fetch e.").append(prop);
                 }
             });
@@ -82,7 +84,7 @@ public class HqlListQueryBuilder {
         boolean isIgnoreCase = ignoreCase == null || (ignoreCase instanceof Boolean && (Boolean) ignoreCase);
 
         if (sort instanceof String) {
-            return buildSortPart((String) sort, order instanceof String ? (String) order : "asc", isIgnoreCase);
+            return buildSortPart((String) sort, order instanceof String ? (String) order : ASC, isIgnoreCase);
         } else if (sort instanceof Map) {
             List<String> parts = new ArrayList<>();
             ((Map<String, String>) sort).forEach((prop, direction) -> {
@@ -114,16 +116,7 @@ public class HqlListQueryBuilder {
     }
 
     private String buildSortPart(String propertyName, String direction, boolean ignoreCase) {
-        if (propertyName == null || propertyName.isBlank()) {
-            return "";
-        }
-        if (!PROPERTY_PATH.matcher(propertyName).matches()) {
-            throw new IllegalArgumentException("Invalid sort property: " + propertyName);
-        }
-        HibernatePersistentProperty prop = entity.getHibernatePropertyByPath(propertyName);
-        if (prop == null) {
-            throw new IllegalArgumentException("Unknown sort property: " + propertyName);
-        }
+        HibernatePersistentProperty prop = requireMappedProperty(propertyName, HibernateQueryArgument.SORT.value());
         String normalizedDirection = normalizeDirection(direction);
         String path = "e." + propertyName;
         if (prop.getType() == String.class && ignoreCase) {
@@ -132,17 +125,37 @@ public class HqlListQueryBuilder {
         return path + " " + normalizedDirection;
     }
 
+    /**
+     * Resolves a caller-supplied property path against the mapping before it is interpolated into
+     * HQL. Blank and malformed paths are rejected together with paths that do not resolve to a
+     * mapped property. The message deliberately omits the value, which usually originates from
+     * request parameters.
+     *
+     * @param propertyPath The property path taken from the query arguments
+     * @param argument The name of the query argument the path came from, for the error message
+     * @return The mapped property
+     * @throws IllegalArgumentException if the path is malformed or does not resolve
+     */
+    private HibernatePersistentProperty requireMappedProperty(String propertyPath, String argument) {
+        if (!NameUtils.isValidPropertyPath(propertyPath)) {
+            throw new IllegalArgumentException("Invalid " + argument + " property");
+        }
+        HibernatePersistentProperty prop = entity.getHibernatePropertyByPath(propertyPath);
+        if (prop == null) {
+            throw new IllegalArgumentException("Invalid " + argument + " property");
+        }
+        return prop;
+    }
+
     private static String normalizeDirection(String direction) {
-        if (direction == null || direction.isBlank()) {
-            return "asc";
+        String normalized = direction == null ? "" : direction.trim();
+        if (normalized.isEmpty() || ASC.equalsIgnoreCase(normalized)) {
+            return ASC;
         }
-        if ("asc".equalsIgnoreCase(direction)) {
-            return "asc";
+        if (DESC.equalsIgnoreCase(normalized)) {
+            return DESC;
         }
-        if ("desc".equalsIgnoreCase(direction)) {
-            return "desc";
-        }
-        throw new IllegalArgumentException("Invalid sort direction: " + direction);
+        throw new IllegalArgumentException("Invalid sort direction");
     }
 
     public static boolean isPaged(Map<String, Object> params) {

--- a/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/SortArgumentValidationSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/grails/gorm/tests/SortArgumentValidationSpec.groovy
@@ -1,0 +1,271 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package grails.gorm.tests
+
+import grails.gorm.annotation.Entity
+import spock.lang.Unroll
+
+/**
+ * Exercises the validation of the {@code sort}, {@code order} and {@code fetch} query arguments
+ * against real Hibernate mappings, through every public entry point that accepts them:
+ * {@code list()}, dynamic finders, where queries and criteria queries. Alongside the rejection
+ * cases it pins the shapes that must keep working: identity and version properties, inherited
+ * properties, embedded and association paths, composite identities, the default sort declared in
+ * the mapping, and aliases that are not persistent properties at all.
+ */
+class SortArgumentValidationSpec extends HibernateGormDatastoreSpec {
+
+    void setupSpec() {
+        manager.registerDomainClasses(SavClub, SavTeam, SavLabelled, SavAnimal, SavDog, SavComposite)
+    }
+
+    void setup() {
+        def united = new SavClub(name: 'United').save()
+        def arsenal = new SavClub(name: 'Arsenal').save()
+        new SavTeam(club: united, name: 'United First', address: new SavAddress(city: 'Manchester'))
+                .addToTags('north')
+                .save()
+        new SavTeam(club: arsenal, name: 'Arsenal First', address: new SavAddress(city: 'London'))
+                .addToTags('south')
+                .save()
+        session.flush()
+        session.clear()
+    }
+
+    void "sorting by the identity and version properties still works"() {
+        expect:
+        SavClub.list(sort: 'id')*.name == ['United', 'Arsenal']
+        SavClub.list(sort: 'id', order: 'desc')*.name == ['Arsenal', 'United']
+        SavClub.list(sort: 'version').size() == 2
+        SavClub.where { name != null }.list(sort: 'id', order: 'desc')*.name == ['Arsenal', 'United']
+        SavClub.findAllByNameLike('%', [sort: 'version']).size() == 2
+    }
+
+    void "sorting a subclass by a property inherited from its superclass still works"() {
+        given:
+        new SavDog(name: 'Rex', breed: 'Collie').save()
+        new SavDog(name: 'Ace', breed: 'Beagle').save(flush: true)
+
+        expect:
+        SavDog.list(sort: 'name')*.name == ['Ace', 'Rex']
+        SavDog.where { breed != null }.list(sort: 'name')*.name == ['Ace', 'Rex']
+        SavDog.findAllByBreedLike('%', [sort: 'name', order: 'desc'])*.name == ['Rex', 'Ace']
+    }
+
+    void "sorting by a path into an embedded component still works"() {
+        expect:
+        SavTeam.list(sort: 'address.city')*.name == ['Arsenal First', 'United First']
+        SavTeam.where { name != null }.list(sort: 'address.city', order: 'desc')*.name == ['United First', 'Arsenal First']
+    }
+
+    void "the default sort declared in the mapping still applies"() {
+        given:
+        new SavLabelled(label: 'b').save()
+        new SavLabelled(label: 'a').save()
+        new SavLabelled(label: 'c').save(flush: true)
+
+        expect:
+        SavLabelled.list()*.label == ['a', 'b', 'c']
+    }
+
+    void "sorting by a path through an association, including the associated identity, still works"() {
+        expect:
+        SavTeam.list(sort: 'club.name')*.name == ['Arsenal First', 'United First']
+        SavTeam.list(sort: 'club.id')*.name == ['United First', 'Arsenal First']
+        SavTeam.where { club.name != null }.list(sort: 'club.name')*.name == ['Arsenal First', 'United First']
+        SavTeam.where { club.name != null }.list(sort: 'club.id', order: 'desc')*.name == ['Arsenal First', 'United First']
+    }
+
+    void "sorting by an alias that is not a persistent property still works for criteria and where queries"() {
+        when:
+        def byCriteriaAlias = SavTeam.createCriteria().list(sort: 'c.name') {
+            createAlias('club', 'c')
+        }
+        def byWhereAlias = SavTeam.where {
+            def c1 = club
+            c1.name != null
+        }.list(sort: 'c1.name', order: 'desc')
+
+        then:
+        byCriteriaAlias*.name == ['Arsenal First', 'United First']
+        byWhereAlias*.name == ['United First', 'Arsenal First']
+    }
+
+    void "sort keys may name the members of a composite identity"() {
+        given:
+        new SavComposite(a: 'x', b: '2').save()
+        new SavComposite(a: 'x', b: '1').save(flush: true)
+
+        expect:
+        SavComposite.list(sort: 'b')*.b == ['1', '2']
+        SavComposite.list(sort: [a: 'asc', b: 'desc'])*.b == ['2', '1']
+        SavComposite.where { a == 'x' }.list(sort: 'b', order: 'desc')*.b == ['2', '1']
+        SavComposite.where { a == 'x' }.list(order: 'desc')*.b == ['2', '1']
+    }
+
+    void "list normalizes the sort direction regardless of case and surrounding whitespace"() {
+        expect:
+        SavClub.list(sort: 'name', order: ' DESC ')*.name == ['United', 'Arsenal']
+        SavClub.list(sort: 'name', order: 'Asc')*.name == ['Arsenal', 'United']
+        SavClub.list(sort: [name: ' desc'])*.name == ['United', 'Arsenal']
+    }
+
+    void "each sort map entry takes its direction from its value rather than the order argument"() {
+        expect:
+        SavClub.list(sort: [name: 'desc'], order: 'asc')*.name == ['United', 'Arsenal']
+        SavClub.where { name != null }.list(sort: [name: 'desc'], order: 'asc')*.name == ['United', 'Arsenal']
+        SavClub.findAllByNameLike('%', [sort: [name: 'desc'], order: 'asc'])*.name == ['United', 'Arsenal']
+    }
+
+    void "list still join-fetches a mapped association and a basic collection"() {
+        expect:
+        SavTeam.list(fetch: [club: 'join'], sort: 'name')*.name == ['Arsenal First', 'United First']
+        SavTeam.list(fetch: [tags: 'eager'], sort: 'name')*.name == ['Arsenal First', 'United First']
+    }
+
+    @Unroll
+    void "list rejects the sort key #description without echoing it"() {
+        when:
+        SavTeam.list(sort: sort)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort property'
+
+        where:
+        sort                      | description
+        'name, e.id'              | 'carrying a second expression'
+        'name desc'               | 'carrying a direction'
+        'upper(name)'             | 'wrapped in a function call'
+        "name'"                   | 'containing a quote'
+        ''                        | 'that is empty'
+        'notAProperty'            | 'naming an unknown property'
+        'club.notAProperty'       | 'naming an unknown property of an association'
+        'name.length'             | 'descending into a property that is not an association'
+        [name: 'asc', '': 'desc'] | 'that is a map with a blank key'
+    }
+
+    void "list rejects a sort direction other than asc or desc without echoing it"() {
+        when:
+        SavTeam.list(sort: 'name', order: 'desc; drop table sav_team')
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort direction'
+    }
+
+    @Unroll
+    void "list rejects the fetch key #description without echoing it"() {
+        when:
+        SavTeam.list(fetch: [(key): 'join'])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid fetch property'
+
+        where:
+        key                           | description
+        'club left join fetch e.tags' | 'carrying a second join'
+        'club, e.tags'                | 'carrying a second expression'
+        'notAnAssociation'            | 'naming an unknown property'
+        ''                            | 'that is empty'
+    }
+
+    @Unroll
+    void "a dynamic finder rejects the sort key #description without echoing it"() {
+        when:
+        SavTeam.findAllByNameLike('%', [sort: sort])
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort property'
+
+        where:
+        sort                | description
+        'name, id'          | 'carrying a second expression'
+        'club.notAProperty' | 'naming an unknown property of an association'
+        'name.length'       | 'descending into a property that is not an association'
+        'tags.value'        | 'descending into a basic collection'
+    }
+
+    @Unroll
+    void "a where query rejects the sort key #description without echoing it"() {
+        when:
+        SavTeam.where { name != null }.list(sort: sort)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort property'
+
+        where:
+        sort                | description
+        'name; drop table'  | 'carrying a statement separator'
+        'club.notAProperty' | 'naming an unknown property of an association'
+        'name.length'       | 'descending into a property that is not an association'
+        'tags.value'        | 'descending into a basic collection'
+    }
+}
+
+@Entity
+class SavClub {
+    String name
+}
+
+@Entity
+class SavTeam {
+    SavClub club
+    String name
+    SavAddress address
+
+    static hasMany = [tags: String]
+    static embedded = ['address']
+}
+
+class SavAddress {
+    String city
+}
+
+@Entity
+class SavLabelled {
+    String label
+
+    static mapping = {
+        sort 'label'
+    }
+}
+
+@Entity
+class SavAnimal {
+    String name
+}
+
+@Entity
+class SavDog extends SavAnimal {
+    String breed
+}
+
+@Entity
+class SavComposite implements Serializable {
+    String a
+    String b
+
+    static mapping = {
+        id composite: ['a', 'b']
+    }
+}

--- a/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/query/HqlListQueryBuilderSpec.groovy
+++ b/grails-data-hibernate7/core/src/test/groovy/org/grails/orm/hibernate/query/HqlListQueryBuilderSpec.groovy
@@ -137,6 +137,8 @@ class HqlListQueryBuilderSpec extends Specification {
 
     void "test buildListHql with join fetch"() {
         given:
+        entity.getHibernatePropertyByPath("books") >> Mock(HibernatePersistentProperty)
+        entity.getHibernatePropertyByPath("profile") >> Mock(HibernatePersistentProperty)
         def builder = new HqlListQueryBuilder(entity, [
                 (HibernateQueryArgument.FETCH.value()): [
                         books: HibernateQueryArgument.JOIN.value(),
@@ -209,25 +211,51 @@ class HqlListQueryBuilderSpec extends Specification {
         [max: 10, offset: 5] | true
     }
 
-    void "test buildListHql rejects injected sort property"() {
+    @Unroll
+    void "test buildListHql rejects sort property #description without echoing it"() {
         when:
-        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.SORT.value()): "name, e.id"]).buildListHql()
+        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.SORT.value()): sort]).buildListHql()
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains("Invalid sort property")
+        e.message == "Invalid sort property"
+
+        where:
+        sort           | description
+        "name, e.id"   | "carrying a second expression"
+        "name desc"    | "carrying a direction"
+        "upper(name)"  | "wrapped in a function call"
+        "notAProperty" | "that the mapping does not know"
+        ""             | "that is empty"
+        " "            | "that is blank"
     }
 
-    void "test buildListHql rejects unknown sort property"() {
+    void "test buildListHql rejects a blank property in a sort map instead of emitting an empty order part"() {
+        given:
+        def prop = Mock(HibernatePersistentProperty)
+        prop.getType() >> String
+        entity.getHibernatePropertyByPath("name") >> prop
+
         when:
-        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.SORT.value()): "notAProperty"]).buildListHql()
+        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.SORT.value()): ["": "asc", name: "asc"]]).buildListHql()
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains("Unknown sort property")
+        e.message == "Invalid sort property"
     }
 
-    void "test buildListHql rejects injected sort direction"() {
+    void "test buildListHql accepts identifier characters beyond ASCII letters in a sort property"() {
+        given:
+        def prop = Mock(HibernatePersistentProperty)
+        prop.getType() >> Integer
+        entity.getHibernatePropertyByPath('total$amount') >> prop
+
+        expect:
+        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.SORT.value()): 'total$amount']).buildListHql() ==
+                'from Person e order by e.total$amount asc'
+    }
+
+    void "test buildListHql rejects injected sort direction without echoing it"() {
         given:
         def prop = Mock(HibernatePersistentProperty)
         prop.getType() >> String
@@ -241,6 +269,53 @@ class HqlListQueryBuilderSpec extends Specification {
 
         then:
         def e = thrown(IllegalArgumentException)
-        e.message.contains("Invalid sort direction")
+        e.message == "Invalid sort direction"
+    }
+
+    @Unroll
+    void "test buildListHql normalizes sort direction '#direction' to #expected"() {
+        given:
+        def prop = Mock(HibernatePersistentProperty)
+        prop.getType() >> Integer
+        entity.getHibernatePropertyByPath("age") >> prop
+
+        expect:
+        new HqlListQueryBuilder(entity, [
+                (HibernateQueryArgument.SORT.value()) : "age",
+                (HibernateQueryArgument.ORDER.value()): direction
+        ]).buildListHql() == "from Person e order by e.age ${expected}"
+
+        where:
+        direction | expected
+        " desc"   | "desc"
+        "DESC "   | "desc"
+        "Asc"     | "asc"
+        ""        | "asc"
+        "   "     | "asc"
+    }
+
+    @Unroll
+    void "test buildListHql rejects fetch key #description without echoing it"() {
+        when:
+        new HqlListQueryBuilder(entity, [(HibernateQueryArgument.FETCH.value()): [(key): HibernateQueryArgument.JOIN.value()]]).buildListHql()
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "Invalid fetch property"
+
+        where:
+        key                                   | description
+        "books left join fetch e.secretNotes" | "carrying a second join"
+        "books, e.secretNotes"                | "carrying a second expression"
+        "notAnAssociation"                    | "that the mapping does not know"
+        ""                                    | "that is empty"
+    }
+
+    void "test buildListHql ignores fetch keys whose value is neither join nor eager"() {
+        given:
+        def builder = new HqlListQueryBuilder(entity, [(HibernateQueryArgument.FETCH.value()): [books: "select"]])
+
+        expect:
+        builder.buildListHql() == "from Person e"
     }
 }

--- a/grails-data-hibernate7/docs/src/docs/asciidoc/querying/finders.adoc
+++ b/grails-data-hibernate7/docs/src/docs/asciidoc/querying/finders.adoc
@@ -146,3 +146,5 @@ The same pagination and sorting parameters available on the `list()` method can 
 def books = Book.findAllByTitleLike("Harry Pot%",
                [max: 3, offset: 2, sort: "title", order: "desc"])
 ----
+
+The `sort` value must be a property path made up of identifiers separated by dots, such as `"title"` or `"author.name"`, that resolves through the domain class mapping. Anything else, for example a value carrying a second expression or a function call, is rejected with an `IllegalArgumentException` before the query is built, so request parameters can be passed through safely. A key whose first segment is not a property of the domain class is left for the query implementation to resolve, so aliases created with `createAlias` or declared in a <<whereQueries,where query>> can still be sorted on.

--- a/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
+++ b/grails-datamapping-core/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
@@ -92,7 +92,6 @@ public abstract class DynamicFinder extends AbstractFinder implements QueryBuild
     public static final String ARGUMENT_IGNORE_CASE = "ignoreCase";
     public static final String ARGUMENT_CACHE = "cache";
     public static final String ARGUMENT_LOCK = "lock";
-    private static final Pattern SORT_PROPERTY_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*");
     protected Pattern pattern;
 
     private static final String OPERATOR_OR = "Or";
@@ -107,6 +106,7 @@ public abstract class DynamicFinder extends AbstractFinder implements QueryBuild
     private static final Object[] EMPTY_OBJECT_ARRAY = {};
 
     private static final String NOT = "Not";
+    private static final String INVALID_SORT_PROPERTY = "Invalid sort property";
     private static final Map<String, Constructor> methodExpressions = new LinkedHashMap<String, Constructor>();
     protected final MappingContext mappingContext;
 
@@ -447,56 +447,39 @@ public abstract class DynamicFinder extends AbstractFinder implements QueryBuild
         }
 
         Object sortObject = argMap.get(ARGUMENT_SORT);
-        if (sortObject == null && orderParam != null) {
-            PersistentEntity entity = null;
-            if (query instanceof AbstractCriteriaBuilder) {
-                entity = ((AbstractCriteriaBuilder) query).getPersistentEntity();
-            }
-            else if (query instanceof AbstractDetachedCriteria) {
-                entity = ((AbstractDetachedCriteria) query).getPersistentEntity();
-            }
-
-            if (entity != null) {
-                PersistentProperty identity = entity.getIdentity();
-                if (identity != null) {
-                    sortObject = identity.getName();
-                } else {
-                    PersistentProperty[] composite = entity.getCompositeIdentity();
-                    if (composite != null && composite.length > 0) {
-                        Map<String, String> sortMap = new LinkedHashMap<>();
-                        for (PersistentProperty p : composite) {
-                            sortMap.put(p.getName(), orderParam);
-                        }
-                        sortObject = sortMap;
+        PersistentEntity entity = resolvePersistentEntity(query);
+        if (sortObject == null && orderParam != null && entity != null) {
+            PersistentProperty identity = entity.getIdentity();
+            if (identity != null) {
+                sortObject = identity.getName();
+            } else {
+                PersistentProperty[] composite = entity.getCompositeIdentity();
+                if (composite != null && composite.length > 0) {
+                    Map<String, String> sortMap = new LinkedHashMap<>();
+                    for (PersistentProperty p : composite) {
+                        sortMap.put(p.getName(), orderParam);
                     }
+                    sortObject = sortMap;
                 }
             }
         }
         boolean ignoreCase = !argMap.containsKey(ARGUMENT_IGNORE_CASE) || ClassUtils.getBooleanFromMap(ARGUMENT_IGNORE_CASE, argMap);
 
-        PersistentEntity sortEntity = resolvePersistentEntity(query);
         if (sortObject != null) {
             if (sortObject instanceof CharSequence) {
                 final String sort = sortObject.toString();
-                validateSortProperty(sortEntity, sort);
-                final Query.Order order = ORDER_DESC.equalsIgnoreCase(orderParam) ? Query.Order.desc(sort) : Query.Order.asc(sort);
-                if (ignoreCase) {
-                    order.ignoreCase();
-                }
-                query.order(order);
+                validateSortProperty(entity, sort);
+                query.order(buildOrder(sort, orderParam, ignoreCase));
             }
             else if (sortObject instanceof Map) {
+                // each entry carries its own direction, as in applySortForMap for the Query overload
                 Map sortMap = (Map) sortObject;
                 for (Object key : sortMap.keySet()) {
                     Object value = sortMap.get(key);
                     String sort = key.toString();
-                    validateSortProperty(sortEntity, sort);
-                    String direction = value != null ? value.toString() : orderParam;
-                    final Query.Order order = ORDER_DESC.equalsIgnoreCase(direction) ? Query.Order.desc(sort) : Query.Order.asc(sort);
-                    if (ignoreCase) {
-                        order.ignoreCase();
-                    }
-                    query.order(order);
+                    String direction = value != null ? value.toString() : ORDER_ASC;
+                    validateSortProperty(entity, sort);
+                    query.order(buildOrder(sort, direction, ignoreCase));
                 }
             }
         }
@@ -784,55 +767,78 @@ public abstract class DynamicFinder extends AbstractFinder implements QueryBuild
     }
 
     /**
-     * Rejects sort keys that are not identifier-shaped property paths, and when a
-     * mapping is available, keys that do not resolve to a persistent property.
+     * Rejects a sort key that is not shaped like a property path. When the entity is known and the
+     * first segment names one of its persistent properties, every further segment must also resolve
+     * through the mapping: associations and embedded components are traversed, and identity
+     * properties, including the members of a composite identity, are recognised. A first segment
+     * that is not a persistent property is accepted on the shape check alone, because criteria and
+     * where-query aliases such as {@code c1.name} are not persistent properties; the underlying
+     * query implementation resolves them, or reports an unknown name, itself.
+     * <p>
+     * The exception message deliberately omits the caller-supplied value: sort keys are commonly
+     * taken straight from request parameters.
      *
      * @param entity the entity being queried, or {@code null} when it cannot be resolved
      * @param sort the requested sort property
+     * @throws IllegalArgumentException if the sort key is malformed or does not resolve
      */
-    public static void validateSortProperty(PersistentEntity entity, String sort) {
-        if (sort == null || !SORT_PROPERTY_PATTERN.matcher(sort).matches()) {
-            throw new IllegalArgumentException("Invalid sort property: " + sort);
+    private static void validateSortProperty(PersistentEntity entity, String sort) {
+        if (!NameUtils.isValidPropertyPath(sort)) {
+            throw new IllegalArgumentException(INVALID_SORT_PROPERTY);
         }
         if (entity == null) {
             return;
         }
-        PersistentEntity current = entity;
-        String[] parts = sort.split("\\.");
-        for (int i = 0; i < parts.length; i++) {
-            PersistentProperty prop = current.getPropertyByName(parts[i]);
-            if (prop == null) {
-                PersistentProperty identity = current.getIdentity();
-                if (identity != null && parts[i].equals(identity.getName()) && i == parts.length - 1) {
-                    return;
-                }
-                throw new IllegalArgumentException("Unknown sort property: " + sort);
+        String[] segments = sort.split("\\.");
+        PersistentProperty property = resolveProperty(entity, segments[0]);
+        if (property == null) {
+            return;
+        }
+        for (int i = 1; i < segments.length; i++) {
+            PersistentEntity associated = property instanceof Association ? ((Association) property).getAssociatedEntity() : null;
+            if (associated == null) {
+                throw new IllegalArgumentException(INVALID_SORT_PROPERTY);
             }
-            if (i < parts.length - 1) {
-                if (!(prop instanceof Association)) {
-                    throw new IllegalArgumentException("Invalid sort property: " + sort);
-                }
-                current = ((Association) prop).getAssociatedEntity();
-                if (current == null) {
-                    throw new IllegalArgumentException("Invalid sort property: " + sort);
-                }
+            property = resolveProperty(associated, segments[i]);
+            if (property == null) {
+                throw new IllegalArgumentException(INVALID_SORT_PROPERTY);
             }
         }
     }
 
+    /**
+     * Resolves one path segment against an entity, including its identity property and the members
+     * of a composite identity, which are not guaranteed to be reachable through
+     * {@link PersistentEntity#getPropertyByName(String)}.
+     */
+    private static PersistentProperty resolveProperty(PersistentEntity entity, String name) {
+        PersistentProperty property = entity.getPropertyByName(name);
+        if (property != null) {
+            return property;
+        }
+        PersistentProperty identity = entity.getIdentity();
+        if (identity != null && name.equals(identity.getName())) {
+            return identity;
+        }
+        PersistentProperty[] compositeIdentity = entity.getCompositeIdentity();
+        if (compositeIdentity != null) {
+            for (PersistentProperty candidate : compositeIdentity) {
+                if (candidate != null && name.equals(candidate.getName())) {
+                    return candidate;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Query.Order buildOrder(String sort, String direction, boolean ignoreCase) {
+        Query.Order order = ORDER_DESC.equalsIgnoreCase(direction) ? Query.Order.desc(sort) : Query.Order.asc(sort);
+        return ignoreCase ? order.ignoreCase() : order;
+    }
+
     private static void addSimpleSort(Query q, String sort, String order, boolean ignoreCase) {
         validateSortProperty(q.getEntity(), sort);
-        Query.Order o;
-        if (ORDER_DESC.equalsIgnoreCase(order)) {
-            o = Query.Order.desc(sort);
-        }
-        else {
-            o = Query.Order.asc(sort);
-        }
-
-        if (ignoreCase) o = o.ignoreCase();
-
-        q.order(o);
+        q.order(buildOrder(sort, order, ignoreCase));
     }
 
     private void populateOperators(String[] operators) {

--- a/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/finders/DynamicFinderCoverageSpec.groovy
+++ b/grails-datamapping-core/src/test/groovy/org/grails/datastore/gorm/finders/DynamicFinderCoverageSpec.groovy
@@ -23,6 +23,7 @@ import jakarta.persistence.FetchType
 import org.grails.datastore.mapping.simple.SimpleMapDatastore
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * {@link DynamicFinderSpec} (pre-existing) covers only {@code buildMatchSpec}. This spec targets
@@ -35,7 +36,7 @@ import spock.lang.Specification
 class DynamicFinderCoverageSpec extends Specification {
 
     @AutoCleanup
-    SimpleMapDatastore datastore = new SimpleMapDatastore(DynamicFinderThing)
+    SimpleMapDatastore datastore = new SimpleMapDatastore(DynamicFinderThing, DynamicFinderOwner, DynamicFinderCompositeThing)
 
     def setup() {
         new DynamicFinderThing(name: 'Alice', age: 30, title: 'Engineer').save(flush: true)
@@ -257,32 +258,121 @@ class DynamicFinderCoverageSpec extends Specification {
         DynamicFinderThing.list(sort: 'age')*.age == [25, 30, 35]
     }
 
-    void "list(sort) rejects injected property names"() {
-        when:
-        DynamicFinderThing.list(sort: 'age, id')
-
-        then:
-        thrown(IllegalArgumentException)
+    void "list(sort) accepts the identity and version properties"() {
+        expect:
+        DynamicFinderThing.list(sort: 'id')*.id == DynamicFinderThing.list()*.id.sort()
+        DynamicFinderThing.list(sort: 'id', order: 'desc')*.id == DynamicFinderThing.list()*.id.sort().reverse()
+        DynamicFinderThing.list(sort: 'version').size() == 3
     }
 
-    void "list(sort) rejects unknown property names"() {
+    @Unroll
+    void "list(sort) rejects a sort key #description with a message that does not echo it"() {
         when:
-        DynamicFinderThing.list(sort: 'notAProperty')
+        DynamicFinderThing.list(sort: sort)
 
         then:
-        thrown(IllegalArgumentException)
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort property'
+
+        where:
+        sort         | description
+        'age, id'    | 'carrying a second expression'
+        'age desc'   | 'carrying a direction'
+        'upper(age)' | 'wrapped in a function call'
+        "age'"       | 'containing a quote'
+        ''           | 'that is empty'
+        ' '          | 'that is blank'
     }
 
-    void "populateArgumentsForCriteria rejects injected sort map keys"() {
+    void "list(sort) accepts a path through an association, including the associated identity"() {
+        // SimpleMapQuery cannot evaluate a nested sort itself, so no owners are persisted: the
+        // empty result shows the key was accepted by every argument-handling entry point
+        expect:
+        DynamicFinderOwner.list(sort: 'thing.name') == []
+        DynamicFinderOwner.list(sort: 'thing.id') == []
+        DynamicFinderOwner.findAllByName('nobody', [sort: 'thing.age']) == []
+        DynamicFinderOwner.where { eq('name', 'nobody') }.list(sort: 'thing.name') == []
+    }
+
+    void "list(sort) leaves a root segment that is not a persistent property to the underlying query so aliases keep working"() {
+        // c1 is what a where-query alias (def c1 = thing) or createAlias('thing', 'c1') looks like
+        expect:
+        DynamicFinderOwner.list(sort: 'c1.name') == []
+        DynamicFinderOwner.list(sort: 'c1.name', order: 'desc') == []
+        DynamicFinderOwner.findAllByName('nobody', [sort: 'c1.name']) == []
+        DynamicFinderOwner.where { eq('name', 'nobody') }.list(sort: 'c1.name') == []
+    }
+
+    @Unroll
+    void "list(sort) rejects #description"() {
+        when:
+        DynamicFinderOwner.list(sort: sort)
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == 'Invalid sort property'
+
+        where:
+        sort             | description
+        'thing.notAProp' | 'an unknown property of the associated entity'
+        'name.length'    | 'a segment beneath a property that is not an association'
+        'tags.value'     | 'a segment beneath a basic collection, which has no associated entity'
+        'thing.id.value' | 'a segment beneath an identity'
+    }
+
+    void "list(sort) accepts the members of a composite identity"() {
+        expect:
+        DynamicFinderCompositeThing.list(sort: 'a') == []
+        DynamicFinderCompositeThing.list(sort: [a: 'asc', b: 'desc']) == []
+        DynamicFinderCompositeThing.list(order: 'desc') == []
+    }
+
+    void "list(Map) takes each sort map entry's direction from its value rather than the order argument"() {
+        expect:
+        DynamicFinderThing.list(sort: [age: 'desc'])*.age == [35, 30, 25]
+        DynamicFinderThing.list(sort: [age: 'desc'], order: 'asc')*.age == [35, 30, 25]
+        DynamicFinderThing.list(sort: [age: 'asc'], order: 'desc')*.age == [25, 30, 35]
+        DynamicFinderThing.list(sort: [age: null], order: 'desc')*.age == [25, 30, 35]
+    }
+
+    void "populateArgumentsForCriteria(BuildableCriteria, Map) takes each sort map entry's direction from its value"() {
         given:
         def api = new org.grails.datastore.gorm.GormStaticApi(DynamicFinderThing, datastore, [])
-        def criteria = api.createCriteria()
+        def descending = api.createCriteria()
+        def ascending = api.createCriteria()
 
         when:
-        DynamicFinder.populateArgumentsForCriteria(criteria, [sort: ['age, id': 'asc']])
+        DynamicFinder.populateArgumentsForCriteria(descending, [sort: [age: 'desc'], order: 'asc'])
+        DynamicFinder.populateArgumentsForCriteria(ascending, [sort: [age: null], order: 'desc'])
 
         then:
-        thrown(IllegalArgumentException)
+        descending.list(null)*.age == [35, 30, 25]
+        ascending.list(null)*.age == [25, 30, 35]
+    }
+
+    void "populateArgumentsForCriteria(BuildableCriteria, Map) validates sort keys the same way as the Query overload"() {
+        given:
+        def api = new org.grails.datastore.gorm.GormStaticApi(DynamicFinderOwner, datastore, [])
+
+        when: 'a key carrying a second expression'
+        DynamicFinder.populateArgumentsForCriteria(api.createCriteria(), [sort: ['name, id': 'asc']])
+
+        then:
+        def injected = thrown(IllegalArgumentException)
+        injected.message == 'Invalid sort property'
+
+        when: 'an unknown property beneath a known association'
+        DynamicFinder.populateArgumentsForCriteria(api.createCriteria(), [sort: 'thing.notAProp'])
+
+        then:
+        def unknown = thrown(IllegalArgumentException)
+        unknown.message == 'Invalid sort property'
+
+        when: 'a root segment that is not a persistent property'
+        DynamicFinder.populateArgumentsForCriteria(api.createCriteria(), [sort: 'c1.name', order: 'desc'])
+
+        then:
+        notThrown(IllegalArgumentException)
     }
 }
 
@@ -292,4 +382,21 @@ class DynamicFinderThing {
     String name
     Integer age
     String title
+}
+
+@Entity
+class DynamicFinderOwner {
+    Long id
+    String name
+    DynamicFinderThing thing
+    static hasMany = [tags: String]
+}
+
+@Entity
+class DynamicFinderCompositeThing {
+    String a
+    String b
+    static mapping = {
+        id composite: ['a', 'b']
+    }
 }

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/NameUtils.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/NameUtils.java
@@ -160,4 +160,40 @@ public class NameUtils {
     public static String capitalize(String name) {
         return BeanUtils.capitalize(name);
     }
+
+    /**
+     * Whether the given value is shaped like a property path: one or more Java identifiers
+     * separated by single dots, for example {@code name} or {@code author.name}. Identifier
+     * segments follow {@link Character#isJavaIdentifierStart(int)} and
+     * {@link Character#isJavaIdentifierPart(int)}, so {@code $} and non-ASCII letters are
+     * accepted while ignorable control characters, whitespace, punctuation and operators are not.
+     * Useful for checking a caller-supplied property name before it is interpolated into a query.
+     *
+     * @param path The candidate property path
+     * @return {@code true} if the value is a well-formed property path
+     */
+    public static boolean isValidPropertyPath(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+        boolean expectSegmentStart = true;
+        int i = 0;
+        while (i < path.length()) {
+            int codePoint = path.codePointAt(i);
+            if (expectSegmentStart) {
+                if (!Character.isJavaIdentifierStart(codePoint)) {
+                    return false;
+                }
+                expectSegmentStart = false;
+            }
+            else if (codePoint == '.') {
+                expectSegmentStart = true;
+            }
+            else if (!Character.isJavaIdentifierPart(codePoint) || Character.isIdentifierIgnorable(codePoint)) {
+                return false;
+            }
+            i += Character.charCount(codePoint);
+        }
+        return !expectSegmentStart;
+    }
 }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/NameUtilsSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/NameUtilsSpec.groovy
@@ -34,4 +34,56 @@ class NameUtilsSpec extends Specification {
         'name'  | 'name'
         'IName' | 'iName'
     }
+
+    @Unroll
+    void "isValidPropertyPath accepts identifier-shaped path #path"() {
+        expect:
+        NameUtils.isValidPropertyPath(path)
+
+        where:
+        path << [
+                'name',
+                'a',
+                '_name',
+                '$name',
+                'name$2',
+                'name2',
+                'author.name',
+                'author.address.city',
+                'c1.name',
+                'naïve',
+                '名前',
+                'name.名前',
+        ]
+    }
+
+    @Unroll
+    void "isValidPropertyPath rejects malformed path #description"() {
+        expect:
+        !NameUtils.isValidPropertyPath(path)
+
+        where:
+        path                | description
+        null                | 'null'
+        ''                  | 'empty'
+        ' '                 | 'blank'
+        'name '             | 'trailing whitespace'
+        ' name'             | 'leading whitespace'
+        'name desc'         | 'embedded whitespace'
+        'name, e.id'        | 'comma with a second expression'
+        'name,id'           | 'comma'
+        'name;'             | 'semicolon'
+        "name'"             | 'quote'
+        'upper(name)'       | 'function call'
+        'name-x'            | 'hyphen'
+        'name/*'            | 'comment opener'
+        '1name'             | 'leading digit'
+        '.name'             | 'leading dot'
+        'name.'             | 'trailing dot'
+        'a..b'              | 'empty segment'
+        'a.1b'              | 'segment starting with digit'
+        'name\u0000'        | 'NUL control character'
+        'na\u200Bme'        | 'zero-width space'
+        'name\n'            | 'newline'
+    }
 }

--- a/grails-doc/src/en/ref/Domain Classes/list.adoc
+++ b/grails-doc/src/en/ref/Domain Classes/list.adoc
@@ -60,10 +60,12 @@ Parameters:
 * `max` - The maximum number to list
 * `offset` - The offset from the first result to list from
 * `order` - How to order the list, either `"desc"` or `"asc"`
-* `sort` - The property name to sort by
+* `sort` - The property name to sort by, which may be a path through an association or embedded component such as `"author.name"`, or a `Map` of property names to directions such as `[title: "asc", "author.name": "desc"]`
 * `ignoreCase` - Whether to ignore the case when sorting. Default is `true`.
 * `fetch` - The fetch policy for the object's associations as a `Map`
 * `readOnly` - true if returned objects should not be automatically dirty-checked (simlar to `read()`)
 * `fetchSize` - number of rows fetched by the underlying JDBC driver per round trip
 * `flushMode` - Hibernate `FlushMode` override, defaults to `FlushMode.AUTO`
 * `timeout` - query timeout in seconds
+
+The `sort`, `order` and `fetch` arguments are validated before the query is built. A `sort` key must be a property path made up of identifiers separated by dots that resolves through the domain class mapping, `order` must be `"asc"` or `"desc"` (case-insensitive, surrounding whitespace ignored), and a `fetch` key must name a persistent property. Any other value, for example one carrying a second expression or a function call, is rejected with an `IllegalArgumentException`, so request parameters can be passed to `list()` without further checks.


### PR DESCRIPTION
> Relocated from [jamesfredley/grails-core#5](https://github.com/jamesfredley/grails-core/pull/5). That follow-up was opened on an archive fork by mistake; Grails PRs belong on `apache/grails-core`. Parent: apache/grails-core#16312.

Follow-up to the review on #16312, targeting `fix/dynamic-finder-sort-validation`.

## Blocking items

- **Alias sorting regression.** `validateSortProperty` rejected any first path segment that is not a persistent property of the root entity, which is what a criteria / where-query alias is. `WhereQueryWithAssociationSortSpec` failed in `grails-data-hibernate7-core` and `grails-data-hibernate5-core`, and `createCriteria().list(sort: 'c.name') { createAlias('club', 'c') }` failed the same way. A first segment that is not a persistent property is now accepted on the shape check alone and left to the query implementation; segments beneath a known property must still resolve through the mapping.
- **`fetch` keys in `HqlListQueryBuilder`.** They are now validated the same way as sort keys before being concatenated into HQL.

## Smaller points

- `validateSortProperty` is `private static`; one generic message that does not echo the caller-supplied value; composite identities checked explicitly via `getCompositeIdentity()`.
- The duplicated regex is replaced by `NameUtils.isValidPropertyPath`, shared by both modules and based on `Character.isJavaIdentifierStart/Part`, so `$` and non-ASCII identifiers are accepted; ignorable control characters are not. The constant is gone from the `ARGUMENT_*` block.
- `resolvePersistentEntity` is reused in the `sortObject == null && orderParam != null` branch.
- Blank sort properties are rejected (no more `order by , e.name`), and `normalizeDirection` trims, so `order: ' desc'` keeps working.
- Sort-map direction: each entry keeps taking its direction from its value (matching `applySortForMap`), with the same `asc` fallback for a `null` value in both overloads. This is tested and documented rather than reverted.

## Tests

- `SortArgumentValidationSpec` (hibernate7-core) runs against real mappings through `list()`, dynamic finders, where queries and criteria: `sort: 'id'` / `'version'`, a subclass sorted by an inherited property, an embedded path, association paths including `club.id`, composite identity members, the `mapping { sort }` default, `createAlias` and where-query aliases, direction normalization, map directions, valid join fetches, and the rejected sort / order / fetch values.
- `DynamicFinderCoverageSpec` covers nested association traversal, identity and composite identity, a non-association mid-path, a basic collection with no associated entity, alias-shaped roots, the map-direction change and both `populateArgumentsForCriteria` overloads.
- `HqlListQueryBuilderSpec` covers the blank-key and trimmed-direction edges, `$` identifiers, and injected / unknown fetch keys.
- `NameUtilsSpec` covers the shared path check.

## Docs

`grails-doc` `list.adoc` and the Hibernate 7 / Hibernate 5 `finders.adoc` describe the accepted `sort`, `order` and `fetch` values and the alias pass-through.

